### PR TITLE
fix(catalog): validate required fields before constructing RemoteConfig

### DIFF
--- a/python/xorq/catalog/annex.py
+++ b/python/xorq/catalog/annex.py
@@ -228,7 +228,12 @@ class Annex:
             and getattr(env_config, a.name)
             and a.name not in config
         }
-        return cls.from_dict(config, **{**env_fallback, **instance_fallback, **kwargs})
+        merged = config | env_fallback | instance_fallback | kwargs
+        # check that all required fields (no default) are present
+        required = {a.name for a in attr.fields(cls) if a.default is attr.NOTHING}
+        if not required.issubset(merged):
+            return None
+        return cls.from_dict(merged)
 
     @property
     def remote_config(self):


### PR DESCRIPTION
resolve_remote_config now checks that all required attrs fields are present in the merged dict before calling from_dict. When credentials are unavailable (no embedcreds, no env vars, no kwargs), it returns None instead of crashing with a TypeError from the attrs constructor.