### PR TITLE
perf(ibis_yaml): defer sklearn import in translate.py

### DIFF
--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -610,6 +610,12 @@ class ExprDumper:
         return op.to_expr(), path_to_writer
 
     def dump_expr(self) -> str:
+        from xorq.ibis_yaml.translate import (  # noqa: PLC0415
+            _ensure_sklearn_to_yaml_registered,
+        )
+
+        _ensure_sklearn_to_yaml_registered()
+
         # we will mutate the expr below
         expr = self.expr
 

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -1138,26 +1138,33 @@ def _schema_from_yaml(yaml_dict: dict, context: TranslationContext) -> Schema:
 
 
 # sklearn estimator YAML translation
-# Registration happens at module import time if sklearn is available
-try:
-    from sklearn.base import BaseEstimator
+# to_yaml registration is deferred to avoid importing sklearn at module load time
+# (sklearn import costs ~0.48s due to scipy/joblib/numpy transitive deps)
 
-    @translate_to_yaml.register(BaseEstimator)
-    def _sklearn_estimator_to_yaml(
-        obj: BaseEstimator, context: TranslationContext
-    ) -> dict:
-        params = freeze(obj.get_params(deep=False))
-        return freeze(
-            {
-                "op": "SklearnEstimator",
-                "estimator_module": type(obj).__module__,
-                "estimator_class": type(obj).__name__,
-                "params": {k: context.translate_to_yaml(v) for k, v in params.items()},
-            }
-        )
 
-except ImportError:
-    pass
+@functools.cache
+def _ensure_sklearn_to_yaml_registered():
+    try:
+        from sklearn.base import BaseEstimator  # noqa: PLC0415
+
+        @translate_to_yaml.register(BaseEstimator)
+        def _sklearn_estimator_to_yaml(
+            obj: BaseEstimator, context: TranslationContext
+        ) -> dict:
+            params = freeze(obj.get_params(deep=False))
+            return freeze(
+                {
+                    "op": "SklearnEstimator",
+                    "estimator_module": type(obj).__module__,
+                    "estimator_class": type(obj).__name__,
+                    "params": {
+                        k: context.translate_to_yaml(v) for k, v in params.items()
+                    },
+                }
+            )
+
+    except ImportError:
+        pass
 
 
 def _import_estimator_class(module: str, classname: str):


### PR DESCRIPTION
## Summary
- Defers the `sklearn.base.BaseEstimator` singledispatch registration in `translate.py` from module-load time to first use via `_ensure_sklearn_to_yaml_registered()` (guarded by `functools.cache`)
- sklearn import pulls in scipy/joblib/numpy transitively, costing ~0.48s — this removes that penalty from CLI cold-start and any codepath that doesn't serialize sklearn estimators
- The registration is triggered in `ExprDumper.dump_expr()`, the single entrypoint for YAML serialization

## Test plan
- [x] Existing `test_benchmark.py` and ibis_yaml tests pass
- [x] Verify sklearn estimator round-trip still works (e.g. `test_sklearn_estimator_yaml`)
- [x] Measure CLI cold-start improvement (~0.48s reduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)