### PR TITLE
fix(udf): use `large_binary` to intermediate state

### DIFF
--- a/python/xorq/expr/pyaggregator.py
+++ b/python/xorq/expr/pyaggregator.py
@@ -61,7 +61,7 @@ class PyAggregator(Accumulator, ABC):
 
     @classproperty
     def state_type(cls):
-        return pa.list_(pa.binary())
+        return pa.list_(pa.large_binary())
 
     @classproperty
     def names(cls):


### PR DESCRIPTION
to avoid "offset overflow" when state is large