### PR TITLE
Feat/elide secrets

### DIFF
--- a/examples/profiles.py
+++ b/examples/profiles.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# profiles_example.py - Comprehensive example of working with xorq profiles
-
 import os
 
 from xorq.vendor.ibis.backends.profiles import Profile, Profiles

--- a/examples/profiles.py
+++ b/examples/profiles.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# profiles_example.py - Comprehensive example of working with xorq profiles
+
+import os
+
+from xorq.vendor.ibis.backends.profiles import Profile, Profiles
+
+
+print("=== XORQ PROFILES DEMONSTRATION ===\n")
+
+# Set environment variables for database connection
+print("Setting up environment variables...")
+# This is a PostgreSQL database running at examples.letsql.com
+os.environ["POSTGRES_DATABASE"] = "letsql"
+os.environ["POSTGRES_HOST"] = "examples.letsql.com"
+os.environ["POSTGRES_USER"] = "letsql"
+os.environ["POSTGRES_PASSWORD"] = "letsql"
+os.environ["POSTGRES_PORT"] = "5432"
+
+# 1. Create a profile with environment variable references
+print("\n1. Creating profile with environment variable references...")
+profile = Profile(
+    con_name="postgres",
+    kwargs_tuple=(
+        ("host", "${POSTGRES_HOST}"),
+        ("port", 5432),
+        ("database", "postgres"),
+        ("user", "${POSTGRES_USER}"),
+        ("password", "${POSTGRES_PASSWORD}"),
+    ),
+)
+
+print(f"Profile representation:\n{profile}")
+
+# 2. Save the profile with an alias
+print("\n2. Saving profile with alias...")
+path = profile.save(alias="postgres_example", clobber=True)
+print(f"Profile saved to: {path}")
+
+# 3. Load the profile
+print("\n3. Loading profile from disk...")
+loaded_profile = Profile.load("postgres_example")
+print(f"Loaded profile representation:\n{loaded_profile}")
+
+# 4. Create a connection from the profile
+print("\n4. Creating connection from profile...")
+connection = loaded_profile.get_con()
+print("Connection successful!")
+
+# 5. Verify connection works
+tables = connection.list_tables()
+print(f"Found tables: {tables[:5]}")
+
+# 6. Verify connection's profile still has environment variables
+print("\n5. Examining connection's profile...")
+conn_profile = connection._profile
+print(f"Connection profile representation:\n{conn_profile}")
+
+# 7. Create a profile from existing connection
+print("\n6. Creating new profile from connection...")
+from_conn_profile = Profile.from_con(connection)
+print(f"Profile from connection representation:\n{from_conn_profile}")
+
+# 8. Save profile from connection with new alias
+print("\n7. Saving profile from connection...")
+from_conn_profile.save(alias="postgres_from_conn", clobber=True)
+
+# 9. Working with multiple profiles
+print("\n8. Working with multiple profiles...")
+profiles = Profiles()
+all_profiles = profiles.list()
+print(f"Available profiles: {all_profiles}")
+
+# 10. Clone a profile with modifications
+print("\n9. Cloning profile with modifications...")
+cloned_profile = profile.clone(**{"connect_timeout": 10})
+print(f"Original profile representation:\n{profile}")
+print(f"Cloned profile representation:\n{cloned_profile}")
+
+# 11. Save the cloned profile
+cloned_profile.save(alias="postgres_other_db", clobber=True)
+
+# 12. Security verification
+print("\n10. Security verification...")
+print("Throughout this entire process, actual values of environment")
+print("variables were never stored in profiles or exposed in output.")
+
+# 13. Demonstrating how to explore with profiles
+print("\n11. Exploring available profiles...")
+profiles = Profiles()
+for name in profiles.list():
+    p = profiles.get(name)
+    print(f"Profile: {name}")
+    print(f"  - Connection: {p.get_con()}")
+    print(f"  - Profile: {p}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "typing-extensions>=4.3.0",
     "pyyaml>=6.0.2",
     "cloudpickle>=3.1.1",
+    "envyaml>=1.10.211231",
 ]
 requires-python = ">=3.10"
 authors = [

--- a/python/xorq/__init__.py
+++ b/python/xorq/__init__.py
@@ -8,7 +8,6 @@ from xorq.expr import api
 from xorq.expr.api import *  # noqa: F403
 from xorq.backends.let import Backend
 from xorq.internal import SessionConfig
-from xorq.vendor.ibis.backends.profiles import parse_env_vars
 
 try:
     import importlib.metadata as importlib_metadata
@@ -45,9 +44,7 @@ def load_backend(name):
         backend.register_options()
 
         def connect(*args, **kwargs):
-            parsed_kwargs = parse_env_vars(kwargs)
-            # breakpoint()
-            return backend.connect(*args, **parsed_kwargs)
+            return backend.connect(*args, **kwargs)
 
         connect.__doc__ = backend.do_connect.__doc__
         connect.__wrapped__ = backend.do_connect

--- a/python/xorq/__init__.py
+++ b/python/xorq/__init__.py
@@ -8,6 +8,7 @@ from xorq.expr import api
 from xorq.expr.api import *  # noqa: F403
 from xorq.backends.let import Backend
 from xorq.internal import SessionConfig
+from xorq.vendor.ibis.backends.profiles import parse_env_vars
 
 try:
     import importlib.metadata as importlib_metadata
@@ -44,7 +45,9 @@ def load_backend(name):
         backend.register_options()
 
         def connect(*args, **kwargs):
-            return backend.connect(*args, **kwargs)
+            parsed_kwargs = parse_env_vars(kwargs)
+            # breakpoint()
+            return backend.connect(*args, **parsed_kwargs)
 
         connect.__doc__ = backend.do_connect.__doc__
         connect.__wrapped__ = backend.do_connect

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -137,7 +137,7 @@ class Pins(Config):
 
 
 class Profiles(Config):
-    profile_dir: pathlib.Path = pathlib.Path("~/.config/letsql/profiles").expanduser()
+    profile_dir: pathlib.Path = pathlib.Path("~/.config/xorq/profiles").expanduser()
 
 
 class Options(Config):

--- a/python/xorq/vendor/ibis/backends/__init__.py
+++ b/python/xorq/vendor/ibis/backends/__init__.py
@@ -5,10 +5,7 @@ import collections.abc
 import contextlib
 import functools
 import importlib.metadata
-import itertools
-import json
 import keyword
-import os
 import re
 import sys
 import urllib.parse
@@ -16,27 +13,14 @@ import weakref
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
-import dask
-import toolz
-import yaml
-from attr import (
-    field,
-    frozen,
-)
-from attr.validators import (
-    instance_of,
-    optional,
-)
-from envyaml import EnvYAML
-
 import xorq as xo
 import xorq.common.exceptions as exc
 import xorq.vendor.ibis.config
 import xorq.vendor.ibis.expr.operations as ops
 import xorq.vendor.ibis.expr.types as ir
-from xorq.common.utils.inspect_utils import get_arguments
 from xorq.vendor import ibis
 from xorq.vendor.ibis import util
+from xorq.vendor.ibis.backends.profiles import Profile
 
 
 if TYPE_CHECKING:
@@ -1520,185 +1504,3 @@ class NoUrl:
 
         """
         return self.connect(**kwargs)
-
-
-@frozen
-class Profiles:
-    profile_dir = field(validator=optional(instance_of(Path)), default=None)
-
-    def __attrs_post_init__(self):
-        if self.profile_dir is None:
-            object.__setattr__(self, "profile_dir", xo.options.profiles.profile_dir)
-        if not self.profile_dir.exists():
-            self.profile_dir.mkdir(exist_ok=True, parents=True)
-
-    def get(self, name):
-        return Profile.load(name, profile_dir=self.profile_dir)
-
-    def __getattr__(self, stem):
-        try:
-            return self.get(
-                next(el.name for el in self.profile_dir.iterdir() if el.stem == stem)
-            )
-        except Exception:
-            return object.__getattribute__(self, stem)
-
-    def __getitem__(self, stem):
-        return self.get(
-            next(el.name for el in self.profile_dir.iterdir() if el.stem == stem)
-        )
-
-    def __dir__(self):
-        return tuple(el for el in self.list() if el.isidentifier())
-
-    def list(self):
-        return tuple(el.stem for el in self.profile_dir.iterdir())
-
-    def _ipython_key_completions_(self):
-        return self.list()
-
-
-@frozen
-class Profile:
-    con_name = field(validator=instance_of(str))
-    kwargs_tuple = field(validator=instance_of(tuple))
-    idx = field(validator=instance_of(int), factory=itertools.count().__next__)
-
-    @con_name.validator
-    def validate_con_name(self, attr, value):
-        assert next(
-            (ep for ep in xo._load_entry_points() if ep.name == value),
-            None,
-        )
-
-    def __attrs_post_init__(self):
-        # Sort kwargs_tuple after initialization
-        object.__setattr__(self, "kwargs_tuple", tuple(sorted(self.kwargs_tuple)))
-
-    @property
-    def kwargs_dict(self):
-        return {k: v for k, v in self.kwargs_tuple}
-
-    @property
-    def hash_name(self):
-        pre_hash = json.loads(self.as_json())
-        pre_hash.pop("idx")
-        return dask.base.tokenize(json.dumps(pre_hash))
-
-    def get_con(self, **kwargs):
-        kwargs = {
-            **kwargs,
-            **dict(self.kwargs_tuple),
-        }
-        connect = getattr(xo.load_backend(self.con_name), "connect")
-        con = connect(**kwargs)
-        return con
-
-    def clone(self, idx=None, **kwargs):
-        idx = idx if idx is not None else self.idx
-        kwargs_tuple = tuple(
-            {
-                **dict(self.kwargs_tuple),
-                **kwargs,
-            }.items()
-        )
-        return type(self)(
-            con_name=self.con_name,
-            kwargs_tuple=kwargs_tuple,
-            idx=idx,
-        )
-
-    def as_dict(self):
-        return {
-            name: getattr(self, name)
-            for name in (attr.name for attr in self.__attrs_attrs__)
-        }
-
-    def as_json(self):
-        return json.dumps(self.as_dict())
-
-    def as_yaml(self):
-        return yaml.safe_dump(
-            dict(con_name=self.con_name, kwargs_dict=self.kwargs_dict, idx=self.idx)
-        )
-
-    def elide_secrets(self):
-        # TODO: Needs more secret keys for different backends
-        SECRET_KEYS = ("password", "secret")
-
-        new_kwargs = {}
-        for k, v in self.kwargs_dict.items():
-            found_env = None
-            # check to see if the value is an env variable
-            # and that it exists before we save it
-            if not v:
-                continue
-            if isinstance(v, str):
-                if v.startswith("${") and v.endswith("}"):
-                    env_name = v[2:-1]
-                    if env_name in os.environ:
-                        new_kwargs[k] = f"${{{env_name}}}"
-                        continue
-
-            for env_name, env_value in os.environ.items():
-                if env_value == v:
-                    found_env = env_name
-                    break
-            if found_env:
-                new_kwargs[k] = f"${{{found_env}}}"
-            else:
-                if k in SECRET_KEYS:
-                    new_kwargs[k] = "***elided***"
-                else:
-                    new_kwargs[k] = v
-        return self.clone(**new_kwargs)
-
-    def save(self, profile_dir=None, alias=None, clobber=False):
-        path = self.get_path(self.hash_name, profile_dir=profile_dir)
-        if not path.exists():
-            elided = self.elide_secrets()
-            path.write_text(elided.as_yaml())
-        if alias:
-            alias_path = self.get_path(alias, profile_dir=profile_dir)
-            if alias_path.exists():
-                if not clobber:
-                    raise ValueError
-                alias_path.unlink()
-            alias_path.symlink_to(path)
-            return alias_path
-        return path
-
-    def almost_equals(self, other):
-        return self.clone(idx=-1) == other.clone(idx=-1)
-
-    @classmethod
-    def get_path(cls, name, profile_dir=None):
-        profile_dir = profile_dir or xo.options.profiles.profile_dir
-        profile_dir.mkdir(exist_ok=True, parents=True)
-        path = profile_dir.joinpath(name).with_suffix(".yaml")
-        return path
-
-    @classmethod
-    def load(cls, name, profile_dir=None):
-        path = cls.get_path(name, profile_dir=profile_dir)
-        env = EnvYAML(path)
-        con_name = env.get("con_name")
-        kwargs_dict = env.get("kwargs_dict")
-        idx = env.get("idx")
-        sorted_kwargs = tuple(sorted(kwargs_dict.items()))
-        return cls(con_name=con_name, kwargs_tuple=sorted_kwargs, idx=idx)
-
-    @classmethod
-    def from_con(cls, con):
-        if con.name == "xorq_flight":
-            return None
-        kwargs_name = "config" if con.name == "duckdb" else "kwargs"
-        arguments = get_arguments(con.do_connect, *con._con_args, **con._con_kwargs)
-        assert not arguments.get("args")
-        kwargs = {
-            **toolz.dissoc(arguments, "args", kwargs_name),
-            **arguments.get(kwargs_name, {}),
-        }
-        if "port" in kwargs and kwargs["port"] is not None:
-            kwargs["port"] = int(kwargs["port"])
-        return cls(con_name=con.name, kwargs_tuple=tuple(kwargs.items()))

--- a/python/xorq/vendor/ibis/backends/__init__.py
+++ b/python/xorq/vendor/ibis/backends/__init__.py
@@ -1571,9 +1571,6 @@ class Profile:
             None,
         )
 
-    # def as_yaml(self):
-    #     return yaml.safe_dump(self.as_dict())
-
     def __attrs_post_init__(self):
         # Sort kwargs_tuple after initialization
         object.__setattr__(self, "kwargs_tuple", tuple(sorted(self.kwargs_tuple)))
@@ -1684,9 +1681,6 @@ class Profile:
     @classmethod
     def load(cls, name, profile_dir=None):
         path = cls.get_path(name, profile_dir=profile_dir)
-        # dct = json.loads(path.read_text())
-        # dct["kwargs_tuple"] = tuple(map(tuple, dct["kwargs_tuple"]))
-        # parse ENV
         env = EnvYAML(path)
         con_name = env.get("con_name")
         kwargs_dict = env.get("kwargs_dict")
@@ -1705,6 +1699,6 @@ class Profile:
             **toolz.dissoc(arguments, "args", kwargs_name),
             **arguments.get(kwargs_name, {}),
         }
-        if "port" in kwargs:
+        if "port" in kwargs and kwargs["port"] is not None:
             kwargs["port"] = int(kwargs["port"])
         return cls(con_name=con.name, kwargs_tuple=tuple(kwargs.items()))

--- a/python/xorq/vendor/ibis/backends/__init__.py
+++ b/python/xorq/vendor/ibis/backends/__init__.py
@@ -863,6 +863,7 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
     supports_in_memory_tables = True
 
     def __init__(self, *args, **kwargs):
+        self._env_var_mapping = kwargs.pop("_env_var_mapping", {})
         self._con_args: tuple[Any] = args
         self._con_kwargs: dict[str, Any] = kwargs
         self._can_reconnect: bool = True

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -1,0 +1,204 @@
+import itertools
+import json
+import os
+from pathlib import Path
+
+import dask
+import toolz
+import yaml
+from attr import (
+    field,
+    frozen,
+)
+from attr.validators import (
+    instance_of,
+    optional,
+)
+from envyaml import EnvYAML
+
+import xorq as xo
+from xorq.common.utils.inspect_utils import get_arguments
+
+
+@frozen
+class Profiles:
+    profile_dir = field(validator=optional(instance_of(Path)), default=None)
+
+    def __attrs_post_init__(self):
+        if self.profile_dir is None:
+            object.__setattr__(self, "profile_dir", xo.options.profiles.profile_dir)
+        if not self.profile_dir.exists():
+            self.profile_dir.mkdir(exist_ok=True, parents=True)
+
+    def get(self, name):
+        return Profile.load(name, profile_dir=self.profile_dir)
+
+    def __getattr__(self, stem):
+        try:
+            return self.get(
+                next(el.name for el in self.profile_dir.iterdir() if el.stem == stem)
+            )
+        except Exception:
+            return object.__getattribute__(self, stem)
+
+    def __getitem__(self, stem):
+        return self.get(
+            next(el.name for el in self.profile_dir.iterdir() if el.stem == stem)
+        )
+
+    def __dir__(self):
+        return tuple(el for el in self.list() if el.isidentifier())
+
+    def list(self):
+        return tuple(el.stem for el in self.profile_dir.iterdir())
+
+    def _ipython_key_completions_(self):
+        return self.list()
+
+
+@frozen
+class Profile:
+    con_name = field(validator=instance_of(str))
+    kwargs_tuple = field(validator=instance_of(tuple))
+    idx = field(validator=instance_of(int), factory=itertools.count().__next__)
+
+    @con_name.validator
+    def validate_con_name(self, attr, value):
+        assert next(
+            (ep for ep in xo._load_entry_points() if ep.name == value),
+            None,
+        )
+
+    def __attrs_post_init__(self):
+        # Sort kwargs_tuple after initialization
+        object.__setattr__(self, "kwargs_tuple", tuple(sorted(self.kwargs_tuple)))
+
+    @property
+    def kwargs_dict(self):
+        return {k: v for k, v in self.kwargs_tuple}
+
+    @property
+    def hash_name(self):
+        pre_hash = json.loads(self.as_json())
+        idx = pre_hash.get("idx")
+        pre_hash = toolz.dissoc(pre_hash, "idx")
+        dask_hash = dask.base.tokenize(json.dumps(pre_hash))
+        return f"{dask_hash}_{idx}"
+
+    def get_con(self, **kwargs):
+        kwargs = {
+            **kwargs,
+            **dict(self.kwargs_tuple),
+        }
+        connect = getattr(xo.load_backend(self.con_name), "connect")
+        con = connect(**kwargs)
+        return con
+
+    def clone(self, idx=None, **kwargs):
+        idx = idx if idx is not None else self.idx
+        kwargs_tuple = tuple(
+            {
+                **dict(self.kwargs_tuple),
+                **kwargs,
+            }.items()
+        )
+        return type(self)(
+            con_name=self.con_name,
+            kwargs_tuple=kwargs_tuple,
+            idx=idx,
+        )
+
+    def as_dict(self):
+        return {
+            name: getattr(self, name)
+            for name in (attr.name for attr in self.__attrs_attrs__)
+        }
+
+    def as_json(self):
+        return json.dumps(self.as_dict())
+
+    def as_yaml(self):
+        return yaml.safe_dump(
+            dict(con_name=self.con_name, kwargs_dict=self.kwargs_dict, idx=self.idx)
+        )
+
+    def elide_secrets(self):
+        # TODO: Needs more secret keys for different backends
+        SECRET_KEYS = ("password", "secret")
+
+        new_kwargs = {}
+        for k, v in self.kwargs_dict.items():
+            found_env = None
+            # check to see if the value is an env variable
+            # and that it exists before we save it
+            if not v:
+                continue
+            if isinstance(v, str):
+                if v.startswith("${") and v.endswith("}"):
+                    env_name = v[2:-1]
+                    if env_name in os.environ:
+                        new_kwargs[k] = f"${{{env_name}}}"
+                        continue
+
+            for env_name, env_value in os.environ.items():
+                if env_value == v:
+                    found_env = env_name
+                    break
+            if found_env:
+                new_kwargs[k] = f"${{{found_env}}}"
+            else:
+                if k in SECRET_KEYS:
+                    new_kwargs[k] = "***elided***"
+                else:
+                    new_kwargs[k] = v
+        return self.clone(**new_kwargs)
+
+    def save(self, profile_dir=None, alias=None, clobber=False):
+        path = self.get_path(self.hash_name, profile_dir=profile_dir)
+        if not path.exists():
+            elided = self.elide_secrets()
+            path.write_text(elided.as_yaml())
+        if alias:
+            alias_path = self.get_path(alias, profile_dir=profile_dir)
+            if alias_path.exists():
+                if not clobber:
+                    raise ValueError
+                alias_path.unlink()
+            alias_path.symlink_to(path)
+            return alias_path
+        return path
+
+    def almost_equals(self, other):
+        return self.clone(idx=-1) == other.clone(idx=-1)
+
+    @classmethod
+    def get_path(cls, name, profile_dir=None):
+        profile_dir = profile_dir or xo.options.profiles.profile_dir
+        profile_dir.mkdir(exist_ok=True, parents=True)
+        path = profile_dir.joinpath(name).with_suffix(".yaml")
+        return path
+
+    @classmethod
+    def load(cls, name, profile_dir=None):
+        path = cls.get_path(name, profile_dir=profile_dir)
+        env = EnvYAML(path)
+        con_name = env.get("con_name")
+        kwargs_dict = env.get("kwargs_dict")
+        idx = env.get("idx")
+        sorted_kwargs = tuple(sorted(kwargs_dict.items()))
+        return cls(con_name=con_name, kwargs_tuple=sorted_kwargs, idx=idx)
+
+    @classmethod
+    def from_con(cls, con):
+        if con.name == "xorq_flight":
+            return None
+        kwargs_name = "config" if con.name == "duckdb" else "kwargs"
+        arguments = get_arguments(con.do_connect, *con._con_args, **con._con_kwargs)
+        assert not arguments.get("args")
+        kwargs = {
+            **toolz.dissoc(arguments, "args", kwargs_name),
+            **arguments.get(kwargs_name, {}),
+        }
+        if "port" in kwargs and kwargs["port"] is not None:
+            kwargs["port"] = int(kwargs["port"])
+        return cls(con_name=con.name, kwargs_tuple=tuple(kwargs.items()))

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -288,7 +288,6 @@ class Profile:
                 if key in relevant_secrets
                 and not (isinstance(value, str) and compiled_env_var_re.match(value))
             ]
-
             if exposed_secrets:
                 secrets_list = ", ".join(f"'{key}'" for key in exposed_secrets)
                 env_var_examples = ", ".join(
@@ -468,6 +467,11 @@ class Profile:
             assert not arguments1.get("args")
             arguments = toolz.dissoc(arguments0 | arguments1, "args")
             return arguments
+
+            # If connection already has a profile, return it to preserve env vars
+
+        if hasattr(con, "_profile") and con._profile is not None:
+            return con._profile
 
         if con.name == "xorq_flight":
             return None

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -78,11 +78,12 @@ class Profile:
 
     @property
     def hash_name(self):
-        pre_hash = json.loads(self.as_json())
-        idx = pre_hash.get("idx")
-        pre_hash = toolz.dissoc(pre_hash, "idx")
-        dask_hash = dask.base.tokenize(json.dumps(pre_hash))
-        return f"{dask_hash}_{idx}"
+        dask_hash = dask.base.tokenize(
+            json.dumps(
+                toolz.dissoc(self.as_dict(), "idx"),
+            )
+        )
+        return f"{dask_hash}_{self.idx}"
 
     def get_con(self, **kwargs):
         """Create a connection using this profile's parameters."""

--- a/python/xorq/vendor/ibis/tests/test_profile.py
+++ b/python/xorq/vendor/ibis/tests/test_profile.py
@@ -85,9 +85,11 @@ def test_save_load(connector, monkeypatch, tmp_path):
             profile.load(profile.hash_name),
         )
     )
