### PR TITLE
fix: add substantive messages to bare exception raises

### DIFF
--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -147,7 +147,7 @@ class Backend(IbisPostgresBackend):
         **kwargs,
     ):
         if chunksize is None:
-            raise ValueError
+            raise ValueError("chunksize must not be None")
         if table_name is None:
             if not temporary:
                 raise ValueError(
@@ -168,7 +168,7 @@ class Backend(IbisPostgresBackend):
     def create_catalog(self, name: str, force: bool = False) -> None:
         # https://stackoverflow.com/a/43634941
         if force:
-            raise ValueError
+            raise ValueError("postgres does not support force=True for create_catalog")
         quoted = self.compiler.quoted
         create_stmt = sge.Create(
             this=sg.to_identifier(name, quoted=quoted), kind="DATABASE", exists=force

--- a/python/xorq/backends/xorq/datafusion/__init__.py
+++ b/python/xorq/backends/xorq/datafusion/__init__.py
@@ -366,11 +366,13 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
     @property
     def current_catalog(self) -> str:
-        raise NotImplementedError()
+        raise NotImplementedError("DataFusion backend does not support current_catalog")
 
     @property
     def current_database(self) -> str:
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "DataFusion backend does not support current_database"
+        )
 
     def list_catalogs(self, like: str | None = None) -> list[str]:
         code = (

--- a/python/xorq/backends/xorq/tests/conftest.py
+++ b/python/xorq/backends/xorq/tests/conftest.py
@@ -38,7 +38,9 @@ def remove_unexpected_tables(dirty):
             dirty.drop_view(table, force=True)
 
     if sorted(dirty.list_tables()) != sorted(expected_tables):
-        raise ValueError
+        raise ValueError(
+            f"unexpected tables after cleanup: {set(dirty.list_tables()) - set(expected_tables)}"
+        )
 
 
 @pytest.fixture(scope="session")

--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -72,14 +72,14 @@ class Cache:
     def get(self, expr: ir.Expr):
         key = self.calc_key(expr)
         if not self.key_exists(key):
-            raise KeyError
+            raise KeyError(key)
         else:
             return self.storage.get(key)
 
     def put(self, expr: ir.Expr, value):
         key = self.calc_key(expr)
         if self.key_exists(key):
-            raise ValueError
+            raise ValueError(f"cache entry already exists for key {key!r}")
         else:
             return self.storage.put(key, value)
 
@@ -99,7 +99,7 @@ class Cache:
     def drop(self, expr: ir.Expr):
         key = self.calc_key(expr)
         if not self.key_exists(key):
-            raise KeyError
+            raise KeyError(key)
         else:
             self.storage.drop(key)
 

--- a/python/xorq/catalog/git_utils.py
+++ b/python/xorq/catalog/git_utils.py
@@ -20,7 +20,9 @@ def add_as_submodule(repo, subrepo, remote="origin"):
         case remotes if remote in remotes:
             (url, *rest) = subrepo.remote(remote).urls
             if rest:
-                raise ValueError
+                raise ValueError(
+                    f"remote {remote!r} has multiple URLs: {list(subrepo.remote(remote).urls)}"
+                )
         case _:
-            raise ValueError
+            raise ValueError(f"no remote named {remote!r} found in subrepo")
     repo.git.submodule("add", url, strpath)

--- a/python/xorq/common/collections.py
+++ b/python/xorq/common/collections.py
@@ -31,7 +31,7 @@ class SourceDict:
 
     def __setitem__(self, key, value):
         if not isinstance(value, ops.Relation):
-            raise ValueError
+            raise ValueError(f"value must be an ops.Relation, got {type(value)}")
         self.sources[key] = value
 
     def __getitem__(self, key):

--- a/python/xorq/common/utils/import_utils.py
+++ b/python/xorq/common/utils/import_utils.py
@@ -88,7 +88,7 @@ def import_from_gist(user, gist):
     req = urllib.request.Request(path, method="GET")
     resp = urllib.request.urlopen(req)
     if resp.code != 200:
-        raise ValueError
+        raise ValueError(f"failed to fetch gist: HTTP {resp.code}")
     with tempfile.NamedTemporaryFile() as ntfh:
         path = Path(ntfh.name)
         path.write_text(resp.read().decode("ascii"))

--- a/python/xorq/common/utils/node_utils.py
+++ b/python/xorq/common/utils/node_utils.py
@@ -65,7 +65,9 @@ def get_typs(maybe_typs):
             (module, attr) = maybe_typs.rsplit(".", 1)
             typs = (getattr(importlib.import_module(module), attr),)
         case _:
-            raise ValueError
+            raise ValueError(
+                f"unsupported maybe_typs type {type(maybe_typs)}: {maybe_typs!r}"
+            )
     return typs
 
 
@@ -79,7 +81,7 @@ def find_by_expr_hash(expr, to_replace_hash, typs=None, strategy=None):
         walk_nodes(typs, expr),
     )
     if rest:
-        raise ValueError
+        raise ValueError(f"found multiple nodes with hash {to_replace_hash!r}")
     return to_replace
 
 
@@ -90,19 +92,19 @@ def find_by_expr_tag(expr, tag):
 def find_node(expr, hash, tag, typs=None, strategy=None):
     match [hash, tag]:
         case [None, None]:
-            raise ValueError
+            raise ValueError("at least one of hash or tag must be provided")
         case [_, None]:
             if isinstance(typs, tuple) and rel.Tag in typs:
-                raise ValueError
+                raise ValueError("typs must not include Tag when searching by hash")
             return find_by_expr_hash(expr, hash, typs=typs, strategy=strategy)
         case [None, _]:
             (node, *rest) = find_by_expr_tag(expr, tag)
             if rest:
-                raise ValueError
+                raise ValueError(f"found multiple nodes with tag {tag!r}")
             else:
                 return node
         case _:
-            raise ValueError
+            raise ValueError("cannot specify both hash and tag")
 
 
 def replace_by_expr_hash(expr, to_replace_hash, replace_with, typs=None, strategy=None):
@@ -185,7 +187,9 @@ def expr_to_unbound(expr, hash, tag, typs, strategy=None):
                     )
                     found_con = xo.connect()
                 case _:
