### PR TITLE
fix(duckdb): use isolated cursors to prevent into_backend invalidation

### DIFF
--- a/docs/adr/0003-isolated-cursors-for-duckdb-into-backend.md
+++ b/docs/adr/0003-isolated-cursors-for-duckdb-into-backend.md
@@ -1,0 +1,90 @@
+# ADR-0003: Use isolated DuckDB cursors for `into_backend` source reads
+
+- **Status:** Accepted
+- **Date:** 2026-03-20
+- **Context area:** `python/xorq/backends/duckdb/__init__.py`, `python/xorq/expr/relations.py`
+
+## Context
+
+`into_backend` transfers data between backends by wrapping source expressions in `RemoteTable` nodes. At execution time, `register_and_transform_remote_tables` materializes these nodes: it calls `to_pyarrow_batches()` on each source expression to get a streaming `RecordBatchReader`, then registers that reader on the target backend.
+
+The function uses a two-phase approach:
+
+1. **Open phase** — iterate over all `RemoteTable` nodes, calling `to_pyarrow_batches()` on each source expression to create streaming readers
+2. **Register phase** — during expression graph replacement, wrap each reader in a `RecordBatchReader` and register it on the target via `read_record_batches()`
+
+DuckDB's `to_pyarrow_batches` calls `self.con.sql(sql).fetch_arrow_reader(chunk_size)`, which opens a **live streaming result** on the connection handle. DuckDB only supports one active streaming result per connection handle. When the open phase processes the second `RemoteTable` from the same source connection, the new `con.sql()` call silently invalidates the first reader, causing it to yield zero batches.
+
+This produced three bugs:
+
+| Source | Target | Same con? | Result |
+|--------|--------|-----------|--------|
+| DuckDB | DuckDB | yes | Deadlock — source read and target registration both need the same handle |
+| DuckDB | DuckDB | no | Empty results — second cursor invalidates the first, no error raised |
+| DuckDB | DataFusion | N/A | Empty results — same invalidation, most dangerous because cross-backend federation is the primary `into_backend` use case |
+
+DataFusion was unaffected as the source because its `to_pyarrow_batches` returns a lazy generator backed by a plan object, not a live cursor. Multiple readers coexist without invalidation.
+
+### Constraints
+
+Several alternative approaches were evaluated and rejected:
+
+- **Eager materialization** (`list(to_pyarrow_batches())`) — consumes the cursor immediately but loads the entire dataset into Python heap memory. For large tables this causes OOM, since Python has no spill-to-disk mechanism.
+
+- **Global cursor in `to_pyarrow_batches`** (always use `con.cursor()`) — DuckDB cursors cannot see replacement scans created by `con.register()` or temporary tables. This breaks normal query execution, where `execute()` calls `to_pyarrow_batches` on expressions that reference registered in-memory tables.
+
+- **Sequential processing** (open one cursor, register, consume, then open the next) — requires the target's `read_record_batches` to eagerly consume the reader before the next cursor opens. DuckDB's `con.register()` is lazy (data is consumed at query time, not registration time), and DataFusion's `register_record_batch_reader` is also lazy. Forcing eager consumption would require creating DuckDB tables (`CREATE TABLE ... AS SELECT`), which materializes data, and modifying every target backend.
+
+- **Locks** — the problem is not concurrent access (everything is single-threaded) but resource lifecycle: multiple streaming results are *created* before any are *consumed*. A lock cannot change this ordering without restructuring the loop, at which point it reduces to sequential processing.
+
+## Decision
+
+Add an `isolated` parameter to `to_pyarrow_batches` on the DuckDB backend. When `isolated=True`, the method uses `self.con.cursor()` to obtain a dedicated DuckDB cursor for the query, so that multiple readers from the same connection coexist without invalidation.
+
+`register_and_transform_remote_tables` calls the source backend's `to_pyarrow_batches` directly (bypassing the `Expr` dispatch) with `isolated=True`, but only when the source backend is DuckDB (`source_backend.name == "duckdb"`). Non-DuckDB backends never receive the parameter.
+
+### Changes
+
+1. **`duckdb/Backend.to_pyarrow_batches`** — new `isolated: bool = False` parameter. When true, calls `self.con.cursor().sql(sql).fetch_arrow_reader(chunk_size)` instead of `self._to_duckdb_relation(expr).fetch_arrow_reader(chunk_size)`. The default path (`isolated=False`) is unchanged. The existing `**_: Any` absorbs the parameter when passed to the base class.
+
+2. **`register_and_transform_remote_tables`** — resolves the source backend via `ex._find_backend()` and calls `source_backend.to_pyarrow_batches(ex, isolated=True)` only when `source_backend.name == "duckdb"`. For all other backends, calls `source_backend.to_pyarrow_batches(ex)` without the parameter. This avoids leaking a DuckDB-specific kwarg to backends that may forward `**kwargs` to internal methods (e.g., DataFusion forwards kwargs to `compile()`).
+
+## Rationale
+
+### Why a parameter, not a separate method?
+
+An earlier iteration added `to_pyarrow_batches_isolated()` as a separate method, with `hasattr`-based dispatch in `register_and_transform_remote_tables`. This was rejected because:
+
+- Protocol-based `hasattr` checks couple generic graph-rewriting code to backend implementation details
+- Every backend with similar constraints would need to add the same ad-hoc method
+- A parameter on the existing method is discoverable, type-checkable, and follows the existing pattern of keyword arguments that backends selectively handle
+
+### Why not change `to_pyarrow_batches` globally?
+
+DuckDB cursors (`con.cursor()`) are independent connection handles that share the database catalog (regular tables) but **not** connection-scoped state:
+
+- Replacement scans (from `con.register()`) are invisible to cursors
+- Temporary tables are invisible to cursors
+
+The vendored Ibis DuckDB backend uses `con.register()` in `read_in_memory`, `_register_in_memory_table`, and `read_record_batches`. If `to_pyarrow_batches` always used a cursor, queries referencing these registered objects would fail with `CatalogException: Table does not exist`.
+
+The `isolated` flag restricts cursor usage to the one call site that needs it — source reads during `RemoteTable` materialization — where the compiled SQL references only the source backend's own tables (not registered objects on the target).
+
+### Why call the source backend directly?
+
+`ex.to_pyarrow_batches()` dispatches through `api.to_pyarrow_batches`, which calls `_transform_expr` (and therefore `register_and_transform_remote_tables` recursively). While the recursion is a no-op for source expressions without `RemoteTable` nodes, it adds unnecessary overhead. Calling `source_backend.to_pyarrow_batches(ex, isolated=True)` directly is both more efficient and more explicit.
+
+## Consequences
+
+### Positive
+
+- All three DuckDB `into_backend` bugs are fixed (same-con deadlock, different-con empty results, cross-backend empty results) without materializing data or changing the streaming execution model.
+- No changes to `register_and_transform_remote_tables` graph replacement logic — only the batch-fetching loop is modified.
+- The `isolated` parameter is opt-in and backward-compatible. Existing callers and the default `execute()` path are unaffected.
+- Only the DuckDB backend is modified. No changes to DataFusion or other backends.
+
+### Negative
+
+- **Cursor lifetime** — the cursor returned by `con.cursor()` must remain alive as long as the `RecordBatchReader` it produced is in use. Currently, the cursor is a local that could be garbage collected. In practice, DuckDB's `fetch_arrow_reader` detaches the result from the cursor, so the reader survives GC. If a future DuckDB version changes this behavior, readers from `isolated=True` calls may silently break.
+- **Backend name check** — `register_and_transform_remote_tables` gates the `isolated` kwarg on `source_backend.name == "duckdb"`. If another backend (e.g., a future DuckDB-compatible engine) needs the same treatment, the check must be extended. An alternative would be a capability flag on the backend class, but this was deemed premature for a single backend.
+- **Single call site** — `isolated=True` is currently used only in `register_and_transform_remote_tables`. If other code needs isolated DuckDB reads in the future, the pattern exists but is not documented beyond this ADR.