+
     for other in others:
         assert profile == other
         assert con.list_tables() == other.get_con().list_tables()
+
     del os.environ["LETSQL_PASSWORD"]
 
 

--- a/python/xorq/vendor/ibis/tests/test_profile.py
+++ b/python/xorq/vendor/ibis/tests/test_profile.py
@@ -5,7 +5,8 @@ import pytest
 import yaml
 
 import xorq as xo
-from xorq.vendor.ibis.backends import BaseBackend, Profile, Profiles
+from xorq.vendor.ibis.backends import BaseBackend
+from xorq.vendor.ibis.backends.profiles import Profile, Profiles
 
 
 local_con_names = ("duckdb", "let", "datafusion", "pandas")
@@ -135,7 +136,6 @@ def test_elide_secrets():
             ("direct_env", "${SOME_ENV}"),
         ),
     )
-
     # elide
     elided_profile = profile.elide_secrets()
 

--- a/python/xorq/vendor/ibis/tests/test_profile.py
+++ b/python/xorq/vendor/ibis/tests/test_profile.py
@@ -57,7 +57,7 @@ def test_remote_con_works(connect):
 
 def test_profiles(monkeypatch, tmp_path):
     default_profile_dir = xo.options.profiles.profile_dir
-    assert default_profile_dir == pathlib.Path("~/.config/letsql/profiles").expanduser()
+    assert default_profile_dir == pathlib.Path("~/.config/xorq/profiles").expanduser()
     profiles = Profiles()
     assert profiles.profile_dir == default_profile_dir
     assert not profiles.list()  # why do this ?

