### PR TITLE
fix(xorq): preserve LargeString when reading parquet

### DIFF
--- a/python/xorq/vendor/ibis/formats/pyarrow.py
+++ b/python/xorq/vendor/ibis/formats/pyarrow.py
@@ -41,7 +41,6 @@ _from_pyarrow_types = {
     pa.null(): dt.Null,
     pa.string(): dt.String,
     pa.large_binary(): dt.Binary,
-    pa.large_string(): dt.String,
     pa.binary(): dt.Binary,
     pa.binary_view(): dt.Binary,
     pa.string_view(): dt.String,


### PR DESCRIPTION
closes #1041 