### PR TITLE
fix(cli): use print_exc

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -383,7 +383,7 @@ def main():
             traceback.print_exception(e)
             pdb.post_mortem(e.__traceback__)
         else:
-            print(e, file=sys.stderr)
+            traceback.print_exc()
         sys.exit(1)
 
 


### PR DESCRIPTION
simply printing the exception won't always give meaningful information and sometimes seems like a silent sucess