### PR TITLE
fix(process_utils): drain both pipes concurrently to prevent deadlock

### DIFF
--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -293,7 +293,7 @@ def uv_tool_run(
         kwargs_tuple = kwargs_tuple + (("env", env),)
     popened = Popened(popened_args, kwargs_tuple=kwargs_tuple)
     if check:
-        popened.popen.wait()
+        popened.wait()
         assert not popened.returncode, popened.stderr
     return popened
 


### PR DESCRIPTION
`communicated` previously only called `communicate()` when `stdout_peeker` was set, leaving stderr unread in other cases. Also adds a `wait()` method that drains pipes before waiting, and updates `packager.py` to use it instead of `popen.wait()` directly.

fixes #1600 