### PR TITLE
perf(lineage): fix quadratic hashing regression in build_column_trees

### DIFF
--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import lru_cache, singledispatch
+from functools import singledispatch
 from itertools import count
 from typing import Any, Callable, Tuple
 
@@ -72,37 +72,46 @@ class GenericNode:
         return evolve(self, **changes)
 
 
-def _build_column_tree(node: Node) -> GenericNode:
+def _build_column_tree(
+    node: Node, _results: dict[Node, GenericNode] | None = None
+) -> GenericNode:
+    if _results is None:
+        _results = {}
+    if node in _results:
+        return _results[node]
+
     graph, _ = bfs(node).toposort()
-    results: dict[Node, GenericNode] = {}
 
     for n in graph:
+        if n in _results:
+            continue
         match n:
             case ops.Field(rel=ops.Project(values=values)) as field_node:
                 # include the field and follow it into its mapped expression
-                child = results[to_node(values[field_node.name])]
-                results[n] = GenericNode(op=field_node, children=(child,))
+                child = _results[to_node(values[field_node.name])]
+                _results[n] = GenericNode(op=field_node, children=(child,))
 
             case ops.Field() as field_node:
-                children = tuple(results[c] for c in gen_children_of(field_node))
-                results[n] = GenericNode(op=field_node, children=children)
+                children = tuple(_results[c] for c in gen_children_of(field_node))
+                _results[n] = GenericNode(op=field_node, children=children)
 
             case ops.Project() as proj:
                 # Project is transparent: resolve to its parent's GenericNode
-                results[n] = results[to_node(proj.parent)]
+                _results[n] = _results[to_node(proj.parent)]
 
             case _:
-                children = tuple(results[c] for c in gen_children_of(n))
-                results[n] = GenericNode(op=n, children=children)
+                children = tuple(_results[c] for c in gen_children_of(n))
+                _results[n] = GenericNode(op=n, children=children)
 
-    return results[node]
+    return _results[node]
 
 
 def build_column_trees(expr: Any) -> dict[str, GenericNode]:
     """Builds a lineage tree for each column in the expression."""
     op = to_node(expr)
     cols = getattr(op, "values", None) or getattr(op, "fields", {})
-    return {k: _build_column_tree(to_node(v)) for k, v in cols.items()}
+    shared: dict[Node, GenericNode] = {}
+    return {k: _build_column_tree(to_node(v), shared) for k, v in cols.items()}
 
 
 @singledispatch
@@ -159,20 +168,6 @@ def _(node: ops.Literal) -> str:
     return f"Literal: {node.value}"
 
 
-@lru_cache
-def _token_node(g: GenericNode) -> str:
-    """unique token for the node based on its operation and children (useful in
-    deduplication)"""
-    op = g.op
-    return dask.base.tokenize(
-        (
-            getattr(op, "name", None),  # is name always set?
-            getattr(op, "schema", None),
-            tuple(_token_node(c) for c in g.children),
-        )
-    )
-
-
 def build_tree(
     node: GenericNode,
     *,
@@ -181,12 +176,28 @@ def build_tree(
 ) -> TextTree:
     seen: dict[str, int] = {}
     seq = count(1)
+    token_memo: dict[int, str] = {}
+
+    def _token(g: GenericNode) -> str:
+        gid = id(g)
+        if gid in token_memo:
+            return token_memo[gid]
+        op = g.op
+        tok = dask.base.tokenize(
+            (
+                getattr(op, "name", None),
+                getattr(op, "schema", None),
+                tuple(_token(c) for c in g.children),
+            )
+        )
+        token_memo[gid] = tok
+        return tok
 
     def _to_tree(g: GenericNode, depth: int) -> TextTree:
         if max_depth is not None and depth > max_depth:
             return TextTree("…")
 
-        digest = _token_node(g) if dedup else None
+        digest = _token(g) if dedup else None
         if digest is not None and digest in seen:
             ref = seen[digest]
             return TextTree(f"↻ see #{ref}")


### PR DESCRIPTION
## Summary

- **Restore shared results dict** across columns in `build_column_trees` — the iterative rewrite in 5ad98851 dropped the shared memo, causing each column to independently rebuild its `GenericNode` sub-trees (8.8x more instances than necessary on a 10-column expression)
- **Replace `@lru_cache` on `_token_node` with `id()`-based memo** inside `build_tree` — eliminates all recursive `GenericNode.__hash__` calls (2.9B → 0) and fixes a memory leak (the old `lru_cache` held references to all `GenericNode` trees forever)

## Problem

Profiling a 19-step moneyball replay showed 91% of 895s runtime was hashing:

| Metric | v0.3.11 (before 5ad98851) | v0.3.12 (after 5ad98851) |
|--------|---------------------------|--------------------------|
| Total time | 472s | 895s |
| `GenericNode.__hash__` calls | 1.5B | 2.9B |
| `GenericNode.__hash__` time | 117s | 233s |
| `builtins.hash` time | 226s | 445s |

Root cause: `GenericNode` is `@frozen` (attrs), so `__hash__` recursively hashes `.op` (ibis Node) and all `.children`. The `@lru_cache` on `_token_node` uses `GenericNode` as a dict key, triggering this expensive hash on every lookup.

## Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Unique GenericNodes (10-col join) | 670 | 76 | 8.8x fewer |
| Microbench (4-table join, 100 iter) | 0.105s | 0.010s | **11x faster** |
| Full moneyball replay (19 steps) | 895s | 507s | **43% faster** |
| `GenericNode.__hash__` calls | 2.9B | 0 | **eliminated** |

## Test plan

- [x] All 6 existing lineage tests pass (`test_lineage_utils.py`)
- [x] All 3 graph utils tests pass (`test_graph_utils.py`)
- [x] `test_build_column_tree_matches_memoized_on_sample` — structural correctness vs gold standard
- [x] `test_build_column_tree_matches_memoized_on_multi_join` — multi-join correctness
- [x] `test_build_column_tree_output_size_bounded` — output DAG bounded by input size

Fixes the regression introduced in #1619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)