### PR TITLE
ci(release-drafter): add autolabeler for conventional commits

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,40 @@ version-template: unreleased
 
 change-template: '- $TITLE (#$NUMBER)'
 
+autolabeler:
+  - label: 'release'
+    title:
+      - '/^release:/i'
+  - label: 'dependencies'
+    title:
+      - '/^chore\(deps\):/i'
+      - '/^fix\(deps\):/i'
+  - label: 'perf'
+    title:
+      - '/^perf(\(.*\))?:/i'
+  - label: 'feature'
+    title:
+      - '/^feat(\(.*\))?:/i'
+  - label: 'fix'
+    title:
+      - '/^fix(\(.*\))?:/i'
+  - label: 'docs'
+    title:
+      - '/^docs(\(.*\))?:/i'
+      - '/^chore\(docs\):/i'
+  - label: 'ci'
+    title:
+      - '/^ci(\(.*\))?:/i'
+      - '/^chore\(ci\):/i'
+  - label: 'chore'
+    title:
+      - '/^chore(\(.*\))?:/i'
+  - label: 'internal'
+    title:
+      - '/^ref(\(.*\))?:/i'
+      - '/^refactor(\(.*\))?:/i'
+      - '/^spike(\(.*\))?:/i'
+
 categories:
   - title: 🚀 Performance improvements
     labels:


### PR DESCRIPTION
Map conventional commit prefixes (feat, fix, docs, chore, perf, ref, refactor, spike) to release-drafter labels so PRs are categorised automatically without manual labelling.