### PR TITLE
fix: resolve DeprecationWarning and FutureWarning in tests

### DIFF
--- a/python/xorq/backends/conftest.py
+++ b/python/xorq/backends/conftest.py
@@ -78,7 +78,6 @@ def pytest_collection_modifyitems(session, config, items):
         backend = _get_backend_from_parts(parts)
         if backend is not None and backend in all_backends:
             item.add_marker(getattr(pytest.mark, backend))
-            item.add_marker(pytest.mark.backend)
         elif "backends" not in parts and not tuple(
             itertools.chain(
                 *(item.iter_markers(name=name) for name in all_backends),

--- a/python/xorq/backends/datafusion/tests/conftest.py
+++ b/python/xorq/backends/datafusion/tests/conftest.py
@@ -25,7 +25,7 @@ def quotes_df():
 def trades_df():
     # Create sample trading data
     np.random.seed(42)
-    dates = pd.date_range(start="2024-01-01", end="2024-01-31", freq="H")
+    dates = pd.date_range(start="2024-01-01", end="2024-01-31", freq="h")
 
     # Trades data
     trades = pd.DataFrame(

--- a/python/xorq/vendor/ibis/backends/datafusion/__init__.py
+++ b/python/xorq/vendor/ibis/backends/datafusion/__init__.py
@@ -344,9 +344,15 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             catalog = self.con.catalog()
 
         if database is not None:
-            database = catalog.database(database)
+            try:
+                database = catalog.schema(database)
+            except AttributeError:
+                database = catalog.database(database)
         else:
-            database = catalog.database()
+            try:
+                database = catalog.schema()
+            except AttributeError:
+                database = catalog.database()
 
         table = database.table(table_name)
         return sch.schema(table.schema)
@@ -414,7 +420,11 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         )
 
     def _in_memory_table_exists(self, name: str) -> bool:
-        db = self.con.catalog().database()
+        try:
+            db = self.con.catalog().schema()
+        except AttributeError:
+            db = self.con.catalog().database()
+
         try:
             db.table(name)
         except Exception:  # noqa: BLE001 because DataFusion has nothing better
@@ -426,7 +436,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         # self.con.register_table is broken, so we do this roundabout thing
         # of constructing a datafusion DataFrame, which has a side effect
         # of registering the table
-        self.con.from_arrow_table(op.data.to_pyarrow(op.schema), op.name)
+        self.con.from_arrow(op.data.to_pyarrow(op.schema), op.name)
 
     def read_csv(
         self, path: str | Path, table_name: str | None = None, **kwargs: Any

--- a/python/xorq/vendor/ibis/backends/sql/compilers/bigquery/udf/core.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/bigquery/udf/core.py
@@ -86,7 +86,11 @@ def rewrite_len(node):
     return ast.Attribute(value=node.args[0], attr="length", ctx=ast.Load())
 
 
-@rewrite.register(ast.Call(func=ast.Attribute(attr="append")))
+_append_attr = ast.Attribute.__new__(ast.Attribute)
+_append_attr.attr = "append"
+
+
+@rewrite.register(ast.Call(func=_append_attr))
 def rewrite_append(node):
     return ast.Call(
         func=ast.Attribute(value=node.func.value, attr="push", ctx=ast.Load()),


### PR DESCRIPTION
- Fix Python 3.13+ DeprecationWarning in bigquery udf/core.py: create ast.Attribute pattern via __new__ to avoid required `value` argument
- Fix pandas FutureWarning: use lowercase 'h' instead of deprecated 'H' freq alias in date_range
- Fix datafusion backend: use catalog().schema() with fallback to catalog().database() for newer datafusion API
- Remove redundant pytest.mark.backend marker in backends/conftest.py