--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -32,8 +32,19 @@ class Backend(IbisDuckDBBackend):
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
         chunk_size: int = 10_000,
+        isolated: bool = False,
         **_: Any,
     ) -> pa.ipc.RecordBatchReader:
+        if isolated:
+            # Use a dedicated cursor so that multiple concurrent readers
+            # from the same connection don't invalidate each other.
+            # DuckDB only supports one active streaming result per
+            # connection handle; a second con.sql() silently exhausts
+            # the first.
+            self._run_pre_execute_hooks(expr)
+            sql = self.compile(expr.as_table(), limit=limit, params=params)
+            cursor = self.con.cursor()
+            return cursor.sql(sql).fetch_arrow_reader(chunk_size)
         return self._to_duckdb_relation(
             expr, params=params, limit=limit
         ).fetch_arrow_reader(chunk_size)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -629,7 +629,10 @@ def register_and_transform_remote_tables(expr, **kwargs):
     batches_table = {}
     for arg, count in counts.items():
         ex = arg.remote_expr
-        batches = ex.to_pyarrow_batches()
+        source_backend = ex._find_backend(use_default=False)
+        batches = source_backend.to_pyarrow_batches(
+            ex, **({"isolated": True} if source_backend.name == "duckdb" else {})
+        )
         schema = ex.as_table().schema().to_pyarrow()
         replicas = SafeTee.tee(batches, count)
         batches_table[arg] = (schema, list(replicas))

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -635,7 +635,6 @@ def test_execution_expr_multiple_tables(ls_con, tables, request, mocker):
     )[lambda t: t.yearID == 2014]
     right_backend = right_t._find_backend(use_default=False)
 
