### PR TITLE
chore(lint): enforce class member ordering

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+per-file-ignores =
+    python/xorq/vendor/**:CCE001,CCE002
+class-attributes-order =
+    field
+    __attrs_post_init__
+    property_method
+    method
+    static_method
+    class_method
+    magic_method
+
+

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run Ruff
         run: uv run --no-sync ruff check --output-format=github python examples docs
 
+      - name: Run flake8-class-attributes-order
+        run: uv run --no-sync --with flake8 --with flake8-class-attributes-order flake8 python examples
+
       - name: Verify no uncommitted changes
         run: |
           echo "Checking for uncommitted changes in the workspace..."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
         args: ["--output-format=full", "--fix", "python", "examples", "docs"]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-class-attributes-order==0.1.3
+        args: ["python", "examples"]
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
     rev: 0.10.7


### PR DESCRIPTION
Enforce class member ordering via flake8-class-attributes-order

Add .flake8 config, pre-commit hook, and CI lint step to enforce class member order: field, __attrs_post_init__, property_method, method, static_method, class_method, magic_method.