### PR TITLE
fix(tests): use connect_env for Postgres test setup

### DIFF
--- a/python/xorq/backends/let/tests/test_api.py
+++ b/python/xorq/backends/let/tests/test_api.py
@@ -51,7 +51,14 @@ def test_executed_on_original_backend(parquet_dir, csv_dir, mocker):
 
 
 def test_read_postgres():
-    uri = "postgres://postgres:postgres@localhost:5432/ibis_testing"
+    con = xo.postgres.connect_env()
+    uri = (
+        f"postgres://{con.con.info.user}:"
+        f"{con.con.info.password}@"
+        f"{con.con.info.host}:"
+        f"{con.con.info.port}/"
+        f"{con.con.info.dbname}"
+    )
     t = xo.read_postgres(uri, table_name="batting")
     res = xo.execute(t)
 

--- a/python/xorq/backends/let/tests/test_execute.py
+++ b/python/xorq/backends/let/tests/test_execute.py
@@ -371,13 +371,7 @@ def test_multiple_execution_letsql_register_table(ls_con, csv_dir):
         xo.connect(),
         xo.datafusion.connect(),
         xo.duckdb.connect(),
-        xo.postgres.connect(
-            host="localhost",
-            port=5432,
-            user="postgres",
-            password="postgres",
-            database="ibis_testing",
-        ),
+        xo.postgres.connect_env(),
     ],
 )
 def test_expr_over_same_table_multiple_times(ls_con, parquet_dir, other_con):


### PR DESCRIPTION
Summary
Replaced hardcoded Postgres connection parameters in tests with connect_env() for better configurability.

Fixes #737