### PR TITLE
chore(ci): switch codspeed mode from instrumentation to simulation

### DIFF
--- a/.github/workflows/ci-codspeed.yaml
+++ b/.github/workflows/ci-codspeed.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: CodSpeedHQ/action@v4
         with:
-          mode: "instrumentation"
+          mode: "simulation"
           run: uv run --no-sync pytest --import-mode=importlib --codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}
           working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Fixes: 

> Warning: The 'instrumentation' runner mode is deprecated and will be removed in a future version. Please use 'simulation' instead.