### PR TITLE
ci: start only required docker services per backend job

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -50,7 +50,7 @@ jobs:
             extras:
               - --extra pyiceberg
           - name: postgres
-            services: true
+            services: postgres
             extras:
               - --extra postgres
               - --extra examples
@@ -60,7 +60,7 @@ jobs:
             services: false
             extras: []
           - name: core
-            services: true
+            services: postgres
             parallel: true
             extras:
               - --extra examples
@@ -74,12 +74,12 @@ jobs:
               - --extra sqlite
               - --extra duckdb
           - name: gizmosql
-            services: true
+            services: gizmosql
             extras:
               - --extra gizmosql
               - --extra duckdb
           - name: trino
-            services: true
+            services: trino
             extras:
               - --extra trino
               - --extra duckdb
@@ -113,9 +113,24 @@ jobs:
         run: uv sync --locked ${{ join(matrix.backend.extras, ' ') }} --group dev --group test
         working-directory: ${{ github.workspace }}
 
+      - name: Set up Docker Buildx
+        if: ${{ matrix.backend.services }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build postgres image with GHA layer cache
+        if: ${{ contains(matrix.backend.services, 'postgres') }}
+        uses: docker/bake-action@v6
+        with:
+          files: compose.yaml
+          targets: postgres
+          load: true
+          set: |
+            postgres.cache-from=type=gha,scope=docker-postgres
+            postgres.cache-to=type=gha,scope=docker-postgres,mode=max
+
       - name: start services
         if: ${{ matrix.backend.services }}
-        run: docker compose up --build --wait
+        run: just up-ci ${{ matrix.backend.services }}
 
       - name: pytest
         run: uv run --no-sync pytest --import-mode=importlib --cov --cov-report=xml -m ${{ matrix.backend.name }} -k 'not script_execution and not slow'${{ matrix.backend.parallel && ' -n auto --dist=loadfile' || '' }}

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ download-data owner="ibis-project" repo="testing-data" rev="master":
 up *backends:
     docker compose up --build --wait {{ backends }}
 
+# start backends in CI: no rebuild, pull only missing images
+up-ci *backends:
+    docker compose up --wait --pull missing {{ backends }}
+
 # generate API documentation
 docs-apigen *args:
     cd docs && uv run --no-sync quartodoc interlinks


### PR DESCRIPTION
- Map matrix `services` field from boolean to the actual compose service name (postgres, gizmosql, trino) so each job starts only what it needs
- Add `docker/setup-buildx-action` and `docker/bake-action` with GHA layer cache for the custom ibis-postgres build, avoiding full rebuilds on every run
- Add `up-ci` justfile recipe using `--pull missing` (no --build) so compose reuses pre-built/pre-pulled images in CI