### PR TITLE
fix: local cache with parquet storage

### DIFF
--- a/examples/local_cache.py
+++ b/examples/local_cache.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import ibis
 
 import letsql as ls
@@ -17,7 +19,10 @@ con.add_connection(
 alltypes = con.table("functional_alltypes")
 
 expr = alltypes.select(alltypes.smallint_col, alltypes.int_col, alltypes.float_col)
-cached = expr.cache()  # cache expression (this creates a local table)
+
+storage = ls.common.caching.ParquetCacheStorage(Path.cwd(), source=con)
+
+cached = expr.cache(storage=storage)  # cache expression (this creates a local table)
 
 cached = cached.filter(
     [

--- a/python/letsql/expr/relations.py
+++ b/python/letsql/expr/relations.py
@@ -12,6 +12,15 @@ def replace_cache_table(node, _, **kwargs):
         return node.__recreate__(kwargs)
 
 
+def replace_source_factory(source: Any):
+    def replace_source(node, _, **kwargs):
+        if "source" in kwargs:
+            kwargs["source"] = source
+        return node.__recreate__(kwargs)
+
+    return replace_source
+
+
 class CachedNode(ops.Relation):
     schema: Schema
     parent: Any


### PR DESCRIPTION
The bug was caused by a combination of two factors:

1. After removing the CachedNodes the source of uncached was always not set accordingly, that is why is needed:
```python
storage.put(key, value.replace(replace_source))
```
2. The function `_get_source_name` was not working correctly was returning always `datafusion`, note that we were setting the name before "cleaning" the expr, which was incorrect
