### PR TITLE
feat(catalog): add ExprComposer.from_expr to recover composer from ta…

### DIFF
--- a/python/xorq/catalog/composer.py
+++ b/python/xorq/catalog/composer.py
@@ -50,3 +50,60 @@ class ExprComposer:
             current = current.hashing_tag(CatalogTag.CODE, code=self.code)
 
         return current
+
+    @classmethod
+    def from_expr(cls, expr, catalog):
+        """Recover an ExprComposer from a tagged expression.
+
+        Walks the HashingTag nodes embedded by a prior ``ExprComposer.expr``
+        call and reconstructs the original ``source``, ``transforms``,
+        ``code``, and ``alias`` fields.
+
+        Parameters
+        ----------
+        expr : Expr
+            An expression previously produced by ``ExprComposer.expr``.
+        catalog : Catalog
+            The catalog that owns the referenced entries.
+        """
+        from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
+        from xorq.expr.relations import HashingTag  # noqa: PLC0415
+
+        # walk_nodes returns outermost-first; reverse to get composition order
+        # reversed order: SOURCE, transforms..., CODE (if present)
+        nodes = tuple(
+            reversed(
+                tuple(
+                    ht
+                    for ht in (walk_nodes(HashingTag, expr) or ())
+                    if ht.metadata.get("tag") in frozenset(CatalogTag)
+                )
+            )
+        )
+        if not nodes or not nodes[0].metadata["tag"] == CatalogTag.SOURCE:
+            raise ValueError(
+                "No catalog-source tag found; expression was not produced by ExprComposer"
+            )
+
+        if nodes[-1].metadata["tag"] == CatalogTag.CODE:
+            (*nodes, code_node) = nodes
+            code = code_node.metadata["code"]
+        else:
+            code = None
+
+        (source_node, *transform_nodes) = nodes
+        if not all(n.metadata["tag"] == CatalogTag.TRANSFORM for n in transform_nodes):
+            raise ValueError(
+                "Unexpected non-transform tag found between source and code tags"
+            )
+
+        (source_entry, *transform_entries) = (
+            catalog.get_catalog_entry(node.metadata["entry_name"]) for node in nodes
+        )
+        alias = source_node.metadata.get("alias")
+        return cls(
+            source=source_entry,
+            transforms=tuple(transform_entries),
+            code=code,
+            alias=alias,
+        )

--- a/python/xorq/catalog/tests/test_bind.py
+++ b/python/xorq/catalog/tests/test_bind.py
@@ -562,3 +562,86 @@ def test_composed_expr_bare_source(catalog_with_entries):
 def test_composed_expr_bad_source_raises():
     with pytest.raises(TypeError, match="must be.*CatalogEntry"):
         ExprComposer(source="not-an-entry", transforms=("also-bad",))
+
+
+# --- ExprComposer.from_expr tests ---
+
+
+def test_from_expr_single_transform(catalog_with_entries):
+    catalog, source_entry, transform_entry = catalog_with_entries
+    original = ExprComposer(source=source_entry, transforms=(transform_entry,))
+    recovered = ExprComposer.from_expr(original.expr, catalog)
+
+    assert recovered.source.name == source_entry.name
+    assert len(recovered.transforms) == 1
+    assert recovered.transforms[0].name == transform_entry.name
+    assert recovered.code is None
+    # alias resolves to the entry's first alias even when not explicitly passed
+    assert recovered.alias == "my-source"
+
+
+def test_from_expr_bare_source(catalog_with_entries):
+    catalog, source_entry, _ = catalog_with_entries
+    original = ExprComposer(source=source_entry)
+    recovered = ExprComposer.from_expr(original.expr, catalog)
+
+    assert recovered.source.name == source_entry.name
+    assert recovered.transforms == ()
+    assert recovered.code is None
+
+
+def test_from_expr_with_code(catalog_with_entries):
+    catalog, source_entry, transform_entry = catalog_with_entries
+    code = "source.filter(source.amount > 15)"
+    original = ExprComposer(
+        source=source_entry, transforms=(transform_entry,), code=code
+    )
+    recovered = ExprComposer.from_expr(original.expr, catalog)
+
+    assert recovered.source.name == source_entry.name
+    assert len(recovered.transforms) == 1
+    assert recovered.transforms[0].name == transform_entry.name
+    assert recovered.code == code
+
+
+def test_from_expr_code_only(catalog_with_entries):
+    catalog, source_entry, _ = catalog_with_entries
+    code = "source.filter(source.amount > 15)"
+    original = ExprComposer(source=source_entry, code=code)
+    recovered = ExprComposer.from_expr(original.expr, catalog)
+
+    assert recovered.source.name == source_entry.name
+    assert recovered.transforms == ()
+    assert recovered.code == code
+
+
+def test_from_expr_with_alias(catalog_with_entries):
+    catalog, source_entry, transform_entry = catalog_with_entries
+    original = ExprComposer(
+        source=source_entry, transforms=(transform_entry,), alias="custom-alias"
+    )
+    recovered = ExprComposer.from_expr(original.expr, catalog)
+
+    assert recovered.alias == "custom-alias"
+
+
+def test_from_expr_chained_transforms(catalog_with_entries):
+    catalog, source_entry, transform_entry = catalog_with_entries
+    output_schema = xo.Schema({"user_id": "int64", "amount": "float64"})
+    ub2 = ops.UnboundTable(name="ph2", schema=output_schema).to_expr()
+    t2_entry = catalog.add(ub2.filter(ub2.amount > 15))
+
+    original = ExprComposer(source=source_entry, transforms=(transform_entry, t2_entry))
+    recovered = ExprComposer.from_expr(original.expr, catalog)
+
+    assert recovered.source.name == source_entry.name
+    assert len(recovered.transforms) == 2
+    assert recovered.transforms[0].name == transform_entry.name
+    assert recovered.transforms[1].name == t2_entry.name
+
+
+def test_from_expr_no_tags_raises(catalog_with_entries):
+    catalog, _, _ = catalog_with_entries
+    bare = xo.memtable({"x": [1, 2, 3]})
+    with pytest.raises(ValueError, match="No catalog-source tag found"):
+        ExprComposer.from_expr(bare, catalog)


### PR DESCRIPTION
…gged expr

Walks HashingTag nodes (SOURCE, TRANSFORM, CODE) embedded during composition and reconstructs the original ExprComposer fields. This enables round-tripping: build an expr via ExprComposer, then recover the recipe from the expression's provenance tags.