### PR TITLE
feat(catalog): add embed-readonly command to verify and embed read-on…

### DIFF
--- a/python/xorq/catalog/annex.py
+++ b/python/xorq/catalog/annex.py
@@ -587,6 +587,15 @@ class S3RemoteConfig(RemoteConfig):
                 return False
             raise
 
+    def assert_readonly(self):
+        """Raise ``ValueError`` if these credentials can write to the bucket."""
+        result = self.check_bucket(check_write=True)
+        if result["writable"]:
+            raise ValueError(
+                f"Credentials for bucket {self.bucket!r} have write access; "
+                f"expected read-only credentials."
+            )
+
     @property
     def initremote_params(self):
         params = [

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from subprocess import Popen
 from urllib.parse import urlparse
 
+import attr
 import toolz
 import yaml12
 from attr import (
@@ -149,6 +150,18 @@ class Catalog:
         git-annex branch.  Use ``catalog.remote_config`` to read it back.
         """
         remote_config.enableremote(self.repo_path)
+
+    def embed_readonly(self, readonly_config):
+        """Embed read-only credentials into the git-annex branch.
+
+        Verifies that *readonly_config* cannot write to the bucket, then
+        sets ``embedcreds=yes`` and writes the config to remote.log.
+
+        Raises ``ValueError`` if the credentials have write access.
+        """
+        readonly_config.assert_readonly()
+        embed_config = attr.evolve(readonly_config, embedcreds="yes")
+        self.set_remote_config(embed_config)
 
     def _add_zip(self, path, sync=True, aliases=(), exist_ok=False):
         # should we enable not syncing?

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -568,6 +568,37 @@ def replay(
             click.echo(f"Pushed to {remote_url}")
 
 
+@cli.command("embed-readonly")
+@click.option(
+    "--env-file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Env file for read-only credentials to embed.",
+)
+@click.option(
+    "--env-prefix",
+    default=None,
+    help="Env var prefix for read-only credentials (e.g. XORQ_CATALOG_S3_).",
+)
+@click.option("--gcs", is_flag=True, help="Apply GCS defaults to S3 remote config.")
+@click.pass_context
+def embed_readonly(ctx, env_file, env_prefix, gcs):
+    """Embed read-only S3 credentials into the catalog's git-annex branch.
+
+    Verifies that the provided credentials cannot write to the bucket
+    before embedding them.
+    """
+    with click_context_catalog(ctx):
+        ro_config = _resolve_annex_option(env_file, env_prefix, gcs)
+        if ro_config is None:
+            raise click.UsageError(
+                "Provide --env-file or --env-prefix for the read-only credentials."
+            )
+        catalog = ctx.obj.make_catalog(init=False)
+        catalog.embed_readonly(ro_config)
+        click.echo(f"Embedded read-only credentials into {catalog.repo_path}")
+
+
 def _eval_entry(catalog_entry, code, instream=None):
     """Evaluate a single catalog entry to an expression."""
     from xorq.catalog.bind import _eval_code, _make_source_expr


### PR DESCRIPTION
…ly S3 creds

Adds S3RemoteConfig.assert_readonly(), Catalog.embed_readonly(), and the `xorq catalog embed-readonly` CLI command. The command verifies credentials cannot write before embedding them into the git-annex branch.