### PR TITLE
fix(tui): prevent DuplicateKey on refresh with threading lock

### DIFF
--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1,5 +1,6 @@
 import re
 import tarfile
+import threading
 from datetime import datetime
 from functools import cache
 from pathlib import Path
@@ -368,6 +369,7 @@ class CatalogScreen(Screen):
         self._row_cache: dict[str, CatalogRowData] = {}
         self._git_log_visible = False
         self._git_log_loaded = False
+        self._refresh_lock = threading.Lock()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -420,8 +422,16 @@ class CatalogScreen(Screen):
         for name, dtype in maybe_schema(row_data.cached_expr):
             schema_table.add_row(name, dtype)
 
-    @work(thread=True, exclusive=True)
+    @work(thread=True)
     def _do_refresh(self) -> None:
+        if not self._refresh_lock.acquire(blocking=False):
+            return
+        try:
+            self._do_refresh_locked()
+        finally:
+            self._refresh_lock.release()
+
+    def _do_refresh_locked(self) -> None:
         catalog = self.app._catalog
         if catalog is None:
             return


### PR DESCRIPTION
## Summary
- Replace `@work(thread=True, exclusive=True)` with a `threading.Lock` in `_do_refresh` to prevent concurrent refresh workers from adding the same row key to the DataTable
- `exclusive=True` sets a cancel flag but doesn't stop the old thread, so two workers could race and both call `_render_catalog_row` for the same entry, causing `DuplicateKey`
- Non-blocking acquire means if a refresh is in progress, the interval tick is skipped — the next tick picks up changes

## Test plan
- [x] All 59 TUI tests pass
- [ ] Manual: `xorq catalog --name <catalog> tui --refresh 2` no longer raises `DuplicateKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)