### PR TITLE
ref(ExprMetadata): extract explicit fields, drop expr dependency

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -474,17 +474,19 @@ class CatalogEntry:
         return load_expr_from_zip(self.catalog_path)
 
     @cached_property
-    def metadata(self) -> dict:
+    def metadata(self):
+        from xorq.vendor.ibis.expr.types.core import ExprMetadata  # noqa: PLC0415
+
         data = self._read_zip_member(DumpFiles.expr_metadata, json.loads)
         if not isinstance(data, dict):
             raise ValueError(
                 f"Expected {DumpFiles.expr_metadata!r} to contain a JSON object in {self.catalog_path}"
             )
-        return data
+        return ExprMetadata.from_dict(data)
 
     @property
     def kind(self) -> ExprKind:
-        return ExprKind(self.metadata["kind"])
+        return self.metadata.kind
 
     @cached_property
     def backends(self) -> tuple[str, ...]:

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -385,7 +385,7 @@ def schema(ctx, name, as_json):
             ) from err
 
         if as_json:
-            click.echo(json_mod.dumps(entry.metadata, indent=2))
+            click.echo(json_mod.dumps(entry.metadata.to_dict(), indent=2))
             return
 
         type_label = (
@@ -395,11 +395,15 @@ def schema(ctx, name, as_json):
         )
         click.echo(f"Type: {type_label}")
 
-        for label, key in (("Schema In", "schema_in"), ("Schema Out", "schema_out")):
-            if (sch := entry.metadata.get(key)) is not None:
+        meta = entry.metadata
+        for label, schema in (
+            ("Schema In", meta.schema_in),
+            ("Schema Out", meta.schema_out),
+        ):
+            if schema is not None:
                 click.echo()
                 click.echo(f"{label}:")
-                for col, dtype in sch.items():
+                for col, dtype in schema.items():
                     click.echo(f"  {col:<24} {dtype}")
 
 

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -360,31 +360,35 @@ def test_extract_kind_partial(catalog):
 def test_schema_out_bound(catalog):
     expr = xo.memtable({"col_a": [1, 2], "col_b": ["x", "y"]})
     entry = catalog.add(expr)
-    assert entry.metadata["schema_out"] == {"col_a": "int64", "col_b": "string"}
+    assert entry.metadata.schema_out == xo.Schema({"col_a": "int64", "col_b": "string"})
 
 
 def test_schema_in_none_for_bound(catalog):
     expr = xo.memtable({"a": [1, 2, 3]})
     entry = catalog.add(expr)
-    assert "schema_in" not in entry.metadata
+    assert entry.metadata.schema_in is None
 
 
 def test_schema_out_unbound(catalog):
     t = xo.table(schema={"amount": "float64", "currency": "string"})
     expr = t.mutate(amount_usd=t.amount * 1.2)
     entry = catalog.add(expr)
-    assert entry.metadata["schema_out"] == {
-        "amount": "float64",
-        "currency": "string",
-        "amount_usd": "float64",
-    }
+    assert entry.metadata.schema_out == xo.Schema(
+        {
+            "amount": "float64",
+            "currency": "string",
+            "amount_usd": "float64",
+        }
+    )
 
 
 def test_schema_in_unbound(catalog):
     t = xo.table(schema={"amount": "float64", "currency": "string"})
     expr = t.filter(t.amount > 0)
     entry = catalog.add(expr)
-    assert entry.metadata["schema_in"] == {"amount": "float64", "currency": "string"}
+    assert entry.metadata.schema_in == xo.Schema(
+        {"amount": "float64", "currency": "string"}
+    )
 
 
 def test_get_entry_by_alias(catalog):

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -39,14 +39,14 @@ def test_flight_udxf_validate_schema_fail(schema_val, pattern):
 
 def test_kind_memtable_is_source():
     expr = xo.memtable({"a": [1, 2, 3]})
-    assert ExprMetadata(expr).kind == ExprKind.Source
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.Source
 
 
 def test_kind_database_table_is_source():
     con = xo.connect()
     con.raw_sql("CREATE TABLE _test_src (a INT, b VARCHAR)")
     expr = con.table("_test_src")
