### PR TITLE
chore(lint): add ruff C4 and FURB rules and fix violations

### DIFF
--- a/examples/sklearn_deferred_metrics_inputs.py
+++ b/examples/sklearn_deferred_metrics_inputs.py
@@ -142,7 +142,7 @@ y_score_ml = ovr.predict_proba(X_ml[70:])
 label_names = tuple(f"label_{i}" for i in range(Y_ml.shape[1]))
 ml_df = pd.DataFrame(y_true_ml, columns=list(label_names))
 # Store scores as a single array-valued column (mimics predict_proba storage)
-ml_df["scores"] = [row for row in y_score_ml]
+ml_df["scores"] = list(y_score_ml)
 ml_expr = con.register(ml_df, "multilabel_array")
 
 make_ml_metric = deferred_sklearn_metric(target=label_names, pred="scores")

--- a/examples/sklearn_metrics_comparison.py
+++ b/examples/sklearn_metrics_comparison.py
@@ -90,7 +90,7 @@ def compute_metrics(clf, X_train, X_test, y_train, y_test):
             target=target,
             pred="my_predicted",
             metric=metric_fn,
-            metric_kwargs=kwargs if kwargs else (),
+            metric_kwargs=kwargs or (),
         ).execute()
         for name, metric_fn, kwargs in metric_configs
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,9 +202,11 @@ drop = [
 
 [tool.ruff.lint]
 extend-select = [
-    "I",    # isort
-    "ICN",  # import conventions
-    "B",    # flake8-bugbear: mutable default args, exception chaining, etc.
+    "I",      # isort
+    "ICN",    # import conventions
+    "B",      # flake8-bugbear: mutable default args, exception chaining, etc.
+    "C4",     # flake8-comprehensions: unnecessary list/dict/set comprehensions
+    "FURB",   # refurb: modernize Python code
 ]
 ignore = [
     "B018",  # useless-expression: side-effect property access is intentional

--- a/python/xorq/backends/pandas/tests/test_join.py
+++ b/python/xorq/backends/pandas/tests/test_join.py
@@ -613,11 +613,11 @@ def harvest_df():
 
 def test_multijoin(tracts_df, fields_df, harvest_df):
     conn = xo.pandas.connect(
-        dict(
-            tracts=tracts_df,
-            fields=fields_df,
-            harvest=harvest_df,
-        )
+        {
+            "tracts": tracts_df,
+            "fields": fields_df,
+            "harvest": harvest_df,
+        }
     )
 
     tracts, fields, harvest = map(conn.table, "tracts fields harvest".split())

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -215,14 +215,14 @@ class Backend(IbisSnowflakeBackend):
         # overwrite session parameters that are required for ibis + snowflake
         # to work
         session_parameters.update(
-            dict(
+            {
                 # Use Arrow for query results
-                PYTHON_CONNECTOR_QUERY_RESULT_FORMAT="arrow_force",
+                "PYTHON_CONNECTOR_QUERY_RESULT_FORMAT": "arrow_force",
                 # JSON output must be strict for null versus undefined
-                STRICT_JSON_OUTPUT=True,
+                "STRICT_JSON_OUTPUT": True,
                 # Timezone must be UTC
-                TIMEZONE="UTC",
-            ),
+                "TIMEZONE": "UTC",
+            },
         )
 
         with contextlib.closing(con.cursor()) as cur:

--- a/python/xorq/backends/sqlite/tests/test_client.py
+++ b/python/xorq/backends/sqlite/tests/test_client.py
@@ -15,7 +15,7 @@ from xorq.vendor import ibis
 def test_attach_file(tmp_path):
     dbpath = str(tmp_path / "attached.db")
     path_client = xo.sqlite.connect(dbpath)
-    path_client.create_table("test", schema=ibis.schema(dict(a="int")))
+    path_client.create_table("test", schema=ibis.schema({"a": "int"}))
 
     client = xo.sqlite.connect()
 

--- a/python/xorq/backends/tests/test_backend.py
+++ b/python/xorq/backends/tests/test_backend.py
@@ -41,7 +41,7 @@ def test_con_equality(connect_parts):
     # where do we want to the connection to be the same?
     n = 3
     connect = get_method(connect_parts)
-    cons = set(connect() for _ in range(3))
+    cons = {connect() for _ in range(3)}
     assert len(cons) == n
 
 

--- a/python/xorq/backends/xorq/datafusion/__init__.py
+++ b/python/xorq/backends/xorq/datafusion/__init__.py
@@ -302,7 +302,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
         for agg_node in expr.op().find(ops.AggUDF):
             if agg_node.__input_type__ == InputType.PYARROW:
-                if set(("evaluate", "evaluate_all")).intersection(agg_node.__config__):
+                if {"evaluate", "evaluate_all"}.intersection(agg_node.__config__):
                     udwf = _compile_pyarrow_udwf(agg_node)
                     self.con.register_udwf(udwf)
                 else:

--- a/python/xorq/backends/xorq/tests/test_cache.py
+++ b/python/xorq/backends/xorq/tests/test_cache.py
@@ -194,11 +194,11 @@ def test_cache_recreate(alltypes):
         expr.cache(cache=SourceCache.from_kwargs(source=con)).execute()
 
     (con_cached_tables0, con_cached_tables1) = (
-        set(
+        {
             table_name
             for table_name in con.list_tables()
             if table_name.startswith(KEY_PREFIX)
-        )
+        }
         for con in cons
     )
 
@@ -375,13 +375,13 @@ def test_cache_default_path_set(batting, ls_con, tmp_path):
 
     result = expr.execute()
 
-    cache_files = list(
+    cache_files = [
         path
         for path in tmp_path.iterdir()
         if path.is_file()
         and path.name.startswith(KEY_PREFIX)
         and path.name.endswith(".parquet")
-    )
+    ]
 
     assert result is not None
     assert cache_files

--- a/python/xorq/backends/xorq/tests/test_client.py
+++ b/python/xorq/backends/xorq/tests/test_client.py
@@ -56,7 +56,7 @@ def test_create_table(con):
 @pytest.mark.parametrize(
     "keys",
     [
-        param(tuple(), id="empty"),
+        param((), id="empty"),
         param((xo.asc("yearID"),), id="one-column"),
         param((xo.asc("yearID"), xo.desc("stint")), id="two-columns"),
     ],

--- a/python/xorq/backends/xorq/tests/test_join.py
+++ b/python/xorq/backends/xorq/tests/test_join.py
@@ -153,7 +153,7 @@ def test_join_with_pandas_non_null_typed_columns(batting, awards_players):
     assert len(batting_schema) == 1
     assert batting_schema["yearID"].is_integer()
 
-    assert sch.infer(awards_players_filt) == sch.Schema(dict(yearID="int"))
+    assert sch.infer(awards_players_filt) == sch.Schema({"yearID": "int"})
     assert isinstance(awards_players_filt, pd.DataFrame)
     expr = batting_filt.join(awards_players_filt, "yearID")
     df = expr.execute()

--- a/python/xorq/backends/xorq/tests/test_map.py
+++ b/python/xorq/backends/xorq/tests/test_map.py
@@ -134,5 +134,5 @@ def test_map_contains_null(con):
 
 
 def test_map_length(con):
-    expr = xo.literal(dict(a="A", b="B")).length()
+    expr = xo.literal({"a": "A", "b": "B"}).length()
     assert con.execute(expr) == 2

--- a/python/xorq/backends/xorq/tests/test_numeric.py
+++ b/python/xorq/backends/xorq/tests/test_numeric.py
@@ -202,7 +202,7 @@ def test_isnan_isinf(
         param(L(5.556).sqrt(), math.sqrt(5.556), id="sqrt"),
         param(
             L(5.556).log(2),
-            math.log(5.556, 2),
+            math.log2(5.556),
             id="log-base",
         ),
         param(
@@ -212,7 +212,7 @@ def test_isnan_isinf(
         ),
         param(
             L(5.556).log2(),
-            math.log(5.556, 2),
+            math.log2(5.556),
             id="log2",
         ),
         param(

--- a/python/xorq/backends/xorq/tests/test_struct.py
+++ b/python/xorq/backends/xorq/tests/test_struct.py
@@ -47,7 +47,7 @@ def test_all_fields(struct, struct_df):
     }
 
 
-_SIMPLE_DICT = dict(a=1, b="2", c=3.0)
+_SIMPLE_DICT = {"a": 1, "b": "2", "c": 3.0}
 _STRUCT_LITERAL = xo.struct(
     _SIMPLE_DICT,
     type="struct<a: int64, b: string, c: float64>",
@@ -67,13 +67,13 @@ def test_literal(con, field):
 
 def test_struct_column(alltypes, alltypes_df):
     t = alltypes
-    expr = t.select(s=xo.struct(dict(a=t.string_col, b=1, c=t.bigint_col)))
-    assert expr.s.type() == dt.Struct(dict(a=dt.string, b=dt.int8, c=dt.int64))
+    expr = t.select(s=xo.struct({"a": t.string_col, "b": 1, "c": t.bigint_col}))
+    assert expr.s.type() == dt.Struct({"a": dt.string, "b": dt.int8, "c": dt.int64})
     result = xo.execute(expr)
     expected = pd.DataFrame(
         {
             "s": [
-                dict(a=a, b=1, c=c)
+                {"a": a, "b": 1, "c": c}
                 for a, c in zip(alltypes_df.string_col, alltypes_df.bigint_col)
             ]
         }
@@ -97,7 +97,7 @@ def test_collect_into_struct(alltypes):
         .group_by(group="string_col")
         .agg(
             val=lambda t: xo.struct(
-                dict(key=t.bigint_col.collect().cast("array<int64>"))
+                {"key": t.bigint_col.collect().cast("array<int64>")}
             )
         )
     )

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -31,9 +31,9 @@ def test_catalog_add(catalog, data_dict):
     for catalog_entry in catalog_entries:
         catalog_entry.assert_consistency()
     catalog.assert_consistency()
-    assert set(catalog.list()) == set(
+    assert set(catalog.list()) == {
         with_pure_suffix(path).name for path in data_dict.values()
-    )
+    }
 
     # test not exists condition
     path = next(iter(data_dict.values()))
@@ -149,7 +149,7 @@ def test_test_tgz(elide, catalog, tmpdir):
 def test_assert_consistency(catalog, tmpdir):
     tgz_path = write_tgz(
         Path(tmpdir).joinpath("build.tgz"),
-        {name: b"" for name in REQUIRED_TGZ_NAMES},
+        dict.fromkeys(REQUIRED_TGZ_NAMES, b""),
     )
     catalog_addition = CatalogAddition(BuildTgz(tgz_path), catalog)
     catalog_addition.ensure_dirs()

--- a/python/xorq/catalog/tests/test_cli.py
+++ b/python/xorq/catalog/tests/test_cli.py
@@ -531,7 +531,7 @@ def test_check_catches_inconsistency(runner, catalog_path, tmpdir):
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     tgz_path = write_tgz(
         Path(tmpdir).joinpath("build.tgz"),
-        {name: b"" for name in REQUIRED_TGZ_NAMES},
+        dict.fromkeys(REQUIRED_TGZ_NAMES, b""),
     )
     catalog_addition = CatalogAddition(BuildTgz(tgz_path), catalog)
     catalog_addition.ensure_dirs()

--- a/python/xorq/common/collections.py
+++ b/python/xorq/common/collections.py
@@ -19,7 +19,7 @@ def _find_backend(value):
         CachedNode,
         Read,
     )
-    (backend, *rest) = set(table.source for table in value.find(node_types))
+    (backend, *rest) = {table.source for table in value.find(node_types)}
     if len(rest) > 1:
         raise ValueError("Multiple backends found for this expression")
     return backend

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_utils.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_utils.py
@@ -22,7 +22,7 @@ def patch_normalize_token(*typs, f):
     try:
         with patch.dict(
             dask.base.normalize_token._lookup,
-            values={typ: f for typ in typs},
+            values=dict.fromkeys(typs, f),
         ) as dct:
             yield dct
     finally:

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -59,7 +59,7 @@ def bfs(node):
     from xorq.vendor.ibis.common.graph import Graph
 
     queue = deque((to_node(node),))
-    dct = dict()
+    dct = {}
     while queue:
         if (node := queue.popleft()) not in dct:
             children = tuple(gen_children_of(node))

--- a/python/xorq/common/utils/ibis_utils.py
+++ b/python/xorq/common/utils/ibis_utils.py
@@ -38,10 +38,10 @@ def map_ibis(val, kwargs=None):
 
         cls = getattr(importlib.import_module(f"xorq.vendor.{module}"), attr)
 
-        kwargs = kwargs if kwargs else dict(zip(val.argnames, val.args))
+        kwargs = kwargs or dict(zip(val.argnames, val.args))
         kwargs = toolz.valmap(
             map_ibis,
-            kwargs if kwargs else dict(zip(val.argnames, val.args)),
+            kwargs or dict(zip(val.argnames, val.args)),
         )
 
         return cls(**kwargs)

--- a/python/xorq/common/utils/node_utils.py
+++ b/python/xorq/common/utils/node_utils.py
@@ -147,11 +147,11 @@ def gen_downstream(expr, downstream_of):
 
 
 def elide_downstream_cached_node(expr, downstream_of):
-    cns = set(
+    cns = {
         el
         for el in gen_downstream(expr, downstream_of)
         if isinstance(el, rel.CachedNode)
-    )
+    }
 
     def elide_cached_node(node, kwargs):
         if node in cns:
@@ -170,7 +170,7 @@ def expr_to_unbound(expr, hash, tag, typs, strategy=None):
 
     found = find_node(expr, hash=hash, tag=tag, typs=typs, strategy=strategy)
     found_expr = found.to_expr()
-    to_unbind_hash = hash if hash else compute_expr_hash(found_expr, strategy)
+    to_unbind_hash = hash or compute_expr_hash(found_expr, strategy)
     found_con = None
     match find_all_sources(found_expr):
         case []:
@@ -214,7 +214,7 @@ def recreate(op, **kwargs):
 
 
 def update_read_kwargs(old_read_kwargs, new_read_kwargs):
-    existing = set(name for name, _ in old_read_kwargs)
+    existing = {name for name, _ in old_read_kwargs}
     to_append = tuple(
         (name, value) for (name, value) in new_read_kwargs if name not in existing
     )

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -22,7 +22,7 @@ def otel_instrument_reader(reader):
     span = trace.get_current_span()
     ctx = span.get_span_context()
     span_link = trace.Link(ctx)
-    event_ids = {"reader_id": id(reader), "trace_id": hex(ctx.trace_id)[2:]}
+    event_ids = {"reader_id": id(reader), "trace_id": f"{ctx.trace_id:x}"}
     span.add_event(
         "span.metrics.rbr.make_reader",
         event_ids,

--- a/python/xorq/common/utils/tests/ibis_utils/conftest.py
+++ b/python/xorq/common/utils/tests/ibis_utils/conftest.py
@@ -30,12 +30,12 @@ def ibis_astronauts(ibis_con):
 @pytest.fixture
 def t():
     return ibis.table(
-        dict(
-            a="int64",
-            b="string",
-            c="float64",
-            d="timestamp",
-            e="date",
-        ),
+        {
+            "a": "int64",
+            "b": "string",
+            "c": "float64",
+            "d": "timestamp",
+            "e": "date",
+        },
         name="test_table",
     )

--- a/python/xorq/common/utils/tests/ibis_utils/test_subquery.py
+++ b/python/xorq/common/utils/tests/ibis_utils/test_subquery.py
@@ -12,8 +12,8 @@ def test_scalar_subquery(t):
 
 
 def test_exists_subquery():
-    t1 = ibis.table(dict(a="int", b="string"), name="t1")
-    t2 = ibis.table(dict(a="int", c="float"), name="t2")
+    t1 = ibis.table({"a": "int", "b": "string"}, name="t1")
+    t2 = ibis.table({"a": "int", "c": "float"}, name="t2")
 
     filtered = t2.filter(t2.a == t1.a)
     expr = ops.ExistsSubquery(filtered).to_expr()
@@ -23,8 +23,8 @@ def test_exists_subquery():
 
 
 def test_in_subquery():
-    t1 = ibis.table(dict(a="int", b="string"), name="t1")
-    t2 = ibis.table(dict(a="int", c="float"), name="t2")
+    t1 = ibis.table({"a": "int", "b": "string"}, name="t1")
+    t2 = ibis.table({"a": "int", "c": "float"}, name="t2")
 
     expr = ops.InSubquery(t1.select("a"), t2.a).to_expr()
 

--- a/python/xorq/common/utils/tests/test_graph_utils.py
+++ b/python/xorq/common/utils/tests/test_graph_utils.py
@@ -78,8 +78,8 @@ def test_walk_nodes():
 def test_find_all_sources():
     (created_sources, _, expr) = make_expr()
     found_sources = find_all_sources(expr)
-    actual = set(con._profile for con in created_sources)
-    expected = set(con._profile for con in found_sources)
+    actual = {con._profile for con in created_sources}
+    expected = {con._profile for con in found_sources}
     assert actual == expected
 
 

--- a/python/xorq/common/utils/trace_utils.py
+++ b/python/xorq/common/utils/trace_utils.py
@@ -108,7 +108,7 @@ def process_value(dct):
                 (lst,) = dissoc_get_all(value, "values")
                 value = tuple(map(process_value, lst))
             else:
-                value = tuple()
+                value = ()
         case _:
             raise ValueError(f"Unhandled type {value_type}")
     return (value_type, value)
@@ -310,7 +310,7 @@ class Trace:
     spans = field(validator=deep_iterable(instance_of(Span), instance_of(tuple)))
 
     def __attrs_post_init__(self):
-        end_datetimes = list(span.end_datetime for span in self.spans)
+        end_datetimes = [span.end_datetime for span in self.spans]
         if not sorted(end_datetimes) == end_datetimes:
             raise ValueError("span end_datetimes must be in sorted order")
 
@@ -326,10 +326,10 @@ class Trace:
 
     @property
     def closed(self):
-        trace_ids = set(span.trace_id for span in self.spans)
-        closed_trace_ids = set(
+        trace_ids = {span.trace_id for span in self.spans}
+        closed_trace_ids = {
             span.trace_id for span in self.spans if not span.parent_span_id
-        )
+        }
         return trace_ids == closed_trace_ids and bool(
             toolz.excepts(Exception, operator.attrgetter("trace_metrics"))(self)
         )
@@ -344,7 +344,7 @@ class Trace:
         with_links = dct.get(True, ())
         without_links = dct.get(False, ())
         if without_links:
-            trace_id, *rest = set(span.trace_id for span in without_links)
+            trace_id, *rest = {span.trace_id for span in without_links}
             assert not rest
             if with_links:
                 # FIXME: handle links within links
@@ -353,9 +353,9 @@ class Trace:
             return trace_id
         elif with_links:
             # for now, require that there only be one linked traceId
-            trace_id, *rest = set(
+            trace_id, *rest = {
                 link.trace_id for span in with_links for link in span.links
-            )
+            }
             assert not rest
             return trace_id
         else:
@@ -418,7 +418,7 @@ class Trace:
         }
         depth = 1
         while spans:
-            parent_span_ids = set(span.span_id for span in depths[depth - 1])
+            parent_span_ids = {span.span_id for span in depths[depth - 1]}
             dct = toolz.groupby(
                 lambda span: span.parent_span_id in parent_span_ids,  # noqa: B023
                 spans,
@@ -568,13 +568,13 @@ class TraceMetrics:
         )
         assert len(oir) == len(mr)
         oir_ids, mr_ids = (
-            set(
+            {
                 attribute.value
                 for el in which
                 for event in el.events
                 for attribute in event.attributes
                 if attribute.name == "reader_id"
-            )
+            }
             for which in (oir, mr)
         )
         assert oir_ids == mr_ids

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -122,12 +122,10 @@ class Pins(Config):
 
     protocol: str = "gcs"
     path: str = "letsql-pins"
-    storage_options: dict[str, Any] = dict(
-        (
-            ("cache_timeout", 0),
-            ("token", "anon"),
-        )
-    )
+    storage_options: dict[str, Any] = {
+        "cache_timeout": 0,
+        "token": "anon",
+    }
 
     def get_board(self, **kwargs):
         import pins

--- a/python/xorq/expr/ml/fit_lib.py
+++ b/python/xorq/expr/ml/fit_lib.py
@@ -76,7 +76,7 @@ def predict_sklearn(model, df):
 def predict_proba_sklearn(model, df):
     """Predict class probabilities using sklearn model."""
     proba = model.predict_proba(df)
-    return [row for row in proba]
+    return list(proba)
 
 
 @toolz.curry

--- a/python/xorq/expr/ml/metrics.py
+++ b/python/xorq/expr/ml/metrics.py
@@ -235,42 +235,42 @@ def _build_metric_return_types():
         {
             # Tuple of scalars -> Struct
             class_likelihood_ratios: dt.Struct(
-                dict(
-                    positive_likelihood_ratio=dt.float64,
-                    negative_likelihood_ratio=dt.float64,
-                )
+                {
+                    "positive_likelihood_ratio": dt.float64,
+                    "negative_likelihood_ratio": dt.float64,
+                }
             ),
             homogeneity_completeness_v_measure: dt.Struct(
-                dict(
-                    homogeneity=dt.float64,
-                    completeness=dt.float64,
-                    v_measure=dt.float64,
-                )
+                {
+                    "homogeneity": dt.float64,
+                    "completeness": dt.float64,
+                    "v_measure": dt.float64,
+                }
             ),
             # Confusion matrices -> Array(Array(int64))
             confusion_matrix: dt.Array(dt.Array(dt.int64)),
             pair_confusion_matrix: dt.Array(dt.Array(dt.int64)),
             # Curves -> Struct of arrays
             roc_curve: dt.Struct(
-                dict(
-                    fpr=dt.Array(dt.float64),
-                    tpr=dt.Array(dt.float64),
-                    thresholds=dt.Array(dt.float64),
-                )
+                {
+                    "fpr": dt.Array(dt.float64),
+                    "tpr": dt.Array(dt.float64),
+                    "thresholds": dt.Array(dt.float64),
+                }
             ),
             precision_recall_curve: dt.Struct(
-                dict(
-                    precision=dt.Array(dt.float64),
-                    recall=dt.Array(dt.float64),
-                    thresholds=dt.Array(dt.float64),
-                )
+                {
+                    "precision": dt.Array(dt.float64),
+                    "recall": dt.Array(dt.float64),
+                    "thresholds": dt.Array(dt.float64),
+                }
             ),
             det_curve: dt.Struct(
-                dict(
-                    fpr=dt.Array(dt.float64),
-                    fnr=dt.Array(dt.float64),
-                    thresholds=dt.Array(dt.float64),
-                )
+                {
+                    "fpr": dt.Array(dt.float64),
+                    "fnr": dt.Array(dt.float64),
+                    "thresholds": dt.Array(dt.float64),
+                }
             ),
             # Per-sample metrics -> Array(float64)
             silhouette_samples: dt.Array(dt.float64),

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -618,9 +618,7 @@ class FittedStep:
         import xorq.api as xo
 
         schema = self.expr.select(self.features).schema()
-        empty_table = xo.memtable(
-            [{name: None for name in schema.names}], schema=schema
-        )
+        empty_table = xo.memtable([dict.fromkeys(schema.names)], schema=schema)
         col = self.feature_importances_raw(empty_table, name)
         return col.as_table().tag(**self.tag_kwargs)
 

--- a/python/xorq/expr/ml/structer.py
+++ b/python/xorq/expr/ml/structer.py
@@ -165,7 +165,7 @@ class KVEncoder:
             Column names that have KV_ENCODED_TYPE
         """
         schema = expr.schema()
-        cols_to_check = features if features else tuple(schema.keys())
+        cols_to_check = features or tuple(schema.keys())
         return tuple(
             col
             for col in cols_to_check
@@ -394,7 +394,7 @@ class Structer:
     @classmethod
     def from_names_typ(cls, names, typ):
         """Create a Structer with known schema."""
-        struct = dt.Struct({name: typ for name in names})
+        struct = dt.Struct(dict.fromkeys(names, typ))
         return cls(struct=struct)
 
     @classmethod

--- a/python/xorq/expr/ml/tests/test_metrics.py
+++ b/python/xorq/expr/ml/tests/test_metrics.py
@@ -1414,7 +1414,7 @@ class TestMetricFnMultilabel:
         label_names = tuple(f"label_{i}" for i in range(Y.shape[1]))
         df = pd.DataFrame(y_true, columns=list(label_names))
         # Store y_score as a single array column (mimics predict_proba storage)
-        df["predict_proba"] = [row for row in y_score]
+        df["predict_proba"] = list(y_score)
 
         expr = api.register(df, "multilabel_test")
         return expr, label_names, y_true, y_score
@@ -1876,11 +1876,11 @@ class TestDeferredAucFromCurve:
 
         # Mock an expression whose .type() returns a dt.Struct with wrong field names
         fake_struct_type = dt.Struct(
-            dict(
-                x=dt.Array(dt.float64),
-                y=dt.Array(dt.float64),
-                z=dt.Array(dt.float64),
-            )
+            {
+                "x": dt.Array(dt.float64),
+                "y": dt.Array(dt.float64),
+                "z": dt.Array(dt.float64),
+            }
         )
         mock_expr = MagicMock()
         mock_expr.type.return_value = fake_struct_type

--- a/python/xorq/expr/ml/tests/test_pipeline_lib.py
+++ b/python/xorq/expr/ml/tests/test_pipeline_lib.py
@@ -506,8 +506,8 @@ def get_scorers_by_type():
     cluster = {name for name, module in non_ml if "cluster" in module}
 
     return FrozenOrderedDict(
-        **dict(
-            (k, tuple(sorted(v)))
+        **{
+            k: tuple(sorted(v))
             for k, v in (
                 ("classification", classification),
                 ("regression", regression),
@@ -515,7 +515,7 @@ def get_scorers_by_type():
                 ("proba", proba),
                 ("multilabel", multilabel),
             )
-        )
+        }
     )
 
 

--- a/python/xorq/expr/ml/tests/test_split_lib.py
+++ b/python/xorq/expr/ml/tests/test_split_lib.py
@@ -25,16 +25,15 @@ def test_train_test_splits_intersections():
 
     # init table
     table = memtable([(i, "val") for i in range(N)], columns=["key1", "val"])
-    results = [
-        r
-        for r in xo.train_test_splits(
+    results = list(
+        xo.train_test_splits(
             table,
             unique_key="key1",
             test_sizes=test_size,
             num_buckets=N,
             random_seed=42,
         )
-    ]
+    )
 
     # make sure all splits mutually exclusive
     # These are all  a \ b  U  a intersect b  where b are the other splits
@@ -300,16 +299,15 @@ def test_train_test_splits_intersections_parameterized_pass(connect_method):
 
     table = con.table(test_table_name)
 
-    results = [
-        r
-        for r in xo.train_test_splits(
+    results = list(
+        xo.train_test_splits(
             table,
             unique_key="key1",
             test_sizes=test_size,
             num_buckets=N,
             random_seed=42,
         )
-    ]
+    )
 
     # make sure all splits mutually exclusive
     # These are all  a \ b  U  a intersect b  where b are the other splits

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -571,7 +571,7 @@ class Read(ops.DatabaseTable):
     def make_dt(self):
         method = getattr(self.source, self.method_name)
         args = tuple(v for k, v in self.read_kwargs if k in ("path", "paths"))
-        kwargs = dict((k, v) for k, v in self.read_kwargs if k not in ("path", "paths"))
+        kwargs = {k: v for k, v in self.read_kwargs if k not in ("path", "paths")}
         dt = method(*args, **kwargs).op()
         return dt
 

--- a/python/xorq/expr/translate.py
+++ b/python/xorq/expr/translate.py
@@ -449,6 +449,6 @@ def sql_to_ibis(
         dialect=dialect,
     )
 
-    catalog = Catalog({name: table for name, table in catalog.items()})
+    catalog = Catalog(dict(catalog.items()))
 
     return convert(plan.to_variant(), catalog=catalog)

--- a/python/xorq/expr/udf.py
+++ b/python/xorq/expr/udf.py
@@ -1063,14 +1063,7 @@ def pyarrow_udwf(
             **config_kwargs,
             # assert which_evaluate in ("evaluate", "evaluate_all", "evaluate_all_with_rank")
             # **{which_evaluate: fn},
-            **{
-                which_evaluate: fn
-                for which_evaluate in (
-                    "evaluate",
-                    "evaluate_all",
-                    "evaluate_all_with_rank",
-                )
-            },
+            **dict.fromkeys(("evaluate", "evaluate_all", "evaluate_all_with_rank"), fn),
         ),
         "__udf_namespace__": namespace,
         "__module__": __name__,

--- a/python/xorq/flight/__init__.py
+++ b/python/xorq/flight/__init__.py
@@ -161,7 +161,7 @@ class FlightServer:
         from xorq.expr.relations import FlightUDXF
 
         # Find all FlightUDXF nodes in the expression
-        exchangers = tuple(set(node.udxf for node in walk_nodes((FlightUDXF,), expr)))
+        exchangers = tuple({node.udxf for node in walk_nodes((FlightUDXF,), expr)})
 
         flight_url_kwargs = {
             key: value for key, value in (("host", host), ("port", port)) if value

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -518,13 +518,12 @@ class ExprDumper:
         expr, path_to_writer0 = self._replace_tables(expr)
 
         profiles = dehydrate_cons(find_all_sources(expr))
-        path_to_writer2 = {
-            path: writer
-            for (path, writer) in (
+        path_to_writer2 = dict(
+            (
                 self._prepare_metadata_file(),
                 self._prepare_profiles_file(profiles),
             )
-        }
+        )
         path_to_writer = path_to_writer0 | path_to_writer2
         if self.debug:
             # write SQL plan and deferred-read artifacts if debug enabled

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -164,7 +164,7 @@ class SdistBuilder:
     @property
     @functools.cache
     def _uv_tool_run_xorq_build(self):
-        args = self.args if self.args else ("xorq", "build", str(self.script_path))
+        args = self.args or ("xorq", "build", str(self.script_path))
         popened = uv_tool_run(
             *args,
             with_=str(self.untgzed_path),
@@ -249,7 +249,7 @@ class SdistRunner:
     @functools.cache
     def _uv_tool_run_xorq_run(self):
         self.ensure_requirements_path()
-        args = self.args if self.args else ("xorq", "run", str(self.build_path))
+        args = self.args or ("xorq", "run", str(self.build_path))
         # FIXME: enable streaming output
         popened = uv_tool_run(
             *args,

--- a/python/xorq/ibis_yaml/tests/conftest.py
+++ b/python/xorq/ibis_yaml/tests/conftest.py
@@ -30,13 +30,13 @@ def get_dtype_yaml(yaml_dict, expression, key="type"):
 @pytest.fixture
 def t():
     return ibis.table(
-        dict(
-            a="int64",
-            b="string",
-            c="float64",
-            d="timestamp",
-            e="date",
-        ),
+        {
+            "a": "int64",
+            "b": "string",
+            "c": "float64",
+            "d": "timestamp",
+            "e": "date",
+        },
         name="test_table",
     )
 

--- a/python/xorq/ibis_yaml/tests/test_relations.py
+++ b/python/xorq/ibis_yaml/tests/test_relations.py
@@ -54,8 +54,8 @@ def test_aggregation(compiler, t):
 
 
 def test_join(compiler):
-    t1 = ibis.table(dict(a="int", b="string"), name="t1")
-    t2 = ibis.table(dict(b="string", c="float"), name="t2")
+    t1 = ibis.table({"a": "int", "b": "string"}, name="t1")
+    t2 = ibis.table({"b": "string", "c": "float"}, name="t2")
     expr = t1.join(t2, t1.b == t2.b)
     yaml_dict = compiler.to_yaml(expr)
     node_ref = yaml_dict["expression"][RefEnum.node_ref]

--- a/python/xorq/ibis_yaml/tests/test_subquery.py
+++ b/python/xorq/ibis_yaml/tests/test_subquery.py
@@ -20,8 +20,8 @@ def test_scalar_subquery(compiler, t):
 
 
 def test_exists_subquery(compiler):
-    t1 = ibis.table(dict(a="int", b="string"), name="t1")
-    t2 = ibis.table(dict(a="int", c="float"), name="t2")
+    t1 = ibis.table({"a": "int", "b": "string"}, name="t1")
+    t2 = ibis.table({"a": "int", "c": "float"}, name="t2")
 
     filtered = t2.filter(t2.a == t1.a)
     expr = ops.ExistsSubquery(filtered).to_expr()
@@ -38,8 +38,8 @@ def test_exists_subquery(compiler):
 
 
 def test_in_subquery(compiler):
-    t1 = ibis.table(dict(a="int", b="string"), name="t1")
-    t2 = ibis.table(dict(a="int", c="float"), name="t2")
+    t1 = ibis.table({"a": "int", "b": "string"}, name="t1")
+    t2 = ibis.table({"a": "int", "c": "float"}, name="t2")
 
     expr = ops.InSubquery(t1.select("a"), t2.a).to_expr()
     yaml_dict = compiler.to_yaml(expr)

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -583,7 +583,7 @@ def warn_on_local_path(items: dict) -> None:
 
     def is_local_path(any: str | Path) -> bool:
         parsed = urlparse(any)
-        return not parsed.scheme or parsed.scheme in ("file",)
+        return not parsed.scheme or parsed.scheme == "file"
 
     if path := next(
         (v for k, v in dict(items).items() if k in ("path", "source")), None

--- a/python/xorq/ibis_yaml/udf.py
+++ b/python/xorq/ibis_yaml/udf.py
@@ -137,7 +137,7 @@ def _namespace_to_yaml(ns: ops.Namespace, context: TranslationContext) -> dict:
     return freeze(
         {
             "op": "Namespace",
-            "dict": {argname: arg for argname, arg in zip(ns.argnames, ns.args)},
+            "dict": dict(zip(ns.argnames, ns.args)),
         }
     )
 
@@ -174,19 +174,12 @@ def make_op_kwargs(op):
     argnames = op.argnames
     if argnames and argnames[-1] == "where":
         (*argnames, _) = argnames
-    kwargs = {argname: arg for (argname, arg) in zip(argnames, op.args)}
+    kwargs = dict(zip(argnames, op.args))
     return kwargs
 
 
 def kwargs_to_schema(kwargs):
-    schema = ibis.schema(
-        {
-            argname: typ
-            for (argname, typ) in (
-                (argname, arg.type()) for argname, arg in kwargs.items()
-            )
-        }
-    )
+    schema = ibis.schema({argname: arg.type() for argname, arg in kwargs.items()})
     return schema
 
 

--- a/python/xorq/tests/test_client.py
+++ b/python/xorq/tests/test_client.py
@@ -57,7 +57,7 @@ def _create_temp_table_with_schema(con, temp_table_name, schema, data=None):
         param(
             xo.memtable(
                 [(1, 2.0, "3")],
-                schema=xo.schema(dict(a="int8", b="float32", c="string")),
+                schema=xo.schema({"a": "int8", "b": "float32", "c": "string"}),
             ),
             pd.DataFrame([(1, 2.0, "3")], columns=list("abc")).astype(
                 {"a": "int8", "b": "float32"}
@@ -76,7 +76,7 @@ def _create_temp_table_with_schema(con, temp_table_name, schema, data=None):
             id="dataframe",
         ),
         param(
-            xo.memtable([dict(a=1), dict(a=2)]),
+            xo.memtable([{"a": 1}, {"a": 2}]),
             pd.DataFrame({"a": [1, 2]}),
             id="list_of_dicts",
         ),

--- a/python/xorq/tests/test_numeric.py
+++ b/python/xorq/tests/test_numeric.py
@@ -202,7 +202,7 @@ def test_isnan_isinf(
         param(L(5.556).sqrt(), math.sqrt(5.556), id="sqrt"),
         param(
             L(5.556).log(2),
-            math.log(5.556, 2),
+            math.log2(5.556),
             id="log-base",
         ),
         param(
@@ -212,7 +212,7 @@ def test_isnan_isinf(
         ),
         param(
             L(5.556).log2(),
-            math.log(5.556, 2),
+            math.log2(5.556),
             id="log2",
         ),
         param(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -84,12 +84,10 @@ def test_save_load(connector, monkeypatch, tmp_path):
     profile = con._profile
     profile.save(check_secrets=False)
 
-    others = tuple(
-        (
-            profiles.get(profile.hash_name),
-            profiles[profile.hash_name],
-            profile.load(profile.hash_name),
-        )
+    others = (
+        profiles.get(profile.hash_name),
+        profiles[profile.hash_name],
+        profile.load(profile.hash_name),
     )
 
     for other in others:

--- a/python/xorq/tests/test_wrapper.py
+++ b/python/xorq/tests/test_wrapper.py
@@ -64,7 +64,7 @@ def test_memtable_ops_dict():
             id="dataframe",
         ),
         param(
-            lambda: xo.memtable([dict(a=1), dict(a=2)]),
+            lambda: xo.memtable([{"a": 1}, {"a": 2}]),
             pd.DataFrame({"a": [1, 2]}),
             id="list_of_dicts",
         ),

--- a/python/xorq/vendor/ibis/backends/__init__.py
+++ b/python/xorq/vendor/ibis/backends/__init__.py
@@ -885,7 +885,7 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         """
 
     def __getstate__(self):
-        return dict(_con_args=self._con_args, _con_kwargs=self._con_kwargs)
+        return {"_con_args": self._con_args, "_con_kwargs": self._con_kwargs}
 
     def __rich_repr__(self):
         yield "name", self.name

--- a/python/xorq/vendor/ibis/backends/gizmosql/__init__.py
+++ b/python/xorq/vendor/ibis/backends/gizmosql/__init__.py
@@ -503,7 +503,7 @@ class Backend(
         if use_encryption:
             connection_scheme += "+tls"
 
-        db_kwargs = dict(username=user, password=password)
+        db_kwargs = {"username": user, "password": password}
         if use_encryption and disable_certificate_verification is not None:
             db_kwargs[DatabaseOptions.TLS_SKIP_VERIFY.value] = str(
                 disable_certificate_verification

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -191,7 +191,7 @@ class Profile:
 
     @property
     def kwargs_dict(self):
-        return {k: v for k, v in self.kwargs_tuple}
+        return dict(self.kwargs_tuple)
 
     @property
     def hash_name(self):
@@ -222,7 +222,11 @@ class Profile:
 
     def as_yaml(self):
         return yaml.safe_dump(
-            dict(con_name=self.con_name, kwargs_dict=self.kwargs_dict, idx=self.idx)
+            {
+                "con_name": self.con_name,
+                "kwargs_dict": self.kwargs_dict,
+                "idx": self.idx,
+            }
         )
 
     def save(self, profile_dir=None, alias=None, clobber=False, check_secrets=True):

--- a/python/xorq/vendor/ibis/backends/snowflake/__init__.py
+++ b/python/xorq/vendor/ibis/backends/snowflake/__init__.py
@@ -299,14 +299,14 @@ $$ {defn["source"]} $$"""
         # overwrite session parameters that are required for ibis + snowflake
         # to work
         session_parameters.update(
-            dict(
+            {
                 # Use Arrow for query results
-                PYTHON_CONNECTOR_QUERY_RESULT_FORMAT="arrow_force",
+                "PYTHON_CONNECTOR_QUERY_RESULT_FORMAT": "arrow_force",
                 # JSON output must be strict for null versus undefined
-                STRICT_JSON_OUTPUT=True,
+                "STRICT_JSON_OUTPUT": True,
                 # Timezone must be UTC
-                TIMEZONE="UTC",
-            ),
+                "TIMEZONE": "UTC",
+            },
         )
 
         with contextlib.closing(con.cursor()) as cur:

--- a/python/xorq/vendor/ibis/common/egraph.py
+++ b/python/xorq/vendor/ibis/common/egraph.py
@@ -774,7 +774,7 @@ class EGraph:
         """
         enode = self._as_enode(node)
         enode = self._eclasses.find(enode)
-        costs = {en: (math.inf, None) for en in self._eclasses.keys()}
+        costs = dict.fromkeys(self._eclasses.keys(), (math.inf, None))
 
         def enode_cost(enode):
             cost = 1

--- a/python/xorq/vendor/ibis/common/temporal.py
+++ b/python/xorq/vendor/ibis/common/temporal.py
@@ -47,8 +47,7 @@ class Unit(Coercible, Enum, metaclass=AbstractEnumMeta):
             pass
 
         # then look for the enum name (unit name)
-        if value.endswith("s"):
-            value = value[:-1]
+        value = value.removesuffix("s")
         try:
             return cls[value.upper()]
         except KeyError:

--- a/python/xorq/vendor/ibis/common/typing.py
+++ b/python/xorq/vendor/ibis/common/typing.py
@@ -189,7 +189,7 @@ def evaluate_annotations(
     if class_name is None:
         localns = None
     else:
-        localns = dict(Self=f"{module_name}.{class_name}")
+        localns = {"Self": f"{module_name}.{class_name}"}
 
     result = {}
     for k, v in annots.items():

--- a/python/xorq/vendor/ibis/expr/datatypes/parse.py
+++ b/python/xorq/vendor/ibis/expr/datatypes/parse.py
@@ -94,7 +94,7 @@ def parse(
 
     def geotype_parser(typ: type[dt.DataType]) -> dt.DataType:
         return spaceless_string(typ.__name__.lower()).then(
-            (srid_geotype | geotype_part | srid_part).optional(dict()).combine_dict(typ)
+            (srid_geotype | geotype_part | srid_part).optional({}).combine_dict(typ)
         )
 
     primitive = (

--- a/python/xorq/vendor/ibis/expr/rewrites.py
+++ b/python/xorq/vendor/ibis/expr/rewrites.py
@@ -235,7 +235,7 @@ def project_wrap_reduction(_, rel):
     if _.relations == {rel}:
         # The reduction is fully originating from the `rel`, so turn
         # it into a window function of `rel`
-        return ops.WindowFunction(_, order_by=getattr(_, "order_by", tuple()))
+        return ops.WindowFunction(_, order_by=getattr(_, "order_by", ()))
     else:
         # 1. The reduction doesn't depend on any table, constructed from
         #    scalar values, so turn it into a scalar subquery.

--- a/python/xorq/vendor/ibis/expr/visualize.py
+++ b/python/xorq/vendor/ibis/expr/visualize.py
@@ -225,8 +225,8 @@ if __name__ == "__main__":
 
     args = p.parse_args()
 
-    left = ibis.table(dict(a="int64", b="string"), name="left")
-    right = ibis.table(dict(b="string", c="int64", d="string"), name="right")
+    left = ibis.table({"a": "int64", "b": "string"}, name="left")
+    right = ibis.table({"b": "string", "c": "int64", "d": "string"}, name="right")
     expr = (
         left.inner_join(right, "b")
         .select(left.a, b=right.c, c=right.d)


### PR DESCRIPTION
Adds flake8-comprehensions (C4) and refurb (FURB) rule sets to ruff extend-select and fixes all violations across the codebase.