--- a/python/xorq/vendor/ibis/tests/test_profile.py
+++ b/python/xorq/vendor/ibis/tests/test_profile.py
@@ -2,11 +2,10 @@ import os
 import pathlib
 
 import pytest
-import yaml
 
 import xorq as xo
 from xorq.vendor.ibis.backends import BaseBackend
-from xorq.vendor.ibis.backends.profiles import Profile, Profiles
+from xorq.vendor.ibis.backends.profiles import Profile, Profiles, parse_env_vars
 
 
 local_con_names = ("duckdb", "let", "datafusion", "pandas")
@@ -92,127 +91,6 @@ def test_save_load(connector, monkeypatch, tmp_path):
     del os.environ["LETSQL_PASSWORD"]
 
 
-def test_elide_secrets():
-    os.environ["TEST_SECRET_USER"] = "test_user"
-    os.environ["TEST_SECRET_PASSWORD"] = "very_secret_password"
-    os.environ["SOME_ENV"] = "some_env"
-    # expected
-    expected_kwargs_dict_elided = dict(
-        host="localhost-dummy",
-        port=5432,
-        user="${TEST_SECRET_USER}",
-        password="${TEST_SECRET_PASSWORD}",
-        database="test_db",
-        secret="***elided***",
-        nonsecret="visible_data",
-        empty_param="",
-        direct_env="${SOME_ENV}",
-    )
-
-    expected_kwargs_dict_raw = dict(
-        host="localhost-dummy",
-        port=5432,
-        user="test_user",
-        password="very_secret_password",
-        database="test_db",
-        secret="another_secret",
-        nonsecret="visible_data",
-        empty_param="",
-        direct_env="${SOME_ENV}",
-    )
-
-    # create profile
-    profile = Profile(
-        con_name="postgres",
-        kwargs_tuple=(
-            ("host", "localhost-dummy"),
-            ("port", 5432),
-            ("user", "test_user"),
-            ("password", "very_secret_password"),
-            ("database", "test_db"),
-            ("secret", "another_secret"),
-            ("nonsecret", "visible_data"),
-            ("empty_param", ""),
-            ("direct_env", "${SOME_ENV}"),
-        ),
-    )
-    # elide
-    elided_profile = profile.elide_secrets()
-
-    # check raw
-    assert profile.kwargs_dict == expected_kwargs_dict_raw
-
-    # no elision
-    assert elided_profile.kwargs_dict == expected_kwargs_dict_elided
-
-    # is it still yaml
-    yaml_content = elided_profile.as_yaml()
-    data = yaml.safe_load(yaml_content)
-
-    # check that on disk is elided
-    assert data["kwargs_dict"] == expected_kwargs_dict_elided
-    # Make sure same back from disk
-    profile.save()
-    loaded_profile = profile.load(profile.hash_name)
-
-    # no env for secret
-    assert loaded_profile.kwargs_dict["secret"] == "***elided***"
-    # assert profile == profile.load(profile.hash_name)
-
-    # Clean up
-    del os.environ["TEST_SECRET_USER"]
-    del os.environ["TEST_SECRET_PASSWORD"]
-    del os.environ["SOME_ENV"]
-
-
-def test_missing_env_var_elided(monkeypatch, tmp_path):
-    # NOTE: in the event a variable does not exist and it is a secret it will be elided
-    # we will only save env vars that exist during save
-    monkeypatch.setattr(xo.options.profiles, "profile_dir", tmp_path)
-    os.environ["EXISTING_ENV"] = "exists"
-
-    profile = Profile(
-        con_name="postgres",
-        kwargs_tuple=(
-            ("user", "${EXISTING_ENV}"),
-            ("password", "${MISSING_ENV_VAR}"),  # This doesn't exist
-            ("host", "localhost-dummy"),
-            ("port", 5432),
-        ),
-    )
-
-    profile.save()
-
-    assert Profile.load(profile.hash_name).kwargs_dict["password"] == "***elided***"
-
-    del os.environ["EXISTING_ENV"]
-
-
-def test_missing_env_var_strict(monkeypatch, tmp_path):
-    monkeypatch.setattr(xo.options.profiles, "profile_dir", tmp_path)
-    os.environ["EXISTING_ENV"] = "exists"
-    expected_value_error = (
-        r"Strict mode enabled, variables \$MISSING_ENV_VAR are not defined!"
-    )
-    profile = Profile(
-        con_name="postgres",
-        kwargs_tuple=(
-            ("user", "${EXISTING_ENV}"),
-            ("password", "BANANIBAL"),  # it will elide secrets
-            ("host", "${MISSING_ENV_VAR}"),
-            ("port", 5432),
-        ),
-    )
-
-    profile_path = profile.save()
-    assert profile_path.exists()
-
-    with pytest.raises(ValueError, match=expected_value_error):
-        Profile.load(profile.hash_name)
-
-    del os.environ["EXISTING_ENV"]
-
-
 def test_profile_hash_order_independence():
     # different order same kwargs
     profile1 = Profile(
@@ -236,10 +114,218 @@ def test_profile_hash_order_independence():
     )
 
     # check hash order agnostic