-    assert ExprMetadata(expr).kind == ExprKind.Source
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.Source
 
 
 def test_kind_deferred_read_is_source():
@@ -54,7 +54,7 @@ def test_kind_deferred_read_is_source():
         "s3://bucket/data.parquet",
         schema={"a": "int64", "b": "string"},
     )
-    assert ExprMetadata(expr).kind == ExprKind.Source
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.Source
 
 
 def test_kind_cached_node_is_source():
@@ -68,53 +68,53 @@ def test_kind_cached_node_is_source():
         source=dt.source,
         parent=table_expr,
     )
-    assert ExprMetadata(cached.to_expr()).kind == ExprKind.Source
+    assert ExprMetadata.from_expr(cached.to_expr()).kind == ExprKind.Source
 
 
 def test_kind_tagged_source_is_source():
     schema = ibis.schema({"a": "int64"})
     inner = xo.memtable({"a": [1, 2, 3]}).op()
     tagged = Tag(schema=schema, parent=inner)
-    assert ExprMetadata(tagged.to_expr()).kind == ExprKind.Source
+    assert ExprMetadata.from_expr(tagged.to_expr()).kind == ExprKind.Source
 
 
 def test_kind_hashing_tagged_source_is_source():
     schema = ibis.schema({"a": "int64"})
     inner = xo.memtable({"a": [1, 2, 3]}).op()
     tagged = HashingTag(schema=schema, parent=inner)
-    assert ExprMetadata(tagged.to_expr()).kind == ExprKind.Source
+    assert ExprMetadata.from_expr(tagged.to_expr()).kind == ExprKind.Source
 
 
 def test_kind_filtered_table_is_expr():
     expr = xo.memtable({"a": [1, 2, 3]}).filter(xo._.a > 1)
-    assert ExprMetadata(expr).kind == ExprKind.Expr
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.Expr
 
 
 def test_kind_projected_table_is_expr():
     expr = xo.memtable({"a": [1, 2], "b": [3, 4]}).select("a")
-    assert ExprMetadata(expr).kind == ExprKind.Expr
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.Expr
 
 
 def test_kind_aggregated_table_is_expr():
     t = xo.memtable({"a": [1, 2, 3]})
     expr = t.aggregate(total=t.a.sum())
-    assert ExprMetadata(expr).kind == ExprKind.Expr
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.Expr
 
 
 def test_kind_unbound_table_is_unbound_expr():
     t = xo.table(schema={"a": "int64"})
-    assert ExprMetadata(t).kind == ExprKind.UnboundExpr
+    assert ExprMetadata.from_expr(t).kind == ExprKind.UnboundExpr
 
 
 def test_kind_filtered_unbound_is_unbound_expr():
     t = xo.table(schema={"a": "int64"})
     expr = t.filter(t.a > 0)
-    assert ExprMetadata(expr).kind == ExprKind.UnboundExpr
+    assert ExprMetadata.from_expr(expr).kind == ExprKind.UnboundExpr
 
 
 def test_kind_source_to_dict():
     expr = xo.memtable({"a": [1, 2, 3]})
-    d = ExprMetadata(expr).to_dict()
+    d = ExprMetadata.from_expr(expr).to_dict()
     assert d["kind"] == "source"
     assert "schema_out" in d
     assert "schema_in" not in d
@@ -145,7 +145,7 @@ def test_ls_kind_matches_metadata():
         xo.table(schema={"a": "int64"}),
     ]
     for expr in exprs:
-        assert expr.ls.kind == ExprMetadata(expr).kind
+        assert expr.ls.kind == ExprMetadata.from_expr(expr).kind
 
 
 # -- .ls.unwrapped accessor ---------------------------------------------------

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -505,7 +505,7 @@ class ExprDumper:
         return path, writer
 
     def _make_expr_metadata(self, expr) -> Dict[str, Any]:
-        return ExprMetadata(expr).to_dict()
+        return ExprMetadata.from_expr(expr).to_dict()
 
     def _prepare_expr_metadata_file(self, expr):
         path = self.artifact_store.get_path(DumpFiles.expr_metadata)

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -14,6 +14,7 @@ from attr import (
 )
 from attr.validators import (
     instance_of,
+    optional,
 )
 from public import public
 
