### PR TITLE
fix: use namespace-aware table lookup in cross-database expr building

### DIFF
--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -202,7 +202,9 @@ def replace_sources(source_mapping, expr, *, transfer_tables=False):
             # DatabaseTable (but not its subclasses like CachedNode, RemoteTable,
             # Read) needs its data transferred to the new backend.
             if type(node) is ops.DatabaseTable:
-                tables_to_transfer.append((source, new_source, node.name))
+                tables_to_transfer.append(
+                    (source, new_source, node.name, node.namespace)
+                )
 
         cache = getattr(node, "cache", None)
         if cache is not None:
@@ -239,18 +241,28 @@ def replace_sources(source_mapping, expr, *, transfer_tables=False):
     return result
 
 
+def _namespace_to_database(namespace):
+    """Convert a Namespace to the ``database`` kwarg accepted by backend methods."""
+    if namespace.catalog and namespace.database:
+        return (namespace.catalog, namespace.database)
+    if namespace.database:
+        return namespace.database
+    return None
+
+
 def _find_missing_tables(tables_to_transfer):
     """Return the subset of tables that don't exist on the target backend."""
     missing = []
     seen = set()
-    for old_backend, new_backend, table_name in tables_to_transfer:
-        key = (id(new_backend), table_name)
+    for old_backend, new_backend, table_name, namespace in tables_to_transfer:
+        key = (id(new_backend), table_name, namespace.catalog, namespace.database)
         if key in seen:
             continue
         seen.add(key)
         try:
-            if table_name in new_backend.list_tables():
-                continue
+            database = _namespace_to_database(namespace)
+            new_backend.table(table_name, database=database)
+            continue
         except Exception:
             pass
         missing.append((old_backend, new_backend, table_name))

--- a/python/xorq/common/utils/tests/test_replace_sources.py
+++ b/python/xorq/common/utils/tests/test_replace_sources.py
@@ -5,8 +5,14 @@ import pytest
 import xorq.api as xo
 import xorq.expr.datatypes as dt
 import xorq.expr.relations as rel
+import xorq.vendor.ibis.expr.operations as ops
 from xorq.caching import ParquetCache, SourceCache
-from xorq.common.utils.graph_utils import find_all_sources, replace_sources
+from xorq.common.utils.graph_utils import (
+    _find_missing_tables,
+    _namespace_to_database,
+    find_all_sources,
+    replace_sources,
+)
 
 
 def assert_result_equal(left, right):
@@ -401,3 +407,88 @@ def test_replace_sources_does_not_mutate_original(parquet_path):
 
     assert find_all_sources(t) == original_sources
     assert original_sources[0] is xo_con
+
+
+# ---------------------------------------------------------------------------
+# _namespace_to_database helper
+# ---------------------------------------------------------------------------
+
+
+def test_namespace_to_database_both():
+    ns = ops.Namespace(catalog="my_cat", database="my_db")
+    assert _namespace_to_database(ns) == ("my_cat", "my_db")
+
+
+def test_namespace_to_database_db_only():
+    ns = ops.Namespace(catalog=None, database="my_db")
+    assert _namespace_to_database(ns) == "my_db"
+
+
+def test_namespace_to_database_empty():
+    ns = ops.Namespace()
+    assert _namespace_to_database(ns) is None
+
+
+# ---------------------------------------------------------------------------
+# _find_missing_tables with namespace
+# ---------------------------------------------------------------------------
+
+
+def test_find_missing_tables_respects_namespace():
+    """A table in a non-default schema should not be flagged as missing."""
+    con = xo.duckdb.connect()
+    con.raw_sql("CREATE SCHEMA IF NOT EXISTS other_schema")
+    con.raw_sql("CREATE TABLE other_schema.my_table AS SELECT 1 AS x")
+
+    ns = ops.Namespace(catalog=None, database="other_schema")
+    result = _find_missing_tables([(con, con, "my_table", ns)])
+    assert result == []
+
+
+def test_find_missing_tables_detects_truly_missing():
+    """A table that doesn't exist anywhere should be flagged as missing."""
+    con = xo.duckdb.connect()
+    ns = ops.Namespace(catalog=None, database="nonexistent_schema")
+    result = _find_missing_tables([(con, con, "no_such_table", ns)])
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-schema / cross-catalog replace_sources (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_replace_sources_cross_schema_no_transfer():
+    """Replacing source on a table in a non-default schema should not
+    require transfer_tables when the table already exists on the target."""
+    con1 = xo.duckdb.connect()
+    con1.raw_sql("CREATE SCHEMA IF NOT EXISTS alt")
+    con1.raw_sql("CREATE TABLE alt.t AS SELECT 1 AS x")
+
+    t = con1.table("t", database="alt")
+
+    con2 = xo.duckdb.connect()
+    con2.raw_sql("CREATE SCHEMA IF NOT EXISTS alt")
+    con2.raw_sql("CREATE TABLE alt.t AS SELECT 1 AS x")
+
+    # Before fix: raises ValueError because list_tables() (default schema) misses "t"
+    result = replace_sources({id(con1): con2}, t)
+    assert_result_equal(result.execute(), t.execute())
+
+
+def test_replace_sources_catalog_and_schema():
+    """Table in catalog.schema is found via namespace, not bare list_tables."""
+    con = xo.duckdb.connect()
+    con.raw_sql("ATTACH ':memory:' AS other_cat")
+    con.raw_sql("CREATE SCHEMA other_cat.my_schema")
+    con.raw_sql("CREATE TABLE other_cat.my_schema.t AS SELECT 42 AS val")
+
+    t = con.table("t", database=("other_cat", "my_schema"))
+
+    con2 = xo.duckdb.connect()
+    con2.raw_sql("ATTACH ':memory:' AS other_cat")
+    con2.raw_sql("CREATE SCHEMA other_cat.my_schema")
+    con2.raw_sql("CREATE TABLE other_cat.my_schema.t AS SELECT 42 AS val")
+
+    result = replace_sources({id(con): con2}, t)
+    assert result.execute()["val"].tolist() == [42]


### PR DESCRIPTION
## Summary
- `_find_missing_tables` was checking `table_name in backend.list_tables()` which only searches the default schema, causing false `ValueError` for tables in non-default schemas/catalogs (e.g. `CREDIT_CARD_ACCOUNTS` in a specific catalog/schema)
- Now propagates the `DatabaseTable` node's `namespace` and uses `backend.table(name, database=...)` to test reachability directly
- Adds `_namespace_to_database` helper to convert `Namespace(catalog, database)` to the `database` kwarg format

## Test plan
- [x] Unit tests for `_namespace_to_database` (catalog+db, db-only, empty)
- [x] `_find_missing_tables` correctly finds table in non-default schema
- [x] `_find_missing_tables` still detects truly missing tables
- [x] End-to-end `replace_sources` with cross-schema table (no transfer needed)
- [x] End-to-end `replace_sources` with catalog + schema namespace
- [x] All 75 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)