### PR TITLE
ci: skip install test on pull requests

### DIFF
--- a/.github/workflows/ci-test-install.yaml
+++ b/.github/workflows/ci-test-install.yaml
@@ -15,7 +15,6 @@ on:
       - master
     tags:
       - '*'
-  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Remove the `pull_request` trigger from the ci-test-install workflow so it only runs on pushes to main/master branches, tags, and manual dispatch.