### PR TITLE
fix(caching): special case for postgres in case of complex types

### DIFF
--- a/python/xorq/backends/postgres/tests/test_cache.py
+++ b/python/xorq/backends/postgres/tests/test_cache.py
@@ -5,15 +5,14 @@ from xorq.caching import SourceStorage
 
 
 @pytest.mark.parametrize(
-    "example",
+    "name",
     (
         "diamonds",
         "hn-data-small.parquet",
     ),
 )
-def test_source_caching(example, pg):
+def test_source_caching(name, pg):
     con = xo.connect()
-    name = "diamonds"
     example = xo.examples.get_table_from_name(name, con)
     expr = example.cache(storage=SourceStorage(pg))
     assert not expr.ls.exists()

--- a/python/xorq/backends/postgres/tests/test_cache.py
+++ b/python/xorq/backends/postgres/tests/test_cache.py
@@ -1,0 +1,27 @@
+import pytest
+
+import xorq as xo
+from xorq.caching import SourceStorage
+
+
+@pytest.mark.parametrize(
+    "example",
+    (
+        "diamonds",
+        "hn-data-small.parquet",
+    ),
+)
+def test_source_caching(example, pg):
+    con = xo.connect()
+    name = "diamonds"
+    example = xo.examples.get_table_from_name(name, con)
+    expr = example.cache(storage=SourceStorage(pg))
+    assert not expr.ls.exists()
+    actual = expr.execute()
+    expected = example.execute()
+    cached = pg.table(expr.ls.get_key()).execute()
+    assert actual.equals(expected)
+    assert actual.equals(cached)
+    assert expr.ls.exists()
+    pg.drop_table(expr.ls.get_key())
+    assert not expr.ls.exists()

--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -291,7 +291,13 @@ class _SourceStorage(CacheStorage):
         return self.source.table(key).op()
 
     def _put(self, key, value):
-        self.source.create_table(key, xo.to_pyarrow(value.to_expr()))
+        if self.source.name == "postgres":
+            self.source.read_record_batches(
+                value.to_expr().to_pyarrow_batches(),
+                key,
+            )
+        else:
+            self.source.create_table(key, xo.to_pyarrow(value.to_expr()))
         return self._get(key)
 
     def _drop(self, key):

--- a/python/xorq/examples/core.py
+++ b/python/xorq/examples/core.py
@@ -17,11 +17,12 @@ whitelist = [
     "iris",
     "penguins",
     "hn_posts_nano",
+    "hn-data-small.parquet",
 ]
 
 
 @functools.cache
-def get_name_to_suffix():
+def get_name_to_suffix() -> dict[str, str]:
     board = xo.options.pins.get_board()
     dct = {
         name: pathlib.Path(board.pin_meta(name).file).suffix


### PR DESCRIPTION
dt.Array(dt.float64) causes failures

running
```
import xorq as xo                  
from xorq.caching import SourceStorage                                                                                                      
from xorq.common.utils.defer_utils import deferred_read_parquet       
from xorq.common.utils.import_utils import import_python              
                                                                      
                                   
m = import_python(xo.options.pins.get_path("hackernews_lib"))         
                                                                                                                                            
                                   
name = "hn-fetcher-input-large"                                       
con = xo.connect()                                                    
pg = xo.postgres.connect_env()     
t = (                                                                 
    deferred_read_parquet(         
        con,                                                                                                                                
        xo.options.pins.get_path(name),                               
        name,                                                                                                                               
    )                              
    .pipe(m.do_hackernews_fetcher_udxf)                               
    .into_backend(pg).cache(storage=SourceStorage(pg))                                                                                      )                                  
t.execute() 
```
results in
```
ProgrammingError: can't adapt type 'numpy.ndarray'
```

trying to address this with
```
# https://stackoverflow.com/a/61183339
import numpy as np
from psycopg2.extensions import AsIs, register_adapter


def addapt_numpy_array(numpy_array):
    return AsIs(tuple(numpy_array))

register_adapter(np.ndarray, addapt_numpy_array)
```

results in
```
SyntaxError: syntax error at or near ")"
LINE 1: ...L, NULL, 1739822833, 'story', (np.int64(43082889),), 0.0, 5....
```
because its inserting rows by way of sql insert strings