### PR TITLE
fix(dev): handle missing parent dirs in worktree setup/cleanup

### DIFF
--- a/dev/cleanup-worktree
+++ b/dev/cleanup-worktree
@@ -8,6 +8,11 @@ manifest="$here/.envrcs/.worktree-manifest"
 if [ -f "$manifest" ]; then
     cd "$here"
     xargs rm -v < "$manifest"
+    # Remove any empty parent directories created by setup
+    while IFS= read -r entry; do
+        dir=$(dirname "$entry")
+        rmdir -p "$dir" 2>/dev/null || true
+    done < "$manifest"
     rm -v "$manifest"
 fi
 

--- a/dev/setup-worktree
+++ b/dev/setup-worktree
@@ -20,8 +20,9 @@ for f in "$main"/.envrcs/.envrc.secrets "$main"/.envrcs/.envrc.user "$main"/.env
 done
 
 # Symlink shared dotfiles from main worktree
-for target in .gitignore .claude/settings.json ci/ibis-testing-data; do
+for target in .gitignore .claude ci/ibis-testing-data; do
     if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
+        mkdir -p "$(dirname "$here/$target")"
         ln -sv "$main/$target" "$here/$target"
         echo "$target" >> "$manifest"
     fi

--- a/dev/setup-worktree
+++ b/dev/setup-worktree
@@ -28,5 +28,20 @@ for target in .gitignore .claude ci/ibis-testing-data; do
     fi
 done
 
+# Symlink user-defined extras from main worktree
+extra="$main/.envrcs/.worktree-symlinks"
+if [ -f "$extra" ]; then
+    while IFS= read -r target || [ -n "$target" ]; do
+        target="${target%%#*}"          # strip inline comments
+        target="${target// /}"          # trim whitespace
+        [ -z "$target" ] && continue    # skip blank lines
+        if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
+            mkdir -p "$(dirname "$here/$target")"
+            ln -sv "$main/$target" "$here/$target"
+            echo "$target" >> "$manifest"
+        fi
+    done < "$extra"
+fi
+
 echo "Manifest written to .envrcs/.worktree-manifest"
 echo "To remove: dev/cleanup-worktree"


### PR DESCRIPTION
## Summary

- **setup-worktree** now creates parent directories before symlinking, so targets like `ci/ibis-testing-data` no longer fail when `ci/` doesn't exist.
- **cleanup-worktree** removes empty parent directories left behind.
- Users can now list additional paths in `.envrcs/.worktree-symlinks` (one per line) to have them automatically symlinked into new worktrees. Cleanup is automatic via the existing manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)