-    # FIXME there seems to be an issue when doing into_backend from duckdb into duckdb
     expr = left_t.join(
         right_t.into_backend(left_backend)
         if right_backend is not left_backend
@@ -740,6 +739,59 @@ def test_multi_engine_cache(pg, ls_con, ls_batting, tmp_path, backend_name):
     )
 
     assert expr.execute() is not None
+
+
+@pytest.fixture()
+def duckdb_tables():
+    """Two tables on the same DuckDB connection for into_backend tests."""
+    con = xo.duckdb.connect()
+    con.raw_sql(
+        "CREATE TABLE flights AS SELECT * FROM "
+        "(VALUES (1, 'ATL'), (2, 'LAX'), (3, 'ATL')) t(id, origin)"
+    )
+    con.raw_sql(
+        "CREATE TABLE airports AS SELECT * FROM "
+        "(VALUES ('ATL', 'Atlanta'), ('LAX', 'Los Angeles')) t(code, city)"
+    )
+    return con, con.table("flights"), con.table("airports")
+
+
+class TestDuckDBIntoBacked:
+    """Regression tests for DuckDB single-cursor invalidation in into_backend.
+
+    DuckDB only supports one active streaming result per connection handle.
+    When register_and_transform_remote_tables opened multiple cursors before
+    consuming any, the second cursor silently invalidated the first, producing
+    empty results or deadlocks.
+    """
+
+    def _assert_join(self, flights, airports, expected=3):
+        result = flights.inner_join(airports, flights.origin == airports.code).execute()
+        assert len(result) == expected, f"Expected {expected} rows, got {len(result)}"
+        return result
+
+    def test_duckdb_same_con(self, duckdb_tables):
+        """Bug 1: into_backend with the same DuckDB connection used to deadlock."""
+        con, flights, airports = duckdb_tables
+        f = flights.into_backend(con)
+        a = airports.into_backend(con)
+        self._assert_join(f, a)
+
+    def test_duckdb_different_cons(self, duckdb_tables):
+        """Bug 2: into_backend between two DuckDB connections returned empty."""
+        _, flights, airports = duckdb_tables
+        target = xo.duckdb.connect()
+        f = flights.into_backend(target)
+        a = airports.into_backend(target)
+        self._assert_join(f, a)
+
+    def test_duckdb_to_datafusion(self, duckdb_tables):
+        """Bug 3: into_backend from DuckDB to DataFusion returned empty."""
+        _, flights, airports = duckdb_tables
+        target = xo.connect()
+        f = flights.into_backend(target)
+        a = airports.into_backend(target)
+        self._assert_join(f, a)
 
 
 def test_multi_backend(parquet_dir):


### PR DESCRIPTION
## Summary

- **DuckDB only supports one active streaming result per connection handle.** When `register_and_transform_remote_tables` opened multiple `RecordBatchReader`s from the same DuckDB source before consuming any, the second `con.sql()` silently invalidated the first reader, causing empty results or deadlocks.
- Added an `isolated` parameter to `DuckDB.to_pyarrow_batches` that uses `con.cursor()` for a dedicated handle, keeping multiple readers alive simultaneously.
- `register_and_transform_remote_tables` now calls the source backend directly with `isolated=True` when the source is DuckDB.

### Bugs fixed

| Source | Target | Same con? | Symptom |
|--------|--------|-----------|---------|
| DuckDB | DuckDB | yes | Deadlock |
| DuckDB | DuckDB | no | Empty results |
| DuckDB | DataFusion | N/A | Empty results |

## Test plan

- [x] Added `TestDuckDBIntoBacked` with three regression tests covering all three bug scenarios
- [ ] Verify existing `test_into_backend.py` tests still pass
- [ ] Verify no regressions in DuckDB `execute()` path (default `isolated=False` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)