### PR TITLE
chore(deps): change Bitnami Catalog (docker images)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -45,7 +45,7 @@ services:
       - trino
 
   minio:
-    image: bitnami/minio:2025.7.23
+    image: bitnamilegacy/minio:2025.7.23
     environment:
       MINIO_ROOT_USER: accesskey
       MINIO_ROOT_PASSWORD: secretkey


### PR DESCRIPTION
The Bitnami Catalog was deleted on the 29th of September, this means we need to use the Bitnami Legacy Catalog