### PR TITLE
fix: warning for not using raw string in regex

### DIFF
--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -20,7 +20,7 @@ import xorq as xo
 from xorq.common.utils.inspect_utils import get_arguments
 
 
-compiled_env_var_re = re.compile("^(?:\${(.*)}$)|(?:\$(.*))$")
+compiled_env_var_re = re.compile(r"^(?:\${(.*)}$)|(?:\$(.*))$")
 
 
 @frozen


### PR DESCRIPTION
While running:

```python
import xorq as xo
from xorq.common.utils.defer_utils import deferred_read_parquet
from xorq.expr.relations import into_backend
from xorq.ibis_yaml.compiler import BuildManager
```


I recieved the error:
```bash
[/home/al/repos/xorq/xorq_playground/venv/lib/python3.12/site-packages/xorq/vendor/ibis/backends/profiles.py:23](http://localhost:8888/home/al/repos/xorq/xorq_playground/venv/lib/python3.12/site-packages/xorq/vendor/ibis/backends/profiles.py#line=22): SyntaxWarning: invalid escape sequence '\$'
  compiled_env_var_re = re.compile("^(?:\${(.*)}$)|(?:\$(.*))$")
```

It was a very small change to make sure the regex expression was using the raw string. 