### PR TITLE
fix(cli): use Path.name instead of Path.stem in run_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ xorq run builds/ca3da8b86a86
 > └── sql.yaml
 > ```
 Notice that we have an expr.yaml file with complete schemas and lineage
-information as well as debug outputs for SQL. The expr can rountrip back and
+information as well as debug outputs for SQL. The expr can roundtrip back and
 forth from Ibis expressions.
 
 >```yaml

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -114,7 +114,7 @@ def run_command(
 
     expr_path = Path(expr_path)
     build_manager = BuildManager(expr_path.parent, cache_dir=cache_dir)
-    expr = build_manager.load_expr(expr_path.stem)
+    expr = build_manager.load_expr(expr_path.name)
 
     match output_format:
         case "csv":

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 import sys
 import threading
 import time
@@ -146,6 +147,20 @@ def test_run_command_default(tmp_path, fixture_dir):
             expression_path,
         ]
         (returncode, _, _) = subprocess_run(test_args)
+
+        # test with problematic name (see https://github.com/xorq-labs/xorq/issues/1116)
+        test_args = [
+            "xorq",
+            "run",
+            str(
+                shutil.move(
+                    expression_path,
+                    Path(expression_path).parent.joinpath("becb4e71406b.bak"),
+                )
+            ),
+        ]
+        (returncode, _, _) = subprocess_run(test_args)
+
         assert returncode == 0
     else:
         raise AssertionError("No expression hash")


### PR DESCRIPTION
closes #1116 