### PR TITLE
feat: make serve outbound display schema in and schema out

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -242,6 +242,18 @@ def unbind_and_serve_command(
     unbound_expr = expr_to_unbound(
         expr, hash=to_unbind_hash, tag=to_unbind_tag, typs=typ
     )
+
+    # Get schema information from the unbound expression
+    from xorq.flight.exchanger import UnboundExprExchanger
+
+    exchanger = UnboundExprExchanger(unbound_expr)
+
+    # Display schema-in and schema-out
+    logger.info(f"Schema-in (required input):\n{exchanger.schema_in_required}")
+    logger.info(
+        f"Schema-out (output):\n{exchanger.calc_schema_out(exchanger.schema_in_required)}"
+    )
+
     flight_url = xorq.flight.FlightUrl(host=host, port=port)
     make_server = functools.partial(
         xorq.flight.FlightServer,

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -570,6 +570,41 @@ def test_serve_unbound_hash(serve_hash, pipeline_https_build):
     serve_popened.popen.terminate()
 
 
+@pytest.mark.slow(level=2)
+def test_serve_unbound_schema_logging(pipeline_https_build):
+    """Test that serve-unbound logs input and output schemas"""
+    import time
+
+    serve_hash = "8cd7850627df82fc184a152d770eb205"  # DropColumns
+
+    serve_args = (
+        "xorq",
+        "serve-unbound",
+        str(pipeline_https_build),
+        "--to_unbind_hash",
+        serve_hash,
+        "--typ",
+        "xorq.vendor.ibis.expr.operations.DropColumns",
+    )
+    serve_popened = Popened(serve_args, deferred=False)
+
+    # Wait for server to start and get the port (validates server starts successfully)
+    _ = peek_port(serve_popened)
+
+    # Give the logger a moment to flush messages
+    time.sleep(0.2)
+
+    # Terminate the server so we can read stdout (where PrintLogger writes)
+    serve_popened.popen.terminate()
+
+    # Read stdout where the logger writes (not stderr)
+    stdout_output = serve_popened.stdout
+
+    # Verify that schema information is logged
+    assert "Schema-in (required input):" in stdout_output, "Schema-in not logged"
+    assert "Schema-out (output):" in stdout_output, "Schema-out not logged"
+
+
 serve_tags = (
     "read-batting",
     "read-players",

--- a/python/xorq/tests/test_examples.py
+++ b/python/xorq/tests/test_examples.py
@@ -13,6 +13,7 @@ LIBRARY_SCRIPTS = (
     "flight_dummy_exchanger",
 )
 GCS_SCRIPTS = ("gcstorage_example",)
+WEATHER_SCRIPTS = ("weather_flight",)
 NON_TESTABLE = (
     "mcp_flight_server.py",
     "duckdb_flight_example.py",
@@ -42,8 +43,21 @@ def maybe_gcs(name: str):
     return pytest.mark.gcs if name in GCS_SCRIPTS else ()
 
 
+def maybe_weather(name: str):
+    import os
+
+    return (
+        pytest.mark.skipif(
+            not os.environ.get("OPENWEATHER_API_KEY"),
+            reason="OPENWEATHER_API_KEY not set",
+        )
+        if name in WEATHER_SCRIPTS
+        else ()
+    )
+
+
 def maybe_marks(name: str):
-    fs = (maybe_library, maybe_gcs)
+    fs = (maybe_library, maybe_gcs, maybe_weather)
     return tuple(filter(None, (f(name) for f in fs)))
 
 


### PR DESCRIPTION
## Summary

This PR enhances the `xorq serve-unbound` command to display the **input and output schema** of the expression being served. Closes #1211.

**The code is generated by Claude Sonnet 4.5.**

## Changes
- [x] Add exchanger instantiation
- [x] Log schema-in
- [x] Log schema-out
- [x] Preserve existing server behavior