### PR TITLE
feat: add poc sklearn functionality in docs/sklearn_interop_design.md

### DIFF
--- a/docs/sklearn_interop_design.md
+++ b/docs/sklearn_interop_design.md
@@ -1,0 +1,620 @@
+# sklearn ↔ xorq Interoperability Design
+
+## Philosophy & Goals
+
+### Core Principle: Wrap, Don't Reimplement
+
+The fundamental design philosophy is to **wrap sklearn for deferred execution**, not to reimplement sklearn functionality within xorq. This means:
+
+- sklearn handles all ML complexity internally (fitting, transforming, feature engineering)
+- xorq provides the deferred execution layer and caching
+- We treat sklearn estimators as opaque units where possible
+- We avoid creating custom `Structer` registrations for every new estimator type
+
+### Why This Approach?
+
+1. **Maintainability**: sklearn has hundreds of estimators; registering each is unsustainable
+2. **Correctness**: sklearn's internal logic is well-tested; reimplementing risks bugs
+3. **Flexibility**: Users can use any sklearn-compatible estimator without xorq changes
+4. **Simplicity**: One generic solution beats many special cases
+
+### The Structer Problem
+
+Previously, each sklearn transformer needed a `Structer` registration to define its output schema:
+
+```python
+# OLD APPROACH - doesn't scale
+@Structer.register(StandardScaler)
+def standard_scaler_structer(...):
+    return StructType(...)
+
+@Structer.register(OneHotEncoder)
+def one_hot_encoder_structer(...):
+    # Complex logic to determine output columns
+    ...
+
+@Structer.register(ColumnTransformer)
+def column_transformer_structer(...):
+    # Even more complex...
+    ...
+```
+
+**Problems:**
+- OneHotEncoder output columns depend on categories found in training data
+- ColumnTransformer combines multiple transformers with different schemas
+- PCA output dimensions are configurable
+- New estimators require new registrations
+
+**Solution**: Packed format as universal fallback (see below).
+
+---
+
+## Key APIs
+
+### `Step.from_instance_name(instance, name)`
+
+Wraps any sklearn estimator instance as a xorq Step.
+
+```python
+from sklearn.preprocessing import StandardScaler
+from sklearn.compose import ColumnTransformer
+
+# Simple transformer
+step = Step.from_instance_name(StandardScaler(), name="scaler")
+
+# Complex transformer with nested structure
+ct = ColumnTransformer([
+    ("num", StandardScaler(), ["age", "income"]),
+    ("cat", OneHotEncoder(), ["gender", "region"])
+])
+step = Step.from_instance_name(ct, name="preprocessor")
+```
+
+**Implementation details:**
+- Extracts `params_tuple` from `instance.get_params(deep=False)`
+- Stores estimator class type for reconstruction
+- Parameters are pickled before passing to deferred functions (handles unhashable types)
+
+### `Pipeline.from_instance(sklearn_pipeline)`
+
+Decomposes an sklearn Pipeline into individual xorq Steps.
+
+```python
+from sklearn.pipeline import Pipeline as SklearnPipeline
+
+sklearn_pipe = SklearnPipeline([
+    ("scaler", StandardScaler()),
+    ("clf", LogisticRegression())
+])
+xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+```
+
+**Important limitation:**
+When a pipeline step outputs packed format (ColumnTransformer, OneHotEncoder), subsequent steps cannot consume it directly. The packed format is `Array[Struct{key, value}]`, not individual columns.
+
+**Workaround:** For complex pipelines with ColumnTransformer, wrap the entire sklearn Pipeline as a single Step:
+
+```python
+# RECOMMENDED for ColumnTransformer pipelines
+step = Step.from_instance_name(sklearn_pipeline, name="full_pipeline")
+```
+
+### `to_sklearn()`
+
+Returns the sklearn estimator (fitted or unfitted) for direct use outside xorq.
+
+```python
+# Unfitted Step -> unfitted sklearn estimator
+sklearn_scaler = step.to_sklearn()
+
+# Fitted Step -> triggers execution, returns fitted sklearn estimator
+fitted_step = step.fit(expr, features=("a", "b"))
+sklearn_fitted = fitted_step.to_sklearn()
+sklearn_fitted.transform(new_df)  # Use sklearn directly on pandas
+
+# Fitted Pipeline -> reconstructs sklearn Pipeline with all fitted steps
+fitted_pipeline = xorq_pipe.fit(expr, features=features, target="y")
+sklearn_pipeline = fitted_pipeline.to_sklearn()
+```
+
+**Design decisions:**
+- `Step.to_sklearn()`: Returns `self.instance` (unfitted clone)
+- `FittedStep.to_sklearn()`: Executes deferred model, unpickles bytes, returns fitted estimator
+- `FittedPipeline.to_sklearn()`: Reconstructs `sklearn.pipeline.Pipeline` with all fitted steps in order
+
+---
+
+## Packed Format: The Universal Fallback
+
+### The Problem
+
+Transformers have varying output schemas:
+- **StandardScaler**: Same columns as input
+- **OneHotEncoder**: Depends on categories found in training data
+- **PCA**: Configurable number of components
+- **ColumnTransformer**: Combines outputs from multiple sub-transformers
+
+At graph construction time, we don't know what the output schema will be. We only know after fitting on actual data.
+
+### The Solution: Packed Format
+
+A universal output type that works for any transformer:
+
+```
+Array[Struct{key: string, value: float64}]
+```
+
+Each row contains an array of key-value pairs representing the transformed features:
+
+```python
+# Example packed output
+[
+    [{"key": "pca_0", "value": 1.23}, {"key": "pca_1", "value": -0.45}],
+    [{"key": "pca_0", "value": 0.89}, {"key": "pca_1", "value": 0.12}],
+    ...
+]
+```
+
+**Advantages:**
+- Fixed return type regardless of actual output schema
+- Feature names resolved at execution time via `get_feature_names_out()`
+- Works for ALL transformers without registration
+- Enables fully deferred execution
+
+**Trade-off:**
+- Less convenient than individual columns for downstream SQL operations
+- Can be unpacked if needed via `unpack_packed_column()`
+
+### When Packed Format Is Used
+
+1. **Unregistered transformers**: Any transformer without a Structer registration
+2. **Dynamic schema transformers**: OneHotEncoder, CountVectorizer, ColumnTransformer
+3. **Dimensionality reduction**: PCA, TruncatedSVD, TSNE
+4. **Probabilistic outputs**: `predict_proba()`, `decision_function()`
+
+### Fallback Logic
+
+```python
+def _pieces(self):
+    if has_structer_registration(self.step.instance, self.expr, self.features):
+        # Use Structer-based approach for registered types
+        f = deferred_fit_transform_sklearn_struct
+    else:
+        # Fallback to packed format for unregistered types
+        f = deferred_fit_transform_sklearn_packed
+```
+
+---
+
+## Predictor Support
+
+### Return Type Registry
+
+A dispatch-based registry determines predict output types:
+
+| Estimator Type | Return Type | Rationale |
+|---------------|-------------|-----------|
+| `LogisticRegression` | Target column type | Classification returns class labels |
+| `LinearRegression` | `float64` | Regression returns continuous values |
+| `ClassifierMixin` | Target column type | Generic classifier catch-all |
+| `RegressorMixin` | `float64` | Generic regressor catch-all |
+| `ClusterMixin` | `int64` | Cluster labels are integers |
+| `sklearn.Pipeline` | Inferred from final step | Pipeline output = final step output |
+
+**Registration hierarchy:**
+1. Specific class registrations (LogisticRegression, KNeighborsClassifier)
+2. Mixin catch-alls (ClassifierMixin, RegressorMixin, ClusterMixin)
+3. Default raises `ValueError` for unregistered types
+
+```python
+@registry.register_lazy("sklearn")
+def lazy_register_sklearn():
+    registry.register(LogisticRegression, get_target_type)
+    registry.register(LinearRegression, return_constant(dt.float64))
+    registry.register(ClassifierMixin, get_target_type)  # Catch-all
+    registry.register(RegressorMixin, return_constant(dt.float64))  # Catch-all
+    registry.register(SklearnPipeline, get_pipeline_return_type)
+```
+
+### Probabilistic Outputs
+
+Beyond `predict()`, classifiers often provide probability estimates:
+
+```python
+# Class probabilities (LogisticRegression, RandomForest, etc.)
+proba_result = fitted.predict_proba(expr)
+# Returns packed format: [{"key": "class_0", "value": 0.3}, {"key": "class_1", "value": 0.7}]
+
+# Decision function values (SVC, LinearSVC, etc.)
+decision_result = fitted.decision_function(expr)
+# Returns packed format: [{"key": "decision", "value": 1.23}]
+```
+
+**Design decisions:**
+- Both methods use packed format for consistency
+- Raises `AttributeError` if estimator doesn't support the method
+- Available on both `FittedStep` and `FittedPipeline`
+
+---
+
+## Transform vs Predict Disambiguation
+
+sklearn estimators can have `transform()`, `predict()`, or both:
+
+| Estimator | transform() | predict() | Classification |
+|-----------|-------------|-----------|----------------|
+| StandardScaler | ✓ | ✗ | Transformer |
+| LogisticRegression | ✗ | ✓ | Predictor |
+| KMeans | ✓ | ✓ | **Predictor** (prioritized) |
+| sklearn.Pipeline | ✓ | ✓ | **Predictor** (prioritized) |
+
+**Rule:** If an estimator has both methods, treat it as a predictor.
+
+```python
+@property
+def is_transform(self):
+    has_transform = hasattr(self.step.typ, "transform")
+    has_predict = hasattr(self.step.typ, "predict")
+    if has_transform and has_predict:
+        return False  # Prioritize predict
+    return has_transform
+
+@property
+def is_predict(self):
+    return hasattr(self.step.typ, "predict")
+```
+
+**Rationale:**
+- Pipelines ending with classifiers should predict, not transform
+- KMeans primary use case is getting cluster assignments (predict), not distances (transform)
+- This matches sklearn's typical usage patterns
+
+---
+
+## Transductive Estimators
+
+Some estimators can only produce results for training data and cannot generalize to new data.
+
+### Fit-Transform-Only (Embeddings)
+
+Estimators like TSNE, MDS, Isomap only have `fit_transform()`:
+
+```python
+TRANSDUCTIVE_FIT_TRANSFORM_ONLY = {
+    "TSNE", "MDS", "Isomap", "LocallyLinearEmbedding",
+    "SpectralEmbedding", "UMAP"  # if installed
+}
+
+def is_fit_transform_only(cls):
+    if cls.__name__ in TRANSDUCTIVE_FIT_TRANSFORM_ONLY:
+        return True
+    # Check if transform raises NotImplementedError
+    ...
+```
+
+### Fit-Predict-Only (Transductive Clusterers)
+
+Estimators like DBSCAN, OPTICS only have `fit_predict()`:
+
+```python
+TRANSDUCTIVE_FIT_PREDICT_ONLY = {
+    "DBSCAN", "OPTICS", "HDBSCAN", "AgglomerativeClustering",
+    "SpectralClustering", "Birch"
+}
+
+def is_fit_predict_only(cls):
+    return cls.__name__ in TRANSDUCTIVE_FIT_PREDICT_ONLY
+```
+
+### Error Handling
+
+When users try to call `transform()` or `predict()` on transductive estimators:
+
+```python
+def transform(self, expr):
+    if self.is_fit_transform_only:
+        raise TypeError(
+            f"{self.step.typ.__name__} is a transductive estimator that only supports "
+            f"fit_transform(). It cannot transform new data. "
+            f"Use the training data results from fit() or re-fit on the new data."
+        )
+    ...
+
+def predict_raw(self, expr):
+    if self.is_fit_predict_only:
+        raise TypeError(
+            f"{self.step.typ.__name__} is a transductive clusterer that only supports "
+            f"fit_predict(). It cannot predict on new data. "
+            f"Use the training data results from fit() or re-fit on the new data."
+        )
+    ...
+```
+
+### Properties for Introspection
+
+```python
+fitted_step.is_fit_transform_only  # True for TSNE, etc.
+fitted_step.is_fit_predict_only    # True for DBSCAN, etc.
+fitted_step.is_transductive        # True if either above is True
+```
+
+---
+
+## Hashability for Deferred Execution
+
+### The Problem
+
+xorq uses `FrozenDict` and `toolz.curry` for deferred execution, which require hashable values. sklearn objects with list parameters break this:
+
+```python
+# ColumnTransformer has a list of transformers
+ct = ColumnTransformer([
+    ("num", StandardScaler(), ["age", "income"]),  # This list breaks hashing
+    ("cat", OneHotEncoder(), ["gender"])
+])
+```
+
+When passed through curry → FrozenDict → hash(), we get:
+```
+TypeError: unhashable type: 'list'
+```
+
+### Solution 1: Pickle Parameters
+
+Before passing params to curry functions, pickle them to bytes (which are hashable):
+
+```python
+@toolz.curry
+def fit_sklearn(df, target=None, *, cls, params_pickled):
+    # Unpickle params to handle unhashable types
+    params = cloudpickle.loads(params_pickled)
+    obj = cls(**dict(params))
+    obj.fit(df, target)
+    return obj
+
+# At call site
+params_pickled = cloudpickle.dumps(params)
+fit=fit_sklearn(cls=cls, params_pickled=params_pickled)
+```
+
+Applied to all deferred functions:
+- `deferred_fit_transform_sklearn`
+- `deferred_fit_predict_sklearn`
+- `deferred_fit_transform_sklearn_packed`
+- `deferred_fit_transform_sklearn_struct`
+- `deferred_fit_transform_only_sklearn_packed`
+- `deferred_fit_predict_only_sklearn`
+- `deferred_fit_transform_series_sklearn`
+
+### Solution 2: Dask Tokenization
+
+For `dask.base.tokenize()` which is used for caching keys:
+
+```python
+def lazy_register_sklearn():
+    from sklearn.base import BaseEstimator
+    from sklearn.pipeline import Pipeline as SklearnPipeline
+
+    @dask.base.normalize_token.register(SklearnPipeline)
+    def normalize_sklearn_pipeline(pipeline):
+        steps_data = tuple(
+            (name, dask.base.tokenize(step))
+            for name, step in pipeline.steps
+        )
+        return normalize_seq_with_caller("SklearnPipeline", steps_data, pipeline.memory)
+
+    @dask.base.normalize_token.register(BaseEstimator)
+    def normalize_sklearn_estimator(estimator):
+        params = estimator.get_params(deep=False)
+        params_hashable = make_hashable(params)  # Convert lists to tuples recursively
+        return normalize_seq_with_caller(
+            type(estimator).__name__,
+            type(estimator).__module__,
+            params_hashable
+        )
+```
+
+### Solution 3: Tag Kwargs
+
+For expression tagging/metadata:
+
+```python
+@property
+def tag_kwargs(self):
+    def make_hashable(v):
+        if isinstance(v, list):
+            return tuple(make_hashable(x) for x in v)
+        elif isinstance(v, dict):
+            return tuple(sorted((k, make_hashable(val)) for k, val in v.items()))
+        elif isinstance(v, tuple):
+            return tuple(make_hashable(x) for x in v)
+        return v
+
+    params_hashable = make_hashable(self.params_tuple)
+    return {"typ": self.typ, "name": self.name, "params_tuple": params_hashable}
+```
+
+---
+
+## FittedStep Caching Considerations
+
+`FittedStep` is a frozen attrs class (`@frozen`), which means attributes cannot be set after initialization. This affects property caching:
+
+```python
+@frozen
+class FittedStep:
+    # Cannot use @functools.cache because it tries to hash self
+    # Cannot use object.__setattr__ because class is frozen
+
+    @property
+    def _pieces(self):
+        # Computed on each access (no caching)
+        # This is acceptable because it's lightweight graph construction
+        ...
+
+    @property
+    def model(self):
+        # Triggers deferred execution on each access
+        # Users should call to_sklearn() once and store the result
+        ...
+```
+
+**Recommendation:** Call `to_sklearn()` once and store the result rather than accessing repeatedly.
+
+---
+
+## Usage Patterns
+
+### Pattern 1: Simple Transformer
+
+```python
+from sklearn.preprocessing import StandardScaler
+
+step = Step.from_instance_name(StandardScaler(), name="scaler")
+fitted = step.fit(expr, features=("age", "income"))
+
+# Deferred execution
+result = fitted.transform(expr).execute()
+
+# Get sklearn for direct use
+sklearn_scaler = fitted.to_sklearn()
+sklearn_scaler.transform(new_pandas_df)
+```
+
+### Pattern 2: Simple Predictor
+
+```python
+from sklearn.linear_model import LogisticRegression
+
+step = Step.from_instance_name(LogisticRegression(max_iter=200), name="clf")
+fitted = step.fit(expr, features=("age", "income"), target="approved")
+
+# Predictions
+predictions = fitted.predict(expr).execute()
+
+# Probabilities
+proba = fitted.predict_proba(expr).execute()
+
+# Get sklearn for direct use
+sklearn_clf = fitted.to_sklearn()
+sklearn_clf.predict_proba(new_pandas_df)
+```
+
+### Pattern 3: Unregistered Transformer (Packed Format)
+
+```python
+from sklearn.preprocessing import MinMaxScaler  # Not in Structer registry
+
+step = Step.from_instance_name(MinMaxScaler(), name="minmax")
+fitted = step.fit(expr, features=("age", "income"))
+
+# Returns packed format
+result = fitted.transform_raw(expr).as_table().execute()
+# result["transformed"] contains Array[Struct{key, value}]
+
+# Unpack if needed
+from xorq.expr.ml.fit_lib import unpack_packed_column
+unpacked = unpack_packed_column(result, "transformed")
+```
+
+### Pattern 4: ColumnTransformer (Recommended Approach)
+
+```python
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline as SklearnPipeline
+
+# Create complex sklearn pipeline
+sklearn_pipe = SklearnPipeline([
+    ("preprocessor", ColumnTransformer([
+        ("num", SklearnPipeline([
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler())
+        ]), numeric_features),
+        ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_features)
+    ])),
+    ("classifier", LogisticRegression(max_iter=500))
+])
+
+# Wrap ENTIRE pipeline as single Step (recommended)
+step = Step.from_instance_name(sklearn_pipe, name="full_pipeline")
+fitted = step.fit(expr, features=all_features, target="approved")
+
+# Predictions
+predictions = fitted.predict(expr).execute()
+
+# Get full fitted sklearn pipeline
+sklearn_fitted = fitted.to_sklearn()
+sklearn_fitted.predict(new_pandas_df)
+```
+
+### Pattern 5: Pipeline Decomposition (Simple Transformers Only)
+
+```python
+# Only use this when all steps have known output schemas
+sklearn_pipe = SklearnPipeline([
+    ("scaler", StandardScaler()),
+    ("clf", LogisticRegression())
+])
+
+xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+fitted = xorq_pipe.fit(expr, features=features, target="y")
+
+# Reconstruct sklearn Pipeline
+sklearn_fitted = fitted.to_sklearn()
+```
+
+---
+
+## Assumptions & Limitations
+
+### Assumptions
+
+1. **sklearn API stability**: We assume sklearn's `get_params()`, `fit()`, `transform()`, `predict()` interfaces remain stable
+2. **Picklability**: All sklearn estimators can be pickled via cloudpickle
+3. **get_feature_names_out()**: Transformers provide this method for packed format feature names (falls back to generic names if not available)
+4. **BaseEstimator inheritance**: All sklearn estimators inherit from `sklearn.base.BaseEstimator`
+
+### Limitations
+
+1. **Intermediate packed format**: When `Pipeline.from_instance()` decomposes a pipeline with ColumnTransformer, subsequent steps can't consume packed format. **Workaround**: Wrap entire pipeline as single Step.
+
+2. **No caching in FittedStep**: Properties like `model` execute on each access due to frozen class constraints. **Workaround**: Call `to_sklearn()` once and store.
+
+3. **Transductive estimators**: TSNE, DBSCAN, etc. can only produce results for training data. Calling `transform()`/`predict()` on new data raises `TypeError`.
+
+4. **Estimators with both transform and predict**: Treated as predictors only. If you need transform behavior, use the estimator directly via `to_sklearn()`.
+
+5. **Custom estimators**: Must follow sklearn conventions (inherit BaseEstimator, implement get_params, etc.) to work with `from_instance_name()`.
+
+---
+
+## Future Considerations
+
+### Not Implemented (Out of Scope)
+
+1. **Feature unions**: `sklearn.pipeline.FeatureUnion` is not specially handled
+2. **Grid search**: `GridSearchCV`, `RandomizedSearchCV` not wrapped
+3. **Model selection**: `cross_val_score`, train/test split utilities
+4. **Incremental learning**: `partial_fit()` not supported
+
+### Potential Enhancements
+
+1. **Automatic unpacking**: Option to automatically unpack packed format to columns
+2. **Schema inference**: Pre-fit schema inference for registered transformers
+3. **Caching improvements**: External cache for FittedStep.model
+4. **Better Pipeline decomposition**: Handle intermediate packed format by auto-unpacking
+
+---
+
+## Summary
+
+| Feature | Approach |
+|---------|----------|
+| Wrapping sklearn | `Step.from_instance_name()`, `Pipeline.from_instance()` |
+| Round-trip conversion | `to_sklearn()` on Step, FittedStep, Pipeline, FittedPipeline |
+| Unknown output schemas | Packed format `Array[Struct{key, value}]` |
+| Predictor return types | Mixin-based registry with catch-alls |
+| Probabilistic outputs | `predict_proba()`, `decision_function()` in packed format |
+| Transductive estimators | Detection + helpful error messages |
+| Unhashable params | Pickle before curry, normalize for dask tokenization |
+| Complex pipelines | Wrap entire sklearn Pipeline as single Step |