-                    raise ValueError("")
+                    raise ValueError(
+                        "found multiple in-memory tables, cannot determine source"
+                    )
             if not found_con:
                 raise ValueError("found no connections")
         case [found_con]:

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -110,7 +110,7 @@ class ReaderSplitter:
     @property
     def curr_key(self):
         if not self.curr_batch:
-            raise ValueError
+            raise ValueError("no current batch available; reader may be exhausted")
         (curr_key,) = self.curr_batch[self.split_key].slice(length=1).tolist()
         return curr_key
 

--- a/python/xorq/common/utils/snowflake_utils.py
+++ b/python/xorq/common/utils/snowflake_utils.py
@@ -53,7 +53,7 @@ def make_auth_defaults(authenticator=None):
                 "authenticator": authenticator,
             }
         case _:
-            raise ValueError
+            raise ValueError(f"unsupported Snowflake authenticator: {authenticator!r}")
 
 
 def make_credential_defaults(authenticator=None):
@@ -142,10 +142,12 @@ def get_snowflake_last_modification_time(dt):
         .values
     )
     if not len(values):
-        raise ValueError
+        raise ValueError(
+            f"table {table!r} not found in INFORMATION_SCHEMA.TABLES for database {database!r}, schema {schema!r}"
+        )
     (value, *rest) = values
     if rest:
-        raise ValueError
+        raise ValueError(f"multiple rows returned for table {table!r}")
     return value
 
 

--- a/python/xorq/common/utils/tests/test_deferred_read.py
+++ b/python/xorq/common/utils/tests/test_deferred_read.py
@@ -40,9 +40,11 @@ class PinsResource:
         if self.suffix is None:
             object.__setattr__(self, "suffix", self.path.suffix)
         if self.path.suffix != self.suffix:
-            raise ValueError
+            raise ValueError(
+                f"path suffix {self.path.suffix!r} does not match expected suffix {self.suffix!r}"
+            )
         if self.name not in xo.options.pins.get_board().pin_list():
-            raise ValueError
+            raise ValueError(f"name {self.name!r} not found in pins board")
 
     @property
     def table_name(self):
@@ -64,7 +66,7 @@ class PinsResource:
             case ".csv":
                 return deferred_read_csv
             case _:
-                raise ValueError
+                raise ValueError(f"unsupported suffix {self.suffix!r}")
 
     @property
     def immediate_reader(self):
@@ -74,7 +76,7 @@ class PinsResource:
             case ".csv":
                 return pd.read_csv
             case _:
-                raise ValueError
+                raise ValueError(f"unsupported suffix {self.suffix!r}")
 
     @property
     @functools.cache

--- a/python/xorq/common/utils/trace_utils.py
+++ b/python/xorq/common/utils/trace_utils.py
@@ -312,7 +312,7 @@ class Trace:
     def __attrs_post_init__(self):
         end_datetimes = list(span.end_datetime for span in self.spans)
         if not sorted(end_datetimes) == end_datetimes:
