### PR TITLE
fix: ensure python3.10 compat

### DIFF
--- a/python/xorq/catalog/tar_utils.py
+++ b/python/xorq/catalog/tar_utils.py
@@ -35,7 +35,7 @@ def make_tgz_context(build_dir):
 def extract_build_tgz_context(tgz_path):
     with tempfile.TemporaryDirectory() as td:
         with tarfile.TarFile.gzopen(tgz_path) as tfh:
-            tfh.extractall(td, filter="data")
+            tfh.extractall(td)
         (path, *rest) = Path(td).iterdir()
         assert not rest
         yield path


### PR DESCRIPTION
The filter parameter was introduced in Python 3.12, so passing filter="data" would raise a TypeError on Python 3.10 and 3.11. Removing it restores compatibility with Python 3.10+.