--- a/examples/sklearn_column_transformer.py
+++ b/examples/sklearn_column_transformer.py
@@ -1,0 +1,385 @@
+"""
+sklearn ColumnTransformer with xorq Example
+
+This example demonstrates using sklearn's ColumnTransformer with xorq
+for complex preprocessing pipelines that handle different feature types.
+
+Key features demonstrated:
+- ColumnTransformer with mixed numeric/categorical preprocessing
+- OneHotEncoder for categorical features (dynamic schema)
+- StandardScaler for numeric features
+- Packed format handles dynamic output schemas automatically
+- Full round-trip with to_sklearn()
+
+The key insight: sklearn handles all the complexity internally.
+xorq just wraps it for deferred execution.
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline as SklearnPipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+import xorq.api as xo
+from xorq.expr.ml.pipeline_lib import Step
+
+
+def create_mixed_data(include_missing=False):
+    """Create dataset with numeric and categorical features."""
+    np.random.seed(42)
+    n_samples = 500
+
+    df = pd.DataFrame(
+        {
+            # Numeric features
+            "age": np.random.randint(18, 80, n_samples).astype(float),
+            "income": np.random.exponential(50000, n_samples),
+            "credit_score": np.random.randint(300, 850, n_samples).astype(float),
+            "account_balance": np.random.normal(10000, 5000, n_samples),
+            # Categorical features
+            "gender": np.random.choice(["M", "F", "Other"], n_samples),
+            "education": np.random.choice(
+                ["High School", "Bachelor", "Master", "PhD"], n_samples
+            ),
+            "employment": np.random.choice(
+                ["Employed", "Self-Employed", "Unemployed", "Retired"], n_samples
+            ),
+            "region": np.random.choice(
+                ["North", "South", "East", "West", "Central"], n_samples
+            ),
+            # Target
+            "approved": np.random.randint(0, 2, n_samples),
+        }
+    )
+
+    # Optionally add some missing values
+    if include_missing:
+        df.loc[np.random.choice(n_samples, 30, replace=False), "income"] = np.nan
+        df.loc[np.random.choice(n_samples, 20, replace=False), "credit_score"] = np.nan
+
+    return df
+
+
+# =============================================================================
+# Example 1: ColumnTransformer as a Single Step
+# =============================================================================
+
+
+def example_column_transformer_step():
+    """
+    Use ColumnTransformer as a single deferred Step.
+
+    The ColumnTransformer handles:
+    - Routing features to appropriate sub-transformers
+    - Fitting all sub-transformers
+    - Concatenating outputs
+    - Providing get_feature_names_out()
+
+    xorq treats it as a single opaque unit.
+    """
+    print("\n" + "=" * 60)
+    print("Example 1: ColumnTransformer as Single Step")
+    print("=" * 60)
+
+    df = create_mixed_data()
+    expr = xo.memtable(df)
+
+    numeric_features = ["age", "income", "credit_score", "account_balance"]
+    categorical_features = ["gender", "education", "employment", "region"]
+
+    # Create ColumnTransformer with nested sklearn Pipelines
+    preprocessor = ColumnTransformer(
+        transformers=[
+            (
+                "num",
+                SklearnPipeline(
+                    [
+                        ("imputer", SimpleImputer(strategy="median")),
+                        ("scaler", StandardScaler()),
+                    ]
+                ),
+                numeric_features,
+            ),
+            (
+                "cat",
+                OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                categorical_features,
+            ),
+        ],
+        remainder="drop",
+    )
+
+    # Wrap as xorq Step - uses packed format for dynamic output
+    step = Step.from_instance_name(preprocessor, name="preprocessor")
+    print("Created Step from ColumnTransformer")
+
+    # Fit (deferred)
+    all_features = tuple(numeric_features + categorical_features)
+    fitted = step.fit(expr, features=all_features)
+    print(f"Fitted step type: {type(fitted)}")
+
+    # Get sklearn ColumnTransformer back
+    sklearn_ct = fitted.to_sklearn()
+    print("\nFitted sklearn ColumnTransformer:")
+    print(f"  Transformers: {[name for name, _, _ in sklearn_ct.transformers_]}")
+
+    # Check output feature names
+    output_names = sklearn_ct.get_feature_names_out()
+    print(f"  Output features count: {len(output_names)}")
+    print(f"  First 5 output names: {output_names[:5].tolist()}")
+    print(
+        f"  Categorical output names: {[n for n in output_names if n.startswith('cat__')][:5]}"
+    )
+
+    # Transform produces packed format
+    result = fitted.transform_raw(expr)
+    result_df = result.as_table().execute()
+    print("\nTransform result (packed format):")
+    print(f"  Columns: {result_df.columns.tolist()}")
+    first_row = result_df["transformed"].iloc[0]
+    print(f"  First row has {len(first_row)} features")
+    print(f"  Sample features: {[item['key'] for item in first_row[:3]]}")
+
+    return fitted
+
+
+# =============================================================================
+# Example 2: Full Pipeline with ColumnTransformer + Classifier
+# =============================================================================
+
+
+def example_full_pipeline_column_transformer():
+    """
+    Complete ML pipeline with ColumnTransformer preprocessing and classifier.
+
+    NOTE: For complex sklearn pipelines with ColumnTransformer, wrap the entire
+    sklearn Pipeline as a single Step (not decomposed). This is because xorq's
+    Pipeline.from_instance() decomposes into steps, and intermediate packed format
+    output from ColumnTransformer can't be consumed by subsequent steps.
+    """
+    print("\n" + "=" * 60)
+    print("Example 2: Full Pipeline (ColumnTransformer + Classifier)")
+    print("=" * 60)
+
+    df = create_mixed_data()
+    expr = xo.memtable(df)
+
+    numeric_features = ["age", "income", "credit_score", "account_balance"]
+    categorical_features = ["gender", "education", "employment", "region"]
+
+    # Create full sklearn pipeline with nested ColumnTransformer
+    sklearn_pipeline = SklearnPipeline(
+        [
+            (
+                "preprocessor",
+                ColumnTransformer(
+                    transformers=[
+                        (
+                            "num",
+                            SklearnPipeline(
+                                [
+                                    ("imputer", SimpleImputer(strategy="median")),
+                                    ("scaler", StandardScaler()),
+                                ]
+                            ),
+                            numeric_features,
+                        ),
+                        (
+                            "cat",
+                            OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                            categorical_features,
+                        ),
+                    ],
+                    remainder="drop",
+                ),
+            ),
+            ("classifier", LogisticRegression(max_iter=500)),
+        ]
+    )
+
+    # Wrap the ENTIRE sklearn pipeline as a single Step
+    # This keeps all sklearn processing together, avoiding packed format issues
+    step = Step.from_instance_name(sklearn_pipeline, name="full_pipeline")
+    print("Created xorq Step wrapping entire sklearn Pipeline")
+
+    # Fit (deferred)
+    all_features = tuple(numeric_features + categorical_features)
+    fitted = step.fit(expr, features=all_features, target="approved")
+    print("Fitted step")
+
+    # Get fitted sklearn pipeline back
+    sklearn_fitted = fitted.to_sklearn()
+    print("\nFitted sklearn Pipeline:")
+    print(f"  Steps: {[name for name, _ in sklearn_fitted.steps]}")
+
+    # Check preprocessor
+    preprocessor = sklearn_fitted.named_steps["preprocessor"]
+    print(
+        f"  Preprocessor output features: {len(preprocessor.get_feature_names_out())}"
+    )
+
+    # Check classifier
+    classifier = sklearn_fitted.named_steps["classifier"]
+    print(f"  Classifier coef shape: {classifier.coef_.shape}")
+    print(f"  Classifier classes: {classifier.classes_}")
+
+    # Execute predictions with xorq (deferred)
+    predictions = fitted.predict(expr)
+    result = predictions.execute()
+    print("\nPredictions:")
+    print(f"  Shape: {result.shape}")
+    print(f"  Columns: {result.columns.tolist()}")
+    print(f"  First 5 predictions: {result['predicted'].head().tolist()}")
+
+    # Get probabilities
+    proba = fitted.predict_proba(expr)
+    proba_result = proba.execute()
+    print("\nProbabilities (packed format):")
+    print(f"  First row: {proba_result['proba'].iloc[0]}")
+
+    # Compare with direct sklearn prediction
+    X_test = df[numeric_features + categorical_features].head(5)
+    sklearn_pred = sklearn_fitted.predict(X_test)
+    print(f"\nDirect sklearn predictions on same data: {sklearn_pred.tolist()}")
+
+    return fitted
+
+
+# =============================================================================
+# Example 3: ColumnTransformer with remainder="passthrough"
+# =============================================================================
+
+
+def example_passthrough_columns():
+    """
+    ColumnTransformer with remainder="passthrough" to keep unprocessed columns.
+    """
+    print("\n" + "=" * 60)
+    print("Example 3: ColumnTransformer with Passthrough")
+    print("=" * 60)
+
+    df = create_mixed_data()
+    # Add an ID column that should pass through
+    df["customer_id"] = range(len(df))
+    expr = xo.memtable(df)
+
+    numeric_features = ["age", "income"]
+    categorical_features = ["gender"]
+
+    # ColumnTransformer with passthrough for remaining columns
+    preprocessor = ColumnTransformer(
+        transformers=[
+            ("num", StandardScaler(), numeric_features),
+            ("cat", OneHotEncoder(sparse_output=False), categorical_features),
+        ],
+        remainder="passthrough",  # Keep other columns
+    )
+
+    step = Step.from_instance_name(preprocessor, name="preprocessor_passthrough")
+    all_features = tuple(
+        numeric_features + categorical_features + ["credit_score", "customer_id"]
+    )
+    fitted = step.fit(expr, features=all_features)
+
+    sklearn_ct = fitted.to_sklearn()
+    output_names = sklearn_ct.get_feature_names_out()
+    print("Output feature names with passthrough:")
+    print(f"  {output_names.tolist()}")
+    print("  Note: 'remainder__' prefix for passthrough columns")
+
+    return fitted
+
+
+# =============================================================================
+# Example 4: Nested Pipelines in ColumnTransformer
+# =============================================================================
+
+
+def example_nested_pipelines():
+    """
+    ColumnTransformer with nested Pipeline objects for each transformer.
+    """
+    print("\n" + "=" * 60)
+    print("Example 4: Nested Pipelines in ColumnTransformer")
+    print("=" * 60)
+
+    df = create_mixed_data()
+    expr = xo.memtable(df)
+
+    numeric_features = ["age", "income", "credit_score", "account_balance"]
+    categorical_features = ["gender", "education", "employment", "region"]
+
+    # Complex nested structure
+    preprocessor = ColumnTransformer(
+        transformers=[
+            (
+                "numeric_pipeline",
+                SklearnPipeline(
+                    [
+                        ("imputer", SimpleImputer(strategy="median")),
+                        ("scaler", StandardScaler()),
+                    ]
+                ),
+                numeric_features,
+            ),
+            (
+                "categorical_pipeline",
+                SklearnPipeline(
+                    [
+                        (
+                            "imputer",
+                            SimpleImputer(strategy="constant", fill_value="missing"),
+                        ),
+                        (
+                            "encoder",
+                            OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                        ),
+                    ]
+                ),
+                categorical_features,
+            ),
+        ],
+    )
+
+    step = Step.from_instance_name(preprocessor, name="nested_preprocessor")
+    all_features = tuple(numeric_features + categorical_features)
+    fitted = step.fit(expr, features=all_features)
+
+    sklearn_ct = fitted.to_sklearn()
+    print("Nested pipeline structure:")
+    for name, transformer, cols in sklearn_ct.transformers_:
+        print(f"  {name}:")
+        print(f"    Columns: {cols}")
+        if hasattr(transformer, "steps"):
+            print(f"    Sub-steps: {[s[0] for s in transformer.steps]}")
+
+    output_names = sklearn_ct.get_feature_names_out()
+    print(f"\nOutput features: {len(output_names)} total")
+    print(f"  Numeric: {[n for n in output_names if n.startswith('numeric')]}")
+    print(
+        f"  Categorical (sample): {[n for n in output_names if n.startswith('categorical')][:5]}..."
+    )
+
+    return fitted
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+if __name__ == "__main__":
+    print("sklearn ColumnTransformer with xorq Examples")
+    print("=" * 60)
+
+    # Run all examples
+    example_column_transformer_step()
+    example_full_pipeline_column_transformer()
+    example_passthrough_columns()
+    example_nested_pipelines()
+
+    print("\n" + "=" * 60)
+    print("All ColumnTransformer examples completed!")
+    print("=" * 60)

--- a/examples/sklearn_interop.py
+++ b/examples/sklearn_interop.py
@@ -1,0 +1,353 @@
+"""
+sklearn ↔ xorq Interoperability Example
+
+This example demonstrates the full round-trip between sklearn and xorq:
+1. from_instance(): Wrap any sklearn pipeline for deferred execution
+2. to_sklearn(): Get the fitted sklearn pipeline back
+3. predict_proba() and decision_function() support
+4. Packed format for transformers with dynamic schemas
+
+Key features demonstrated:
+- Pipeline.from_instance() accepts any sklearn Pipeline
+- fit(), transform(), predict() are deferred (lazy)
+- Fitted models are cached
+- to_sklearn() returns fitted sklearn objects for direct use
+- All execution happens at .execute() time
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline as SklearnPipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC
+
+import xorq.api as xo
+from xorq.expr.ml.pipeline_lib import Pipeline, Step
+
+
+def create_sample_data(include_missing=False):
+    """Create a sample dataset with numeric and categorical features."""
+    np.random.seed(42)
+    n_samples = 1000
+
+    # Generate numeric features
+    X_numeric, y = make_classification(
+        n_samples=n_samples,
+        n_features=4,
+        n_informative=3,
+        n_redundant=1,
+        random_state=42,
+    )
+
+    # Create DataFrame with numeric features
+    df = pd.DataFrame(
+        X_numeric,
+        columns=["age", "income", "score", "balance"],
+    )
+
+    # Add categorical features
+    df["gender"] = np.random.choice(["M", "F"], n_samples)
+    df["region"] = np.random.choice(["North", "South", "East", "West"], n_samples)
+    df["category"] = np.random.choice(["A", "B", "C"], n_samples)
+
+    # Optionally add some missing values (for imputer examples)
+    if include_missing:
+        df.loc[np.random.choice(n_samples, 50, replace=False), "income"] = np.nan
+        df.loc[np.random.choice(n_samples, 30, replace=False), "balance"] = np.nan
+
+    # Add target
+    df["target"] = y
+
+    return df
+
+
+# =============================================================================
+# Example 1: Basic Pipeline Round-Trip
+# =============================================================================
+
+
+def example_basic_roundtrip():
+    """
+    Demonstrate basic from_instance() and to_sklearn() round-trip.
+    """
+    print("\n" + "=" * 60)
+    print("Example 1: Basic Pipeline Round-Trip")
+    print("=" * 60)
+
+    # Create sample data
+    df = create_sample_data()
+    numeric_features = ["age", "income", "score", "balance"]
+
+    # Create xorq expression
+    expr = xo.memtable(df)
+
+    # Create sklearn pipeline
+    sklearn_pipe = SklearnPipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("clf", LogisticRegression(max_iter=200)),
+        ]
+    )
+
+    # Wrap with xorq for deferred execution
+    xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+    print(f"Created xorq Pipeline from sklearn: {type(xorq_pipe)}")
+
+    # Get unfitted sklearn pipeline back
+    sklearn_unfitted = xorq_pipe.to_sklearn()
+    print(f"Round-trip unfitted: {type(sklearn_unfitted)}")
+    print(f"Steps match: {[s[0] for s in sklearn_unfitted.steps]}")
+
+    # Fit the xorq pipeline (deferred)
+    fitted_xorq = xorq_pipe.fit(
+        expr,
+        features=tuple(numeric_features),
+        target="target",
+    )
+    print(f"Fitted xorq pipeline: {type(fitted_xorq)}")
+
+    # Get fitted sklearn pipeline back
+    sklearn_fitted = fitted_xorq.to_sklearn()
+    print(f"Round-trip fitted: {type(sklearn_fitted)}")
+    print(f"Scaler fitted: {hasattr(sklearn_fitted.named_steps['scaler'], 'mean_')}")
+    print(f"Classifier fitted: {hasattr(sklearn_fitted.named_steps['clf'], 'coef_')}")
+
+    # Use sklearn directly on pandas
+    X_test = df[numeric_features].head(10).fillna(0)
+    sklearn_predictions = sklearn_fitted.predict(X_test)
+    print(f"Direct sklearn predictions: {sklearn_predictions[:5]}")
+
+    # Use xorq for deferred execution
+    xorq_predictions = fitted_xorq.predict(expr)
+    result = xorq_predictions.execute()
+    print(f"xorq predictions shape: {result.shape}")
+
+    return fitted_xorq
+
+
+# =============================================================================
+# Example 2: predict_proba() and decision_function()
+# =============================================================================
+
+
+def example_probabilistic_outputs():
+    """
+    Demonstrate predict_proba() and decision_function() support.
+    """
+    print("\n" + "=" * 60)
+    print("Example 2: Probabilistic Outputs")
+    print("=" * 60)
+
+    df = create_sample_data()
+    numeric_features = ["age", "income", "score", "balance"]
+    expr = xo.memtable(df)
+
+    # Example with LogisticRegression (has predict_proba)
+    print("\n--- LogisticRegression with predict_proba ---")
+    sklearn_pipe = SklearnPipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("clf", LogisticRegression(max_iter=200)),
+        ]
+    )
+
+    xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+    fitted = xorq_pipe.fit(expr, features=tuple(numeric_features), target="target")
+
+    # Get class probabilities (packed format)
+    proba_result = fitted.predict_proba(expr)
+    proba_df = proba_result.execute()
+    print(f"predict_proba result columns: {proba_df.columns.tolist()}")
+    print(f"First row proba (packed): {proba_df['proba'].iloc[0]}")
+
+    # Example with SVC (has decision_function)
+    print("\n--- SVC with decision_function ---")
+    sklearn_pipe_svc = SklearnPipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("clf", SVC(kernel="linear")),
+        ]
+    )
+
+    xorq_pipe_svc = Pipeline.from_instance(sklearn_pipe_svc)
+    fitted_svc = xorq_pipe_svc.fit(
+        expr, features=tuple(numeric_features), target="target"
+    )
+
+    # Get decision function values
+    decision_result = fitted_svc.decision_function(expr)
+    decision_df = decision_result.execute()
+    print(f"decision_function result columns: {decision_df.columns.tolist()}")
+    print(f"First row decision (packed): {decision_df['decision'].iloc[0]}")
+
+    return fitted
+
+
+# =============================================================================
+# Example 3: Unregistered Transformers (Packed Format Fallback)
+# =============================================================================
+
+
+def example_unregistered_transformers():
+    """
+    Demonstrate that unregistered transformers automatically use packed format.
+    """
+    print("\n" + "=" * 60)
+    print("Example 3: Unregistered Transformers (Auto Packed Format)")
+    print("=" * 60)
+
+    df = create_sample_data()
+    numeric_features = ["age", "income", "score", "balance"]
+    expr = xo.memtable(df)
+
+    # MinMaxScaler is not explicitly registered - uses packed format fallback
+    from sklearn.preprocessing import MinMaxScaler, RobustScaler
+
+    print("\n--- MinMaxScaler (unregistered, uses packed format) ---")
+    step = Step.from_instance_name(MinMaxScaler(), name="minmax")
+    fitted = step.fit(expr, features=tuple(numeric_features))
+
+    # Transform returns packed format
+    result = fitted.transform_raw(expr)
+    result_df = result.as_table().execute()
+    print("Transform result type: packed Array[Struct{key, value}]")
+    print(f"First row (packed): {result_df['transformed'].iloc[0][:2]}...")
+
+    print("\n--- RobustScaler (unregistered, uses packed format) ---")
+    step2 = Step.from_instance_name(RobustScaler(), name="robust")
+    fitted2 = step2.fit(expr, features=tuple(numeric_features))
+    result2 = fitted2.transform_raw(expr)
+    result2_df = result2.as_table().execute()
+    print(f"First row (packed): {result2_df['transformed'].iloc[0][:2]}...")
+
+    return fitted
+
+
+# =============================================================================
+# Example 4: Regressor with Mixin Catch-All
+# =============================================================================
+
+
+def example_regressor_mixin():
+    """
+    Demonstrate RegressorMixin catch-all for regressors.
+    """
+    print("\n" + "=" * 60)
+    print("Example 4: Regressor Mixin Catch-All")
+    print("=" * 60)
+
+    df = create_sample_data()
+    numeric_features = ["age", "income", "score", "balance"]
+    expr = xo.memtable(df)
+
+    from sklearn.ensemble import GradientBoostingRegressor
+    from sklearn.linear_model import Ridge
+
+    # Ridge regression - uses RegressorMixin catch-all
+    print("\n--- Ridge Regression ---")
+    sklearn_pipe = SklearnPipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("reg", Ridge(alpha=1.0)),
+        ]
+    )
+
+    xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+    fitted = xorq_pipe.fit(expr, features=tuple(numeric_features), target="target")
+
+    predictions = fitted.predict(expr)
+    result = predictions.execute()
+    print(f"Ridge predictions shape: {result.shape}")
+    print(f"First 5 predictions: {result['predicted'].head().tolist()}")
+
+    # GradientBoostingRegressor - also uses RegressorMixin
+    print("\n--- GradientBoostingRegressor ---")
+    step = Step.from_instance_name(
+        GradientBoostingRegressor(n_estimators=10, max_depth=3),
+        name="gbr",
+    )
+    fitted_gbr = step.fit(expr, features=tuple(numeric_features), target="target")
+
+    # Get sklearn model back
+    sklearn_gbr = fitted_gbr.to_sklearn()
+    print(f"Fitted GBR n_estimators: {sklearn_gbr.n_estimators_}")
+
+    return fitted
+
+
+# =============================================================================
+# Example 5: Complex Pipeline with Multiple Steps
+# =============================================================================
+
+
+def example_complex_pipeline():
+    """
+    Demonstrate a complex multi-step pipeline.
+    """
+    print("\n" + "=" * 60)
+    print("Example 5: Complex Multi-Step Pipeline")
+    print("=" * 60)
+
+    df = create_sample_data()
+    expr = xo.memtable(df)
+
+    # Create individual steps
+    from sklearn.feature_selection import SelectKBest, f_classif
+
+    numeric_features = ["age", "income", "score", "balance"]
+
+    # Multi-step sklearn pipeline
+    sklearn_pipe = SklearnPipeline(
+        [
+            ("imputer", SimpleImputer(strategy="mean")),
+            ("scaler", StandardScaler()),
+            ("selector", SelectKBest(f_classif, k=3)),
+            ("clf", RandomForestClassifier(n_estimators=10, random_state=42)),
+        ]
+    )
+
+    # Wrap and fit
+    xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+    fitted = xorq_pipe.fit(expr, features=tuple(numeric_features), target="target")
+
+    # Get all fitted sklearn models
+    sklearn_fitted = fitted.to_sklearn()
+    print(f"Pipeline steps: {[name for name, _ in sklearn_fitted.steps]}")
+    print(
+        f"Imputer statistics: {sklearn_fitted.named_steps['imputer'].statistics_[:2]}..."
+    )
+    print(f"Scaler mean: {sklearn_fitted.named_steps['scaler'].mean_[:2]}...")
+    print(
+        f"Selected features mask: {sklearn_fitted.named_steps['selector'].get_support()}"
+    )
+    print(f"RF n_estimators: {sklearn_fitted.named_steps['clf'].n_estimators}")
+
+    # Execute predictions
+    result = fitted.predict(expr).execute()
+    print(f"Predictions shape: {result.shape}")
+
+    return fitted
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+if __name__ == "__main__":
+    print("sklearn ↔ xorq Interoperability Examples")
+    print("=" * 60)
+
+    # Run all examples
+    example_basic_roundtrip()
+    example_probabilistic_outputs()
+    example_unregistered_transformers()
+    example_regressor_mixin()
+    example_complex_pipeline()
+
+    print("\n" + "=" * 60)
+    print("All examples completed successfully!")
+    print("=" * 60)