-    assert profile1.hash_name == profile2.hash_name
+    assert profile1.hash_name.split("_")[0] == profile2.hash_name.split("_")[0]
+    assert profile1.hash_name.split("_")[1] != profile2.hash_name.split("_")[1]
     # check sort
     assert profile1.kwargs_tuple == profile2.kwargs_tuple
 
     # check clone
     cloned = profile1.clone()
-    assert cloned.hash_name == profile1.hash_name
+    assert cloned.hash_name.split("_")[0] == profile1.hash_name.split("_")[0]
+
+
+class TestParseEnvVars:
+    def test_empty_dict(self):
+        """Test with empty dictionary."""
+        assert parse_env_vars({}) == {}
+
+    def test_no_env_vars(self):
+        """Test with dictionary containing no environment variables."""
+        input_dict = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "non_string": 123,
+            "none_value": None,
+            "empty_string": "",
+        }
+        assert parse_env_vars(input_dict) == input_dict
+
+    def test_dollar_brace_format(self, monkeypatch):
+        """Test with ${VAR} format environment variables."""
+        # Set environment variables for testing
+        monkeypatch.setenv("TEST_USER", "testuser")
+        monkeypatch.setenv("TEST_PASSWORD", "secretpass")
+
+        input_dict = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "${TEST_USER}",
+            "password": "${TEST_PASSWORD}",
+            "non_env": "regular_value",
+        }
+
+        expected = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "testuser",
+            "password": "secretpass",
+            "non_env": "regular_value",
+        }
+
+        assert parse_env_vars(input_dict) == expected
+
+    def test_dollar_format(self, monkeypatch):
+        """Test with $VAR format environment variables."""
+        # Set environment variables for testing
+        monkeypatch.setenv("TEST_USER", "testuser")
+        monkeypatch.setenv("TEST_PASSWORD", "secretpass")
+
+        input_dict = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "$TEST_USER",
+            "password": "$TEST_PASSWORD",
+            "non_env": "regular_value",
+        }
+
+        expected = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "testuser",
+            "password": "secretpass",
+            "non_env": "regular_value",
+        }
+
+        assert parse_env_vars(input_dict) == expected
+
+    def test_mixed_formats(self, monkeypatch):
+        """Test with mixed ${VAR} and $VAR formats."""
+        # Set environment variables for testing
+        monkeypatch.setenv("TEST_USER", "testuser")
+        monkeypatch.setenv("TEST_PASSWORD", "secretpass")
+
+        input_dict = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "${TEST_USER}",
+            "password": "$TEST_PASSWORD",
+            "non_env": "regular_value",
+        }
+
+        expected = {
+            "host": "localhost",
+            "port": 5432,
+            "user": "testuser",
+            "password": "secretpass",
+            "non_env": "regular_value",
+        }
+
+        assert parse_env_vars(input_dict) == expected
+
+    def test_non_string_values(self, monkeypatch):
+        """Test with non-string values."""
+        monkeypatch.setenv("TEST_VAR", "test_value")
+
+        input_dict = {
+            "string": "${TEST_VAR}",
+            "integer": 123,
+            "float": 45.67,
+            "boolean": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "dict": {"a": 1, "b": 2},
+        }
+
+        expected = {
+            "string": "test_value",
+            "integer": 123,
+            "float": 45.67,
+            "boolean": True,
+            "none": None,
+            "list": [1, 2, 3],
+            "dict": {"a": 1, "b": 2},
+        }
+
+        assert parse_env_vars(input_dict) == expected
+
+    def test_missing_env_var(self, monkeypatch):
+        """Test with missing environment variables - should raise ValueError."""
+        monkeypatch.setenv("EXISTING_VAR", "exists")
+
+        input_dict = {
+            "existing": "${EXISTING_VAR}",
+            "missing": "${MISSING_VAR}",
+            "regular": "value",
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_env_vars(input_dict)
+
+        assert "Environment variable(s) 'MISSING_VAR' not set" in str(exc_info.value)
+
+    def test_multiple_missing_env_vars(self, monkeypatch):
+        """Test with multiple missing environment variables."""
+        monkeypatch.setenv("EXISTING_VAR", "exists")
+
+        input_dict = {
+            "existing": "${EXISTING_VAR}",
+            "missing1": "${MISSING_VAR1}",
+            "missing2": "$MISSING_VAR2",
+            "regular": "value",
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_env_vars(input_dict)
+
+        # Check both missing variables are mentioned
+        error_msg = str(exc_info.value)
+        assert "MISSING_VAR1" in error_msg
+        assert "MISSING_VAR2" in error_msg
+
+    def test_dollar_sign_in_string(self, monkeypatch):
+        """Test with strings containing dollar signs but not as env vars."""
+        input_dict = {
+            "code": "a$b$c",
+            "text": "This costs $5",
+            "complex": "a${non-env}b",  # Not a proper env var syntax
+        }
+
+        expected = {
+            "code": "a$b$c",
+            "text": "This costs $5",
+            "complex": "a${non-env}b",
+        }
+
+        assert parse_env_vars(input_dict) == expected
+
+    def test_preserve_case(self, monkeypatch):
+        """Test that environment variable case is preserved."""
+        monkeypatch.setenv("UPPERCASE", "value1")
+        monkeypatch.setenv("lowercase", "value2")
+        monkeypatch.setenv("MixedCase", "value3")
+
+        input_dict = {
+            "var1": "${UPPERCASE}",
+            "var2": "${lowercase}",
+            "var3": "${MixedCase}",
+        }
+
+        expected = {
+            "var1": "value1",
+            "var2": "value2",
+            "var3": "value3",
+        }
+
+        assert parse_env_vars(input_dict) == expected
+
+    def test_nested_structures(self, monkeypatch):
+        """Test how function handles nested structures (should only process top level)."""
+        monkeypatch.setenv("TEST_VAR", "test_value")
+
+        input_dict = {
+            "top_level": "${TEST_VAR}",
+            "nested_dict": {
+                "env_var": "${TEST_VAR}",  # This should not be processed
+                "normal": "value",
+            },
+            "list_with_vars": ["${TEST_VAR}", "normal"],  # This should not be processed
+        }
+
+        expected = {
+            "top_level": "test_value",
+            "nested_dict": {"env_var": "${TEST_VAR}", "normal": "value"},
+            "list_with_vars": ["${TEST_VAR}", "normal"],
+        }
+
+        assert parse_env_vars(input_dict) == expected

--- a/python/xorq/vendor/ibis/tests/test_profile.py
+++ b/python/xorq/vendor/ibis/tests/test_profile.py
@@ -1,6 +1,8 @@
+import os
 import pathlib
 
 import pytest
+import yaml
 
 import xorq as xo
 from xorq.vendor.ibis.backends import BaseBackend, Profile, Profiles
@@ -58,7 +60,7 @@ def test_profiles(monkeypatch, tmp_path):
     assert default_profile_dir == pathlib.Path("~/.config/letsql/profiles").expanduser()
     profiles = Profiles()
     assert profiles.profile_dir == default_profile_dir
-    assert not profiles.list()
+    assert not profiles.list()  # why do this ?
 
     monkeypatch.setattr(xo.options.profiles, "profile_dir", tmp_path)
     profiles = Profiles()
@@ -68,11 +70,12 @@ def test_profiles(monkeypatch, tmp_path):
 @pytest.mark.parametrize("connector", remote_connectors + local_connectors)
 def test_save_load(connector, monkeypatch, tmp_path):
     monkeypatch.setattr(xo.options.profiles, "profile_dir", tmp_path)
-
+    # In the is case letsql has a raw passwords so its value is
+    # ***elided*** so we can't instantiate it
+    os.environ["LETSQL_PASSWORD"] = "letsql"
     con = connector()
     profiles = Profiles()
     profile = con._profile
-
     profile.save()
 
     others = tuple(
@@ -85,3 +88,158 @@ def test_save_load(connector, monkeypatch, tmp_path):
     for other in others:
         assert profile == other
         assert con.list_tables() == other.get_con().list_tables()
+    del os.environ["LETSQL_PASSWORD"]
+
+
+def test_elide_secrets():
+    os.environ["TEST_SECRET_USER"] = "test_user"
+    os.environ["TEST_SECRET_PASSWORD"] = "very_secret_password"
+    os.environ["SOME_ENV"] = "some_env"
+    # expected
+    expected_kwargs_dict_elided = dict(
+        host="localhost-dummy",
+        port=5432,
+        user="${TEST_SECRET_USER}",
+        password="${TEST_SECRET_PASSWORD}",
+        database="test_db",
+        secret="***elided***",
+        nonsecret="visible_data",
+        empty_param="",
+        direct_env="${SOME_ENV}",
+    )
+
+    expected_kwargs_dict_raw = dict(
+        host="localhost-dummy",
+        port=5432,
+        user="test_user",
+        password="very_secret_password",
+        database="test_db",
+        secret="another_secret",
+        nonsecret="visible_data",
+        empty_param="",
+        direct_env="${SOME_ENV}",
+    )
+
+    # create profile
+    profile = Profile(
+        con_name="postgres",
+        kwargs_tuple=(
+            ("host", "localhost-dummy"),
+            ("port", 5432),
+            ("user", "test_user"),
+            ("password", "very_secret_password"),
+            ("database", "test_db"),
+            ("secret", "another_secret"),
+            ("nonsecret", "visible_data"),
+            ("empty_param", ""),
+            ("direct_env", "${SOME_ENV}"),
+        ),
+    )
+
+    # elide
+    elided_profile = profile.elide_secrets()
+
+    # check raw
+    assert profile.kwargs_dict == expected_kwargs_dict_raw
+
+    # no elision
+    assert elided_profile.kwargs_dict == expected_kwargs_dict_elided
+
+    # is it still yaml
+    yaml_content = elided_profile.as_yaml()
+    data = yaml.safe_load(yaml_content)
+
+    # check that on disk is elided
+    assert data["kwargs_dict"] == expected_kwargs_dict_elided
+    # Make sure same back from disk
+    profile.save()
+    loaded_profile = profile.load(profile.hash_name)
+
+    # no env for secret
+    assert loaded_profile.kwargs_dict["secret"] == "***elided***"
+    # assert profile == profile.load(profile.hash_name)
+
+    # Clean up
+    del os.environ["TEST_SECRET_USER"]
+    del os.environ["TEST_SECRET_PASSWORD"]
+    del os.environ["SOME_ENV"]
+
+
+def test_missing_env_var_elided(monkeypatch, tmp_path):
+    # NOTE: in the event a variable does not exist and it is a secret it will be elided
+    # we will only save env vars that exist during save
+    monkeypatch.setattr(xo.options.profiles, "profile_dir", tmp_path)
+    os.environ["EXISTING_ENV"] = "exists"
+
+    profile = Profile(
+        con_name="postgres",
+        kwargs_tuple=(
+            ("user", "${EXISTING_ENV}"),
+            ("password", "${MISSING_ENV_VAR}"),  # This doesn't exist
+            ("host", "localhost-dummy"),
+            ("port", 5432),
+        ),
+    )
+
+    profile.save()
+
+    assert Profile.load(profile.hash_name).kwargs_dict["password"] == "***elided***"
+
+    del os.environ["EXISTING_ENV"]
+
+
+def test_missing_env_var_strict(monkeypatch, tmp_path):
+    monkeypatch.setattr(xo.options.profiles, "profile_dir", tmp_path)
+    os.environ["EXISTING_ENV"] = "exists"
+    expected_value_error = (
+        r"Strict mode enabled, variables \$MISSING_ENV_VAR are not defined!"
+    )
+    profile = Profile(
+        con_name="postgres",
+        kwargs_tuple=(
+            ("user", "${EXISTING_ENV}"),
+            ("password", "BANANIBAL"),  # it will elide secrets
+            ("host", "${MISSING_ENV_VAR}"),
+            ("port", 5432),
+        ),
+    )
+
+    profile_path = profile.save()
+    assert profile_path.exists()
+
+    with pytest.raises(ValueError, match=expected_value_error):
+        Profile.load(profile.hash_name)
+
+    del os.environ["EXISTING_ENV"]
+
+
+def test_profile_hash_order_independence():
+    # different order same kwargs
+    profile1 = Profile(
+        con_name="postgres",
+        kwargs_tuple=(
+            ("host", "localhost-dum"),
+            ("port", 5432),
+            ("user", "testuser"),
+            ("database", "testdb"),
+        ),
+    )
+
+    profile2 = Profile(
+        con_name="postgres",
+        kwargs_tuple=(
+            ("port", 5432),
+            ("database", "testdb"),
+            ("user", "testuser"),
+            ("host", "localhost-dum"),
+        ),
+    )
+
+    # check hash order agnostic
+    assert profile1.hash_name == profile2.hash_name
+    # check sort
+    assert profile1.kwargs_tuple == profile2.kwargs_tuple
+
+    # check clone
+    cloned = profile1.clone()
+    assert cloned.hash_name == profile1.hash_name

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,6 +38,7 @@ debugpy==1.8.12
 decorator==5.2.0
 distlib==0.3.9
 duckdb==1.2.0
+envyaml==1.10.211231
 exceptiongroup==1.2.2 ; python_full_version < '3.11'
 executing==2.2.0
 fastjsonschema==2.21.1

--- a/uv.lock
+++ b/uv.lock
@@ -783,6 +783,18 @@ wheels = [
 ]
 
 [[package]]
+name = "envyaml"
+version = "1.10.211231"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/ce/bcc062f1d55368713674cf55851a4d9dfa77835c0258753d0f23dff70743/envyaml-1.10.211231.tar.gz", hash = "sha256:88f8a076159e3c317d3450a5f404132b6ac91aecee4934ea72eac65f911f1244", size = 7591 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/99/6612dcf7d494223041c029cc4fa325cb513fe99bf989e6895a1de357f1eb/envyaml-1.10.211231-py2.py3-none-any.whl", hash = "sha256:8d7a7a6be12587cc5da32a587067506b47b849f4643981099ad148015a72de52", size = 8138 },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3330,6 +3342,7 @@ dependencies = [
     { name = "cloudpickle" },
     { name = "connectorx", marker = "python_full_version < '4.0'" },
     { name = "dask", marker = "python_full_version < '4.0'" },
+    { name = "envyaml" },
     { name = "geoarrow-types", marker = "python_full_version < '4.0'" },
     { name = "pandas", marker = "python_full_version < '4.0'" },
     { name = "parsy" },
@@ -3417,6 +3430,7 @@ requires-dist = [
     { name = "datafusion", marker = "python_full_version >= '3.10' and python_full_version < '4.0' and extra == 'datafusion'", specifier = ">=0.6,<44" },
     { name = "duckdb", marker = "python_full_version >= '3.10' and python_full_version < '4.0' and extra == 'examples'", specifier = ">=0.10.3,<2" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.1.3" },
+    { name = "envyaml", specifier = ">=1.10.211231" },
     { name = "fsspec", marker = "python_full_version >= '3.10' and python_full_version < '4.0' and extra == 'examples'", specifier = ">=2024.6.1,<2025.2.1" },
     { name = "geoarrow-types", marker = "python_full_version >= '3.10' and python_full_version < '4.0'", specifier = ">=0.2,<1" },
     { name = "pandas", marker = "python_full_version >= '3.10' and python_full_version < '4.0'", specifier = ">=1.5.3,<3" },


### PR DESCRIPTION
Adds the elision of secrets to profiles.

- If env vars exist they will be saved in ${VAR_NAME} format
- Raw values will be converted to existing env vars
- Raw values that are secret will be converted to `***elided***`
- Secret Non existent environment variables will be converted to  `***elided***`
- Env vars that do not exist will fail to load eg ${NOT_A_REAL_ENV_VAR} will fail to load if NOT_A_REAL_ENV_VAR does not exist

- Kwargs tuple now is sorted before hash
- Hash no longer uses idx  
```python
from pathlib import Path
import os
from xorq.vendor.ibis.backends import Profile
# First set up some environment variables
os.environ['SNOWFLAKE_USER'] = 'myuser'
os.environ['SNOWFLAKE_PASSWORD'] = 'mypassword'

# Create the profile
profile = Profile(
    con_name='snowflake',
    kwargs_tuple=(
        ('account', 'gzb05818.us-east-1'),
        ('database', 'SNOWFLAKE_SAMPLE_DATA'),
        ('password', 'mypassword'),  # This will be automatically converted to ${SNOWFLAKE_PASSWORD}
        ('role', 'PUBLIC'),
        ('schema', 'PUBLIC'),
        ('user', 'myuser'),  # This will be automatically converted to ${SNOWFLAKE_USER}
        ('warehouse', 'COMPUTE_WH'),
    )
)

profile_path = profile.save(
    alias='snowflake_sample'
)


# Load the profile
loaded_profile = Profile.load('snowflake_sample')

# Get a connection from the profile
connection = loaded_profile.get_con()
```