### PR TITLE
fix(examples): ensure expr results in a non-empty result

### DIFF
--- a/examples/iris_example.py
+++ b/examples/iris_example.py
@@ -8,7 +8,7 @@ t = xo.examples.iris.fetch()
 con = t.op().source
 storage = ParquetStorage(source=con, path=Path.cwd())
 
-expr = t.filter([t.species == "Adelie"]).cache(storage=storage)
+expr = t.filter([t.species == "Setosa"]).cache(storage=storage)
 
 
 if __name__ == "__pytest_main__":


### PR DESCRIPTION
the filter value was for the penguins example and had an empty result