--- a/python/xorq/expr/ml/fit_lib.py
+++ b/python/xorq/expr/ml/fit_lib.py
@@ -10,15 +10,70 @@ from xorq.expr.udf import make_pandas_expr_udf
 from xorq.vendor import ibis
 
 
+# Universal packed format for all transformers - enables fully deferred execution
+# without needing to know output schema at graph construction time
+PACKED_TRANSFORM_TYPE = dt.Array(dt.Struct({"key": dt.string, "value": dt.float64}))
+
+
+def unpack_packed_column(df, col_name="transformed"):
+    """
+    Unpack Array[Struct{key, value}] column to named columns in a pandas DataFrame.
+
+    Used at pipeline boundaries or before predictors that need unpacked features.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame containing a packed column
+    col_name : str
+        Name of the column containing Array[Struct{key, value}] data
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with the packed column replaced by individual feature columns
+    """
+
+    packed_col = df[col_name]
+
+    # Extract keys and values from first row to get column names
+    if len(packed_col) == 0:
+        return df.drop(columns=[col_name])
+
+    first_row = packed_col.iloc[0]
+    if first_row is None or len(first_row) == 0:
+        return df.drop(columns=[col_name])
+
+    column_names = [item["key"] for item in first_row]
+
+    # Build new columns
+    unpacked_data = {
+        name: [row[i]["value"] if row is not None else None for row in packed_col]
+        for i, name in enumerate(column_names)
+    }
+
+    # Create result DataFrame
+    other_cols = [c for c in df.columns if c != col_name]
+    result = df[other_cols].copy()
+    for name, values in unpacked_data.items():
+        result[name] = values
+
+    return result
+
+
 @toolz.curry
