### PR TITLE
feat/yaml/pandas udf schema

### DIFF
--- a/python/xorq/ibis_yaml/udf.py
+++ b/python/xorq/ibis_yaml/udf.py
@@ -39,7 +39,7 @@ def _scalar_udf_to_yaml(op: ops.ScalarUDF, compiler: Any) -> dict:
         {
             "op": "ScalarUDF",
             "func_name": op.__func_name__,
-            "input_type": input_type,
+            "input_type": str(input_type),
             "args": [translate_to_yaml(arg, compiler) for arg in op.args],
             "type": translate_to_yaml(op.dtype, None),
             "pickle": serialize_callable(op.__func__),
@@ -52,48 +52,56 @@ def _scalar_udf_to_yaml(op: ops.ScalarUDF, compiler: Any) -> dict:
 
 @register_from_yaml_handler("ScalarUDF")
 def _scalar_udf_from_yaml(yaml_dict: dict, compiler: any) -> any:
-    # TODO: use make_pandas_udf (expr/udf.py)
     encoded_fn = yaml_dict.get("pickle")
     if not encoded_fn:
         raise ValueError("Missing pickle data for ScalarUDF")
     fn = deserialize_callable(encoded_fn)
 
-    args = tuple(
-        translate_from_yaml(arg, compiler) for arg in yaml_dict.get("args", [])
-    )
+    args_yaml = yaml_dict.get("args", [])
+    args = [translate_from_yaml(arg, compiler) for arg in args_yaml]
     if not args:
         raise ValueError("ScalarUDF requires at least one argument")
 
-    arg_names = yaml_dict.get("arg_names", [f"arg{i}" for i in range(len(args))])
-    input_type = yaml_dict.get("input_type")
+    input_type_str = yaml_dict.get("input_type")
 
-    if input_type == "BUILTIN":
+    if input_type_str == "InputType.BUILTIN":
         input_type = ops.udf.InputType.BUILTIN
-    elif input_type == "PYARROW":
+    elif input_type_str == "InputType.PYARROW":
         input_type = ops.udf.InputType.PYARROW
+    else:
+        raise ValueError(f"Unsupported input type: {input_type_str}")
 
-    fields = {
-        name: Argument(pattern=rlz.ValueOf(arg.type()), typehint=arg.type())
-        for name, arg in zip(arg_names, args)
-    }
+    dtype = dt.dtype(yaml_dict["type"]["type"])
+    class_name = yaml_dict.get("class_name", yaml_dict["func_name"])
 
-    bases = (ops.ScalarUDF,)
+    schema = {}
+    for i, arg_yaml in enumerate(args_yaml):
+        if "node_ref" in arg_yaml:
+            node_id = arg_yaml["node_ref"]
+            node = compiler.definitions["nodes"].get(node_id)
+            if node and "op" in node and node["op"] == "Field" and "name" in node:
+                schema[node["name"]] = args[i].type()
+                continue
+        schema[f"arg{i}"] = args[i].type()
+
+    fields = {}
+    for name, typ in schema.items():
+        fields[name] = Argument(pattern=rlz.ValueOf(typ), typehint=typ)
+
     meta = {
-        "dtype": dt.dtype(yaml_dict["type"]["type"]),
+        "dtype": dtype,
         "__input_type__": input_type,
         "__func__": udf.property_wrap_fn(fn),
-        "__config__": {"volatility": "immutable"},
+        "__config__": {"volatility": "immutable", "fn": fn, "schema": schema},
         "__udf_namespace__": None,
         "__module__": yaml_dict.get("module", "__main__"),
         "__func_name__": yaml_dict["func_name"],
     }
 
     kwds = {**fields, **meta}
-    class_name = yaml_dict.get("class_name", yaml_dict["func_name"])
-
     node = type(
         class_name,
-        bases,
+        (ops.ScalarUDF,),
         kwds,
     )
 


### PR DESCRIPTION
previously, I was getting a 
``` python
✗ xorq --pdb run builds/5bc709f21740/
/nix/store/6s06k6hdxl8mdd9w9w72p75sv2a60f99-xorq/lib/python3.12/site-packages/snowflake/connector/options.py:104: UserWarning: You have an incompatible version of 'pyarrow' installed (20.0.0), please install a version that adheres to: 'pyarrow<19.0.0; extra == "pandas"'
  warn_incompatible_dep(
Traceback (most recent call last):
  File "/home/hussainsultan/workspace/xorq/python/xorq/cli.py", line 191, in main
    f(*f_args)
  File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/cli.py", line 112, in run_command
    expr.to_parquet(output_path)
  File "/home/hussainsultan/workspace/xorq/python/xorq/vendor/ibis/expr/types/core.py", line 511, in to_parquet
    return to_parquet(self, path=path, params=params, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/api.py", line 453, in to_parquet
    with to_pyarrow_batches(expr, params=params) as batch_reader:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/api.py", line 421, in to_pyarrow_batches
    (expr, created) = _transform_expr(expr)
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/api.py", line 401, in _transform_expr
    expr, created = register_and_transform_remote_tables(expr)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/relations.py", line 486, in register_and_transform_remote_tables
    expr = op.replace(replacer).to_expr()
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/vendor/ibis/common/graph.py", line 526, in replace
    result = fn(node, kwargs if changed else None)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/relations.py", line 475, in replacer
    kwargs = {k: recursive_update(v, updated) for k, v in kwargs.items()}
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/relations.py", line 85, in recursive_update
    recursive_update(k, replacements): recursive_update(v, replacements)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hussainsultan/workspace/xorq/python/xorq/expr/relations.py", line 78, in recursive_update
    for name, arg in zip(obj.argnames, obj.args)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'Field' object is not iterable
```
when serializing this udf:
```python
@xo.udf.make_pandas_udf(
    schema=xo.schema({"L_EXTENDEDPRICE": float,
                      "L_DISCOUNT":      float}),
    return_type=dt.float,
    name="calculate_discount_value",
)
def calculate_discount_value(df):
    return df["L_EXTENDEDPRICE"] * df["L_DISCOUNT"]
```