### PR TITLE
fix(ibis_yaml): use typed cache to prevent int/bool collision in translate_from_yaml

### DIFF
--- a/python/xorq/ibis_yaml/common.py
+++ b/python/xorq/ibis_yaml/common.py
@@ -223,7 +223,7 @@ def default_handler(yaml_dict: dict, context: TranslationContext):
     ).to_expr()
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None, typed=True)
 @functools.singledispatch
 def translate_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     match yaml_dict:

--- a/python/xorq/ibis_yaml/tests/test_relations.py
+++ b/python/xorq/ibis_yaml/tests/test_relations.py
@@ -92,3 +92,20 @@ def test_limit(compiler, t):
     assert expression["n"] == 10
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
+
+
+def test_limit_not_coerced_to_bool(compiler, alltypes):
+    """Limit n=1 must stay int, not become True via cache collision.
+
+    functools.cache treats 1 and True as the same key because 1 == True
+    in Python. When a boolean field is cached before the limit value,
+    the limit roundtrips as True instead of 1, causing DataFusion to
+    reject it with: "Expected LIMIT to be an integer or null, but got Boolean".
+    """
+    expr = alltypes.filter(alltypes.bool_col).limit(1)
+    yaml_dict = compiler.to_yaml(expr)
+    roundtrip_expr = compiler.from_yaml(yaml_dict)
+
+    assert roundtrip_expr.op().n == 1
+    assert type(roundtrip_expr.op().n) is int
+    assert roundtrip_expr.equals(expr)


### PR DESCRIPTION
## Summary
- `functools.cache` on `translate_from_yaml` treats `1` and `True` as the same cache key (since `1 == True` in Python), causing `Limit(n=1)` to roundtrip as `Limit(n=True)` when a boolean value is cached first
- DataFusion then rejects the query with: `Expected LIMIT to be an integer or null, but got Boolean`
- Fix: switch to `lru_cache(maxsize=None, typed=True)` to distinguish `int` from `bool`, matching the existing `translate_to_yaml` implementation

## Test plan
- [x] Added `test_limit_not_coerced_to_bool` that filters on a boolean column then applies `.limit(1)`, verifying the roundtripped limit is `int(1)` not `True`
- [x] All existing `test_relations.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)