### PR TITLE
fix(hash): stabilize ScalarUDF normalization across processes

### DIFF
--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -453,9 +453,52 @@ def tokenize_input_type(obj):
     )
 
 
+def _normalize_computed_kwargs_expr(cke):
+    """Content-stable normalization of a computed_kwargs_expr.
+
+    The default ``normalize_expr`` path generates SQL that includes
+    session-dependent UDF class names (e.g. ``_inner_fit_0`` vs
+    ``_inner_fit_3``).  These names contain a process-global counter that
+    changes depending on how many UDFs were created before this expression
+    was imported — making the token (and therefore the build hash)
+    non-deterministic under parallel test execution or multi-module import.
+
+    Instead of relying on the SQL string, we decompose the expression into
+    components whose registered normalizers are already name-insensitive:
+
+    * ``normalize_inmemorytable`` hashes pyarrow batch content
+    * ``normalize_agg_udf`` / ``normalize_scalar_udf`` hash ``__func__``
+      and arg types (excluding ``__func_name__``)
+    * ``normalize_read`` / ``normalize_cached_node`` are stable
+    """
+    op = cke.op()
+    mems = op.find(ir.InMemoryTable)
+    agg_udfs = op.find(AggUDF)
+    scalar_udfs = op.find(ScalarUDF)
+    reads = op.find(rel.Read)
+    cached = op.find(rel.CachedNode)
+    return normalize_seq_with_caller(
+        cke.schema() if isinstance(cke, ibis.expr.types.Table) else cke.type(),
+        tuple(map(normalize_inmemorytable, mems)),
+        agg_udfs,
+        scalar_udfs,
+        reads,
+        cached,
+        caller="normalize_computed_kwargs_expr",
+    )
+
+
 @dask.base.normalize_token.register(ScalarUDF)
 def normalize_scalar_udf(udf):
     typs = tuple(arg.dtype for arg in udf.args)
+    computed_kwargs_expr = udf.__config__.get("computed_kwargs_expr")
+    # Normalize computed_kwargs_expr via content-stable decomposition
+    # rather than the default normalize_expr -> normalize_op -> SQL path,
+    # which includes session-dependent UDF class names.
+    if computed_kwargs_expr is not None:
+        computed_kwargs_token = _normalize_computed_kwargs_expr(computed_kwargs_expr)
+    else:
+        computed_kwargs_token = None
     return normalize_seq_with_caller(
         ScalarUDF,
         typs,
@@ -463,7 +506,7 @@ def normalize_scalar_udf(udf):
         udf.__func__,
         #
         # ExprScalarUDF
-        udf.__config__.get("computed_kwargs_expr"),
+        computed_kwargs_token,
         # we are insensitive to these for now
         # udf.__udf_namespace__,
         # udf.__func_name__,

--- a/python/xorq/common/utils/tests/test_dask_normalize.py
+++ b/python/xorq/common/utils/tests/test_dask_normalize.py
@@ -1,6 +1,7 @@
 import hashlib
 import operator
 import pathlib
+import pickle
 import re
 from unittest.mock import (
     Mock,
@@ -14,6 +15,7 @@ import toolz
 
 import xorq.api as xo
 import xorq.common.utils.dask_normalize  # noqa: F401
+import xorq.expr.datatypes as dt
 from xorq.caching import (
     ParquetCache,
     SourceSnapshotCache,
@@ -28,6 +30,7 @@ from xorq.common.utils.dask_normalize.dask_normalize_utils import (
     patch_normalize_token,
     walk_normalized,
 )
+from xorq.expr.udf import agg, make_pandas_expr_udf
 from xorq.ibis_yaml.compiler import build_expr
 
 
@@ -261,3 +264,51 @@ def test_different_cache_types_produce_different_hashes():
     b0 = build_expr(c0)
     b1 = build_expr(c1)
     assert b0 != b1
+
+
+def test_scalar_udf_token_stable_across_udf_counter_states():
+    """Token of a ScalarUDF with computed_kwargs_expr must not depend on
+    the process-global UDF name counter."""
+
+    def train(df):
+        return pickle.dumps({"trained": True})
+
+    def predict(model, df):
+        return [0.0] * len(df)
+
+    def _build_scalar_udf():
+        t = xo.memtable({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+        schema = t[("a", "b")].schema()
+        model_udaf = agg.pandas_df(
+            fn=train,
+            schema=schema,
+            return_type=dt.binary,
+            name="mymodel",
+        )
+        predict_udf = make_pandas_expr_udf(
+            computed_kwargs_expr=model_udaf.on_expr(t),
+            fn=predict,
+            schema=schema,
+            return_type=dt.float64,
+            name="mypredict",
+        )
+        return predict_udf(t.a, t.b).op()
+
+    udf_op_1 = _build_scalar_udf()
+    token_1 = dask.base.tokenize(udf_op_1)
+
+    # Bump the global counter by creating throwaway AggUDFs,
+    # simulating a different import order or parallel worker.
+    for _ in range(5):
+        agg.pandas_df(
+            fn=train,
+            schema=xo.memtable({"x": [1]}).schema(),
+            return_type=dt.binary,
+        )
+
+    udf_op_2 = _build_scalar_udf()
+    token_2 = dask.base.tokenize(udf_op_2)
+
+    assert token_1 == token_2, (
+        f"ScalarUDF token changed with UDF counter state: {token_1} != {token_2}"
+    )


### PR DESCRIPTION
normalize_scalar_udf was passing computed_kwargs_expr through normalize_expr -> normalize_op -> unbound_expr_to_default_sql, which embeds session-dependent AggUDF class names (e.g. _inner_fit_0) whose numeric suffix is a process-global counter. Under pytest-xdist or multi-module import, the counter value is non-deterministic, producing different tokens for functionally identical expressions.

Add _normalize_computed_kwargs_expr that decomposes the sub-expression into content-stable components (InMemoryTable data, AggUDF/ScalarUDF via their registered normalizers, Read/CachedNode), bypassing SQL generation entirely.