### PR TITLE
refactor: consolidate backend-discovery 

### DIFF
--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -24,8 +24,9 @@ from xorq.vendor.ibis.expr.operations.udf import (
 
 
 def expr_is_bound(expr):
-    backends, _ = expr._find_backends()
-    return bool(backends)
+    from xorq.common.utils.graph_utils import find_all_sources  # noqa: PLC0415
+
+    return bool(find_all_sources(expr))
 
 
 def unbound_expr_to_default_sql(expr, compiler=None):

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -336,6 +336,16 @@ class Expr(Immutable, Coercible):
         -------
         list[BaseBackend]
             A list of the backends found.
+
+        Notes
+        -----
+        This method uses ibis's native graph traversal which stops at the
+        outermost opaque node boundaries (CachedNode, RemoteTable, etc.),
+        returning only the immediate executors. This is intentionally different
+        from find_all_sources() in graph_utils, which traverses *through* those
+        boundaries to find every backend at every depth. The distinction matters
+        for _find_backend(): you want the single outermost executor, not the
+        full recursive set.
         """
 
         import xorq.expr.relations as rel


### PR DESCRIPTION
expr_is_bound() in dask_normalize_expr.py now uses find_all_sources() directly instead of going through the vendor _find_backends() method. Both return the same result for its only call-site (post-replacement expressions with no opaque nodes), but this removes the dependency on a vendor method.

_find_backends() is kept as-is with an explanatory docstring: it uses ibis's native traversal which stops at the outermost opaque-node boundary, intentionally returning only the immediate executors. This is semantically different from find_all_sources() which recurses through CachedNode.parent, RemoteTable.remote_expr, etc. to find every backend at every depth. Swapping them breaks _find_backend() for multi-backend expressions.