-def fit_sklearn(df, target=None, *, cls, params):
+def fit_sklearn(df, target=None, *, cls, params_pickled):
+    # Unpickle params to handle unhashable types like lists in ColumnTransformer
+    params = cloudpickle.loads(params_pickled)
     obj = cls(**dict(params))
     obj.fit(df, target)
     return obj
 
 
 @toolz.curry
-def fit_sklearn_series(df, col, cls, params):
+def fit_sklearn_series(df, col, cls, params_pickled):
+    # Unpickle params to handle unhashable types
+    params = cloudpickle.loads(params_pickled)
     model = cls(**dict(params))
     model.fit(df[col])
     return model
@@ -52,6 +107,54 @@ def transform_sklearn_feature_names_out(model, df):
 def predict_sklearn(model, df):
     predicted = model.predict(df)
     return predicted
+
+
+@toolz.curry
+def predict_proba_sklearn_packed(model, df):
+    """
+    Call predict_proba and return as packed format Array[Struct{key, value}].
+
+    The keys are the class labels from model.classes_.
+    """
+    import pandas as pd
+
+    proba = model.predict_proba(df)
+    classes = model.classes_
+
+    return pd.Series(
+        [
+            tuple({"key": str(cls), "value": float(p)} for cls, p in zip(classes, row))
+            for row in proba
+        ]
+    )
+
+
+@toolz.curry
+def decision_function_sklearn_packed(model, df):
+    """
+    Call decision_function and return as packed format Array[Struct{key, value}].
+
+    For binary classification, returns single value; for multiclass, one per class.
+    """
+    import pandas as pd
+
+    decision = model.decision_function(df)
+
+    # Handle both binary (1D) and multiclass (2D) cases
+    if decision.ndim == 1:
+        # Binary classification - single decision value
+        return pd.Series([({"key": "decision", "value": float(d)},) for d in decision])
+    else:
+        # Multiclass - one value per class
+        classes = model.classes_
+        return pd.Series(
+            [
+                tuple(
+                    {"key": str(cls), "value": float(d)} for cls, d in zip(classes, row)
+                )
+                for row in decision
+            ]
+        )
 
 
 @toolz.curry
