### PR TITLE
fix: decompile() crash on zero-arg window functions

### DIFF
--- a/python/xorq/vendor/ibis/expr/decompile.py
+++ b/python/xorq/vendor/ibis/expr/decompile.py
@@ -92,8 +92,11 @@ def value(op, *args, **kwargs):
 
     if args:
         this, *args = args
-    else:
+    elif kwargs:
         (_, this), *kwargs = kwargs
+    else:
+        # Zero-arg analytic functions (row_number, rank, dense_rank, etc.)
+        return f"ibis.{method}()"
 
     # if there is a single keyword argument prefer to pass that as positional
     if not args and len(kwargs) == 1:

--- a/python/xorq/vendor/ibis/expr/decompile.py
+++ b/python/xorq/vendor/ibis/expr/decompile.py
@@ -90,7 +90,12 @@ def value(op, *args, **kwargs):
     method = _get_method_name(op)
     kwargs = [(k, v) for k, v in kwargs.items() if v is not None]
 
-    if args:
+    if args and kwargs:
+        raise NotImplementedError(
+            f"decompile does not support ops with both positional and keyword "
+            f"arguments: {type(op).__name__} args={args} kwargs={kwargs}"
+        )
+    elif args:
         this, *args = args
     elif kwargs:
         (_, this), *kwargs = kwargs

--- a/python/xorq/vendor/ibis/expr/test_decompile.py
+++ b/python/xorq/vendor/ibis/expr/test_decompile.py
@@ -1,0 +1,58 @@
+"""Tests for the expression decompiler."""
+
+import pytest
+
+import xorq.vendor.ibis as ibis
+from xorq.vendor.ibis.expr.decompile import decompile
+
+
+class TestDecompileZeroArgAnalytics:
+    """decompile() should handle zero-argument window/analytic functions.
+
+    Regression test for https://github.com/xorq-labs/xorq/issues/1700
+    """
+
+    @pytest.fixture
+    def table(self):
+        return ibis.table(name="t", schema={"x": "int64", "y": "string"})
+
+    def test_row_number(self, table):
+        expr = table.mutate(rn=ibis.row_number())
+        code = decompile(expr)
+        assert "row_number()" in code
+
+    def test_dense_rank(self, table):
+        expr = table.mutate(rn=ibis.dense_rank())
+        code = decompile(expr)
+        assert "dense_rank()" in code
+
+    def test_rank(self, table):
+        expr = table.mutate(rn=ibis.rank())
+        code = decompile(expr)
+        assert "rank()" in code
+
+    def test_percent_rank(self, table):
+        expr = table.mutate(rn=ibis.percent_rank())
+        code = decompile(expr)
+        assert "percent_rank()" in code
+
+    def test_cume_dist(self, table):
+        expr = table.mutate(rn=ibis.cume_dist())
+        code = decompile(expr)
+        assert "cume_dist()" in code
+
+    def test_row_number_with_filter(self, table):
+        """Ensure decompile works when row_number appears in a filter."""
+        expr = table.filter(ibis.row_number() < 10)
+        code = decompile(expr)
+        assert "row_number()" in code
+
+    def test_row_number_combined_with_other_ops(self, table):
+        """Ensure decompile works with row_number mixed into larger expressions."""
+        expr = table.mutate(
+            rn=ibis.row_number(),
+            x_doubled=table.x * 2,
+        )
+        code = decompile(expr)
+        assert "row_number()" in code
+        assert "t.x" in code


### PR DESCRIPTION
## Summary

- Adds failing tests for #1700 — `decompile()` crashes with `ValueError: not enough values to unpack` on expressions containing zero-argument analytic functions (`row_number()`, `rank()`, `dense_rank()`, `percent_rank()`, `cume_dist()`)
- **Tests only — no fix yet.** CI should show 7 failures confirming the bug.
- Fix will follow in a subsequent commit once CI confirms the failures.

## Test plan

- [x] 7 new tests in `python/xorq/vendor/ibis/expr/test_decompile.py`
- [x] All 7 fail with `ValueError` on current main
- [ ] Fix commit will make all 7 pass

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)