### PR TITLE
fix(ibis_yaml): uv_tool_run: enable setting python version

### DIFF
--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -329,7 +329,7 @@ def get_uv_python_version(directory):
 
 def get_acceptable_python_versions(
     path: str | Path,
-    known_minors: Iterable[int] = range(8, 15),
+    known_minors: Iterable[int] = range(8, 14),
 ) -> tuple[Version, ...]:
     if (path := Path(path)).name == PYPROJECT_NAME:
         pass


### PR DESCRIPTION
`uv tool run` does not respect `pyproject.toml`'s `requires-python`, so we must read `pyproject.toml` to determine a valid python version and then set it with `--python`

depends on #1601 