@@ -678,44 +679,66 @@ class Expr(Immutable, Coercible):
         return LETSQLAccessor(self.op())
 
 
+def _extract_unbound_node(expr):
+    from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
+
+    unbound_node, *rest = walk_nodes(ops.UnboundTable, expr) or (None,)
+    if rest:
+        raise ValueError("Expected at most one UnboundTable")
+    return unbound_node
+
+
+def _extract_is_source(expr):
+    from xorq.expr.relations import CachedNode, Read  # noqa: PLC0415
+
+    source_nodes = (ops.DatabaseTable, Read, ops.InMemoryTable, CachedNode)
+    root = expr.ls.unwrapped
+    return isinstance(root, source_nodes)
+
+
+def _extract_kind(unbound_node, is_source):
+    match (unbound_node, is_source):
+        case (node, _) if node is not None:
+            return ExprKind.UnboundExpr
+        case (_, True):
+            return ExprKind.Source
+        case _:
+            return ExprKind.Expr
+
+
 @frozen
 class ExprMetadata:
-    expr = field(validator=instance_of(Expr))
+    kind: ExprKind = field(validator=instance_of(ExprKind))
+    schema_out: Schema = field(validator=instance_of(ibis.expr.schema.Schema))
+    schema_in: Optional[Schema] = field(
+        default=None, validator=optional(instance_of(ibis.expr.schema.Schema))
+    )
 
-    @cached_property
-    def _unbound_node(self):
-        from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
+    @classmethod
+    def from_dict(cls, data):
+        schema_in_raw = data.get("schema_in")
+        return cls(
+            kind=ExprKind(data["kind"]),
+            schema_out=ibis.Schema.from_tuples(
+                [(k, v) for k, v in data["schema_out"].items()]
+            ),
+            schema_in=(
+                ibis.Schema.from_tuples([(k, v) for k, v in schema_in_raw.items()])
+                if schema_in_raw
+                else None
+            ),
+        )
 
-        unbound_node, *rest = walk_nodes(ops.UnboundTable, self.expr) or (None,)
-        if rest:
-            raise ValueError("Expected at most one UnboundTable")
-        return unbound_node
+    @classmethod
+    def from_expr(cls, expr):
+        unbound_node = _extract_unbound_node(expr)
+        is_source = _extract_is_source(expr)
 
-    @cached_property
-    def _is_source(self):
-        from xorq.expr.relations import CachedNode, Read
-
-        source_nodes = (ops.DatabaseTable, Read, ops.InMemoryTable, CachedNode)
-        root = self.expr.ls.unwrapped
-        return isinstance(root, source_nodes)
-
-    @cached_property
-    def kind(self) -> ExprKind:
-        match (self._unbound_node, self._is_source):
-            case (node, _) if node is not None:
-                return ExprKind.UnboundExpr
-            case (_, True):
-                return ExprKind.Source
-            case _:
-                return ExprKind.Expr
-
-    @cached_property
-    def schema_in(self) -> Optional[Schema]:
-        return node.schema if (node := self._unbound_node) else None
-
-    @cached_property
-    def schema_out(self):
-        return self.expr.as_table().schema()
+        return cls(
+            kind=_extract_kind(unbound_node, is_source),
+            schema_in=unbound_node.schema if unbound_node else None,
+            schema_out=expr.as_table().schema(),
+        )
 
     def to_dict(self):
         return {
@@ -743,11 +766,19 @@ class LETSQLAccessor:
 
     @cached_property
     def metadata(self):
-        return ExprMetadata(self.expr)
+        return ExprMetadata.from_expr(self.expr)
 
     @property
     def kind(self) -> ExprKind:
         return self.metadata.kind
+
+    @property
+    def is_source(self):
+        return _extract_is_source(self.expr)
+
+    @property
+    def sources(self):
+        return self.metadata.sources
 
     @property
     def cached_nodes(self):


### PR DESCRIPTION
Refactor ExprMetadata from cached_property-on-expr to explicit attrs fields (kind, schema_out, schema_in) with from_expr and from_dict classmethods. This makes ExprMetadata a standalone value object that can be constructed from either a live expression or serialized dict, without holding a reference to the original expr.