### PR TITLE
feat(xorq): LETSQLAccessor: add property `tokenized`

### DIFF
--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -138,7 +138,7 @@ class ModificationTimeStrategy(CacheStrategy):
     )
 
     def get_key(self, expr: ir.Expr):
-        return dask.base.tokenize(expr)
+        return expr.ls.tokenized
 
 
 @frozen
@@ -192,7 +192,7 @@ class SnapshotStrategy(CacheStrategy):
         # can we cache this?
         with self.normalization_context(expr):
             replaced = self.replace_remote_table(expr)
-            tokenized = dask.tokenize.tokenize(replaced)
+            tokenized = replaced.ls.tokenized
             return "-".join(("snapshot", tokenized))
 
     @staticmethod

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_utils.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_utils.py
@@ -134,3 +134,8 @@ def patch_normalize_op_caching():
     cached_attr = functools.cache(getattr(mod, attr))
     with patch.object(mod, attr, cached_attr):
         yield
+
+
+def patched_tokenize(expr):
+    with patch_normalize_op_caching():
+        return dask.base.tokenize(expr)

--- a/python/xorq/common/utils/node_utils.py
+++ b/python/xorq/common/utils/node_utils.py
@@ -1,13 +1,9 @@
 import importlib
 
-import dask
 import toolz
 
 import xorq.expr.relations as rel
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.common.utils.dask_normalize.dask_normalize_utils import (
-    patch_normalize_op_caching,
-)
 from xorq.common.utils.graph_utils import (
     bfs,
     replace_nodes,
@@ -50,12 +46,11 @@ def get_typs(maybe_typs):
 
 def find_by_expr_hash(expr, to_replace_hash, typs=None):
     typs = get_typs(typs)
-    with patch_normalize_op_caching():
-        (to_replace, *rest) = (
-            node
-            for node in walk_nodes(typs, expr)
-            if dask.base.tokenize(node.to_expr()) == to_replace_hash
-        )
+    (to_replace, *rest) = (
+        node
+        for node in walk_nodes(typs, expr)
+        if node.to_expr().ls.tokenized == to_replace_hash
+    )
     if rest:
         raise ValueError
     return to_replace

--- a/python/xorq/flight/exchanger.py
+++ b/python/xorq/flight/exchanger.py
@@ -275,13 +275,6 @@ class UnboundExprExchanger(AbstractExchanger):
         return replace_nodes(set_name, expr).to_expr()
 
     @property
-    def op_hash(self):
-        import xorq.common.utils.dask_normalize.dask_normalize_utils as DNU
-
-        with DNU.patch_normalize_op_caching():
-            return dask.base.tokenize(self.unbound_expr)
-
-    @property
     def exchange_f(self):
         return functools.partial(
             streaming_expr_exchange, self.unbound_expr, self.make_connection
@@ -303,7 +296,7 @@ class UnboundExprExchanger(AbstractExchanger):
 
     @property
     def command(self):
-        return f"execute-unbound-expr-{self.op_hash}"
+        return f"execute-unbound-expr-{self.unbound_expr.ls.tokenized}"
 
     @property
     def query_result(self):

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -780,6 +780,14 @@ class LETSQLAccessor:
         else:
             return self.expr
 
+    @property
+    def tokenized(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (
+            patched_tokenize,
+        )
+
+        return patched_tokenize(self.expr)
+
     def get_key(self):
         if self.is_cached:
             return self.storage.get_key(self.uncached_one)


### PR DESCRIPTION
patches normalize_op to be cached for a single top level invocation