### PR TITLE
fix(ml): allow Pipeline.fit without target for ClusterMixin predict step

### DIFF
--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -776,7 +776,10 @@ class Pipeline:
         """
 
         if not target and self.predict_step:
-            raise ValueError("Can't infer target for a prediction step")
+            from sklearn.base import ClusterMixin
+
+            if not isinstance(self.predict_step.instance, ClusterMixin):
+                raise ValueError("Can't infer target for a prediction step")
         features = features or tuple(col for col in expr.columns if col != target)
         fitted_steps = ()
         transformed = expr

--- a/python/xorq/expr/ml/tests/test_pipeline_lib.py
+++ b/python/xorq/expr/ml/tests/test_pipeline_lib.py
@@ -1077,3 +1077,39 @@ class TestClusteringPredict:
 
         with pytest.raises(ValueError, match="must have transform or predict method"):
             step.fit(t, features=features)
+
+    def test_pipeline_fit_without_target_for_clustering(self, cluster_data):
+        """Test Pipeline.fit allows ClusterMixin predict steps without a target."""
+        import numpy as np
+        from sklearn.cluster import MiniBatchKMeans
+        from sklearn.pipeline import Pipeline as SklearnPipeline
+        from sklearn.preprocessing import StandardScaler
+
+        from xorq.expr.ml.pipeline_lib import Pipeline
+
+        t = xo.memtable(cluster_data)
+        features = ("num1", "num2")
+
+        sklearn_pipe = SklearnPipeline(
+            [
+                ("scaler", StandardScaler()),
+                (
+                    "clusterer",
+                    MiniBatchKMeans(n_clusters=2, random_state=42, n_init=10),
+                ),
+            ]
+        )
+
+        xorq_pipeline = Pipeline.from_instance(sklearn_pipe)
+        fitted = xorq_pipeline.fit(t, features=features)
+
+        # Should be able to predict without ever providing a target
+        result = fitted.predict(t)
+        xorq_labels = result.execute()[ResponseMethod.PREDICT].values
+
+        # Verify against sklearn
+        X = np.array([cluster_data["num1"], cluster_data["num2"]]).T
+        sklearn_pipe.fit(X)
+        sklearn_labels = sklearn_pipe.predict(X)
+
+        np.testing.assert_array_equal(xorq_labels, sklearn_labels)


### PR DESCRIPTION


The `ClusterMixin` exemption existed at the FittedStep level but Pipeline.fit unconditionally rejected missing targets for any predict step, blocking unsupervised clusterers like `MiniBatchKMeans` to be used properly. 