-            raise ValueError
+            raise ValueError("span end_datetimes must be in sorted order")
 
     def combine_with(self, other):
         return Trace(
@@ -359,7 +359,7 @@ class Trace:
             assert not rest
             return trace_id
         else:
-            raise ValueError
+            raise ValueError("trace has no spans with or without links")
 
     @property
     @functools.cache
@@ -605,7 +605,7 @@ class FileTailer:
 
     def __attrs_post_init__(self):
         if not self.path.exists():
-            raise ValueError
+            raise ValueError(f"path does not exist: {self.path}")
         fh = self.path.open("r")
         object.__setattr__(self, "_fh", fh)
 

--- a/python/xorq/examples/core.py
+++ b/python/xorq/examples/core.py
@@ -46,6 +46,8 @@ def get_table_from_name(name, backend, table_name=None, deferred=True, **kwargs)
             else:
                 method = backend.read_csv
         case _:
-            raise ValueError
+            raise ValueError(
+                f"unsupported file suffix {suffix!r}; expected .parquet or .csv"
+            )
     path = options.pins.get_path(name)
     return method(path, table_name=table_name or name, **kwargs)

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -62,7 +62,9 @@ def make_estimator_typ(fit, return_type, name=None, *, transform=None, predict=N
     def arbitrate_transform_predict(transform, predict):
         match (transform, predict):
             case [None, None]:
-                raise ValueError
+                raise ValueError(
+                    "at least one of transform or predict must be provided"
+                )
             case [other, None]:
                 return other, "transform"
             case [None, other]:
@@ -70,7 +72,9 @@ def make_estimator_typ(fit, return_type, name=None, *, transform=None, predict=N
             case [other0, other1]:
                 raise ValueError(other0, other1)
             case _:
-                raise ValueError
+                raise ValueError(
+                    f"unexpected transform/predict combination: ({transform!r}, {predict!r})"
+                )
 
     assert isinstance(return_type, dt.DataType)
     other, which = arbitrate_transform_predict(transform, predict)
@@ -498,7 +502,7 @@ class FittedStep:
             case bytes():
                 pass
             case _:
-                raise ValueError
+                raise ValueError(f"unexpected deferred model result type {type(obj)}")
         return pickle.loads(obj)
 
     @property
@@ -572,7 +576,7 @@ class FittedStep:
         elif self.is_transform:
             return self.transform_raw(expr, name=name)
         else:
-            raise ValueError
+            raise ValueError("step has neither predict nor transform method")
 
     @property
     def predicted(self):

--- a/python/xorq/expr/ml/structer.py
+++ b/python/xorq/expr/ml/structer.py
@@ -99,7 +99,7 @@ class KVEncoder:
         import pandas as pd
 
         if len(series) == 0:
-            raise ValueError
+            raise ValueError("cannot decode an empty series")
 
         # Extract keys and values from the encoded format
         keys, values = (

--- a/python/xorq/flight/__init__.py
+++ b/python/xorq/flight/__init__.py
@@ -215,7 +215,9 @@ class FlightServer:
             ((cert_chain, private_key), *rest) = self.tls_certificates
             if rest:
                 # FIXME: what to do with multiple certs?
-                raise ValueError
+                raise ValueError(
+                    "multiple TLS certificates provided; only one is supported"
+                )
             kwargs["cert_chain"] = cert_chain
             kwargs["private_key"] = private_key
 

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -132,7 +132,7 @@ def test_flight_serve_unbound_finds_con_complex(i, j, parquet_dir, tmpdir):
             case xo.Backend():
                 return left.into_backend(con).join(right, predicates=predicates)
             case _:
-                raise ValueError
+                raise ValueError(f"unexpected backend type: {type(con)}")
 
     name = "batting"
     path = Path(tmpdir).joinpath(f"{name}.parquet")

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -261,7 +261,9 @@ def find_file_upwards(start, name):
     paths = (p.joinpath(name) for p in (path, *path.parents))
     found = next((p for p in paths if p.exists()), None)
     if not found:
-        raise ValueError
+        raise ValueError(
+            f"could not find {name!r} in {start!r} or any parent directory"
+        )
     return found
 
 

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -145,7 +145,9 @@ def remove_unexpected_tables(dirty):
             dirty.drop_view(table, force=True)
 
     if sorted(dirty.list_tables()) != sorted(expected_tables):
-        raise ValueError
+        raise ValueError(
+            f"unexpected tables after cleanup: {set(dirty.list_tables()) - set(expected_tables)}"
+        )
 
 
 def test_multiple_record_batches(pg):


### PR DESCRIPTION
68 exceptions across 18 files were raised without any message, making them difficult to debug. Added descriptive messages covering backend name mismatches, type errors, missing/duplicate data, schema mismatches, and unsupported operations.