### PR TITLE
feat(expr): add ExprKind.Composed and sources to ExprMetadata

### DIFF
--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class CatalogTag(StrEnum):
+    SOURCE = "catalog-source"
+    TRANSFORM = "catalog-transform"
+    CODE = "catalog-code"

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -507,6 +507,11 @@ class CatalogEntry:
         return self.metadata.root_tag or ""
 
     @cached_property
+    def sources(self) -> tuple:
+        """Catalog source references for composed entries."""
+        return self.metadata.sources
+
+    @cached_property
     def backends(self) -> tuple[str, ...]:
         data = self._read_zip_member(DumpFiles.profiles, yaml.safe_load)
         if not isinstance(data, dict):

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -4,6 +4,7 @@ import json
 import operator
 import pathlib
 import sys
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Dict
 
@@ -98,6 +99,9 @@ class CleanDictYAMLDumper(yaml.SafeDumper):
         schema_dict = {name: str(dtype) for name, dtype in zip(data.names, data.types)}
         return self.represent_mapping("tag:yaml.org,2002:map", schema_dict)
 
+    def represent_str_enum(self, data):
+        return self.represent_scalar("tag:yaml.org,2002:str", str(data))
+
     def represent_posix_path(self, data):
         return self.represent_scalar("tag:yaml.org,2002:str", str(data))
 
@@ -109,10 +113,14 @@ class CleanDictYAMLDumper(yaml.SafeDumper):
         (pathlib.PosixPath, represent_posix_path),
     )
 
+    yaml_multi_representer_pairs = ((StrEnum, represent_str_enum),)
+
     @classmethod
     def add_representers(cls):
         for to_register, representer in cls.yaml_representer_pairs:
             cls.add_representer(to_register, representer)
+        for to_register, representer in cls.yaml_multi_representer_pairs:
+            cls.add_multi_representer(to_register, representer)
 
 
 CleanDictYAMLDumper.add_representers()

--- a/python/xorq/ibis_yaml/enums.py
+++ b/python/xorq/ibis_yaml/enums.py
@@ -25,6 +25,7 @@ class ExprKind(StrEnum):
     Source = "source"
     Expr = "expr"
     UnboundExpr = "unbound_expr"
+    Composed = "composed"
 
 
 class MemtableTypes(StrEnum):

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -13,6 +13,7 @@ from attr import (
     frozen,
 )
 from attr.validators import (
+    deep_iterable,
     instance_of,
     optional,
 )
@@ -696,11 +697,41 @@ def _extract_is_source(expr):
     return isinstance(root, source_nodes)
 
 
-def _extract_kind(unbound_node, is_source):
-    match (unbound_node, is_source):
-        case (node, _) if node is not None:
+def _extract_catalog_tag_nodes(expr):
+    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
+    from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
+    from xorq.expr.relations import HashingTag  # noqa: PLC0415
+
+    return tuple(
+        ht
+        for ht in (walk_nodes(HashingTag, expr) or ())
+        if ht.metadata.get("tag") in frozenset(CatalogTag)
+    )
+
+
+def _extract_sources(catalog_tag_nodes):
+    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
+
+    return tuple(
+        {
+            "entry_name": ht.metadata.get("entry_name"),
+            "alias": ht.metadata.get("alias"),
+            "kind": ht.metadata.get("kind"),
+        }
+        for ht in catalog_tag_nodes
+        if ht.metadata.get("tag") in (CatalogTag.SOURCE, CatalogTag.TRANSFORM)
+    )
+
+
+def _extract_kind(unbound_node, catalog_tag_nodes, is_source):
+    # Priority: UnboundExpr (incomplete/has placeholder) > Composed (has
+    # catalog HashingTag nodes) > Source (plain table) > Expr (everything else).
+    match (unbound_node, bool(catalog_tag_nodes), is_source):
+        case (node, _, _) if node is not None:
             return ExprKind.UnboundExpr
-        case (_, True):
+        case (_, True, _):
+            return ExprKind.Composed
+        case (_, _, True):
             return ExprKind.Source
         case _:
             return ExprKind.Expr
@@ -715,6 +746,7 @@ class ExprMetadata:
     )
     root_tag: Optional[str] = field(default=None)
     parquet_cache_paths: tuple[str, ...] = field(factory=tuple)
+    sources: tuple = field(factory=tuple, validator=deep_iterable(instance_of(dict)))
 
     @classmethod
     def from_dict(cls, data):
@@ -731,6 +763,7 @@ class ExprMetadata:
             ),
             root_tag=data.get("root_tag"),
             parquet_cache_paths=tuple(data.get("parquet_cache_paths") or ()),
+            sources=tuple(data.get("sources", ())),
         )
 
     @classmethod
@@ -741,6 +774,7 @@ class ExprMetadata:
 
         unbound_node = _extract_unbound_node(expr)
         is_source = _extract_is_source(expr)
+        catalog_tag_nodes = _extract_catalog_tag_nodes(expr)
 
         tags = expr.ls.tags
         root_tag = tags[0].tag if tags else None
@@ -753,11 +787,12 @@ class ExprMetadata:
         )
 
         return cls(
-            kind=_extract_kind(unbound_node, is_source),
+            kind=_extract_kind(unbound_node, catalog_tag_nodes, is_source),
             schema_in=unbound_node.schema if unbound_node else None,
             schema_out=expr.as_table().schema(),
             root_tag=root_tag,
             parquet_cache_paths=parquet_cache_paths,
+            sources=_extract_sources(catalog_tag_nodes),
         )
 
     def to_dict(self):
@@ -772,6 +807,7 @@ class ExprMetadata:
                 ("schema_out", toolz.valmap(str, self.schema_out)),
                 ("root_tag", self.root_tag),
                 ("parquet_cache_paths", list(self.parquet_cache_paths) or None),
+                ("sources", list(self.sources) if self.sources else None),
             )
             if value is not None
         }


### PR DESCRIPTION
## Summary
- Add `ExprKind.Composed` for expressions built from catalog entries with provenance tags
- Add `sources` field to `ExprMetadata` capturing catalog source/transform references from `CatalogTag` `HashingTag` nodes
- Add `CatalogTag` enum in `catalog/bind.py` (minimal; full bind logic follows in a later PR)
- Add `StrEnum` YAML multi-representer to `CleanDictYAMLDumper` for correct serialization of `CatalogTag` values
- Add `CatalogEntry.sources` property
- Fixes latent bug where `LETSQLAccessor.sources` referenced non-existent `ExprMetadata.sources`

Existing fields (`root_tag`, `parquet_cache_paths`) are preserved.

## Test plan
- [x] All 23 relation tests pass
- [x] All 366 ibis_yaml tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)