@@ -168,11 +271,13 @@ def deferred_fit_transform_sklearn(
     name_infix="transformed",
     cache=None,
 ):
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
     deferred_model, model_udaf, deferred_transform = _deferred_fit_other(
         expr=expr,
         target=target,
         features=features,
-        fit=fit_sklearn(cls=cls, params=params),
+        fit=fit_sklearn(cls=cls, params_pickled=params_pickled),
         other=transform_sklearn,
         return_type=return_type,
         name_infix=name_infix,
@@ -192,11 +297,13 @@ def deferred_fit_predict_sklearn(
     name_infix="predicted",
     cache=None,
 ):
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
     deferred_model, model_udaf, deferred_predict = _deferred_fit_other(
         expr=expr,
         target=target,
         features=features,
-        fit=fit_sklearn(cls=cls, params=params),
+        fit=fit_sklearn(cls=cls, params_pickled=params_pickled),
         other=predict_sklearn,
         return_type=return_type,
         name_infix=name_infix,
@@ -209,11 +316,13 @@ def deferred_fit_predict_sklearn(
 def deferred_fit_transform_series_sklearn(
     expr, col, cls, return_type, params=(), name="predicted", cache=None
 ):
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
     deferred_model, model_udaf, deferred_transform = _deferred_fit_other(
         expr=expr,
         target=None,
         features=(col,),
-        fit=fit_sklearn_series(col=col, cls=cls, params=params),
+        fit=fit_sklearn_series(col=col, cls=cls, params_pickled=params_pickled),
         other=transform_sklearn_series(col=col),
         return_type=return_type,
         name_infix=name,
@@ -227,7 +336,9 @@ def deferred_fit_transform_sklearn_struct(
     expr, features, cls, params=(), target=None, name_infix="transformed", cache=None
 ):
     @toolz.curry
-    def fit(df, *args, cls, params):
+    def fit(df, *args, cls, params_pickled):
+        # Unpickle params to handle unhashable types
+        params = cloudpickle.loads(params_pickled)
         instance = cls(**dict(params))
         # if args exists, is likely (target,): see TfidfVectorizer
         instance.fit(df, *args)
@@ -237,14 +348,215 @@ def deferred_fit_transform_sklearn_struct(
     def transform(convert_array, model, df):
         return convert_array(model.transform(df))
 
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
     structer = Structer.from_instance_expr(cls(**dict(params)), expr, features=features)
     return deferred_fit_transform(
         expr=expr,
         features=list(features),
-        fit=fit(cls=cls, params=params),
+        fit=fit(cls=cls, params_pickled=params_pickled),
         transform=transform(structer.get_convert_array()),
         return_type=structer.return_type,
         target=target,
+        name_infix=name_infix,
+        cache=cache,
+    )
+
+
+@toolz.curry
+def pack_transform_output(model, df, features):
+    """
+    Convert sklearn transform output to Array[Struct{key, value}] packed format.
+
+    This enables fully deferred execution by using a fixed return type regardless
+    of the actual output schema, which is resolved at execution time via
+    get_feature_names_out().
+    """
+    import pandas as pd
+
+    result = model.transform(df)
+    # Handle sparse matrices
+    if hasattr(result, "toarray"):
+        result = result.toarray()
+
+    # Get feature names from model if available, otherwise use input features
+    if hasattr(model, "get_feature_names_out"):
+        names = model.get_feature_names_out()
+    else:
+        names = features
+
+    return pd.Series(
+        [
+            tuple(
+                {"key": str(name), "value": float(val)} for name, val in zip(names, row)
+            )
+            for row in result
+        ]
+    )
+
+
+@toolz.curry
+def deferred_fit_transform_sklearn_packed(
+    expr,
+    features,
+    cls,
+    params=(),
+    target=None,
+    name_infix="transformed_packed",
+    cache=None,
+):
+    """
+    Generic wrapper for ANY sklearn transformer using packed format.
+
+    Uses Array[Struct{key, value}] as output type, which allows fully deferred
+    execution without needing to know the output schema at graph construction time.
+    Feature names are resolved at execution time via get_feature_names_out().
+
+    This works for all transformers including:
+    - Dynamic schema (OneHotEncoder, CountVectorizer, ColumnTransformer)
+    - Static schema (StandardScaler, SimpleImputer)
+    - Dimensionality reduction (PCA, TruncatedSVD)
+    """
+
+    @toolz.curry
+    def fit(df, *args, cls, params_pickled):
+        # Unpickle params to handle unhashable types like lists in ColumnTransformer
+        params = cloudpickle.loads(params_pickled)
+        instance = cls(**dict(params))
+        instance.fit(df, *args)
+        return instance
+
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
+
+    return deferred_fit_transform(
+        expr=expr,
+        features=list(features),
+        fit=fit(cls=cls, params_pickled=params_pickled),
+        transform=pack_transform_output(features=tuple(features)),
+        return_type=PACKED_TRANSFORM_TYPE,
+        target=target,
+        name_infix=name_infix,
+        cache=cache,
+    )
+
+
+@toolz.curry
+def deferred_fit_transform_only_sklearn_packed(
+    expr,
+    features,
+    cls,
+    params=(),
+    name_infix="fit_transform_only",
+    cache=None,
+):
+    """
+    Wrapper for estimators that only have fit_transform (TSNE, MDS, etc.).
+
+    These estimators cannot transform new data - they only produce embeddings
+    for the training data. The transform() method on new data will raise an error.
+    """
+
+    @toolz.curry
+    def fit_and_pack(df, cls, params_pickled, features):
+        import pandas as pd
+
+        # Unpickle params to handle unhashable types
+        params = cloudpickle.loads(params_pickled)
+        instance = cls(**dict(params))
+        result = instance.fit_transform(df)
+
+        # Handle sparse matrices
+        if hasattr(result, "toarray"):
+            result = result.toarray()
+
+        # Get feature names if available, otherwise generate generic names
+        if hasattr(instance, "get_feature_names_out"):
+            names = instance.get_feature_names_out()
+        else:
+            names = [f"component_{i}" for i in range(result.shape[1])]
+
+        packed = pd.Series(
+            [
+                tuple(
+                    {"key": str(name), "value": float(val)}
+                    for name, val in zip(names, row)
+                )
+                for row in result
+            ]
+        )
+        # Return instance and packed result - instance stored for to_sklearn()
+        return (instance, packed)
+
+    @toolz.curry
+    def extract_packed(model_and_result, df, features):
+        """Extract the pre-computed packed result from fit_transform"""
+        _, packed = model_and_result
+        return packed
+
+    # Note: This is a simplified implementation. The fit produces both model and result,
+    # and transform just extracts the result. This means transform() only works on
+    # the training data - calling it on new data will return wrong results.
+    # A proper implementation should raise an error when transform is called on new data.
+
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
+
+    return deferred_fit_transform(
+        expr=expr,
+        features=list(features),
+        fit=fit_and_pack(
+            cls=cls, params_pickled=params_pickled, features=tuple(features)
+        ),
+        transform=extract_packed(features=tuple(features)),
+        return_type=PACKED_TRANSFORM_TYPE,
+        target=None,
+        name_infix=name_infix,
+        cache=cache,
+    )
+
+
+@toolz.curry
+def deferred_fit_predict_only_sklearn(
+    expr,
+    features,
+    cls,
+    params=(),
+    name_infix="fit_predict_only",
+    cache=None,
+):
+    """
+    Wrapper for transductive clusterers that only have fit_predict (DBSCAN, etc.).
+
+    These estimators cannot predict on new data - they only produce cluster labels
+    for the training data. The predict() method on new data will raise an error.
+    """
+
+    @toolz.curry
+    def fit_predict(df, cls, params_pickled):
+        # Unpickle params to handle unhashable types
+        params = cloudpickle.loads(params_pickled)
+        instance = cls(**dict(params))
+        labels = instance.fit_predict(df)
+        # Return both instance and labels
+        return (instance, labels)
+
+    @toolz.curry
+    def extract_labels(model_and_labels, df, features):
+        """Extract the pre-computed labels from fit_predict"""
+        _, labels = model_and_labels
+        return labels
+
+    # Pickle params to make them hashable for FrozenDict/curry
+    params_pickled = cloudpickle.dumps(params)
+
+    return deferred_fit_predict(
+        expr=expr,
+        target=None,
+        features=list(features),
+        fit=fit_predict(cls=cls, params_pickled=params_pickled),
+        predict=extract_labels(features=tuple(features)),
+        return_type=dt.int64,
         name_infix=name_infix,
         cache=cache,
     )

--- a/python/xorq/expr/ml/tests/test_sklearn_compat.py
+++ b/python/xorq/expr/ml/tests/test_sklearn_compat.py
@@ -1,0 +1,427 @@
+"""
+Integration tests for sklearn ↔ xorq interoperability.
+
+Tests the following features:
+- to_sklearn() round-trip for Step, FittedStep, Pipeline, FittedPipeline
+- Packed format for transformers with dynamic schemas
+- Mixin catch-alls for predictors (RegressorMixin, ClusterMixin)
+- Transductive/fit-only estimators (TSNE, DBSCAN)
+"""
+
+import pandas as pd
+import pytest
+
+import xorq.api as xo
+from xorq.expr.ml.fit_lib import (
+    pack_transform_output,
+    unpack_packed_column,
+)
+from xorq.expr.ml.pipeline_lib import (
+    Pipeline,
+    Step,
+    has_structer_registration,
+    is_fit_predict_only,
+    is_fit_transform_only,
+)
+
+
+sklearn = pytest.importorskip("sklearn")
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def sample_data():
+    """Simple dataset for testing transformers and predictors."""
+    return pd.DataFrame(
+        {
+            "feature_0": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "feature_1": [5.0, 4.0, 3.0, 2.0, 1.0],
+            "category": ["a", "b", "a", "b", "a"],
+            "target": [0, 1, 0, 1, 0],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def expr(sample_data):
+    """xorq expression from sample data."""
+    return xo.memtable(sample_data)
+
+
+@pytest.fixture(scope="module")
+def numeric_features():
+    return ("feature_0", "feature_1")
+
+
+# =============================================================================
+# Test: to_sklearn() for Step (unfitted)
+# =============================================================================
+
+
+class TestStepToSklearn:
+    """Tests for Step.to_sklearn() method."""
+
+    def test_step_to_sklearn_standard_scaler(self):
+        """Step.to_sklearn() returns unfitted StandardScaler."""
+        from sklearn.preprocessing import StandardScaler
+
+        original = StandardScaler()
+        step = Step.from_instance_name(original, name="scaler")
+        result = step.to_sklearn()
+
+        assert isinstance(result, StandardScaler)
+        # Not fitted yet
+        assert not hasattr(result, "mean_") or result.mean_ is None
+
+    def test_step_to_sklearn_preserves_params(self):
+        """Step.to_sklearn() preserves estimator parameters."""
+        from sklearn.neighbors import KNeighborsClassifier
+
+        original = KNeighborsClassifier(n_neighbors=7, weights="distance")
+        step = Step.from_instance_name(original, name="knn")
+        result = step.to_sklearn()
+
+        assert result.n_neighbors == 7
+        assert result.weights == "distance"
+
+
+# =============================================================================
+# Test: to_sklearn() for FittedStep
+# =============================================================================
+
+
+class TestFittedStepToSklearn:
+    """Tests for FittedStep.to_sklearn() method."""
+
+    def test_fitted_step_to_sklearn_transformer(self, expr, numeric_features):
+        """FittedStep.to_sklearn() returns fitted transformer."""
+        from sklearn.preprocessing import StandardScaler
+
+        step = Step.from_instance_name(StandardScaler(), name="scaler")
+        fitted_step = step.fit(expr, features=numeric_features)
+        sklearn_model = fitted_step.to_sklearn()
+
+        assert isinstance(sklearn_model, StandardScaler)
+        # Should be fitted - has mean_ attribute
+        assert hasattr(sklearn_model, "mean_")
+        assert sklearn_model.mean_ is not None
+
+    def test_fitted_step_to_sklearn_predictor(self, expr, numeric_features):
+        """FittedStep.to_sklearn() returns fitted predictor."""
+        from sklearn.linear_model import LogisticRegression
+
+        step = Step.from_instance_name(LogisticRegression(max_iter=200), name="clf")
+        fitted_step = step.fit(expr, features=numeric_features, target="target")
+        sklearn_model = fitted_step.to_sklearn()
+
+        assert isinstance(sklearn_model, LogisticRegression)
+        # Should be fitted - has coef_ attribute
+        assert hasattr(sklearn_model, "coef_")
+
+
+# =============================================================================
+# Test: to_sklearn() for Pipeline (unfitted)
+# =============================================================================
+
+
+class TestPipelineToSklearn:
+    """Tests for Pipeline.to_sklearn() method."""
+
+    def test_pipeline_to_sklearn_roundtrip(self):
+        """Pipeline.to_sklearn() round-trip preserves structure."""
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.pipeline import Pipeline as SklearnPipeline
+        from sklearn.preprocessing import StandardScaler
+
+        sklearn_pipe = SklearnPipeline(
+            [
+                ("scaler", StandardScaler()),
+                ("clf", LogisticRegression(max_iter=200)),
+            ]
+        )
+
+        xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+        sklearn_pipe_back = xorq_pipe.to_sklearn()
+
+        assert isinstance(sklearn_pipe_back, SklearnPipeline)
+        assert len(sklearn_pipe_back.steps) == 2
+        assert sklearn_pipe_back.steps[0][0] == "scaler"
+        assert sklearn_pipe_back.steps[1][0] == "clf"
+
+
+# =============================================================================
+# Test: to_sklearn() for FittedPipeline
+# =============================================================================
+
+
+class TestFittedPipelineToSklearn:
+    """Tests for FittedPipeline.to_sklearn() method."""
+
+    def test_fitted_pipeline_to_sklearn(self, expr, numeric_features):
+        """FittedPipeline.to_sklearn() returns fitted sklearn Pipeline."""
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.pipeline import Pipeline as SklearnPipeline
+        from sklearn.preprocessing import StandardScaler
+
+        sklearn_pipe = SklearnPipeline(
+            [
+                ("scaler", StandardScaler()),
+                ("clf", LogisticRegression(max_iter=200)),
+            ]
+        )
+
+        xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+        fitted_xorq = xorq_pipe.fit(expr, features=numeric_features, target="target")
+        sklearn_fitted = fitted_xorq.to_sklearn()
+
+        assert isinstance(sklearn_fitted, SklearnPipeline)
+        # Should be fitted
+        assert hasattr(sklearn_fitted.named_steps["scaler"], "mean_")
+        assert hasattr(sklearn_fitted.named_steps["clf"], "coef_")
+
+    def test_fitted_pipeline_can_predict(self, expr, numeric_features, sample_data):
+        """Fitted sklearn pipeline from to_sklearn() can predict."""
+        from sklearn.linear_model import LogisticRegression
+        from sklearn.pipeline import Pipeline as SklearnPipeline
+        from sklearn.preprocessing import StandardScaler
+
+        sklearn_pipe = SklearnPipeline(
+            [
+                ("scaler", StandardScaler()),
+                ("clf", LogisticRegression(max_iter=200)),
+            ]
+        )
+
+        xorq_pipe = Pipeline.from_instance(sklearn_pipe)
+        fitted_xorq = xorq_pipe.fit(expr, features=numeric_features, target="target")
+        sklearn_fitted = fitted_xorq.to_sklearn()
+
+        # Should be able to predict
+        X_test = sample_data[list(numeric_features)]
+        predictions = sklearn_fitted.predict(X_test)
+        assert len(predictions) == len(X_test)
+
+
+# =============================================================================
+# Test: Mixin catch-alls
+# =============================================================================
+
+
+class TestMixinCatchAlls:
+    """Tests for mixin catch-all registrations."""
+
+    def test_regressor_mixin_returns_float64(self, expr, numeric_features):
+        """RegressorMixin predictors return float64."""
+        from sklearn.linear_model import Ridge
+
+        step = Step.from_instance_name(Ridge(), name="ridge")
+        fitted = step.fit(expr, features=numeric_features, target="target")
+
+        # Should be able to predict without explicit registration
+        result = fitted.predict(expr)
+        assert result is not None
+
+    @pytest.mark.skip(
+        reason="KMeans has both transform and predict, which FittedStep doesn't support"
+    )
+    def test_cluster_mixin_works(self, expr, numeric_features):
+        """ClusterMixin estimators work via catch-all (for inductive clusterers).
+
+        NOTE: This test is skipped because KMeans has both transform() and predict()
+        methods, which violates FittedStep's assumption that estimators are either
+        transformers OR predictors (not both). This is a limitation in the current
+        design that would need to be addressed in a future iteration.
+
+        The ClusterMixin catch-all registration is still functional for estimators
+        that only have predict() (not transform()).
+        """
+        from sklearn.cluster import KMeans
+
+        step = Step.from_instance_name(KMeans(n_clusters=2, n_init=3), name="kmeans")
+        fitted = step.fit(expr, features=numeric_features, target="target")
+        result = fitted.predict(expr)
+        assert result is not None
+
+
+# =============================================================================
+# Test: Packed format utilities
+# =============================================================================
+
+
+class TestPackedFormat:
+    """Tests for packed format utilities."""
+
+    def test_pack_transform_output(self):
+        """pack_transform_output creates Array[Struct{key, value}] format."""
+        from sklearn.preprocessing import StandardScaler
+
+        df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+        scaler = StandardScaler()
+        scaler.fit(df)
+
+        packed = pack_transform_output(scaler, df, features=("a", "b"))
+
+        assert isinstance(packed, pd.Series)
+        assert len(packed) == 3
+        # Each row should be a tuple of dicts with key/value
+        first_row = packed.iloc[0]
+        assert isinstance(first_row, tuple)
+        assert all("key" in item and "value" in item for item in first_row)
+
+    def test_unpack_packed_column(self):
+        """unpack_packed_column converts packed format back to columns."""
+        # Create packed data
+        packed_data = [
+            ({"key": "a", "value": 1.0}, {"key": "b", "value": 4.0}),
+            ({"key": "a", "value": 2.0}, {"key": "b", "value": 5.0}),
+            ({"key": "a", "value": 3.0}, {"key": "b", "value": 6.0}),
+        ]
+        df = pd.DataFrame({"id": [1, 2, 3], "transformed": packed_data})
+
+        result = unpack_packed_column(df, col_name="transformed")
+
+        assert "a" in result.columns
+        assert "b" in result.columns
+        assert "transformed" not in result.columns
+        assert list(result["a"]) == [1.0, 2.0, 3.0]
+        assert list(result["b"]) == [4.0, 5.0, 6.0]
+
+
+# =============================================================================
+# Test: Estimator mode detection
+# =============================================================================
+
+
+class TestEstimatorModeDetection:
+    """Tests for estimator mode detection helpers."""
+
+    def test_is_fit_transform_only(self):
+        """is_fit_transform_only correctly identifies transductive embeddings."""
+        from sklearn.manifold import TSNE
+
+        assert is_fit_transform_only(TSNE) is True
+
+    def test_is_fit_transform_only_regular_transformer(self):
+        """is_fit_transform_only returns False for regular transformers."""
+        from sklearn.preprocessing import StandardScaler
+
+        assert is_fit_transform_only(StandardScaler) is False
+
+    def test_is_fit_predict_only(self):
+        """is_fit_predict_only correctly identifies transductive clusterers."""
+        from sklearn.cluster import DBSCAN
+
+        assert is_fit_predict_only(DBSCAN) is True
+
+    def test_is_fit_predict_only_regular_clusterer(self):
+        """is_fit_predict_only returns False for inductive clusterers."""
+        from sklearn.cluster import KMeans
+
+        assert is_fit_predict_only(KMeans) is False
+
+
+# =============================================================================
+# Test: Structer registration detection
+# =============================================================================
+
+
+class TestStructerRegistration:
+    """Tests for Structer registration detection."""
+
+    def test_has_structer_registration_for_registered_type(
+        self, expr, numeric_features
+    ):
+        """has_structer_registration returns True for registered types."""
+        from sklearn.preprocessing import StandardScaler
+
+        scaler = StandardScaler()
+        assert has_structer_registration(scaler, expr, numeric_features) is True
+
+    def test_has_structer_registration_for_unregistered_type(
+        self, expr, numeric_features
+    ):
+        """has_structer_registration returns False for unregistered types."""
+        from sklearn.preprocessing import MinMaxScaler
+
+        # MinMaxScaler is not explicitly registered in structer.py
+        scaler = MinMaxScaler()
+        result = has_structer_registration(scaler, expr, numeric_features)
+        # Should be False since MinMaxScaler is not in the Structer registry
+        assert result is False
+
+
+# =============================================================================
+# Test: Packed format fallback for unregistered transformers
+# =============================================================================
+
+
+class TestPackedFormatFallback:
+    """Tests for packed format fallback for unregistered transformers."""
+
+    def test_unregistered_transformer_uses_packed_format(self, expr, numeric_features):
+        """Unregistered transformers fall back to packed format."""
+        from sklearn.preprocessing import MinMaxScaler
+
+        step = Step.from_instance_name(MinMaxScaler(), name="minmax")
+        fitted = step.fit(expr, features=numeric_features)
+
+        # Should be able to transform using packed format
+        result = fitted.transform_raw(expr)
+        assert result is not None
+
+
+# =============================================================================
+# Test: predict_proba() and decision_function()
+# =============================================================================
+
+
+class TestProbabilisticOutputs:
+    """Tests for predict_proba() and decision_function() methods."""
+
+    def test_predict_proba_returns_packed_format(self, expr, numeric_features):
+        """predict_proba() returns packed format with class probabilities."""
+        from sklearn.linear_model import LogisticRegression
+
+        step = Step.from_instance_name(LogisticRegression(max_iter=200), name="clf")
+        fitted = step.fit(expr, features=numeric_features, target="target")
+
+        # Should return packed format
+        result = fitted.predict_proba(expr, retain_others=False)
+        assert result is not None
+        assert "proba" in result.columns
+
+    def test_predict_proba_raises_for_non_classifier(self, expr, numeric_features):
+        """predict_proba() raises AttributeError for estimators without it."""
+        from sklearn.linear_model import LinearRegression
+
+        step = Step.from_instance_name(LinearRegression(), name="reg")
+        fitted = step.fit(expr, features=numeric_features, target="target")
+
+        with pytest.raises(AttributeError, match="does not have predict_proba"):
+            fitted.predict_proba(expr)
+
+    def test_decision_function_returns_packed_format(self, expr, numeric_features):
+        """decision_function() returns packed format with decision values."""
+        from sklearn.svm import SVC
+
+        step = Step.from_instance_name(SVC(kernel="linear"), name="svc")
+        fitted = step.fit(expr, features=numeric_features, target="target")
+
+        # Should return packed format
+        result = fitted.decision_function(expr, retain_others=False)
+        assert result is not None
+        assert "decision" in result.columns
+
+    def test_decision_function_raises_for_non_svm(self, expr, numeric_features):
+        """decision_function() raises AttributeError for estimators without it."""
+        from sklearn.neighbors import KNeighborsClassifier
+
+        step = Step.from_instance_name(KNeighborsClassifier(n_neighbors=3), name="knn")
+        fitted = step.fit(expr, features=numeric_features, target="target")
+
+        with pytest.raises(AttributeError, match="does not have decision_function"):
+            fitted.decision_function(expr)


### PR DESCRIPTION
Added experimental scikit-learn compatibility layer with `ColumnTransformer` support

  This adds a proof-of-concept implementation that lets you use scikit-learn estimators within
  xorq pipelines, including support for ColumnTransformer to apply different transformations to
   different columns. Includes working examples and tests.
   
   There are plenty of things that could be better but the cool thing is that it should unlock alot of scitkit functionality the structor tries to do the known things first but when that fails it defaults to a generic wrapper that makes any scikit pipeline deferred. The draw back is deferred column level lineage and more granular caching. 
   
   Also .to_sklearn() will only work on a pipeline and only if the entire pipeline is sklearnish. 
   
-check here for complex with round trip [ColumnTransformer](https://github.com/xorq-labs/xorq/blob/xorq-sklearn-extend-experimental/examples/sklearn_column_transformer.py)for the 

-check here for [more sklearn examples](https://github.com/xorq-labs/xorq/blob/xorq-sklearn-extend-experimental/examples/sklearn_interop.py)

-higher level design changes check out [this markdown](https://github.com/xorq-labs/xorq/blob/xorq-sklearn-extend-experimental/docs/sklearn_interop_design.md)