### PR TITLE
chore(deps): ensure requests is installed for examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ examples = [
     "adbc-driver-postgresql>=1.4.0",
     "psycopg2-binary>=2.9.10",
     "mcp>=1.5.0",
+    "requests>=2.32.3",
 ]
 postgres = [
     "adbc-driver-postgresql>=1.4.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -605,6 +605,7 @@ requests==2.32.3
     #   snowflake-connector-python
     #   trino
     #   vendoring
+    #   xorq
 requests-oauthlib==2.0.0 ; python_full_version < '4.0'
     # via google-auth-oauthlib
 rfc3339-validator==0.1.4

--- a/uv.lock
+++ b/uv.lock
@@ -4489,6 +4489,7 @@ examples = [
     { name = "pins", extra = ["gcs"], marker = "python_full_version < '4.0'" },
     { name = "psycopg2-binary" },
     { name = "quickgrove" },
+    { name = "requests" },
     { name = "scikit-learn" },
     { name = "xgboost", marker = "python_full_version < '4.0'" },
 ]
@@ -4575,6 +4576,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "quickgrove", marker = "extra == 'examples'", specifier = ">=0.1.2" },
     { name = "quickgrove", marker = "extra == 'quickgrove'", specifier = ">=0.1.2" },
+    { name = "requests", marker = "extra == 'examples'", specifier = ">=2.32.3" },
     { name = "scikit-learn", marker = "extra == 'examples'", specifier = ">=1.4.0,<2.0.0" },
     { name = "snowflake-connector-python", marker = "python_full_version >= '3.10' and python_full_version < '4.0' and extra == 'snowflake'", specifier = ">=3.10.1,<4" },
     { name = "sqlglot", specifier = "==25.20.2" },


### PR DESCRIPTION
Since `UrlOperatorExchanger`, `RowSumExchanger`, and `RowSumAppendExchanger `  were removed, the only step is to ensure the requests package is installed for the `examples` extra.

closes #696