### PR TITLE
perf(otel): defer OTLP exporter imports until first use

### DIFF
--- a/python/xorq/common/utils/otel_utils.py
+++ b/python/xorq/common/utils/otel_utils.py
@@ -2,10 +2,6 @@ import os
 import sys
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-    OTLPSpanExporter as OTLPSpanExporterGRPC,
-)
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -54,8 +50,16 @@ def get_otlp_exporter():
     protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
 
     if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # noqa: PLC0415
+            OTLPSpanExporter as OTLPSpanExporterGRPC,
+        )
+
         return OTLPSpanExporterGRPC()
     else:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # noqa: PLC0415
+            OTLPSpanExporter,
+        )
+
         return OTLPSpanExporter()
 
 


### PR DESCRIPTION
Importing otel_utils was costing ~0.18s on every process start because the gRPC and HTTP OTLP exporter packages (which pulls in requests) were imported at module level. Since these exporters are only needed when a traces endpoint is configured and listening, move their imports inside get_otlp_exporter(). This halves xorq.vendor.ibis import time (0.58s → 0.25s) and speeds up all CLI commands that don't use OTLP tracing.