### PR TITLE
fix(docs): correct backend reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ expr = expr.filter(
     expr.body_mass_g.isnull() == False,
 )
 print(expr.schema())
-print(expr.ls.backend)
+print(expr.ls.backends)
 ```
 > ```sh
 > Out[2]:


### PR DESCRIPTION
When running through the README, this section was giving me a `AttributeError: 'LETSQLAccessor' object has no attribute 'backend'`. I added the "s".

```
---------------------------------------------------------------------------
In [2]: pandas_con = xo.pandas.connect()
AttributeError                            Traceback (most recent call last)
Cell In[2], line 12
       ...
---> 12 print(expr.ls.backend)

AttributeError: 'LETSQLAccessor' object has no attribute 'backend'
In [3]: print(expr.ls.backends)
(<xorq.backends.pandas.Backend object at 0x103701a90>,)
```