### PR TITLE
release: 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.10] - 2026-02-18
+### Details
+#### Added
+- Add YAML serialization for DateUnit, TimeUnit, and TimestampUnit… by @hussainsultan in [#1577](https://github.com/xorq-labs/xorq/pull/1577)
+- Add YAML serialization for ParquetTTLSnapshotCache and SourceSn… by @hussainsultan in [#1578](https://github.com/xorq-labs/xorq/pull/1578)
+- Add xorq.ibis_yaml.{build_expr,load_expr} by @dlovell in [#1574](https://github.com/xorq-labs/xorq/pull/1574)
+- Add attr_utils.{convert_sorted_kwargs_tuple,validate_kwargs_tuple} by @dlovell in [#1585](https://github.com/xorq-labs/xorq/pull/1585)
+
+#### Changed
+- Sklearn-non-scorer-metrics by @ghoersti in [#1576](https://github.com/xorq-labs/xorq/pull/1576)
+
+#### Fixed
+- Sanitize read names by @dlovell in [#1581](https://github.com/xorq-labs/xorq/pull/1581)
+- Relocatable builds by @dlovell in [#1582](https://github.com/xorq-labs/xorq/pull/1582)
+- Cache hash collision by @hussainsultan in [#1587](https://github.com/xorq-labs/xorq/pull/1587)
+
 ## [0.3.9] - 2026-02-10
 ### Details
 #### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ only-include = ["python"]
 
 [project]
 name = "xorq"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
     "dask==2025.1.0; python_version >= '3.10' and python_version < '4.0'",
     "attrs>=24.0.0,<26; python_version >= '3.10' and python_version < '4.0'",

--- a/uv.lock
+++ b/uv.lock
@@ -5257,7 +5257,7 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "atpublic" },


### PR DESCRIPTION
## Summary
- Bump version from 0.3.9 to 0.3.10
- Update CHANGELOG.md with changes since v0.3.9

## Changes in this release
### Added
- YAML serialization for DateUnit, TimeUnit, and TimestampUnit (#1577)
- YAML serialization for ParquetTTLSnapshotCache and SourceSnapshot (#1578)
- `xorq.ibis_yaml.{build_expr,load_expr}` (#1574)
- `attr_utils.{convert_sorted_kwargs_tuple,validate_kwargs_tuple}` (#1585)

### Changed
- sklearn-non-scorer-metrics (#1576)

### Fixed
- Sanitize read names (#1581)
- Relocatable builds (#1582)
- Cache hash collision (#1587)

## Test plan
- [ ] Trigger `ci-pre-release` workflow to test on TestPyPI
- [ ] Verify package installs correctly from TestPyPI
- [ ] Squash and merge after tests pass
- [ ] Tag `v0.3.10` on main and push tag
- [ ] Create GitHub release to publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)