### PR TITLE
ci: add release-drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+exclude-labels:
+  - ignore
+  - release
+  - dependencies
+name-template: 'xorq unreleased'
+version-template: unreleased
+
+change-template: '- $TITLE (#$NUMBER)'
+
+categories:
+  - title: 🚀 Performance improvements
+    labels:
+      - performance
+      - perf
+  - title: ✨ Enhancements
+    labels:
+      - feature
+      - enhancement
+  - title: 🐞 Bug fixes
+    labels:
+      - fix
+      - bugfix
+      - bug
+  - title: 📖 Documentation
+    labels:
+      - documentation
+      - docs
+  - title: 📦 Build system
+    labels:
+      - build
+      - ci
+      - chore
+  - title: 🛠️ Other improvements
+    labels:
+      - internal
+      - maintenance
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  Thank you to all our contributors for making this release possible!
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: release-drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write       # to create/update draft release
+      pull-requests: write  # to add labels to PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automatically maintains a draft GitHub release that groups merged PRs by label (breaking change, feature, fix, docs, deps, ci) and resolves the next semver version. Draft is published manually, which then triggers the existing ci-release PyPI publish workflow.