### PR TITLE
feat(cli): add catalog list-aliases command

### DIFF
--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -242,6 +242,17 @@ def list_entries(ctx):
             click.echo(name)
 
 
+@cli.command("list-aliases")
+@click.pass_context
+def list_aliases(ctx):
+    """List all aliases."""
+    with click_context_catalog(ctx):
+        catalog = ctx.obj.make_catalog(init=False)
+        aliases = catalog.list_aliases() or ("No aliases.",)
+        for alias in aliases:
+            click.echo(alias)
+
+
 @cli.command()
 @click.pass_context
 def info(ctx):

--- a/python/xorq/catalog/tests/test_cli.py
+++ b/python/xorq/catalog/tests/test_cli.py
@@ -458,6 +458,33 @@ def test_list_populated(runner, catalog_path, data_dict):
         assert name in result.output
 
 
+# --- list-aliases command ---
+
+
+def test_list_aliases_invalid_path(runner):
+    result = runner.invoke(cli, ["--path", "/nonexistent/path", "list-aliases"])
+    assert result.exit_code != 0
+    assert "init" in result.output
+
+
+def test_list_aliases_empty(runner, catalog_path):
+    result = runner.invoke(cli, ["--path", catalog_path, "list-aliases"])
+    assert result.exit_code == 0, result.output
+    assert "No aliases." in result.output
+
+
+def test_list_aliases_populated(runner, catalog_path, data_dict):
+    path = str(next(iter(data_dict.values())))
+    runner.invoke(cli, ["--path", catalog_path, "add", path])
+    name = Path(path).name.removesuffix("".join(Path(path).suffixes))
+    runner.invoke(cli, ["--path", catalog_path, "add-alias", name, "alias-a"])
+    runner.invoke(cli, ["--path", catalog_path, "add-alias", name, "alias-b"])
+    result = runner.invoke(cli, ["--path", catalog_path, "list-aliases"])
+    assert result.exit_code == 0, result.output
+    assert "alias-a" in result.output
+    assert "alias-b" in result.output
+
+
 # --- get command ---
 
 
@@ -657,6 +684,7 @@ def test_subcommand_help(runner):
         "remove-alias",
         "info",
         "list",
+        "list-aliases",
         "get",
         "push",
         "pull",


### PR DESCRIPTION
## Summary

- Adds `xorq catalog list-aliases` subcommand to list all aliases in a catalog
- Mirrors the existing `list` command pattern, printing `"No aliases."` when empty
- Includes `list-aliases` in the `test_subcommand_help` coverage

## Test plan

- [x] `test_list_aliases_invalid_path` — non-existent catalog path exits non-zero and hints at `init`
- [x] `test_list_aliases_empty` — empty catalog prints `"No aliases."`
- [x] `test_list_aliases_populated` — aliases added via `add-alias` appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)