### PR TITLE
release: 0.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.14] - 2026-03-09
+### Details
+#### Added
+- Add HashingTag node for hash-contributing metadata tags by @hussainsultan in [#1681](https://github.com/xorq-labs/xorq/pull/1681)
+- Add benchmark workflow with PR regression alerts by @mesejo in [#1694](https://github.com/xorq-labs/xorq/pull/1694)
+- Add actionlint to pre-commit config by @mesejo in [#1699](https://github.com/xorq-labs/xorq/pull/1699)
+- Add pipeline introspection via structured tag metadata by @dlovell in [#1691](https://github.com/xorq-labs/xorq/pull/1691)
+
+#### Changed
+- Defer OTLP exporter imports until first use by @dlovell in [#1690](https://github.com/xorq-labs/xorq/pull/1690)
+- Convert test classes to standalone functions by @ghoersti in [#1667](https://github.com/xorq-labs/xorq/pull/1667)
+- Update template commit hashes by @mesejo in [#1695](https://github.com/xorq-labs/xorq/pull/1695)
+
+#### Fixed
+- Defer import of xorq.ibis_yaml.translate by @dlovell in [#1689](https://github.com/xorq-labs/xorq/pull/1689)
+- Ensure python3.10 compat by @dlovell in [#1693](https://github.com/xorq-labs/xorq/pull/1693)
+- Cli no subcommand prints help by @dlovell in [#1696](https://github.com/xorq-labs/xorq/pull/1696)
+- Race condition on tui refresh by @dlovell in [#1697](https://github.com/xorq-labs/xorq/pull/1697)
+
+#### Removed
+- Remove redundant handlers by @dlovell in [#1692](https://github.com/xorq-labs/xorq/pull/1692)
+
 ## [0.3.13] - 2026-03-06
 ### Details
 #### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ only-include = ["python"]
 
 [project]
 name = "xorq"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
     "dask==2025.1.0; python_version >= '3.10' and python_version < '4.0'",
     "attrs>=24.0.0,<26; python_version >= '3.10' and python_version < '4.0'",

--- a/uv.lock
+++ b/uv.lock
@@ -5734,7 +5734,7 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.13"
+version = "0.3.14"
 source = { editable = "." }
 dependencies = [
     { name = "atpublic" },


### PR DESCRIPTION
## Summary
- Bump version to 0.3.14
- Update CHANGELOG.md with git-cliff

### Changes in this release
#### Added
- Add HashingTag node for hash-contributing metadata tags (#1681)
- Add benchmark workflow with PR regression alerts (#1694)
- Add actionlint to pre-commit config (#1699)
- Add pipeline introspection via structured tag metadata (#1691)

#### Changed
- Defer OTLP exporter imports until first use (#1690)
- Convert test classes to standalone functions (#1667)
- Update template commit hashes (#1695)

#### Fixed
- Defer import of xorq.ibis_yaml.translate (#1689)
- Ensure python3.10 compat (#1693)
- CLI no subcommand prints help (#1696)
- Race condition on tui refresh (#1697)

#### Removed
- Remove redundant handlers (#1692)