### PR TITLE
feat(tui): add interactive expression composition to DataViewScreen

### DIFF
--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -43,7 +43,6 @@ from xorq.catalog.tui import (
     _build_git_log_rows,
     _entry_info,
     _format_cached,
-    build_code,
     get_cache_key_path,
 )
 from xorq.common.utils.defer_utils import deferred_read_parquet
@@ -754,7 +753,6 @@ def _mock_catalog_run(monkeypatch):
     )
 
 
-
 def test_data_view_screen_construction(entry_a):
     row_data = CatalogRowData(entry=entry_a)
     screen = DataViewScreen(entry=entry_a, row_data=row_data)
@@ -962,18 +960,6 @@ def test_expr_stack_fork_discards_after_cursor():
     assert forked.steps[1] is step3  # step2 was replaced
 
 
-def test_expr_stack_current_expr_evaluates():
-    base = xo.memtable({"x": [1, 2, 3]})
-    step = ExprStep(
-        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
-    )
-    stack = ExprStack(base_expr=base).push(step)
-    result = stack.current_expr()
-    df = result.execute()
-    assert len(df) == 2
-    assert list(df["x"]) == [2, 3]
-
-
 def test_expr_stack_current_code():
     base = xo.memtable({"x": [1, 2, 3]})
     step1 = ExprStep(
@@ -984,8 +970,11 @@ def test_expr_stack_current_code():
     )
     stack = ExprStack(base_expr=base).push(step1).push(step2)
     code = stack.current_code
-    # Steps are chained into a single evaluable expression
-    assert code == "(source.filter(source.x > 1)).mutate(y=source.x * 2)"
+    # Each step is wrapped in a lambda so its `source` binds to the prior result.
+    assert code == (
+        "(lambda source: source.mutate(y=source.x * 2))"
+        "((lambda source: source.filter(source.x > 1))(source))"
+    )
 
 
 def test_expr_stack_current_code_single_step():
@@ -994,7 +983,7 @@ def test_expr_stack_current_code_single_step():
         verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
     )
     stack = ExprStack(base_expr=base).push(step)
-    assert stack.current_code == "source.filter(source.x > 1)"
+    assert stack.current_code == "(lambda source: source.filter(source.x > 1))(source)"
 
 
 def test_expr_stack_current_code_evaluable():
@@ -1015,30 +1004,28 @@ def test_expr_stack_current_code_evaluable():
     assert list(df["y"]) == [20]
 
 
-def test_build_code_filter():
-    assert build_code("filter", "source.x > 1") == "source.filter(source.x > 1)"
+def test_expr_stack_current_code_inner_source_rebinds():
+    """Every `source` in a step must bind to the prior step's result, not only the first."""
 
-
-def test_build_code_mutate():
-    assert build_code("mutate", "y=source.x * 2") == "source.mutate(y=source.x * 2)"
-
-
-def test_build_code_select():
-    assert build_code("select", '"x", "y"') == 'source.select("x", "y")'
-
-
-def test_build_code_freeform():
-    assert build_code("freeform", "source.distinct()") == "source.distinct()"
-
-
-def test_build_code_agg():
-    code = build_code("agg", "avg=source.x.mean()", group='"category"')
-    assert code == 'source.group_by("category").agg(avg=source.x.mean())'
-
-
-def test_build_code_agg_empty_group():
-    code = build_code("agg", "total=source.x.sum()", group="")
-    assert code == "source.group_by().agg(total=source.x.sum())"
+    base = xo.memtable({"x": [1, 2, 3], "y": [10, 20, 30]})
+    step1 = ExprStep(
+        verb="freeform",
+        user_input='source.select("x")',
+        code='source.select("x")',
+    )
+    # This step references source.x; after select("x"), source.y is gone.
+    # If `source` inside the mutate bound to the original base, this would
+    # silently succeed using base.x rather than the selected projection.
+    step2 = ExprStep(
+        verb="freeform",
+        user_input="source.mutate(z=source.x * 10)",
+        code="source.mutate(z=source.x * 10)",
+    )
+    stack = ExprStack(base_expr=base).push(step1).push(step2)
+    result = _eval_code(stack.current_code, base)
+    df = result.execute()
+    assert list(df.columns) == ["x", "z"]
+    assert list(df["z"]) == [10, 20, 30]
 
 
 # ---------------------------------------------------------------------------
@@ -1066,7 +1053,7 @@ def test_data_view_has_command_input_hidden(catalog, entry_a):
     _run(_test())
 
 
-def test_data_view_f_opens_filter_input(catalog, entry_a):
+def test_data_view_colon_opens_freeform_input(catalog, entry_a):
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:
@@ -1081,16 +1068,15 @@ def test_data_view_f_opens_filter_input(catalog, entry_a):
             data_screen = app.screen
             assert isinstance(data_screen, DataViewScreen)
 
-            # Wait for data to load first
             data_table = data_screen.query_one("#data-view-table", DataTable)
             await wait_until(pilot, lambda: data_table.row_count > 0)
 
-            await pilot.press("f")
+            await pilot.press(":")
             await settle(pilot)
 
             cmd = data_screen.query_one("#command-input", Input)
             assert cmd.display is not False
-            assert "filter" in str(cmd.border_title)
+            assert ":" in str(cmd.border_title)
 
     _run(_test())
 
@@ -1112,7 +1098,7 @@ def test_data_view_escape_closes_command_input(catalog, entry_a):
             await wait_until(pilot, lambda: data_table.row_count > 0)
 
             # Open command input
-            await pilot.press("f")
+            await pilot.press(":")
             await settle(pilot)
 
             cmd = data_screen.query_one("#command-input", Input)

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -18,7 +18,7 @@ import asyncio
 from pathlib import Path
 
 import pytest
-from textual.widgets import DataTable, Static, Tree
+from textual.widgets import DataTable, Input, Static, Tree
 
 import xorq.api as xo
 from xorq.caching import ParquetSnapshotCache
@@ -35,11 +35,14 @@ from xorq.catalog.tui import (
     CatalogScreen,
     CatalogTUI,
     DataViewScreen,
+    ExprStack,
+    ExprStep,
     GitLogRowData,
     RevisionRowData,
     _build_git_log_rows,
     _entry_info,
     _format_cached,
+    build_code,
     get_cache_keys_paths,
 )
 from xorq.common.utils.defer_utils import deferred_read_parquet
@@ -862,3 +865,296 @@ def test_memtable_cached_lifecycle(catalog, tmp_path):
 
     entry.expr.execute()
     assert CatalogRowData(entry=entry).cached is True
+
+
+# ---------------------------------------------------------------------------
+# 12. ExprStack: pure unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_expr_step_is_frozen():
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    with pytest.raises(AttributeError):
+        step.verb = "mutate"
+
+
+def test_expr_stack_initial_state():
+    base = xo.memtable({"x": [1, 2, 3]})
+    stack = ExprStack(base_expr=base)
+    assert stack.cursor == 0
+    assert stack.steps == ()
+    assert stack.current_code == ""
+    assert not stack.can_undo
+    assert not stack.can_redo
+
+
+def test_expr_stack_push():
+    base = xo.memtable({"x": [1, 2, 3]})
+    stack = ExprStack(base_expr=base)
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack2 = stack.push(step)
+    assert stack2.cursor == 1
+    assert len(stack2.steps) == 1
+    assert stack2.steps[0] is step
+    # original unchanged (immutable)
+    assert stack.cursor == 0
+    assert len(stack.steps) == 0
+
+
+def test_expr_stack_undo_redo():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    assert stack.can_undo
+    assert not stack.can_redo
+
+    undone = stack.undo()
+    assert undone.cursor == 0
+    assert not undone.can_undo
+    assert undone.can_redo
+
+    redone = undone.redo()
+    assert redone.cursor == 1
+    assert redone.can_undo
+    assert not redone.can_redo
+
+
+def test_expr_stack_undo_at_zero():
+    base = xo.memtable({"x": [1, 2, 3]})
+    stack = ExprStack(base_expr=base)
+    assert stack.undo().cursor == 0
+
+
+def test_expr_stack_redo_at_end():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    assert stack.redo().cursor == 1
+
+
+def test_expr_stack_fork_discards_after_cursor():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step1 = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    step2 = ExprStep(
+        verb="mutate", user_input="y=source.x * 2", code="source.mutate(y=source.x * 2)"
+    )
+    stack = ExprStack(base_expr=base).push(step1).push(step2)
+    assert stack.cursor == 2
+
+    # Undo to step 1, then push a new step — step2 should be discarded
+    undone = stack.undo()
+    assert undone.cursor == 1
+    step3 = ExprStep(verb="select", user_input='"x"', code='source.select("x")')
+    forked = undone.push(step3)
+    assert forked.cursor == 2
+    assert len(forked.steps) == 2
+    assert forked.steps[1] is step3  # step2 was replaced
+
+
+def test_expr_stack_current_expr_evaluates():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    result = stack.current_expr()
+    df = result.execute()
+    assert len(df) == 2
+    assert list(df["x"]) == [2, 3]
+
+
+def test_expr_stack_current_code():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step1 = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    step2 = ExprStep(
+        verb="mutate", user_input="y=source.x * 2", code="source.mutate(y=source.x * 2)"
+    )
+    stack = ExprStack(base_expr=base).push(step1).push(step2)
+    code = stack.current_code
+    assert "source.filter(source.x > 1)" in code
+    assert "source.mutate(y=source.x * 2)" in code
+
+
+def test_build_code_filter():
+    assert build_code("filter", "source.x > 1") == "source.filter(source.x > 1)"
+
+
+def test_build_code_mutate():
+    assert build_code("mutate", "y=source.x * 2") == "source.mutate(y=source.x * 2)"
+
+
+def test_build_code_select():
+    assert build_code("select", '"x", "y"') == 'source.select("x", "y")'
+
+
+def test_build_code_freeform():
+    assert build_code("freeform", "source.distinct()") == "source.distinct()"
+
+
+def test_build_code_agg():
+    code = build_code("agg", "avg=source.x.mean()", group='"category"')
+    assert code == 'source.group_by("category").agg(avg=source.x.mean())'
+
+
+def test_build_code_agg_empty_group():
+    code = build_code("agg", "total=source.x.sum()", group="")
+    assert code == "source.group_by().agg(total=source.x.sum())"
+
+
+# ---------------------------------------------------------------------------
+# 13. DataViewScreen compose: pilot tests
+# ---------------------------------------------------------------------------
+
+
+def test_data_view_has_command_input_hidden(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            assert isinstance(app.screen, DataViewScreen)
+
+            cmd = app.screen.query_one("#command-input", Input)
+            assert cmd.display is False
+
+    _run(_test())
+
+
+def test_data_view_f_opens_filter_input(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            assert isinstance(data_screen, DataViewScreen)
+
+            # Wait for data to load first
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            await pilot.press("f")
+            await settle(pilot)
+
+            cmd = data_screen.query_one("#command-input", Input)
+            assert cmd.display is not False
+            assert "filter" in str(cmd.border_title)
+
+    _run(_test())
+
+
+def test_data_view_escape_closes_command_input(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            # Open command input
+            await pilot.press("f")
+            await settle(pilot)
+
+            cmd = data_screen.query_one("#command-input", Input)
+            assert cmd.display is not False
+
+            # Escape closes it
+            await pilot.press("escape")
+            await settle(pilot)
+            assert cmd.display is False
+            # Still on DataViewScreen
+            assert isinstance(app.screen, DataViewScreen)
+
+    _run(_test())
+
+
+def test_data_view_stack_browser_toggle(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            assert isinstance(data_screen, DataViewScreen)
+
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            panel = data_screen.query_one("#stack-browser-panel")
+            assert panel.display is False
+
+            await run_script(
+                pilot,
+                Press(("e",)),
+                Assert(lambda p: panel.display is not False),
+                Press(("e",)),
+                Assert(lambda p: panel.display is False),
+            )
+
+    _run(_test())
+
+
+def test_data_view_undo_redo_no_crash_when_empty(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            assert isinstance(data_screen, DataViewScreen)
+
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            # Undo/redo with empty stack should not crash
+            await pilot.press("u")
+            await settle(pilot)
+            await pilot.press("ctrl+r")
+            await settle(pilot)
+            assert isinstance(app.screen, DataViewScreen)
+
+    _run(_test())

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -1137,9 +1137,9 @@ def test_data_view_stack_browser_toggle(catalog, entry_a):
 
             await run_script(
                 pilot,
-                Press(("e",)),
+                Press(("s",)),
                 Assert(lambda p: panel.display is not False),
-                Press(("e",)),
+                Press(("s",)),
                 Assert(lambda p: panel.display is False),
             )
 

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -750,6 +750,7 @@ def _mock_catalog_run(monkeypatch):
     )
 
 
+
 def test_data_view_screen_construction(entry_a):
     row_data = CatalogRowData(entry=entry_a)
     screen = DataViewScreen(entry=entry_a, row_data=row_data)

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -22,6 +22,7 @@ from textual.widgets import DataTable, Input, Static, Tree
 
 import xorq.api as xo
 from xorq.caching import ParquetSnapshotCache
+from xorq.catalog.bind import _eval_code
 from xorq.catalog.tests.testing import (
     Assert,
     Press,
@@ -983,8 +984,35 @@ def test_expr_stack_current_code():
     )
     stack = ExprStack(base_expr=base).push(step1).push(step2)
     code = stack.current_code
-    assert "source.filter(source.x > 1)" in code
-    assert "source.mutate(y=source.x * 2)" in code
+    # Steps are chained into a single evaluable expression
+    assert code == "(source.filter(source.x > 1)).mutate(y=source.x * 2)"
+
+
+def test_expr_stack_current_code_single_step():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    assert stack.current_code == "source.filter(source.x > 1)"
+
+
+def test_expr_stack_current_code_evaluable():
+    """current_code must be a single expression that _eval_code can evaluate."""
+
+    base = xo.memtable({"x": [1, 2, 3], "y": [10, 20, 30]})
+    step1 = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    step2 = ExprStep(
+        verb="filter", user_input="source.y < 25", code="source.filter(source.y < 25)"
+    )
+    stack = ExprStack(base_expr=base).push(step1).push(step2)
+    result = _eval_code(stack.current_code, base)
+    df = result.execute()
+    assert len(df) == 1
+    assert list(df["x"]) == [2]
+    assert list(df["y"]) == [20]
 
 
 def test_build_code_filter():

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -18,7 +18,7 @@ import asyncio
 from pathlib import Path
 
 import pytest
-from textual.widgets import DataTable, Static, Tree
+from textual.widgets import DataTable, Input, Static, Tree
 
 import xorq.api as xo
 from xorq.caching import ParquetSnapshotCache
@@ -35,11 +35,14 @@ from xorq.catalog.tui import (
     CatalogScreen,
     CatalogTUI,
     DataViewScreen,
+    ExprStack,
+    ExprStep,
     GitLogRowData,
     RevisionRowData,
     _build_git_log_rows,
     _entry_info,
     _format_cached,
+    build_code,
     get_cache_key_path,
 )
 from xorq.common.utils.defer_utils import deferred_read_parquet
@@ -862,3 +865,296 @@ def test_memtable_cached_lifecycle(catalog, tmp_path):
 
     entry.expr.execute()
     assert CatalogRowData(entry=entry).cached is True
+
+
+# ---------------------------------------------------------------------------
+# 12. ExprStack: pure unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_expr_step_is_frozen():
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    with pytest.raises(AttributeError):
+        step.verb = "mutate"
+
+
+def test_expr_stack_initial_state():
+    base = xo.memtable({"x": [1, 2, 3]})
+    stack = ExprStack(base_expr=base)
+    assert stack.cursor == 0
+    assert stack.steps == ()
+    assert stack.current_code == ""
+    assert not stack.can_undo
+    assert not stack.can_redo
+
+
+def test_expr_stack_push():
+    base = xo.memtable({"x": [1, 2, 3]})
+    stack = ExprStack(base_expr=base)
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack2 = stack.push(step)
+    assert stack2.cursor == 1
+    assert len(stack2.steps) == 1
+    assert stack2.steps[0] is step
+    # original unchanged (immutable)
+    assert stack.cursor == 0
+    assert len(stack.steps) == 0
+
+
+def test_expr_stack_undo_redo():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    assert stack.can_undo
+    assert not stack.can_redo
+
+    undone = stack.undo()
+    assert undone.cursor == 0
+    assert not undone.can_undo
+    assert undone.can_redo
+
+    redone = undone.redo()
+    assert redone.cursor == 1
+    assert redone.can_undo
+    assert not redone.can_redo
+
+
+def test_expr_stack_undo_at_zero():
+    base = xo.memtable({"x": [1, 2, 3]})
+    stack = ExprStack(base_expr=base)
+    assert stack.undo().cursor == 0
+
+
+def test_expr_stack_redo_at_end():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    assert stack.redo().cursor == 1
+
+
+def test_expr_stack_fork_discards_after_cursor():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step1 = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    step2 = ExprStep(
+        verb="mutate", user_input="y=source.x * 2", code="source.mutate(y=source.x * 2)"
+    )
+    stack = ExprStack(base_expr=base).push(step1).push(step2)
+    assert stack.cursor == 2
+
+    # Undo to step 1, then push a new step — step2 should be discarded
+    undone = stack.undo()
+    assert undone.cursor == 1
+    step3 = ExprStep(verb="select", user_input='"x"', code='source.select("x")')
+    forked = undone.push(step3)
+    assert forked.cursor == 2
+    assert len(forked.steps) == 2
+    assert forked.steps[1] is step3  # step2 was replaced
+
+
+def test_expr_stack_current_expr_evaluates():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    stack = ExprStack(base_expr=base).push(step)
+    result = stack.current_expr()
+    df = result.execute()
+    assert len(df) == 2
+    assert list(df["x"]) == [2, 3]
+
+
+def test_expr_stack_current_code():
+    base = xo.memtable({"x": [1, 2, 3]})
+    step1 = ExprStep(
+        verb="filter", user_input="source.x > 1", code="source.filter(source.x > 1)"
+    )
+    step2 = ExprStep(
+        verb="mutate", user_input="y=source.x * 2", code="source.mutate(y=source.x * 2)"
+    )
+    stack = ExprStack(base_expr=base).push(step1).push(step2)
+    code = stack.current_code
+    assert "source.filter(source.x > 1)" in code
+    assert "source.mutate(y=source.x * 2)" in code
+
+
+def test_build_code_filter():
+    assert build_code("filter", "source.x > 1") == "source.filter(source.x > 1)"
+
+
+def test_build_code_mutate():
+    assert build_code("mutate", "y=source.x * 2") == "source.mutate(y=source.x * 2)"
+
+
+def test_build_code_select():
+    assert build_code("select", '"x", "y"') == 'source.select("x", "y")'
+
+
+def test_build_code_freeform():
+    assert build_code("freeform", "source.distinct()") == "source.distinct()"
+
+
+def test_build_code_agg():
+    code = build_code("agg", "avg=source.x.mean()", group='"category"')
+    assert code == 'source.group_by("category").agg(avg=source.x.mean())'
+
+
+def test_build_code_agg_empty_group():
+    code = build_code("agg", "total=source.x.sum()", group="")
+    assert code == "source.group_by().agg(total=source.x.sum())"
+
+
+# ---------------------------------------------------------------------------
+# 13. DataViewScreen compose: pilot tests
+# ---------------------------------------------------------------------------
+
+
+def test_data_view_has_command_input_hidden(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            assert isinstance(app.screen, DataViewScreen)
+
+            cmd = app.screen.query_one("#command-input", Input)
+            assert cmd.display is False
+
+    _run(_test())
+
+
+def test_data_view_f_opens_filter_input(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            assert isinstance(data_screen, DataViewScreen)
+
+            # Wait for data to load first
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            await pilot.press("f")
+            await settle(pilot)
+
+            cmd = data_screen.query_one("#command-input", Input)
+            assert cmd.display is not False
+            assert "filter" in str(cmd.border_title)
+
+    _run(_test())
+
+
+def test_data_view_escape_closes_command_input(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            # Open command input
+            await pilot.press("f")
+            await settle(pilot)
+
+            cmd = data_screen.query_one("#command-input", Input)
+            assert cmd.display is not False
+
+            # Escape closes it
+            await pilot.press("escape")
+            await settle(pilot)
+            assert cmd.display is False
+            # Still on DataViewScreen
+            assert isinstance(app.screen, DataViewScreen)
+
+    _run(_test())
+
+
+def test_data_view_stack_browser_toggle(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            assert isinstance(data_screen, DataViewScreen)
+
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            panel = data_screen.query_one("#stack-browser-panel")
+            assert panel.display is False
+
+            await run_script(
+                pilot,
+                Press(("e",)),
+                Assert(lambda p: panel.display is not False),
+                Press(("e",)),
+                Assert(lambda p: panel.display is False),
+            )
+
+    _run(_test())
+
+
+def test_data_view_undo_redo_no_crash_when_empty(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await run_script(
+                pilot,
+                Press(("j",)),
+                Press(("e",)),
+            )
+            await settle(pilot)
+            data_screen = app.screen
+            assert isinstance(data_screen, DataViewScreen)
+
+            data_table = data_screen.query_one("#data-view-table", DataTable)
+            await wait_until(pilot, lambda: data_table.row_count > 0)
+
+            # Undo/redo with empty stack should not crash
+            await pilot.press("u")
+            await settle(pilot)
+            await pilot.press("ctrl+r")
+            await settle(pilot)
+            assert isinstance(app.screen, DataViewScreen)
+
+    _run(_test())

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -307,10 +307,20 @@ class ExprStack:
 
     @property
     def current_code(self) -> str:
-        """Composable --code string for the active steps."""
+        """Single evaluable expression chaining all active steps.
+
+        Each step's code starts with ``source.verb(...)``.  For steps after
+        the first, the leading ``source`` is replaced with the accumulated
+        expression so the result is one chained call that ``_eval_code`` can
+        evaluate in a single ``eval()``.
+        """
         if self.cursor == 0:
             return ""
-        return "\n".join(step.code for step in self.steps[: self.cursor])
+        steps = self.steps[: self.cursor]
+        result = steps[0].code
+        for step in steps[1:]:
+            result = step.code.replace("source", f"({result})", 1)
+        return result
 
 def _entry_info(entry: CatalogEntry) -> tuple[int | None, bool | None]:
     path = get_cache_key_path(entry.projected_cache_key)

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1179,23 +1179,32 @@ class DataViewScreen(Screen):
         self._stack = self._stack.push(step)
         self._execute_current()
 
-    @work(thread=True, exit_on_error=False)
+    @work(thread=True, exit_on_error=False, exclusive=True, group="execute_current")
     def _execute_current(self) -> None:
         """Evaluate current stack expression via subprocess."""
+        stack = self._stack
         try:
-            stack = self._stack
             code = stack.current_code or None
             df = self._run_catalog_subprocess(code)
-            self.app.call_from_thread(self._on_stack_executed, df)
         except Exception as e:
-            self._stack = stack.undo()
-            self.app.call_from_thread(self._show_command_error, str(e))
+            self.app.call_from_thread(self._on_stack_execute_failed, stack, str(e))
+            return
+        self.app.call_from_thread(self._on_stack_executed, stack, df)
 
-    def _on_stack_executed(self, df) -> None:
+    def _on_stack_executed(self, stack, df) -> None:
+        if self._stack is not stack:
+            return
         self._df = df
         self._cursor_column_index = 0
         self._render_table()
         self._update_command_suggester()
+        self._render_stack_browser()
+
+    def _on_stack_execute_failed(self, stack, message) -> None:
+        if self._stack is not stack:
+            return
+        self._stack = stack.undo()
+        self._show_command_error(message)
         self._render_stack_browser()
 
     def _show_command_error(self, message) -> None:

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1033,7 +1033,6 @@ class DataViewScreen(Screen):
         ("[", "sort_desc", "Sort ↓"),
         ("]", "sort_asc", "Sort ↑"),
         ("d", "drop_column", "Drop col"),
-        ("s", "toggle_stats", "Stats"),
         ("u", "undo", "Undo"),
         ("ctrl+r", "redo", "Redo"),
         ("e", "toggle_stack_browser", "Stack"),
@@ -1052,8 +1051,6 @@ class DataViewScreen(Screen):
         self._stack = None
         self._df = None
         self._cursor_column_index = 0
-        self._stats_visible = False
-        self._stats_loaded = False
         self._stack_browser_visible = False
         self._command_verb = None
         self._agg_group = None
@@ -1065,8 +1062,6 @@ class DataViewScreen(Screen):
             yield DataTable(id="data-view-table")
             with Vertical(id="stack-browser-panel"):
                 yield Static("", id="stack-browser-content")
-        with Vertical(id="stats-panel"):
-            yield DataTable(id="stats-table")
         yield Input(id="command-input", placeholder="")
         yield Footer()
 
@@ -1075,14 +1070,6 @@ class DataViewScreen(Screen):
         table.cursor_type = "row"
         table.zebra_stripes = True
         table.loading = True
-
-        stats_panel = self.query_one("#stats-panel")
-        stats_panel.border_title = "Stats"
-        stats_panel.display = False
-
-        stats_table = self.query_one("#stats-table", DataTable)
-        stats_table.cursor_type = "none"
-        stats_table.zebra_stripes = True
 
         stack_panel = self.query_one("#stack-browser-panel")
         stack_panel.border_title = "Expression Stack"
@@ -1230,7 +1217,6 @@ class DataViewScreen(Screen):
     def _on_stack_executed(self, df) -> None:
         self._df = df
         self._cursor_column_index = 0
-        self._stats_loaded = False
         self._render_table()
         self._update_command_suggester()
         self._render_stack_browser()
@@ -1512,120 +1498,6 @@ class DataViewScreen(Screen):
     def _show_persist_success(self, message) -> None:
         self.query_one("#data-view-status", Static).update(f" \u2713 {message}")
 
-    # --- Stats ---
-
-    def action_toggle_stats(self) -> None:
-        panel = self.query_one("#stats-panel")
-        self._stats_visible = not self._stats_visible
-        panel.display = self._stats_visible
-        if self._stats_visible and not self._stats_loaded:
-            panel.border_subtitle = "loading..."
-            self._load_stats()
-
-    @work(thread=True, exit_on_error=False)
-    def _load_stats(self) -> None:
-        try:
-            from xorq.vendor import ibis  # noqa: PLC0415
-            from xorq.vendor.ibis import literal as lit  # noqa: PLC0415
-            from xorq.vendor.ibis.expr import datatypes as dt  # noqa: PLC0415
-
-            expr = self._stack.current_expr() if self._stack else None
-            if expr is None:
-                return
-            aggs = []
-            string_cols = []
-            for pos, colname in enumerate(expr.columns):
-                col = expr[colname]
-                typ = col.type()
-
-                col_mean = lit(None).cast(float)
-                col_std = lit(None).cast(float)
-                col_min = lit(None).cast(float)
-                col_max = lit(None).cast(float)
-                col_p25 = lit(None).cast(float)
-                col_p50 = lit(None).cast(float)
-                col_p75 = lit(None).cast(float)
-
-                if typ.is_numeric():
-                    col_mean = col.mean()
-                    col_std = col.std()
-                    col_min = col.min().cast(float)
-                    col_max = col.max().cast(float)
-                    col_p25 = col.quantile(0.25).cast(float)
-                    col_p50 = col.quantile(0.50).cast(float)
-                    col_p75 = col.quantile(0.75).cast(float)
-                elif typ.is_boolean():
-                    col_mean = col.mean()
-
-                if typ.is_string():
-                    string_cols.append(colname)
-
-                aggs.append(
-                    expr.agg(
-                        name=lit(colname),
-                        pos=lit(pos, type=dt.int16),
-                        type=lit(str(typ)),
-                        count=col.count(),
-                        nulls=col.isnull().sum(),
-                        unique=col.nunique(),
-                        mean=col_mean,
-                        std=col_std,
-                        min=col_min,
-                        p25=col_p25,
-                        p50=col_p50,
-                        p75=col_p75,
-                        max=col_max,
-                    )
-                )
-
-            stats_df = ibis.union(*aggs).execute()
-
-            # Compute mode for string columns in a single batched query
-            # (avoids unsupported Mode operation)
-            if string_cols:
-                mode_exprs = []
-                for colname in string_cols:
-                    mode_exprs.append(
-                        expr.group_by(colname)
-                        .agg(_cnt=expr[colname].count())
-                        .order_by(ibis.desc("_cnt"))
-                        .limit(1)
-                        .select(
-                            _col_name=lit(colname),
-                            _mode_val=expr[colname].cast(str),
-                        )
-                    )
-                modes_df = ibis.union(*mode_exprs).execute()
-                modes = dict(zip(modes_df["_col_name"], modes_df["_mode_val"]))
-                stats_df["mode"] = stats_df["name"].map(modes).fillna("")
-
-            self.app.call_from_thread(self._render_stats, stats_df)
-        except Exception as e:
-            self.app.call_from_thread(
-                self._render_stats_error, f"{type(e).__name__}: {e}"
-            )
-
-    def _render_stats(self, stats_df) -> None:
-        self._stats_loaded = True
-        with self.app.batch_update():
-            panel = self.query_one("#stats-panel")
-            panel.border_subtitle = ""
-            table = self.query_one("#stats-table", DataTable)
-            table.clear(columns=True)
-            for col in stats_df.columns:
-                table.add_column(str(col), key=str(col))
-            for i, row in enumerate(stats_df.itertuples(index=False)):
-                table.add_row(
-                    *(
-                        str(round(v, 2)) if isinstance(v, float) else str(v)
-                        for v in row
-                    ),
-                    key=str(i),
-                )
-
-    def _render_stats_error(self, message) -> None:
-        self.query_one("#stats-panel").border_subtitle = f"Error: {message}"
-
 
 class CatalogTUI(App):
     TITLE = "xorq catalog"
@@ -1752,15 +1624,6 @@ class CatalogTUI(App):
         padding: 0 1;
     }
     DataViewScreen #stack-browser-content {
-        height: auto;
-    }
-    DataViewScreen #stats-panel {
-        height: auto;
-        max-height: 12;
-        border: solid #4AA8EC;
-        border-title-color: #4AA8EC;
-    }
-    DataViewScreen #stats-table {
         height: auto;
     }
     DataViewScreen #command-input {

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1085,13 +1085,13 @@ class DataViewScreen(Screen):
         self.query_one("#data-view-status", Static).update(f" Loading {label}...")
         self._load_data()
 
-    def _catalog_run_cmd(self) -> list[str]:
+    def _catalog_run_cmd(self, code=None) -> list[str]:
         """Build the xorq catalog run subprocess command."""
         catalog = self.app._catalog
         entry_name = (
             self._row_data.aliases[0] if self._row_data.aliases else self._entry.name
         )
-        return [
+        cmd = [
             "xorq",
             "catalog",
             "--path",
@@ -1105,12 +1105,15 @@ class DataViewScreen(Screen):
             "-f",
             "arrow",
         ]
+        if code:
+            cmd.extend(["-c", code])
+        return cmd
 
-    def _run_catalog_subprocess(self):
+    def _run_catalog_subprocess(self, code=None):
         """Run xorq catalog run and return a pandas DataFrame."""
         import pyarrow as pa  # noqa: PLC0415
 
-        cmd = self._catalog_run_cmd()
+        cmd = self._catalog_run_cmd(code)
         proc = subprocess.run(cmd, capture_output=True)
         if proc.returncode != 0:
             raise RuntimeError(proc.stderr.decode().strip())
@@ -1120,11 +1123,8 @@ class DataViewScreen(Screen):
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
         try:
-            from xorq.catalog.bind import _make_source_expr  # noqa: PLC0415
-
-            base_expr = _make_source_expr(self._entry)
-            self._stack = ExprStack(base_expr=base_expr)
-            df = base_expr.limit(VIEW_LIMIT).execute()
+            self._stack = ExprStack(base_expr=self._entry)
+            df = self._run_catalog_subprocess()
             self.app.call_from_thread(self._on_data_loaded, df)
         except Exception as e:
             self.app.call_from_thread(self._render_error, str(e))
@@ -1214,11 +1214,11 @@ class DataViewScreen(Screen):
 
     @work(thread=True, exit_on_error=False)
     def _execute_current(self) -> None:
-        """Evaluate current stack expression and update the table."""
+        """Evaluate current stack expression via subprocess."""
         try:
             stack = self._stack
-            expr = stack.current_expr()
-            df = expr.limit(VIEW_LIMIT).execute()
+            code = stack.current_code or None
+            df = self._run_catalog_subprocess(code)
             self.app.call_from_thread(self._on_stack_executed, df)
         except Exception as e:
             self._stack = stack.undo()

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -241,6 +241,14 @@ class RevisionRowData:
 VIEW_LIMIT = 50_000
 
 
+@cache
+def _ibis_table_method_names() -> tuple[str, ...]:
+    """Public method names on the ibis Table class, for tab-completion."""
+    from xorq.vendor.ibis.expr.types.relations import Table  # noqa: PLC0415
+
+    return tuple(name for name in dir(Table) if not name.startswith("_"))
+
+
 @frozen
 class ExprStep:
     """A single user-applied Ibis operation."""
@@ -992,8 +1000,9 @@ class CatalogScreen(Screen):
 class DataViewScreen(Screen):
     """Full-screen data viewer with interactive expression composition.
 
-    Every user action (filter, mutate, select, sort, aggregate) is a raw Ibis
-    API call pushed onto an undo/redo ExprStack.
+    Column-level verbs (sort, drop) and a freeform `:` prompt each push an
+    Ibis call onto an undo/redo ExprStack; the full chain is re-evaluated via
+    ``xorq catalog run -c`` on every change.
     """
 
     BINDINGS = (
@@ -1010,23 +1019,9 @@ class DataViewScreen(Screen):
         Binding("d", "drop_column", "Drop"),
         Binding("u", "undo", "Undo"),
         Binding("ctrl+r", "redo", "Redo"),
-        Binding("e", "toggle_stack_browser", "Stack"),
+        Binding("s", "toggle_stack_browser", "Stack"),
         Binding("w", "persist", "Save"),
         Binding(":", "open_freeform", "Expr"),
-    )
-
-    _IBIS_METHOD_SUGGESTIONS = (
-        "filter",
-        "mutate",
-        "select",
-        "order_by",
-        "group_by",
-        "agg",
-        "distinct",
-        "head",
-        "limit",
-        "join",
-        "drop",
     )
 
     def __init__(self, entry, row_data):
@@ -1066,19 +1061,24 @@ class DataViewScreen(Screen):
         self.query_one("#data-view-status", Static).update(f" Loading {label}...")
         self._load_data()
 
-    def _catalog_run_cmd(self, code=None) -> list[str]:
-        """Build the xorq catalog run subprocess command."""
+    def _catalog_base_cmd(self, subcommand: str) -> list[str]:
+        """Shared ``xorq catalog --path <repo> <subcommand> <entry>`` prefix."""
         catalog = self.app._catalog
         entry_name = (
             self._row_data.aliases[0] if self._row_data.aliases else self._entry.name
         )
-        cmd = [
+        return [
             "xorq",
             "catalog",
             "--path",
             str(catalog.repo_path),
-            "run",
+            subcommand,
             entry_name,
+        ]
+
+    def _catalog_run_cmd(self, code=None) -> list[str]:
+        """Build the xorq catalog run subprocess command."""
+        cmd = self._catalog_base_cmd("run") + [
             "--limit",
             str(VIEW_LIMIT),
             "-o",
@@ -1168,7 +1168,7 @@ class DataViewScreen(Screen):
         """Update tab-completion suggestions from current expression columns."""
         cols = tuple(self._df.columns) if self._df is not None else ()
         self.query_one("#command-input", Input).suggester = SuggestFromList(
-            cols + self._IBIS_METHOD_SUGGESTIONS, case_sensitive=False
+            cols + _ibis_table_method_names(), case_sensitive=False
         )
 
     # --- Stack operations ---
@@ -1208,37 +1208,25 @@ class DataViewScreen(Screen):
         self._render_stack_browser()
 
     def _show_command_error(self, message) -> None:
-        cmd = self.query_one("#command-input", Input)
-        cmd.display = True
-        cmd.value = f"Error: {message}"
-        cmd.add_class("error")
+        self.app.notify(message, title="Error", severity="error", timeout=6)
 
     # --- Command input ---
+
+    def _close_command_input(self) -> None:
+        self.query_one("#command-input", Input).display = False
+        self._command_mode = None
+        self.query_one("#data-view-table", DataTable).focus()
 
     @on(Input.Submitted, "#command-input")
     def _on_command_submitted(self, event: Input.Submitted) -> None:
         user_input = event.value.strip()
-        cmd = self.query_one("#command-input", Input)
         mode = self._command_mode
+        self._close_command_input()
 
         if mode == "save":
-            alias = user_input or None
-            cmd.display = False
-            self._command_mode = None
-            self.query_one("#data-view-table", DataTable).focus()
-            self._do_persist(alias)
-            return
-
-        if not user_input:
-            cmd.display = False
-            self._command_mode = None
-            self.query_one("#data-view-table", DataTable).focus()
-            return
-
-        cmd.display = False
-        self._command_mode = None
-        self.query_one("#data-view-table", DataTable).focus()
-        self._push_step("freeform", user_input, user_input)
+            self._do_persist(user_input or None)
+        elif user_input:
+            self._push_step("freeform", user_input, user_input)
 
     # --- Freeform action ---
 
@@ -1247,7 +1235,6 @@ class DataViewScreen(Screen):
             return
         self._command_mode = "freeform"
         cmd = self.query_one("#command-input", Input)
-        cmd.remove_class("error")
         cmd.value = ""
         cmd.placeholder = ":\u25b8 type expression, Tab to complete, Enter to apply"
         cmd.border_title = ":\u25b8"
@@ -1296,9 +1283,7 @@ class DataViewScreen(Screen):
     def action_cancel_or_back(self) -> None:
         cmd = self.query_one("#command-input", Input)
         if cmd.display:
-            cmd.display = False
-            self._command_mode = None
-            self.query_one("#data-view-table", DataTable).focus()
+            self._close_command_input()
         else:
             self._df = None
             self._stack = None
@@ -1359,7 +1344,7 @@ class DataViewScreen(Screen):
         )
         code = stack.current_code
         code_lines = (
-            ("--code equivalent:", code) if code else ("(no transforms applied)",)
+            ("\u2014 code equivalent:", code) if code else ("(no transforms applied)",)
         )
         lines = (f"{base_marker}0  base: {label}", *step_lines, "", *code_lines)
         self.query_one("#stack-browser-content", Static).update("\n".join(lines))
@@ -1371,7 +1356,6 @@ class DataViewScreen(Screen):
             return
         self._command_mode = "save"
         cmd = self.query_one("#command-input", Input)
-        cmd.remove_class("error")
         cmd.value = ""
         cmd.placeholder = "alias name (leave empty to save without alias)"
         cmd.border_title = "save\u25b8"
@@ -1384,20 +1368,7 @@ class DataViewScreen(Screen):
         self._persist_to_catalog(alias)
 
     def _catalog_compose_cmd(self, code: str, alias: str | None) -> list[str]:
-        catalog = self.app._catalog
-        entry_name = (
-            self._row_data.aliases[0] if self._row_data.aliases else self._entry.name
-        )
-        cmd = [
-            "xorq",
-            "catalog",
-            "--path",
-            str(catalog.repo_path),
-            "compose",
-            entry_name,
-            "-c",
-            code,
-        ]
+        cmd = self._catalog_base_cmd("compose") + ["-c", code]
         if alias:
             cmd.extend(["-a", alias])
         return cmd
@@ -1500,11 +1471,6 @@ class CatalogTUI(App):
         border: solid #2BBE75;
         border-title-color: #2BBE75;
         padding: 0 1;
-    }
-    DataViewScreen #command-input.error {
-        border: solid #FF4757;
-        border-title-color: #FF4757;
-        color: #FF4757;
     }
     """
 

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1083,13 +1083,13 @@ class DataViewScreen(Screen):
         self.query_one("#data-view-status", Static).update(f" Loading {label}...")
         self._load_data()
 
-    def _catalog_run_cmd(self) -> list[str]:
+    def _catalog_run_cmd(self, code=None) -> list[str]:
         """Build the xorq catalog run subprocess command."""
         catalog = self.app._catalog
         entry_name = (
             self._row_data.aliases[0] if self._row_data.aliases else self._entry.name
         )
-        return [
+        cmd = [
             "xorq",
             "catalog",
             "--path",
@@ -1103,12 +1103,15 @@ class DataViewScreen(Screen):
             "-f",
             "arrow",
         ]
+        if code:
+            cmd.extend(["-c", code])
+        return cmd
 
-    def _run_catalog_subprocess(self):
+    def _run_catalog_subprocess(self, code=None):
         """Run xorq catalog run and return a pandas DataFrame."""
         import pyarrow as pa  # noqa: PLC0415
 
-        cmd = self._catalog_run_cmd()
+        cmd = self._catalog_run_cmd(code)
         proc = subprocess.run(cmd, capture_output=True)
         if proc.returncode != 0:
             raise RuntimeError(proc.stderr.decode().strip())
@@ -1118,11 +1121,8 @@ class DataViewScreen(Screen):
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
         try:
-            from xorq.catalog.bind import _make_source_expr  # noqa: PLC0415
-
-            base_expr = _make_source_expr(self._entry)
-            self._stack = ExprStack(base_expr=base_expr)
-            df = base_expr.limit(VIEW_LIMIT).execute()
+            self._stack = ExprStack(base_expr=self._entry)
+            df = self._run_catalog_subprocess()
             self.app.call_from_thread(self._on_data_loaded, df)
         except Exception as e:
             self.app.call_from_thread(self._render_error, str(e))
@@ -1212,11 +1212,11 @@ class DataViewScreen(Screen):
 
     @work(thread=True, exit_on_error=False)
     def _execute_current(self) -> None:
-        """Evaluate current stack expression and update the table."""
+        """Evaluate current stack expression via subprocess."""
         try:
             stack = self._stack
-            expr = stack.current_expr()
-            df = expr.limit(VIEW_LIMIT).execute()
+            code = stack.current_code or None
+            df = self._run_catalog_subprocess(code)
             self.app.call_from_thread(self._on_stack_executed, df)
         except Exception as e:
             self._stack = stack.undo()

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -307,10 +307,20 @@ class ExprStack:
 
     @property
     def current_code(self) -> str:
-        """Composable --code string for the active steps."""
+        """Single evaluable expression chaining all active steps.
+
+        Each step's code starts with ``source.verb(...)``.  For steps after
+        the first, the leading ``source`` is replaced with the accumulated
+        expression so the result is one chained call that ``_eval_code`` can
+        evaluate in a single ``eval()``.
+        """
         if self.cursor == 0:
             return ""
-        return "\n".join(step.code for step in self.steps[: self.cursor])
+        steps = self.steps[: self.cursor]
+        result = steps[0].code
+        for step in steps[1:]:
+            result = step.code.replace("source", f"({result})", 1)
+        return result
 
 def _entry_info(entry: CatalogEntry) -> tuple[int | None, bool | None]:
     cache_keys_paths = get_cache_keys_paths(entry.parquet_snapshot_cache_keys)

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1026,10 +1026,10 @@ class DataViewScreen(Screen):
     BINDINGS = (
         ("escape", "cancel_or_back", "Back"),
         ("q", "cancel_or_back", "Back"),
-        ("h", "scroll_left", "Left"),
+        ("h", "cursor_left", "Col ←"),
         ("j", "cursor_down", "Down"),
         ("k", "cursor_up", "Up"),
-        ("l", "scroll_right", "Right"),
+        ("l", "cursor_right", "Col →"),
         ("g", "scroll_top", "Top"),
         ("shift+g", "scroll_bottom", "Bottom"),
         ("[", "sort_desc", "Sort ↓"),
@@ -1069,7 +1069,7 @@ class DataViewScreen(Screen):
 
     def on_mount(self) -> None:
         table = self.query_one("#data-view-table", DataTable)
-        table.cursor_type = "row"
+        table.cursor_type = "cell"
         table.zebra_stripes = True
         table.loading = True
 
@@ -1154,7 +1154,7 @@ class DataViewScreen(Screen):
                     ),
                     key=str(i),
                 )
-            table.cursor_type = "row"
+            table.cursor_type = "cell"
             self._update_status_bar()
 
     def _update_status_bar(self) -> None:
@@ -1167,8 +1167,13 @@ class DataViewScreen(Screen):
         if stack and stack.cursor > 0:
             step = stack.steps[stack.cursor - 1]
             step_info = f" | step {stack.cursor}/{len(stack.steps)} {step.verb}"
+        col_info = ""
+        cols = df.columns
+        idx = self._cursor_column_index
+        if 0 <= idx < len(cols):
+            col_info = f" | [{cols[idx]}]"
         self.query_one("#data-view-status", Static).update(
-            f" {label} \u2014 {len(df)} rows \u00d7 {len(df.columns)} cols{step_info}"
+            f" {label} \u2014 {len(df)} rows \u00d7 {len(cols)} cols{col_info}{step_info}"
         )
 
     def _render_error(self, message) -> None:
@@ -1397,13 +1402,11 @@ class DataViewScreen(Screen):
     def action_cursor_up(self) -> None:
         self.query_one("#data-view-table", DataTable).action_cursor_up()
 
-    def action_scroll_left(self) -> None:
-        self.query_one("#data-view-table", DataTable).action_scroll_left()
-        self._track_cursor_column()
+    def action_cursor_left(self) -> None:
+        self.query_one("#data-view-table", DataTable).action_cursor_left()
 
-    def action_scroll_right(self) -> None:
-        self.query_one("#data-view-table", DataTable).action_scroll_right()
-        self._track_cursor_column()
+    def action_cursor_right(self) -> None:
+        self.query_one("#data-view-table", DataTable).action_cursor_right()
 
     def action_scroll_top(self) -> None:
         table = self.query_one("#data-view-table", DataTable)
@@ -1414,14 +1417,12 @@ class DataViewScreen(Screen):
         if table.row_count > 0:
             table.move_cursor(row=table.row_count - 1)
 
-    def _track_cursor_column(self) -> None:
-        """Update tracked column index from DataTable cursor position."""
-        if self._df is None:
-            return
-        table = self.query_one("#data-view-table", DataTable)
-        col = table.cursor_column
-        if 0 <= col < len(self._df.columns):
+    @on(DataTable.CellHighlighted, "#data-view-table")
+    def _on_cell_highlighted(self, event: DataTable.CellHighlighted) -> None:
+        col = event.coordinate.column
+        if self._df is not None and 0 <= col < len(self._df.columns):
             self._cursor_column_index = col
+            self._update_status_bar()
 
     # --- Stack browser ---
 

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -240,23 +240,6 @@ class RevisionRowData:
 
 VIEW_LIMIT = 50_000
 
-VERB_TEMPLATES = {
-    "filter": "source.filter({input})",
-    "mutate": "source.mutate({input})",
-    "select": "source.select({input})",
-    "order_by": "source.order_by({input})",
-    "drop": "source.drop({input})",
-    "agg": "source.group_by({group}).agg({input})",
-}
-
-
-def build_code(verb: str, user_input: str, group: str = "") -> str:
-    if verb == "freeform":
-        return user_input
-    if verb == "agg":
-        return VERB_TEMPLATES[verb].format(group=group, input=user_input)
-    return VERB_TEMPLATES[verb].format(input=user_input)
-
 
 @frozen
 class ExprStep:
@@ -297,31 +280,22 @@ class ExprStack:
     def can_redo(self) -> bool:
         return self.cursor < len(self.steps)
 
-    def current_expr(self):
-        """Replay active steps onto base via _eval_code."""
-        from xorq.catalog.bind import _eval_code  # noqa: PLC0415
-
-        expr = self.base_expr
-        for step in self.steps[: self.cursor]:
-            expr = _eval_code(step.code, expr)
-        return expr
-
     @property
     def current_code(self) -> str:
         """Single evaluable expression chaining all active steps.
 
-        Each step's code starts with ``source.verb(...)``.  For steps after
-        the first, the leading ``source`` is replaced with the accumulated
-        expression so the result is one chained call that ``_eval_code`` can
-        evaluate in a single ``eval()``.
+        Each step is wrapped in a ``(lambda source: step_code)(prior)`` call,
+        so every ``source`` identifier in the step binds to the prior step's
+        result via the same namespace mechanism ``_eval_code`` uses — no
+        string substitution of ``source`` inside user code.
         """
         if self.cursor == 0:
             return ""
-        steps = self.steps[: self.cursor]
-        result = steps[0].code
-        for step in steps[1:]:
-            result = step.code.replace("source", f"({result})", 1)
+        result = "source"
+        for step in self.steps[: self.cursor]:
+            result = f"(lambda source: {step.code})({result})"
         return result
+
 
 def _entry_info(entry: CatalogEntry) -> tuple[int | None, bool | None]:
     path = get_cache_key_path(entry.projected_cache_key)
@@ -1038,11 +1012,21 @@ class DataViewScreen(Screen):
         Binding("ctrl+r", "redo", "Redo"),
         Binding("e", "toggle_stack_browser", "Stack"),
         Binding("w", "persist", "Save"),
-        Binding("f", "verb_filter", "Filter"),
-        Binding("=", "verb_mutate", "Mutate"),
-        Binding("-", "verb_select", "Select"),
-        Binding("#", "verb_agg", "Agg"),
-        Binding(":", "verb_freeform", "Free"),
+        Binding(":", "open_freeform", "Expr"),
+    )
+
+    _IBIS_METHOD_SUGGESTIONS = (
+        "filter",
+        "mutate",
+        "select",
+        "order_by",
+        "group_by",
+        "agg",
+        "distinct",
+        "head",
+        "limit",
+        "join",
+        "drop",
     )
 
     def __init__(self, entry, row_data):
@@ -1053,8 +1037,7 @@ class DataViewScreen(Screen):
         self._df = None
         self._cursor_column_index = 0
         self._stack_browser_visible = False
-        self._command_verb = None
-        self._agg_group = None
+        self._command_mode = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -1181,20 +1164,6 @@ class DataViewScreen(Screen):
         self.query_one("#data-view-status", Static).update(f" Error: {message}")
         self.query_one("#data-view-table", DataTable).loading = False
 
-    _IBIS_METHOD_SUGGESTIONS = (
-        "filter",
-        "mutate",
-        "select",
-        "order_by",
-        "group_by",
-        "agg",
-        "distinct",
-        "head",
-        "limit",
-        "join",
-        "drop",
-    )
-
     def _update_command_suggester(self) -> None:
         """Update tab-completion suggestions from current expression columns."""
         cols = tuple(self._df.columns) if self._df is not None else ()
@@ -1237,114 +1206,44 @@ class DataViewScreen(Screen):
 
     # --- Command input ---
 
-    def _open_command_input(self, verb: str) -> None:
-        """Show the command input docked at bottom with verb prompt."""
-        self._command_verb = verb
-        cmd = self.query_one("#command-input", Input)
-        cmd.remove_class("error")
-        cmd.value = ""
-        prompt = verb if verb != "freeform" else ":"
-        cmd.placeholder = (
-            f"{prompt}\u25b8 type expression, Tab to complete, Enter to apply"
-        )
-        cmd.border_title = f"{prompt}\u25b8"
-        cmd.display = True
-        cmd.focus()
-
     @on(Input.Submitted, "#command-input")
     def _on_command_submitted(self, event: Input.Submitted) -> None:
         user_input = event.value.strip()
         cmd = self.query_one("#command-input", Input)
+        mode = self._command_mode
 
-        verb = self._command_verb
-
-        # Save accepts empty input (no alias)
-        if verb == "save":
+        if mode == "save":
             alias = user_input or None
             cmd.display = False
-            self._command_verb = None
+            self._command_mode = None
             self.query_one("#data-view-table", DataTable).focus()
             self._do_persist(alias)
             return
 
         if not user_input:
             cmd.display = False
-            self._command_verb = None
-            self._agg_group = None
+            self._command_mode = None
             self.query_one("#data-view-table", DataTable).focus()
-            return
-
-        if verb is None:
-            cmd.display = False
-            self.query_one("#data-view-table", DataTable).focus()
-            return
-
-        # Two-phase aggregate: first group_by, then agg
-        if verb == "agg_group":
-            self._agg_group = user_input
-            self._command_verb = "agg"
-            cmd.value = ""
-            cmd.placeholder = (
-                "agg\u25b8 aggregation expressions (e.g. avg=source.amount.mean())"
-            )
-            cmd.border_title = "agg\u25b8"
-            return
-
-        try:
-            if verb == "agg":
-                group = self._agg_group or ""
-                code = build_code(verb, user_input, group=group)
-                display_input = f"group_by({group}).agg({user_input})"
-            else:
-                code = build_code(verb, user_input)
-                display_input = user_input
-        except Exception as e:
-            cmd.value = f"Error building code: {e}"
-            cmd.add_class("error")
             return
 
         cmd.display = False
-        self._command_verb = None
-        self._agg_group = None
+        self._command_mode = None
         self.query_one("#data-view-table", DataTable).focus()
-        self._push_step(verb, display_input, code)
+        self._push_step("freeform", user_input, user_input)
 
-    # --- Verb actions ---
+    # --- Freeform action ---
 
-    def action_verb_filter(self) -> None:
+    def action_open_freeform(self) -> None:
         if self._stack is None:
             return
-        self._open_command_input("filter")
-
-    def action_verb_mutate(self) -> None:
-        if self._stack is None:
-            return
-        self._open_command_input("mutate")
-
-    def action_verb_select(self) -> None:
-        if self._stack is None:
-            return
-        self._open_command_input("select")
-
-    def action_verb_agg(self) -> None:
-        if self._stack is None:
-            return
-        self._agg_group = None
-        self._command_verb = "agg_group"
+        self._command_mode = "freeform"
         cmd = self.query_one("#command-input", Input)
         cmd.remove_class("error")
         cmd.value = ""
-        cmd.placeholder = (
-            'group_by\u25b8 column names to group by (e.g. "category", "region")'
-        )
-        cmd.border_title = "group_by\u25b8"
+        cmd.placeholder = ":\u25b8 type expression, Tab to complete, Enter to apply"
+        cmd.border_title = ":\u25b8"
         cmd.display = True
         cmd.focus()
-
-    def action_verb_freeform(self) -> None:
-        if self._stack is None:
-            return
-        self._open_command_input("freeform")
 
     # --- Instant actions (no input required) ---
 
@@ -1389,8 +1288,7 @@ class DataViewScreen(Screen):
         cmd = self.query_one("#command-input", Input)
         if cmd.display:
             cmd.display = False
-            self._command_verb = None
-            self._agg_group = None
+            self._command_mode = None
             self.query_one("#data-view-table", DataTable).focus()
         else:
             self._df = None
@@ -1462,7 +1360,7 @@ class DataViewScreen(Screen):
     def action_persist(self) -> None:
         if self._stack is None or self._stack.cursor == 0:
             return
-        self._command_verb = "save"
+        self._command_mode = "save"
         cmd = self.query_one("#command-input", Input)
         cmd.remove_class("error")
         cmd.value = ""
@@ -1472,29 +1370,38 @@ class DataViewScreen(Screen):
         cmd.focus()
 
     def _do_persist(self, alias=None) -> None:
-        """Persist current stack expression to catalog via ExprComposer."""
         if self._stack is None or self._stack.cursor == 0:
             return
         self._persist_to_catalog(alias)
 
+    def _catalog_compose_cmd(self, code: str, alias: str | None) -> list[str]:
+        catalog = self.app._catalog
+        entry_name = (
+            self._row_data.aliases[0] if self._row_data.aliases else self._entry.name
+        )
+        cmd = [
+            "xorq",
+            "catalog",
+            "--path",
+            str(catalog.repo_path),
+            "compose",
+            entry_name,
+            "-c",
+            code,
+        ]
+        if alias:
+            cmd.extend(["-a", alias])
+        return cmd
+
     @work(thread=True, exit_on_error=False)
     def _persist_to_catalog(self, alias) -> None:
         try:
-            from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
-
             code = self._stack.current_code
-            composer = ExprComposer(source=self._entry, code=code, alias=alias)
-            expr = composer.expr
-            catalog = self.app._catalog
-            if catalog is None:
-                self.app.call_from_thread(
-                    self._show_command_error, "No catalog available"
-                )
-                return
-            entry = catalog.add(expr)
-            if alias:
-                catalog.add_alias(entry.name, alias)
-            msg = f"Saved as '{alias or entry.name[:12]}'"
+            cmd = self._catalog_compose_cmd(code, alias)
+            proc = subprocess.run(cmd, capture_output=True)
+            if proc.returncode != 0:
+                raise RuntimeError(proc.stderr.decode().strip())
+            msg = f"Saved as '{alias}'" if alias else "Saved"
             self.app.call_from_thread(self._show_persist_success, msg)
         except Exception as e:
             self.app.call_from_thread(self._show_command_error, f"Save failed: {e}")

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1033,6 +1033,8 @@ class DataViewScreen(Screen):
         self._cursor_column_index = 0
         self._stack_browser_visible = False
         self._command_mode = None
+        self._active_proc = None
+        self._proc_lock = threading.Lock()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -1060,6 +1062,9 @@ class DataViewScreen(Screen):
         label = self._row_data.aliases_display or self._row_data.hash[:12]
         self.query_one("#data-view-status", Static).update(f" Loading {label}...")
         self._load_data()
+
+    def on_unmount(self) -> None:
+        self._kill_active_proc()
 
     def _catalog_base_cmd(self, subcommand: str) -> list[str]:
         """Shared ``xorq catalog --path <repo> <subcommand> <entry>`` prefix."""
@@ -1095,11 +1100,28 @@ class DataViewScreen(Screen):
         import pyarrow as pa  # noqa: PLC0415
 
         cmd = self._catalog_run_cmd(code)
-        proc = subprocess.run(cmd, capture_output=True)
+        with self._proc_lock:
+            prior = self._active_proc
+            if prior is not None and prior.poll() is None:
+                prior.kill()
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self._active_proc = proc
+        try:
+            stdout, stderr = proc.communicate()
+        finally:
+            with self._proc_lock:
+                if self._active_proc is proc:
+                    self._active_proc = None
         if proc.returncode != 0:
-            raise RuntimeError(proc.stderr.decode().strip())
-        reader = pa.ipc.open_stream(proc.stdout)
+            raise RuntimeError(stderr.decode().strip())
+        reader = pa.ipc.open_stream(stdout)
         return reader.read_pandas()
+
+    def _kill_active_proc(self) -> None:
+        with self._proc_lock:
+            proc = self._active_proc
+        if proc is not None and proc.poll() is None:
+            proc.kill()
 
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -422,19 +422,19 @@ def _revision_pair(i, rev_entry, commit):
 
 class CatalogScreen(Screen):
     BINDINGS = (
-        ("q", "quit_app", "Quit"),
-        ("ctrl+c", "quit_app", "Quit"),
-        ("h", "tree_collapse", "Collapse"),
-        ("j", "cursor_down", "Down"),
-        ("k", "cursor_up", "Up"),
-        ("l", "tree_expand", "Expand"),
-        ("tab", "focus_next_panel", "Next"),
-        ("shift+tab", "focus_prev_panel", "Prev"),
-        ("1", "view_sql", "SQL"),
-        ("2", "view_data", "Data"),
-        ("e", "open_data_view", "Explore"),
-        ("v", "toggle_revisions", "Revisions"),
-        ("g", "toggle_git_log", "Git Log"),
+        Binding("q", "quit_app", "Quit"),
+        Binding("ctrl+c", "quit_app", "Quit", show=False),
+        Binding("h", "tree_collapse", "Collapse", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("l", "tree_expand", "Expand", show=False),
+        Binding("tab", "focus_next_panel", "Next", show=False),
+        Binding("shift+tab", "focus_prev_panel", "Prev", show=False),
+        Binding("e", "open_data_view", "Explore"),
+        Binding("v", "toggle_revisions", "Revisions"),
+        Binding("g", "toggle_git_log", "Git Log"),
+        Binding("1", "view_sql", "SQL"),
+        Binding("2", "view_data", "Data"),
     )
 
     FOCUS_CYCLE = (

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1035,7 +1035,6 @@ class DataViewScreen(Screen):
         ("[", "sort_desc", "Sort ↓"),
         ("]", "sort_asc", "Sort ↑"),
         ("d", "drop_column", "Drop col"),
-        ("s", "toggle_stats", "Stats"),
         ("u", "undo", "Undo"),
         ("ctrl+r", "redo", "Redo"),
         ("e", "toggle_stack_browser", "Stack"),
@@ -1054,8 +1053,6 @@ class DataViewScreen(Screen):
         self._stack = None
         self._df = None
         self._cursor_column_index = 0
-        self._stats_visible = False
-        self._stats_loaded = False
         self._stack_browser_visible = False
         self._command_verb = None
         self._agg_group = None
@@ -1067,8 +1064,6 @@ class DataViewScreen(Screen):
             yield DataTable(id="data-view-table")
             with Vertical(id="stack-browser-panel"):
                 yield Static("", id="stack-browser-content")
-        with Vertical(id="stats-panel"):
-            yield DataTable(id="stats-table")
         yield Input(id="command-input", placeholder="")
         yield Footer()
 
@@ -1077,14 +1072,6 @@ class DataViewScreen(Screen):
         table.cursor_type = "row"
         table.zebra_stripes = True
         table.loading = True
-
-        stats_panel = self.query_one("#stats-panel")
-        stats_panel.border_title = "Stats"
-        stats_panel.display = False
-
-        stats_table = self.query_one("#stats-table", DataTable)
-        stats_table.cursor_type = "none"
-        stats_table.zebra_stripes = True
 
         stack_panel = self.query_one("#stack-browser-panel")
         stack_panel.border_title = "Expression Stack"
@@ -1232,7 +1219,6 @@ class DataViewScreen(Screen):
     def _on_stack_executed(self, df) -> None:
         self._df = df
         self._cursor_column_index = 0
-        self._stats_loaded = False
         self._render_table()
         self._update_command_suggester()
         self._render_stack_browser()
@@ -1514,120 +1500,6 @@ class DataViewScreen(Screen):
     def _show_persist_success(self, message) -> None:
         self.query_one("#data-view-status", Static).update(f" \u2713 {message}")
 
-    # --- Stats ---
-
-    def action_toggle_stats(self) -> None:
-        panel = self.query_one("#stats-panel")
-        self._stats_visible = not self._stats_visible
-        panel.display = self._stats_visible
-        if self._stats_visible and not self._stats_loaded:
-            panel.border_subtitle = "loading..."
-            self._load_stats()
-
-    @work(thread=True, exit_on_error=False)
-    def _load_stats(self) -> None:
-        try:
-            from xorq.vendor import ibis  # noqa: PLC0415
-            from xorq.vendor.ibis import literal as lit  # noqa: PLC0415
-            from xorq.vendor.ibis.expr import datatypes as dt  # noqa: PLC0415
-
-            expr = self._stack.current_expr() if self._stack else None
-            if expr is None:
-                return
-            aggs = []
-            string_cols = []
-            for pos, colname in enumerate(expr.columns):
-                col = expr[colname]
-                typ = col.type()
-
-                col_mean = lit(None).cast(float)
-                col_std = lit(None).cast(float)
-                col_min = lit(None).cast(float)
-                col_max = lit(None).cast(float)
-                col_p25 = lit(None).cast(float)
-                col_p50 = lit(None).cast(float)
-                col_p75 = lit(None).cast(float)
-
-                if typ.is_numeric():
-                    col_mean = col.mean()
-                    col_std = col.std()
-                    col_min = col.min().cast(float)
-                    col_max = col.max().cast(float)
-                    col_p25 = col.quantile(0.25).cast(float)
-                    col_p50 = col.quantile(0.50).cast(float)
-                    col_p75 = col.quantile(0.75).cast(float)
-                elif typ.is_boolean():
-                    col_mean = col.mean()
-
-                if typ.is_string():
-                    string_cols.append(colname)
-
-                aggs.append(
-                    expr.agg(
-                        name=lit(colname),
-                        pos=lit(pos, type=dt.int16),
-                        type=lit(str(typ)),
-                        count=col.count(),
-                        nulls=col.isnull().sum(),
-                        unique=col.nunique(),
-                        mean=col_mean,
-                        std=col_std,
-                        min=col_min,
-                        p25=col_p25,
-                        p50=col_p50,
-                        p75=col_p75,
-                        max=col_max,
-                    )
-                )
-
-            stats_df = ibis.union(*aggs).execute()
-
-            # Compute mode for string columns in a single batched query
-            # (avoids unsupported Mode operation)
-            if string_cols:
-                mode_exprs = []
-                for colname in string_cols:
-                    mode_exprs.append(
-                        expr.group_by(colname)
-                        .agg(_cnt=expr[colname].count())
-                        .order_by(ibis.desc("_cnt"))
-                        .limit(1)
-                        .select(
-                            _col_name=lit(colname),
-                            _mode_val=expr[colname].cast(str),
-                        )
-                    )
-                modes_df = ibis.union(*mode_exprs).execute()
-                modes = dict(zip(modes_df["_col_name"], modes_df["_mode_val"]))
-                stats_df["mode"] = stats_df["name"].map(modes).fillna("")
-
-            self.app.call_from_thread(self._render_stats, stats_df)
-        except Exception as e:
-            self.app.call_from_thread(
-                self._render_stats_error, f"{type(e).__name__}: {e}"
-            )
-
-    def _render_stats(self, stats_df) -> None:
-        self._stats_loaded = True
-        with self.app.batch_update():
-            panel = self.query_one("#stats-panel")
-            panel.border_subtitle = ""
-            table = self.query_one("#stats-table", DataTable)
-            table.clear(columns=True)
-            for col in stats_df.columns:
-                table.add_column(str(col), key=str(col))
-            for i, row in enumerate(stats_df.itertuples(index=False)):
-                table.add_row(
-                    *(
-                        str(round(v, 2)) if isinstance(v, float) else str(v)
-                        for v in row
-                    ),
-                    key=str(i),
-                )
-
-    def _render_stats_error(self, message) -> None:
-        self.query_one("#stats-panel").border_subtitle = f"Error: {message}"
-
 
 class CatalogTUI(App):
     TITLE = "xorq catalog"
@@ -1754,15 +1626,6 @@ class CatalogTUI(App):
         padding: 0 1;
     }
     DataViewScreen #stack-browser-content {
-        height: auto;
-    }
-    DataViewScreen #stats-panel {
-        height: auto;
-        max-height: 12;
-        border: solid #4AA8EC;
-        border-title-color: #4AA8EC;
-    }
-    DataViewScreen #stats-table {
         height: auto;
     }
     DataViewScreen #command-input {

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -7,7 +7,7 @@ from functools import cache, cached_property
 from pathlib import Path
 from typing import Literal
 
-from attr import field, frozen
+from attr import evolve, field, frozen
 from attr.validators import instance_of, optional
 from pygments.style import Style as PygmentsStyle
 from pygments.token import (
@@ -25,11 +25,13 @@ from textual import on, work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
+from textual.suggester import SuggestFromList
 from textual.theme import Theme
 from textual.widgets import (
     DataTable,
     Footer,
     Header,
+    Input,
     Static,
     Tree,
 )
@@ -237,6 +239,78 @@ class RevisionRowData:
 
 VIEW_LIMIT = 50_000
 
+VERB_TEMPLATES = {
+    "filter": "source.filter({input})",
+    "mutate": "source.mutate({input})",
+    "select": "source.select({input})",
+    "order_by": "source.order_by({input})",
+    "drop": "source.drop({input})",
+    "agg": "source.group_by({group}).agg({input})",
+}
+
+
+def build_code(verb: str, user_input: str, group: str = "") -> str:
+    if verb == "freeform":
+        return user_input
+    if verb == "agg":
+        return VERB_TEMPLATES[verb].format(group=group, input=user_input)
+    return VERB_TEMPLATES[verb].format(input=user_input)
+
+
+@frozen
+class ExprStep:
+    """A single user-applied Ibis operation."""
+
+    verb: str = field(validator=instance_of(str))
+    user_input: str = field(validator=instance_of(str))
+    code: str = field(validator=instance_of(str))
+
+
+@frozen
+class ExprStack:
+    """Immutable operation stack with undo/redo cursor."""
+
+    base_expr: object = field(repr=False)
+    steps: tuple[ExprStep, ...] = field(factory=tuple)
+    cursor: int = field(default=0, validator=instance_of(int))
+
+    def push(self, step: ExprStep) -> "ExprStack":
+        """Apply new step, discard any steps after cursor (fork)."""
+        return evolve(
+            self,
+            steps=self.steps[: self.cursor] + (step,),
+            cursor=self.cursor + 1,
+        )
+
+    def undo(self) -> "ExprStack":
+        return evolve(self, cursor=max(0, self.cursor - 1))
+
+    def redo(self) -> "ExprStack":
+        return evolve(self, cursor=min(len(self.steps), self.cursor + 1))
+
+    @property
+    def can_undo(self) -> bool:
+        return self.cursor > 0
+
+    @property
+    def can_redo(self) -> bool:
+        return self.cursor < len(self.steps)
+
+    def current_expr(self):
+        """Replay active steps onto base via _eval_code."""
+        from xorq.catalog.bind import _eval_code  # noqa: PLC0415
+
+        expr = self.base_expr
+        for step in self.steps[: self.cursor]:
+            expr = _eval_code(step.code, expr)
+        return expr
+
+    @property
+    def current_code(self) -> str:
+        """Composable --code string for the active steps."""
+        if self.cursor == 0:
+            return ""
+        return "\n".join(step.code for step in self.steps[: self.cursor])
 
 def _entry_info(entry: CatalogEntry) -> tuple[int | None, bool | None]:
     path = get_cache_key_path(entry.projected_cache_key)
@@ -931,33 +1005,59 @@ class CatalogScreen(Screen):
 
 
 class DataViewScreen(Screen):
-    """Full-screen data viewer for a single catalog entry."""
+    """Full-screen data viewer with interactive expression composition.
+
+    Every user action (filter, mutate, select, sort, aggregate) is a raw Ibis
+    API call pushed onto an undo/redo ExprStack.
+    """
 
     BINDINGS = (
-        ("escape", "go_back", "Back"),
-        ("q", "go_back", "Back"),
+        ("escape", "cancel_or_back", "Back"),
+        ("q", "cancel_or_back", "Back"),
         ("h", "scroll_left", "Left"),
         ("j", "cursor_down", "Down"),
         ("k", "cursor_up", "Up"),
         ("l", "scroll_right", "Right"),
         ("g", "scroll_top", "Top"),
         ("shift+g", "scroll_bottom", "Bottom"),
-        ("[", "sort_prev", "Sort ←"),
-        ("]", "sort_next", "Sort →"),
+        ("[", "sort_desc", "Sort ↓"),
+        ("]", "sort_asc", "Sort ↑"),
+        ("d", "drop_column", "Drop col"),
+        ("s", "toggle_stats", "Stats"),
+        ("u", "undo", "Undo"),
+        ("ctrl+r", "redo", "Redo"),
+        ("e", "toggle_stack_browser", "Stack"),
+        ("w", "persist", "Save"),
+        ("f", "verb_filter", "Filter"),
+        ("=", "verb_mutate", "Mutate"),
+        ("-", "verb_select", "Select"),
+        ("#", "verb_agg", "Agg"),
+        (":", "verb_freeform", "Freeform"),
     )
 
     def __init__(self, entry, row_data):
         super().__init__()
         self._entry = entry
         self._row_data = row_data
-        self._ibis_expr = None
+        self._stack = None
         self._df = None
-        self._sort_column_index = -1
+        self._cursor_column_index = 0
+        self._stats_visible = False
+        self._stats_loaded = False
+        self._stack_browser_visible = False
+        self._command_verb = None
+        self._agg_group = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Static("", id="data-view-status")
-        yield DataTable(id="data-view-table")
+        with Horizontal(id="data-view-split"):
+            yield DataTable(id="data-view-table")
+            with Vertical(id="stack-browser-panel"):
+                yield Static("", id="stack-browser-content")
+        with Vertical(id="stats-panel"):
+            yield DataTable(id="stats-table")
+        yield Input(id="command-input", placeholder="")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -965,6 +1065,21 @@ class DataViewScreen(Screen):
         table.cursor_type = "row"
         table.zebra_stripes = True
         table.loading = True
+
+        stats_panel = self.query_one("#stats-panel")
+        stats_panel.border_title = "Stats"
+        stats_panel.display = False
+
+        stats_table = self.query_one("#stats-table", DataTable)
+        stats_table.cursor_type = "none"
+        stats_table.zebra_stripes = True
+
+        stack_panel = self.query_one("#stack-browser-panel")
+        stack_panel.border_title = "Expression Stack"
+        stack_panel.display = False
+
+        cmd_input = self.query_one("#command-input", Input)
+        cmd_input.display = False
 
         label = self._row_data.aliases_display or self._row_data.hash[:12]
         self.query_one("#data-view-status", Static).update(f" Loading {label}...")
@@ -1005,14 +1120,18 @@ class DataViewScreen(Screen):
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
         try:
-            df = self._run_catalog_subprocess()
+            base_expr = self._entry.expr
+            self._stack = ExprStack(base_expr=base_expr)
+            df = base_expr.limit(VIEW_LIMIT).execute()
             self.app.call_from_thread(self._on_data_loaded, df)
         except Exception as e:
             self.app.call_from_thread(self._render_error, str(e))
 
     def _on_data_loaded(self, df) -> None:
         self._df = df
+        self._cursor_column_index = 0
         self._render_table()
+        self._update_command_suggester()
 
     def _render_table(self) -> None:
         df = self._df
@@ -1037,25 +1156,242 @@ class DataViewScreen(Screen):
                     key=str(i),
                 )
             table.cursor_type = "row"
-            label = self._row_data.aliases_display or self._row_data.hash[:12]
-            sort_info = ""
-            if self._sort_column_index >= 0:
-                col_name = df.columns[self._sort_column_index]
-                sort_info = f" | sorted by {col_name}"
-            self.query_one("#data-view-status", Static).update(
-                f" {label} \u2014 {len(df)} rows \u00d7 {len(df.columns)} cols{sort_info}"
-            )
+            self._update_status_bar()
+
+    def _update_status_bar(self) -> None:
+        df = self._df
+        if df is None:
+            return
+        label = self._row_data.aliases_display or self._row_data.hash[:12]
+        stack = self._stack
+        step_info = ""
+        if stack and stack.cursor > 0:
+            step = stack.steps[stack.cursor - 1]
+            step_info = f" | step {stack.cursor}/{len(stack.steps)} {step.verb}"
+        self.query_one("#data-view-status", Static).update(
+            f" {label} \u2014 {len(df)} rows \u00d7 {len(df.columns)} cols{step_info}"
+        )
 
     def _render_error(self, message) -> None:
         self.query_one("#data-view-status", Static).update(f" Error: {message}")
         self.query_one("#data-view-table", DataTable).loading = False
 
+    _IBIS_METHOD_SUGGESTIONS = (
+        "filter",
+        "mutate",
+        "select",
+        "order_by",
+        "group_by",
+        "agg",
+        "distinct",
+        "head",
+        "limit",
+        "join",
+        "drop",
+    )
+
+    def _update_command_suggester(self) -> None:
+        """Update tab-completion suggestions from current expression columns."""
+        cols = tuple(self._df.columns) if self._df is not None else ()
+        self.query_one("#command-input", Input).suggester = SuggestFromList(
+            cols + self._IBIS_METHOD_SUGGESTIONS, case_sensitive=False
+        )
+
+    # --- Stack operations ---
+
+    def _push_step(self, verb: str, user_input: str, code: str) -> None:
+        """Push a step and re-execute in background."""
+        step = ExprStep(verb=verb, user_input=user_input, code=code)
+        self._stack = self._stack.push(step)
+        self._execute_current()
+
+    @work(thread=True, exit_on_error=False)
+    def _execute_current(self) -> None:
+        """Evaluate current stack expression and update the table."""
+        try:
+            stack = self._stack
+            expr = stack.current_expr()
+            df = expr.limit(VIEW_LIMIT).execute()
+            self.app.call_from_thread(self._on_stack_executed, df)
+        except Exception as e:
+            self._stack = stack.undo()
+            self.app.call_from_thread(self._show_command_error, str(e))
+
+    def _on_stack_executed(self, df) -> None:
+        self._df = df
+        self._cursor_column_index = 0
+        self._stats_loaded = False
+        self._render_table()
+        self._update_command_suggester()
+        self._render_stack_browser()
+
+    def _show_command_error(self, message) -> None:
+        cmd = self.query_one("#command-input", Input)
+        cmd.display = True
+        cmd.value = f"Error: {message}"
+        cmd.add_class("error")
+
+    # --- Command input ---
+
+    def _open_command_input(self, verb: str) -> None:
+        """Show the command input docked at bottom with verb prompt."""
+        self._command_verb = verb
+        cmd = self.query_one("#command-input", Input)
+        cmd.remove_class("error")
+        cmd.value = ""
+        prompt = verb if verb != "freeform" else ":"
+        cmd.placeholder = (
+            f"{prompt}\u25b8 type expression, Tab to complete, Enter to apply"
+        )
+        cmd.border_title = f"{prompt}\u25b8"
+        cmd.display = True
+        cmd.focus()
+
+    @on(Input.Submitted, "#command-input")
+    def _on_command_submitted(self, event: Input.Submitted) -> None:
+        user_input = event.value.strip()
+        cmd = self.query_one("#command-input", Input)
+
+        verb = self._command_verb
+
+        # Save accepts empty input (no alias)
+        if verb == "save":
+            alias = user_input if user_input else None
+            cmd.display = False
+            self._command_verb = None
+            self.query_one("#data-view-table", DataTable).focus()
+            self._do_persist(alias)
+            return
+
+        if not user_input:
+            cmd.display = False
+            self._command_verb = None
+            self._agg_group = None
+            self.query_one("#data-view-table", DataTable).focus()
+            return
+
+        if verb is None:
+            cmd.display = False
+            self.query_one("#data-view-table", DataTable).focus()
+            return
+
+        # Two-phase aggregate: first group_by, then agg
+        if verb == "agg_group":
+            self._agg_group = user_input
+            self._command_verb = "agg"
+            cmd.value = ""
+            cmd.placeholder = (
+                "agg\u25b8 aggregation expressions (e.g. avg=source.amount.mean())"
+            )
+            cmd.border_title = "agg\u25b8"
+            return
+
+        try:
+            if verb == "agg":
+                group = self._agg_group or ""
+                code = build_code(verb, user_input, group=group)
+                display_input = f"group_by({group}).agg({user_input})"
+            else:
+                code = build_code(verb, user_input)
+                display_input = user_input
+        except Exception as e:
+            cmd.value = f"Error building code: {e}"
+            cmd.add_class("error")
+            return
+
+        cmd.display = False
+        self._command_verb = None
+        self._agg_group = None
+        self.query_one("#data-view-table", DataTable).focus()
+        self._push_step(verb, display_input, code)
+
+    # --- Verb actions ---
+
+    def action_verb_filter(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("filter")
+
+    def action_verb_mutate(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("mutate")
+
+    def action_verb_select(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("select")
+
+    def action_verb_agg(self) -> None:
+        if self._stack is None:
+            return
+        self._agg_group = None
+        self._command_verb = "agg_group"
+        cmd = self.query_one("#command-input", Input)
+        cmd.remove_class("error")
+        cmd.value = ""
+        cmd.placeholder = (
+            'group_by\u25b8 column names to group by (e.g. "category", "region")'
+        )
+        cmd.border_title = "group_by\u25b8"
+        cmd.display = True
+        cmd.focus()
+
+    def action_verb_freeform(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("freeform")
+
+    # --- Instant actions (no input required) ---
+
+    def action_sort_asc(self) -> None:
+        if self._stack is None or self._df is None:
+            return
+        col = self._df.columns[self._cursor_column_index]
+        code = f'source.order_by("{col}")'
+        self._push_step("order_by", f'"{col}"', code)
+
+    def action_sort_desc(self) -> None:
+        if self._stack is None or self._df is None:
+            return
+        col = self._df.columns[self._cursor_column_index]
+        code = f'source.order_by(ibis.desc("{col}"))'
+        self._push_step("order_by", f'ibis.desc("{col}")', code)
+
+    def action_drop_column(self) -> None:
+        if self._stack is None or self._df is None:
+            return
+        col = self._df.columns[self._cursor_column_index]
+        code = f'source.drop("{col}")'
+        self._push_step("drop", f'"{col}"', code)
+
+    # --- Undo / Redo ---
+
+    def action_undo(self) -> None:
+        if self._stack is None or not self._stack.can_undo:
+            return
+        self._stack = self._stack.undo()
+        self._execute_current()
+
+    def action_redo(self) -> None:
+        if self._stack is None or not self._stack.can_redo:
+            return
+        self._stack = self._stack.redo()
+        self._execute_current()
+
     # --- Navigation ---
 
-    def action_go_back(self) -> None:
-        self._df = None
-        self._ibis_expr = None
-        self.app.pop_screen()
+    def action_cancel_or_back(self) -> None:
+        cmd = self.query_one("#command-input", Input)
+        if cmd.display:
+            cmd.display = False
+            self._command_verb = None
+            self._agg_group = None
+            self.query_one("#data-view-table", DataTable).focus()
+        else:
+            self._df = None
+            self._stack = None
+            self.app.pop_screen()
 
     def action_cursor_down(self) -> None:
         self.query_one("#data-view-table", DataTable).action_cursor_down()
@@ -1065,9 +1401,11 @@ class DataViewScreen(Screen):
 
     def action_scroll_left(self) -> None:
         self.query_one("#data-view-table", DataTable).action_scroll_left()
+        self._track_cursor_column()
 
     def action_scroll_right(self) -> None:
         self.query_one("#data-view-table", DataTable).action_scroll_right()
+        self._track_cursor_column()
 
     def action_scroll_top(self) -> None:
         table = self.query_one("#data-view-table", DataTable)
@@ -1078,29 +1416,205 @@ class DataViewScreen(Screen):
         if table.row_count > 0:
             table.move_cursor(row=table.row_count - 1)
 
-    # --- Sorting ---
-
-    def action_sort_prev(self) -> None:
+    def _track_cursor_column(self) -> None:
+        """Update tracked column index from DataTable cursor position."""
         if self._df is None:
             return
-        ncols = len(self._df.columns)
-        if self._sort_column_index <= 0:
-            self._sort_column_index = ncols - 1
-        else:
-            self._sort_column_index -= 1
-        self._apply_sort()
+        table = self.query_one("#data-view-table", DataTable)
+        col = table.cursor_column
+        if 0 <= col < len(self._df.columns):
+            self._cursor_column_index = col
 
-    def action_sort_next(self) -> None:
-        if self._df is None:
+    # --- Stack browser ---
+
+    def action_toggle_stack_browser(self) -> None:
+        self._stack_browser_visible = not self._stack_browser_visible
+        panel = self.query_one("#stack-browser-panel")
+        panel.display = self._stack_browser_visible
+        if self._stack_browser_visible:
+            self._render_stack_browser()
+
+    def _render_stack_browser(self) -> None:
+        if not self._stack_browser_visible or self._stack is None:
             return
-        ncols = len(self._df.columns)
-        self._sort_column_index = (self._sort_column_index + 1) % ncols
-        self._apply_sort()
+        stack = self._stack
+        label = self._row_data.aliases_display or self._row_data.hash[:12]
+        base_marker = "\u2192 " if stack.cursor == 0 else "  "
+        step_lines = tuple(
+            "{}{:<3} {:<9} {}{}".format(
+                "\u2192 " if (i + 1) == stack.cursor else "  ",
+                i + 1,
+                step.verb,
+                step.user_input,
+                "  (undone)" if (i + 1) > stack.cursor else "",
+            )
+            for i, step in enumerate(stack.steps)
+        )
+        code = stack.current_code
+        code_lines = (
+            ("--code equivalent:", code) if code else ("(no transforms applied)",)
+        )
+        lines = (f"{base_marker}0  base: {label}", *step_lines, "", *code_lines)
+        self.query_one("#stack-browser-content", Static).update("\n".join(lines))
 
-    def _apply_sort(self) -> None:
-        col = self._df.columns[self._sort_column_index]
-        self._df = self._df.sort_values(by=col, na_position="last")
-        self._render_table()
+    # --- Persist to catalog ---
+
+    def action_persist(self) -> None:
+        if self._stack is None or self._stack.cursor == 0:
+            return
+        self._command_verb = "save"
+        cmd = self.query_one("#command-input", Input)
+        cmd.remove_class("error")
+        cmd.value = ""
+        cmd.placeholder = "alias name (leave empty to save without alias)"
+        cmd.border_title = "save\u25b8"
+        cmd.display = True
+        cmd.focus()
+
+    def _do_persist(self, alias=None) -> None:
+        """Persist current stack expression to catalog via ExprComposer."""
+        if self._stack is None or self._stack.cursor == 0:
+            return
+        self._persist_to_catalog(alias)
+
+    @work(thread=True, exit_on_error=False)
+    def _persist_to_catalog(self, alias) -> None:
+        try:
+            from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
+
+            code = self._stack.current_code
+            composer = ExprComposer(source=self._entry, code=code, alias=alias)
+            expr = composer.expr
+            catalog = self.app._catalog
+            if catalog is None:
+                self.app.call_from_thread(
+                    self._show_command_error, "No catalog available"
+                )
+                return
+            entry = catalog.add(expr)
+            if alias:
+                catalog.add_alias(entry.name, alias)
+            msg = f"Saved as '{alias or entry.name[:12]}'"
+            self.app.call_from_thread(self._show_persist_success, msg)
+        except Exception as e:
+            self.app.call_from_thread(self._show_command_error, f"Save failed: {e}")
+
+    def _show_persist_success(self, message) -> None:
+        self.query_one("#data-view-status", Static).update(f" \u2713 {message}")
+
+    # --- Stats ---
+
+    def action_toggle_stats(self) -> None:
+        panel = self.query_one("#stats-panel")
+        self._stats_visible = not self._stats_visible
+        panel.display = self._stats_visible
+        if self._stats_visible and not self._stats_loaded:
+            panel.border_subtitle = "loading..."
+            self._load_stats()
+
+    @work(thread=True, exit_on_error=False)
+    def _load_stats(self) -> None:
+        try:
+            from xorq.vendor import ibis  # noqa: PLC0415
+            from xorq.vendor.ibis import literal as lit  # noqa: PLC0415
+            from xorq.vendor.ibis.expr import datatypes as dt  # noqa: PLC0415
+
+            expr = self._stack.current_expr() if self._stack else None
+            if expr is None:
+                return
+            aggs = []
+            string_cols = []
+            for pos, colname in enumerate(expr.columns):
+                col = expr[colname]
+                typ = col.type()
+
+                col_mean = lit(None).cast(float)
+                col_std = lit(None).cast(float)
+                col_min = lit(None).cast(float)
+                col_max = lit(None).cast(float)
+                col_p25 = lit(None).cast(float)
+                col_p50 = lit(None).cast(float)
+                col_p75 = lit(None).cast(float)
+
+                if typ.is_numeric():
+                    col_mean = col.mean()
+                    col_std = col.std()
+                    col_min = col.min().cast(float)
+                    col_max = col.max().cast(float)
+                    col_p25 = col.quantile(0.25).cast(float)
+                    col_p50 = col.quantile(0.50).cast(float)
+                    col_p75 = col.quantile(0.75).cast(float)
+                elif typ.is_boolean():
+                    col_mean = col.mean()
+
+                if typ.is_string():
+                    string_cols.append(colname)
+
+                aggs.append(
+                    expr.agg(
+                        name=lit(colname),
+                        pos=lit(pos, type=dt.int16),
+                        type=lit(str(typ)),
+                        count=col.count(),
+                        nulls=col.isnull().sum(),
+                        unique=col.nunique(),
+                        mean=col_mean,
+                        std=col_std,
+                        min=col_min,
+                        p25=col_p25,
+                        p50=col_p50,
+                        p75=col_p75,
+                        max=col_max,
+                    )
+                )
+
+            stats_df = ibis.union(*aggs).execute()
+
+            # Compute mode for string columns in a single batched query
+            # (avoids unsupported Mode operation)
+            if string_cols:
+                mode_exprs = []
+                for colname in string_cols:
+                    mode_exprs.append(
+                        expr.group_by(colname)
+                        .agg(_cnt=expr[colname].count())
+                        .order_by(ibis.desc("_cnt"))
+                        .limit(1)
+                        .select(
+                            _col_name=lit(colname),
+                            _mode_val=expr[colname].cast(str),
+                        )
+                    )
+                modes_df = ibis.union(*mode_exprs).execute()
+                modes = dict(zip(modes_df["_col_name"], modes_df["_mode_val"]))
+                stats_df["mode"] = stats_df["name"].map(modes).fillna("")
+
+            self.app.call_from_thread(self._render_stats, stats_df)
+        except Exception as e:
+            self.app.call_from_thread(
+                self._render_stats_error, f"{type(e).__name__}: {e}"
+            )
+
+    def _render_stats(self, stats_df) -> None:
+        self._stats_loaded = True
+        with self.app.batch_update():
+            panel = self.query_one("#stats-panel")
+            panel.border_subtitle = ""
+            table = self.query_one("#stats-table", DataTable)
+            table.clear(columns=True)
+            for col in stats_df.columns:
+                table.add_column(str(col), key=str(col))
+            for i, row in enumerate(stats_df.itertuples(index=False)):
+                table.add_row(
+                    *(
+                        str(round(v, 2)) if isinstance(v, float) else str(v)
+                        for v in row
+                    ),
+                    key=str(i),
+                )
+
+    def _render_stats_error(self, message) -> None:
+        self.query_one("#stats-panel").border_subtitle = f"Error: {message}"
 
 
 class CatalogTUI(App):
@@ -1215,8 +1729,41 @@ class CatalogTUI(App):
         padding: 0 2;
         background: $surface;
     }
+    DataViewScreen #data-view-split {
+        height: 1fr;
+    }
     DataViewScreen #data-view-table {
         height: 1fr;
+    }
+    DataViewScreen #stack-browser-panel {
+        width: 40;
+        border: solid #5abfb5;
+        border-title-color: #5abfb5;
+        padding: 0 1;
+    }
+    DataViewScreen #stack-browser-content {
+        height: auto;
+    }
+    DataViewScreen #stats-panel {
+        height: auto;
+        max-height: 12;
+        border: solid #4AA8EC;
+        border-title-color: #4AA8EC;
+    }
+    DataViewScreen #stats-table {
+        height: auto;
+    }
+    DataViewScreen #command-input {
+        dock: bottom;
+        height: 3;
+        border: solid #2BBE75;
+        border-title-color: #2BBE75;
+        padding: 0 1;
+    }
+    DataViewScreen #command-input.error {
+        border: solid #FF4757;
+        border-title-color: #FF4757;
+        color: #FF4757;
     }
     """
 

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -23,6 +23,7 @@ from pygments.token import (
 from rich.syntax import Syntax
 from textual import on, work
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.suggester import SuggestFromList
@@ -1024,26 +1025,26 @@ class DataViewScreen(Screen):
     """
 
     BINDINGS = (
-        ("escape", "cancel_or_back", "Back"),
-        ("q", "cancel_or_back", "Back"),
-        ("h", "cursor_left", "Col ←"),
-        ("j", "cursor_down", "Down"),
-        ("k", "cursor_up", "Up"),
-        ("l", "cursor_right", "Col →"),
-        ("g", "scroll_top", "Top"),
-        ("shift+g", "scroll_bottom", "Bottom"),
-        ("[", "sort_desc", "Sort ↓"),
-        ("]", "sort_asc", "Sort ↑"),
-        ("d", "drop_column", "Drop col"),
-        ("u", "undo", "Undo"),
-        ("ctrl+r", "redo", "Redo"),
-        ("e", "toggle_stack_browser", "Stack"),
-        ("w", "persist", "Save"),
-        ("f", "verb_filter", "Filter"),
-        ("=", "verb_mutate", "Mutate"),
-        ("-", "verb_select", "Select"),
-        ("#", "verb_agg", "Agg"),
-        (":", "verb_freeform", "Freeform"),
+        Binding("escape", "cancel_or_back", "Back"),
+        Binding("q", "cancel_or_back", "Back", show=False),
+        Binding("h", "cursor_left", "Col ←", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("l", "cursor_right", "Col →", show=False),
+        Binding("g", "scroll_top", "Top", show=False),
+        Binding("shift+g", "scroll_bottom", "Bottom", show=False),
+        Binding("[", "sort_desc", "Sort ↓", show=False),
+        Binding("]", "sort_asc", "Sort ↑", show=False),
+        Binding("d", "drop_column", "Drop"),
+        Binding("u", "undo", "Undo"),
+        Binding("ctrl+r", "redo", "Redo"),
+        Binding("e", "toggle_stack_browser", "Stack"),
+        Binding("w", "persist", "Save"),
+        Binding("f", "verb_filter", "Filter"),
+        Binding("=", "verb_mutate", "Mutate"),
+        Binding("-", "verb_select", "Select"),
+        Binding("#", "verb_agg", "Agg"),
+        Binding(":", "verb_freeform", "Free"),
     )
 
     def __init__(self, entry, row_data):

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1413,130 +1413,78 @@ class DataViewScreen(Screen):
 class CatalogTUI(App):
     TITLE = "xorq catalog"
     CSS = """
-    #main-split {
-        height: 1fr;
+    #main-split { height: 1fr; }
+    #left-column { width: 2fr; }
+    #right-column { width: 3fr; }
+
+    #catalog-panel,
+    #revisions-panel,
+    #git-log-panel,
+    #sql-panel,
+    #info-panel,
+    #schema-panel,
+    #data-preview-panel,
+    DataViewScreen #stack-browser-panel {
+        border: solid #3d6670;
+        border-title-color: #7aa8b2;
+        border-subtitle-color: #7aa8b2;
     }
-    #left-column {
-        width: 2fr;
-    }
-    #right-column {
-        width: 3fr;
-    }
-    #catalog-panel {
-        height: 2fr;
-        border: solid #C1F0FF;
-        border-title-color: #C1F0FF;
-        background: $surface;
-    }
-    #catalog-tree {
-        height: 1fr;
-    }
-    #revisions-panel {
-        height: 1fr;
-        border: solid #5abfb5;
-        border-title-color: #5abfb5;
-        border-subtitle-color: #5abfb5;
-    }
-    #revisions-preview-table {
-        height: 1fr;
-    }
-    #git-log-panel {
-        height: 1fr;
-        border: solid #4AA8EC;
-        border-title-color: #4AA8EC;
-    }
-    #git-log-table {
-        height: 1fr;
-    }
-    #sql-panel {
-        height: 2fr;
-        border: solid #2BBE75;
-        border-title-color: #2BBE75;
-        border-subtitle-color: #2BBE75;
-    }
-    #sql-panel:focus-within {
-        border: double #2BBE75;
-    }
-    #sql-preview {
-        height: auto;
-        padding: 1 2;
-    }
-    DataTable:focus {
-        border: none;
-    }
-    Tree:focus {
-        border: none;
-    }
-    #info-panel {
-        height: auto;
-        max-height: 6;
-        border: solid #5abfb5;
-        border-title-color: #5abfb5;
-        padding: 0 1;
-    }
-    #info-content {
-        height: auto;
-    }
-    #schema-panel {
-        height: 1fr;
-        border: solid #4AA8EC;
-        border-title-color: #4AA8EC;
-        border-subtitle-color: #4AA8EC;
-    }
-    #schema-split {
-        height: 1fr;
-    }
-    #schema-in-half {
-        width: 1fr;
-    }
-    #schema-out-half {
-        width: 1fr;
-    }
-    #schema-in-table {
-        height: 1fr;
-    }
-    #schema-preview-table {
-        height: 1fr;
-    }
-    #data-preview-panel {
-        height: 2fr;
+    #catalog-panel:focus-within,
+    #revisions-panel:focus-within,
+    #git-log-panel:focus-within,
+    #sql-panel:focus-within,
+    #info-panel:focus-within,
+    #schema-panel:focus-within,
+    #data-preview-panel:focus-within,
+    DataViewScreen #stack-browser-panel:focus-within {
         border: solid #C1F0FF;
         border-title-color: #C1F0FF;
         border-subtitle-color: #C1F0FF;
     }
-    #data-preview-status {
-        height: 1;
-        padding: 0 2;
-    }
-    #data-preview-table {
-        height: 1fr;
-    }
+
+    #catalog-panel { height: 2fr; background: $surface; }
+    #catalog-tree { height: 1fr; }
+    #revisions-panel { height: 1fr; }
+    #revisions-preview-table { height: 1fr; }
+    #git-log-panel { height: 1fr; }
+    #git-log-table { height: 1fr; }
+    #sql-panel { height: 2fr; }
+    #sql-preview { height: auto; padding: 1 2; }
+
+    DataTable:focus { border: none; }
+    Tree:focus { border: none; }
+
+    #info-panel { height: auto; max-height: 6; padding: 0 1; }
+    #info-content { height: auto; }
+
+    #schema-panel { height: 1fr; }
+    #schema-split { height: 1fr; }
+    #schema-in-half { width: 1fr; }
+    #schema-out-half { width: 1fr; }
+    #schema-in-table { height: 1fr; }
+    #schema-preview-table { height: 1fr; }
+
+    #data-preview-panel { height: 2fr; }
+    #data-preview-status { height: 1; padding: 0 2; }
+    #data-preview-table { height: 1fr; }
+
     #status-bar {
         dock: bottom;
         height: 1;
         padding: 0 2;
         background: $surface;
     }
+
     DataViewScreen #data-view-status {
         height: 1;
         padding: 0 2;
         background: $surface;
     }
-    DataViewScreen #data-view-split {
-        height: 1fr;
-    }
-    DataViewScreen #data-view-table {
-        height: 1fr;
-    }
-    DataViewScreen #stack-browser-panel {
-        width: 40;
-        border: solid #5abfb5;
-        border-title-color: #5abfb5;
-        padding: 0 1;
-    }
-    DataViewScreen #stack-browser-content {
-        height: auto;
-    }
+    DataViewScreen #data-view-split { height: 1fr; }
+    DataViewScreen #data-view-table { height: 1fr; }
+    DataViewScreen #stack-browser-panel { width: 40; padding: 0 1; }
+    DataViewScreen #stack-browser-content { height: auto; }
+
     DataViewScreen #command-input {
         dock: bottom;
         height: 3;

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1120,7 +1120,9 @@ class DataViewScreen(Screen):
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
         try:
-            base_expr = self._entry.expr
+            from xorq.catalog.bind import _make_source_expr  # noqa: PLC0415
+
+            base_expr = _make_source_expr(self._entry)
             self._stack = ExprStack(base_expr=base_expr)
             df = base_expr.limit(VIEW_LIMIT).execute()
             self.app.call_from_thread(self._on_data_loaded, df)

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1118,7 +1118,9 @@ class DataViewScreen(Screen):
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
         try:
-            base_expr = self._entry.expr
+            from xorq.catalog.bind import _make_source_expr  # noqa: PLC0415
+
+            base_expr = _make_source_expr(self._entry)
             self._stack = ExprStack(base_expr=base_expr)
             df = base_expr.limit(VIEW_LIMIT).execute()
             self.app.call_from_thread(self._on_data_loaded, df)

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -950,6 +950,7 @@ class DataViewScreen(Screen):
         super().__init__()
         self._entry = entry
         self._row_data = row_data
+        self._ibis_expr = None
         self._df = None
         self._sort_column_index = -1
 
@@ -1053,6 +1054,7 @@ class DataViewScreen(Screen):
 
     def action_go_back(self) -> None:
         self._df = None
+        self._ibis_expr = None
         self.app.pop_screen()
 
     def action_cursor_down(self) -> None:

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1266,7 +1266,7 @@ class DataViewScreen(Screen):
 
         # Save accepts empty input (no alias)
         if verb == "save":
-            alias = user_input if user_input else None
+            alias = user_input or None
             cmd.display = False
             self._command_verb = None
             self.query_one("#data-view-table", DataTable).focus()

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1268,7 +1268,7 @@ class DataViewScreen(Screen):
 
         # Save accepts empty input (no alias)
         if verb == "save":
-            alias = user_input if user_input else None
+            alias = user_input or None
             cmd.display = False
             self._command_verb = None
             self.query_one("#data-view-table", DataTable).focus()

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -23,6 +23,7 @@ from pygments.token import (
 from rich.syntax import Syntax
 from textual import on, work
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.suggester import SuggestFromList
@@ -1022,26 +1023,26 @@ class DataViewScreen(Screen):
     """
 
     BINDINGS = (
-        ("escape", "cancel_or_back", "Back"),
-        ("q", "cancel_or_back", "Back"),
-        ("h", "cursor_left", "Col ←"),
-        ("j", "cursor_down", "Down"),
-        ("k", "cursor_up", "Up"),
-        ("l", "cursor_right", "Col →"),
-        ("g", "scroll_top", "Top"),
-        ("shift+g", "scroll_bottom", "Bottom"),
-        ("[", "sort_desc", "Sort ↓"),
-        ("]", "sort_asc", "Sort ↑"),
-        ("d", "drop_column", "Drop col"),
-        ("u", "undo", "Undo"),
-        ("ctrl+r", "redo", "Redo"),
-        ("e", "toggle_stack_browser", "Stack"),
-        ("w", "persist", "Save"),
-        ("f", "verb_filter", "Filter"),
-        ("=", "verb_mutate", "Mutate"),
-        ("-", "verb_select", "Select"),
-        ("#", "verb_agg", "Agg"),
-        (":", "verb_freeform", "Freeform"),
+        Binding("escape", "cancel_or_back", "Back"),
+        Binding("q", "cancel_or_back", "Back", show=False),
+        Binding("h", "cursor_left", "Col ←", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("l", "cursor_right", "Col →", show=False),
+        Binding("g", "scroll_top", "Top", show=False),
+        Binding("shift+g", "scroll_bottom", "Bottom", show=False),
+        Binding("[", "sort_desc", "Sort ↓", show=False),
+        Binding("]", "sort_asc", "Sort ↑", show=False),
+        Binding("d", "drop_column", "Drop"),
+        Binding("u", "undo", "Undo"),
+        Binding("ctrl+r", "redo", "Redo"),
+        Binding("e", "toggle_stack_browser", "Stack"),
+        Binding("w", "persist", "Save"),
+        Binding("f", "verb_filter", "Filter"),
+        Binding("=", "verb_mutate", "Mutate"),
+        Binding("-", "verb_select", "Select"),
+        Binding("#", "verb_agg", "Agg"),
+        Binding(":", "verb_freeform", "Free"),
     )
 
     def __init__(self, entry, row_data):

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -952,6 +952,7 @@ class DataViewScreen(Screen):
         super().__init__()
         self._entry = entry
         self._row_data = row_data
+        self._ibis_expr = None
         self._df = None
         self._sort_column_index = -1
 
@@ -1055,6 +1056,7 @@ class DataViewScreen(Screen):
 
     def action_go_back(self) -> None:
         self._df = None
+        self._ibis_expr = None
         self.app.pop_screen()
 
     def action_cursor_down(self) -> None:

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -7,7 +7,7 @@ from functools import cache, cached_property
 from pathlib import Path
 from typing import Literal
 
-from attr import field, frozen
+from attr import evolve, field, frozen
 from attr.validators import instance_of, optional
 from pygments.style import Style as PygmentsStyle
 from pygments.token import (
@@ -25,11 +25,13 @@ from textual import on, work
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
+from textual.suggester import SuggestFromList
 from textual.theme import Theme
 from textual.widgets import (
     DataTable,
     Footer,
     Header,
+    Input,
     Static,
     Tree,
 )
@@ -237,6 +239,78 @@ class RevisionRowData:
 
 VIEW_LIMIT = 50_000
 
+VERB_TEMPLATES = {
+    "filter": "source.filter({input})",
+    "mutate": "source.mutate({input})",
+    "select": "source.select({input})",
+    "order_by": "source.order_by({input})",
+    "drop": "source.drop({input})",
+    "agg": "source.group_by({group}).agg({input})",
+}
+
+
+def build_code(verb: str, user_input: str, group: str = "") -> str:
+    if verb == "freeform":
+        return user_input
+    if verb == "agg":
+        return VERB_TEMPLATES[verb].format(group=group, input=user_input)
+    return VERB_TEMPLATES[verb].format(input=user_input)
+
+
+@frozen
+class ExprStep:
+    """A single user-applied Ibis operation."""
+
+    verb: str = field(validator=instance_of(str))
+    user_input: str = field(validator=instance_of(str))
+    code: str = field(validator=instance_of(str))
+
+
+@frozen
+class ExprStack:
+    """Immutable operation stack with undo/redo cursor."""
+
+    base_expr: object = field(repr=False)
+    steps: tuple[ExprStep, ...] = field(factory=tuple)
+    cursor: int = field(default=0, validator=instance_of(int))
+
+    def push(self, step: ExprStep) -> "ExprStack":
+        """Apply new step, discard any steps after cursor (fork)."""
+        return evolve(
+            self,
+            steps=self.steps[: self.cursor] + (step,),
+            cursor=self.cursor + 1,
+        )
+
+    def undo(self) -> "ExprStack":
+        return evolve(self, cursor=max(0, self.cursor - 1))
+
+    def redo(self) -> "ExprStack":
+        return evolve(self, cursor=min(len(self.steps), self.cursor + 1))
+
+    @property
+    def can_undo(self) -> bool:
+        return self.cursor > 0
+
+    @property
+    def can_redo(self) -> bool:
+        return self.cursor < len(self.steps)
+
+    def current_expr(self):
+        """Replay active steps onto base via _eval_code."""
+        from xorq.catalog.bind import _eval_code  # noqa: PLC0415
+
+        expr = self.base_expr
+        for step in self.steps[: self.cursor]:
+            expr = _eval_code(step.code, expr)
+        return expr
+
+    @property
+    def current_code(self) -> str:
+        """Composable --code string for the active steps."""
+        if self.cursor == 0:
+            return ""
+        return "\n".join(step.code for step in self.steps[: self.cursor])
 
 def _entry_info(entry: CatalogEntry) -> tuple[int | None, bool | None]:
     cache_keys_paths = get_cache_keys_paths(entry.parquet_snapshot_cache_keys)
@@ -933,33 +1007,59 @@ class CatalogScreen(Screen):
 
 
 class DataViewScreen(Screen):
-    """Full-screen data viewer for a single catalog entry."""
+    """Full-screen data viewer with interactive expression composition.
+
+    Every user action (filter, mutate, select, sort, aggregate) is a raw Ibis
+    API call pushed onto an undo/redo ExprStack.
+    """
 
     BINDINGS = (
-        ("escape", "go_back", "Back"),
-        ("q", "go_back", "Back"),
+        ("escape", "cancel_or_back", "Back"),
+        ("q", "cancel_or_back", "Back"),
         ("h", "scroll_left", "Left"),
         ("j", "cursor_down", "Down"),
         ("k", "cursor_up", "Up"),
         ("l", "scroll_right", "Right"),
         ("g", "scroll_top", "Top"),
         ("shift+g", "scroll_bottom", "Bottom"),
-        ("[", "sort_prev", "Sort ←"),
-        ("]", "sort_next", "Sort →"),
+        ("[", "sort_desc", "Sort ↓"),
+        ("]", "sort_asc", "Sort ↑"),
+        ("d", "drop_column", "Drop col"),
+        ("s", "toggle_stats", "Stats"),
+        ("u", "undo", "Undo"),
+        ("ctrl+r", "redo", "Redo"),
+        ("e", "toggle_stack_browser", "Stack"),
+        ("w", "persist", "Save"),
+        ("f", "verb_filter", "Filter"),
+        ("=", "verb_mutate", "Mutate"),
+        ("-", "verb_select", "Select"),
+        ("#", "verb_agg", "Agg"),
+        (":", "verb_freeform", "Freeform"),
     )
 
     def __init__(self, entry, row_data):
         super().__init__()
         self._entry = entry
         self._row_data = row_data
-        self._ibis_expr = None
+        self._stack = None
         self._df = None
-        self._sort_column_index = -1
+        self._cursor_column_index = 0
+        self._stats_visible = False
+        self._stats_loaded = False
+        self._stack_browser_visible = False
+        self._command_verb = None
+        self._agg_group = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Static("", id="data-view-status")
-        yield DataTable(id="data-view-table")
+        with Horizontal(id="data-view-split"):
+            yield DataTable(id="data-view-table")
+            with Vertical(id="stack-browser-panel"):
+                yield Static("", id="stack-browser-content")
+        with Vertical(id="stats-panel"):
+            yield DataTable(id="stats-table")
+        yield Input(id="command-input", placeholder="")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -967,6 +1067,21 @@ class DataViewScreen(Screen):
         table.cursor_type = "row"
         table.zebra_stripes = True
         table.loading = True
+
+        stats_panel = self.query_one("#stats-panel")
+        stats_panel.border_title = "Stats"
+        stats_panel.display = False
+
+        stats_table = self.query_one("#stats-table", DataTable)
+        stats_table.cursor_type = "none"
+        stats_table.zebra_stripes = True
+
+        stack_panel = self.query_one("#stack-browser-panel")
+        stack_panel.border_title = "Expression Stack"
+        stack_panel.display = False
+
+        cmd_input = self.query_one("#command-input", Input)
+        cmd_input.display = False
 
         label = self._row_data.aliases_display or self._row_data.hash[:12]
         self.query_one("#data-view-status", Static).update(f" Loading {label}...")
@@ -1007,14 +1122,18 @@ class DataViewScreen(Screen):
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
         try:
-            df = self._run_catalog_subprocess()
+            base_expr = self._entry.expr
+            self._stack = ExprStack(base_expr=base_expr)
+            df = base_expr.limit(VIEW_LIMIT).execute()
             self.app.call_from_thread(self._on_data_loaded, df)
         except Exception as e:
             self.app.call_from_thread(self._render_error, str(e))
 
     def _on_data_loaded(self, df) -> None:
         self._df = df
+        self._cursor_column_index = 0
         self._render_table()
+        self._update_command_suggester()
 
     def _render_table(self) -> None:
         df = self._df
@@ -1039,25 +1158,242 @@ class DataViewScreen(Screen):
                     key=str(i),
                 )
             table.cursor_type = "row"
-            label = self._row_data.aliases_display or self._row_data.hash[:12]
-            sort_info = ""
-            if self._sort_column_index >= 0:
-                col_name = df.columns[self._sort_column_index]
-                sort_info = f" | sorted by {col_name}"
-            self.query_one("#data-view-status", Static).update(
-                f" {label} \u2014 {len(df)} rows \u00d7 {len(df.columns)} cols{sort_info}"
-            )
+            self._update_status_bar()
+
+    def _update_status_bar(self) -> None:
+        df = self._df
+        if df is None:
+            return
+        label = self._row_data.aliases_display or self._row_data.hash[:12]
+        stack = self._stack
+        step_info = ""
+        if stack and stack.cursor > 0:
+            step = stack.steps[stack.cursor - 1]
+            step_info = f" | step {stack.cursor}/{len(stack.steps)} {step.verb}"
+        self.query_one("#data-view-status", Static).update(
+            f" {label} \u2014 {len(df)} rows \u00d7 {len(df.columns)} cols{step_info}"
+        )
 
     def _render_error(self, message) -> None:
         self.query_one("#data-view-status", Static).update(f" Error: {message}")
         self.query_one("#data-view-table", DataTable).loading = False
 
+    _IBIS_METHOD_SUGGESTIONS = (
+        "filter",
+        "mutate",
+        "select",
+        "order_by",
+        "group_by",
+        "agg",
+        "distinct",
+        "head",
+        "limit",
+        "join",
+        "drop",
+    )
+
+    def _update_command_suggester(self) -> None:
+        """Update tab-completion suggestions from current expression columns."""
+        cols = tuple(self._df.columns) if self._df is not None else ()
+        self.query_one("#command-input", Input).suggester = SuggestFromList(
+            cols + self._IBIS_METHOD_SUGGESTIONS, case_sensitive=False
+        )
+
+    # --- Stack operations ---
+
+    def _push_step(self, verb: str, user_input: str, code: str) -> None:
+        """Push a step and re-execute in background."""
+        step = ExprStep(verb=verb, user_input=user_input, code=code)
+        self._stack = self._stack.push(step)
+        self._execute_current()
+
+    @work(thread=True, exit_on_error=False)
+    def _execute_current(self) -> None:
+        """Evaluate current stack expression and update the table."""
+        try:
+            stack = self._stack
+            expr = stack.current_expr()
+            df = expr.limit(VIEW_LIMIT).execute()
+            self.app.call_from_thread(self._on_stack_executed, df)
+        except Exception as e:
+            self._stack = stack.undo()
+            self.app.call_from_thread(self._show_command_error, str(e))
+
+    def _on_stack_executed(self, df) -> None:
+        self._df = df
+        self._cursor_column_index = 0
+        self._stats_loaded = False
+        self._render_table()
+        self._update_command_suggester()
+        self._render_stack_browser()
+
+    def _show_command_error(self, message) -> None:
+        cmd = self.query_one("#command-input", Input)
+        cmd.display = True
+        cmd.value = f"Error: {message}"
+        cmd.add_class("error")
+
+    # --- Command input ---
+
+    def _open_command_input(self, verb: str) -> None:
+        """Show the command input docked at bottom with verb prompt."""
+        self._command_verb = verb
+        cmd = self.query_one("#command-input", Input)
+        cmd.remove_class("error")
+        cmd.value = ""
+        prompt = verb if verb != "freeform" else ":"
+        cmd.placeholder = (
+            f"{prompt}\u25b8 type expression, Tab to complete, Enter to apply"
+        )
+        cmd.border_title = f"{prompt}\u25b8"
+        cmd.display = True
+        cmd.focus()
+
+    @on(Input.Submitted, "#command-input")
+    def _on_command_submitted(self, event: Input.Submitted) -> None:
+        user_input = event.value.strip()
+        cmd = self.query_one("#command-input", Input)
+
+        verb = self._command_verb
+
+        # Save accepts empty input (no alias)
+        if verb == "save":
+            alias = user_input if user_input else None
+            cmd.display = False
+            self._command_verb = None
+            self.query_one("#data-view-table", DataTable).focus()
+            self._do_persist(alias)
+            return
+
+        if not user_input:
+            cmd.display = False
+            self._command_verb = None
+            self._agg_group = None
+            self.query_one("#data-view-table", DataTable).focus()
+            return
+
+        if verb is None:
+            cmd.display = False
+            self.query_one("#data-view-table", DataTable).focus()
+            return
+
+        # Two-phase aggregate: first group_by, then agg
+        if verb == "agg_group":
+            self._agg_group = user_input
+            self._command_verb = "agg"
+            cmd.value = ""
+            cmd.placeholder = (
+                "agg\u25b8 aggregation expressions (e.g. avg=source.amount.mean())"
+            )
+            cmd.border_title = "agg\u25b8"
+            return
+
+        try:
+            if verb == "agg":
+                group = self._agg_group or ""
+                code = build_code(verb, user_input, group=group)
+                display_input = f"group_by({group}).agg({user_input})"
+            else:
+                code = build_code(verb, user_input)
+                display_input = user_input
+        except Exception as e:
+            cmd.value = f"Error building code: {e}"
+            cmd.add_class("error")
+            return
+
+        cmd.display = False
+        self._command_verb = None
+        self._agg_group = None
+        self.query_one("#data-view-table", DataTable).focus()
+        self._push_step(verb, display_input, code)
+
+    # --- Verb actions ---
+
+    def action_verb_filter(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("filter")
+
+    def action_verb_mutate(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("mutate")
+
+    def action_verb_select(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("select")
+
+    def action_verb_agg(self) -> None:
+        if self._stack is None:
+            return
+        self._agg_group = None
+        self._command_verb = "agg_group"
+        cmd = self.query_one("#command-input", Input)
+        cmd.remove_class("error")
+        cmd.value = ""
+        cmd.placeholder = (
+            'group_by\u25b8 column names to group by (e.g. "category", "region")'
+        )
+        cmd.border_title = "group_by\u25b8"
+        cmd.display = True
+        cmd.focus()
+
+    def action_verb_freeform(self) -> None:
+        if self._stack is None:
+            return
+        self._open_command_input("freeform")
+
+    # --- Instant actions (no input required) ---
+
+    def action_sort_asc(self) -> None:
+        if self._stack is None or self._df is None:
+            return
+        col = self._df.columns[self._cursor_column_index]
+        code = f'source.order_by("{col}")'
+        self._push_step("order_by", f'"{col}"', code)
+
+    def action_sort_desc(self) -> None:
+        if self._stack is None or self._df is None:
+            return
+        col = self._df.columns[self._cursor_column_index]
+        code = f'source.order_by(ibis.desc("{col}"))'
+        self._push_step("order_by", f'ibis.desc("{col}")', code)
+
+    def action_drop_column(self) -> None:
+        if self._stack is None or self._df is None:
+            return
+        col = self._df.columns[self._cursor_column_index]
+        code = f'source.drop("{col}")'
+        self._push_step("drop", f'"{col}"', code)
+
+    # --- Undo / Redo ---
+
+    def action_undo(self) -> None:
+        if self._stack is None or not self._stack.can_undo:
+            return
+        self._stack = self._stack.undo()
+        self._execute_current()
+
+    def action_redo(self) -> None:
+        if self._stack is None or not self._stack.can_redo:
+            return
+        self._stack = self._stack.redo()
+        self._execute_current()
+
     # --- Navigation ---
 
-    def action_go_back(self) -> None:
-        self._df = None
-        self._ibis_expr = None
-        self.app.pop_screen()
+    def action_cancel_or_back(self) -> None:
+        cmd = self.query_one("#command-input", Input)
+        if cmd.display:
+            cmd.display = False
+            self._command_verb = None
+            self._agg_group = None
+            self.query_one("#data-view-table", DataTable).focus()
+        else:
+            self._df = None
+            self._stack = None
+            self.app.pop_screen()
 
     def action_cursor_down(self) -> None:
         self.query_one("#data-view-table", DataTable).action_cursor_down()
@@ -1067,9 +1403,11 @@ class DataViewScreen(Screen):
 
     def action_scroll_left(self) -> None:
         self.query_one("#data-view-table", DataTable).action_scroll_left()
+        self._track_cursor_column()
 
     def action_scroll_right(self) -> None:
         self.query_one("#data-view-table", DataTable).action_scroll_right()
+        self._track_cursor_column()
 
     def action_scroll_top(self) -> None:
         table = self.query_one("#data-view-table", DataTable)
@@ -1080,29 +1418,205 @@ class DataViewScreen(Screen):
         if table.row_count > 0:
             table.move_cursor(row=table.row_count - 1)
 
-    # --- Sorting ---
-
-    def action_sort_prev(self) -> None:
+    def _track_cursor_column(self) -> None:
+        """Update tracked column index from DataTable cursor position."""
         if self._df is None:
             return
-        ncols = len(self._df.columns)
-        if self._sort_column_index <= 0:
-            self._sort_column_index = ncols - 1
-        else:
-            self._sort_column_index -= 1
-        self._apply_sort()
+        table = self.query_one("#data-view-table", DataTable)
+        col = table.cursor_column
+        if 0 <= col < len(self._df.columns):
+            self._cursor_column_index = col
 
-    def action_sort_next(self) -> None:
-        if self._df is None:
+    # --- Stack browser ---
+
+    def action_toggle_stack_browser(self) -> None:
+        self._stack_browser_visible = not self._stack_browser_visible
+        panel = self.query_one("#stack-browser-panel")
+        panel.display = self._stack_browser_visible
+        if self._stack_browser_visible:
+            self._render_stack_browser()
+
+    def _render_stack_browser(self) -> None:
+        if not self._stack_browser_visible or self._stack is None:
             return
-        ncols = len(self._df.columns)
-        self._sort_column_index = (self._sort_column_index + 1) % ncols
-        self._apply_sort()
+        stack = self._stack
+        label = self._row_data.aliases_display or self._row_data.hash[:12]
+        base_marker = "\u2192 " if stack.cursor == 0 else "  "
+        step_lines = tuple(
+            "{}{:<3} {:<9} {}{}".format(
+                "\u2192 " if (i + 1) == stack.cursor else "  ",
+                i + 1,
+                step.verb,
+                step.user_input,
+                "  (undone)" if (i + 1) > stack.cursor else "",
+            )
+            for i, step in enumerate(stack.steps)
+        )
+        code = stack.current_code
+        code_lines = (
+            ("--code equivalent:", code) if code else ("(no transforms applied)",)
+        )
+        lines = (f"{base_marker}0  base: {label}", *step_lines, "", *code_lines)
+        self.query_one("#stack-browser-content", Static).update("\n".join(lines))
 
-    def _apply_sort(self) -> None:
-        col = self._df.columns[self._sort_column_index]
-        self._df = self._df.sort_values(by=col, na_position="last")
-        self._render_table()
+    # --- Persist to catalog ---
+
+    def action_persist(self) -> None:
+        if self._stack is None or self._stack.cursor == 0:
+            return
+        self._command_verb = "save"
+        cmd = self.query_one("#command-input", Input)
+        cmd.remove_class("error")
+        cmd.value = ""
+        cmd.placeholder = "alias name (leave empty to save without alias)"
+        cmd.border_title = "save\u25b8"
+        cmd.display = True
+        cmd.focus()
+
+    def _do_persist(self, alias=None) -> None:
+        """Persist current stack expression to catalog via ExprComposer."""
+        if self._stack is None or self._stack.cursor == 0:
+            return
+        self._persist_to_catalog(alias)
+
+    @work(thread=True, exit_on_error=False)
+    def _persist_to_catalog(self, alias) -> None:
+        try:
+            from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
+
+            code = self._stack.current_code
+            composer = ExprComposer(source=self._entry, code=code, alias=alias)
+            expr = composer.expr
+            catalog = self.app._catalog
+            if catalog is None:
+                self.app.call_from_thread(
+                    self._show_command_error, "No catalog available"
+                )
+                return
+            entry = catalog.add(expr)
+            if alias:
+                catalog.add_alias(entry.name, alias)
+            msg = f"Saved as '{alias or entry.name[:12]}'"
+            self.app.call_from_thread(self._show_persist_success, msg)
+        except Exception as e:
+            self.app.call_from_thread(self._show_command_error, f"Save failed: {e}")
+
+    def _show_persist_success(self, message) -> None:
+        self.query_one("#data-view-status", Static).update(f" \u2713 {message}")
+
+    # --- Stats ---
+
+    def action_toggle_stats(self) -> None:
+        panel = self.query_one("#stats-panel")
+        self._stats_visible = not self._stats_visible
+        panel.display = self._stats_visible
+        if self._stats_visible and not self._stats_loaded:
+            panel.border_subtitle = "loading..."
+            self._load_stats()
+
+    @work(thread=True, exit_on_error=False)
+    def _load_stats(self) -> None:
+        try:
+            from xorq.vendor import ibis  # noqa: PLC0415
+            from xorq.vendor.ibis import literal as lit  # noqa: PLC0415
+            from xorq.vendor.ibis.expr import datatypes as dt  # noqa: PLC0415
+
+            expr = self._stack.current_expr() if self._stack else None
+            if expr is None:
+                return
+            aggs = []
+            string_cols = []
+            for pos, colname in enumerate(expr.columns):
+                col = expr[colname]
+                typ = col.type()
+
+                col_mean = lit(None).cast(float)
+                col_std = lit(None).cast(float)
+                col_min = lit(None).cast(float)
+                col_max = lit(None).cast(float)
+                col_p25 = lit(None).cast(float)
+                col_p50 = lit(None).cast(float)
+                col_p75 = lit(None).cast(float)
+
+                if typ.is_numeric():
+                    col_mean = col.mean()
+                    col_std = col.std()
+                    col_min = col.min().cast(float)
+                    col_max = col.max().cast(float)
+                    col_p25 = col.quantile(0.25).cast(float)
+                    col_p50 = col.quantile(0.50).cast(float)
+                    col_p75 = col.quantile(0.75).cast(float)
+                elif typ.is_boolean():
+                    col_mean = col.mean()
+
+                if typ.is_string():
+                    string_cols.append(colname)
+
+                aggs.append(
+                    expr.agg(
+                        name=lit(colname),
+                        pos=lit(pos, type=dt.int16),
+                        type=lit(str(typ)),
+                        count=col.count(),
+                        nulls=col.isnull().sum(),
+                        unique=col.nunique(),
+                        mean=col_mean,
+                        std=col_std,
+                        min=col_min,
+                        p25=col_p25,
+                        p50=col_p50,
+                        p75=col_p75,
+                        max=col_max,
+                    )
+                )
+
+            stats_df = ibis.union(*aggs).execute()
+
+            # Compute mode for string columns in a single batched query
+            # (avoids unsupported Mode operation)
+            if string_cols:
+                mode_exprs = []
+                for colname in string_cols:
+                    mode_exprs.append(
+                        expr.group_by(colname)
+                        .agg(_cnt=expr[colname].count())
+                        .order_by(ibis.desc("_cnt"))
+                        .limit(1)
+                        .select(
+                            _col_name=lit(colname),
+                            _mode_val=expr[colname].cast(str),
+                        )
+                    )
+                modes_df = ibis.union(*mode_exprs).execute()
+                modes = dict(zip(modes_df["_col_name"], modes_df["_mode_val"]))
+                stats_df["mode"] = stats_df["name"].map(modes).fillna("")
+
+            self.app.call_from_thread(self._render_stats, stats_df)
+        except Exception as e:
+            self.app.call_from_thread(
+                self._render_stats_error, f"{type(e).__name__}: {e}"
+            )
+
+    def _render_stats(self, stats_df) -> None:
+        self._stats_loaded = True
+        with self.app.batch_update():
+            panel = self.query_one("#stats-panel")
+            panel.border_subtitle = ""
+            table = self.query_one("#stats-table", DataTable)
+            table.clear(columns=True)
+            for col in stats_df.columns:
+                table.add_column(str(col), key=str(col))
+            for i, row in enumerate(stats_df.itertuples(index=False)):
+                table.add_row(
+                    *(
+                        str(round(v, 2)) if isinstance(v, float) else str(v)
+                        for v in row
+                    ),
+                    key=str(i),
+                )
+
+    def _render_stats_error(self, message) -> None:
+        self.query_one("#stats-panel").border_subtitle = f"Error: {message}"
 
 
 class CatalogTUI(App):
@@ -1217,8 +1731,41 @@ class CatalogTUI(App):
         padding: 0 2;
         background: $surface;
     }
+    DataViewScreen #data-view-split {
+        height: 1fr;
+    }
     DataViewScreen #data-view-table {
         height: 1fr;
+    }
+    DataViewScreen #stack-browser-panel {
+        width: 40;
+        border: solid #5abfb5;
+        border-title-color: #5abfb5;
+        padding: 0 1;
+    }
+    DataViewScreen #stack-browser-content {
+        height: auto;
+    }
+    DataViewScreen #stats-panel {
+        height: auto;
+        max-height: 12;
+        border: solid #4AA8EC;
+        border-title-color: #4AA8EC;
+    }
+    DataViewScreen #stats-table {
+        height: auto;
+    }
+    DataViewScreen #command-input {
+        dock: bottom;
+        height: 3;
+        border: solid #2BBE75;
+        border-title-color: #2BBE75;
+        padding: 0 1;
+    }
+    DataViewScreen #command-input.error {
+        border: solid #FF4757;
+        border-title-color: #FF4757;
+        color: #FF4757;
     }
     """
 

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1024,10 +1024,10 @@ class DataViewScreen(Screen):
     BINDINGS = (
         ("escape", "cancel_or_back", "Back"),
         ("q", "cancel_or_back", "Back"),
-        ("h", "scroll_left", "Left"),
+        ("h", "cursor_left", "Col ←"),
         ("j", "cursor_down", "Down"),
         ("k", "cursor_up", "Up"),
-        ("l", "scroll_right", "Right"),
+        ("l", "cursor_right", "Col →"),
         ("g", "scroll_top", "Top"),
         ("shift+g", "scroll_bottom", "Bottom"),
         ("[", "sort_desc", "Sort ↓"),
@@ -1067,7 +1067,7 @@ class DataViewScreen(Screen):
 
     def on_mount(self) -> None:
         table = self.query_one("#data-view-table", DataTable)
-        table.cursor_type = "row"
+        table.cursor_type = "cell"
         table.zebra_stripes = True
         table.loading = True
 
@@ -1152,7 +1152,7 @@ class DataViewScreen(Screen):
                     ),
                     key=str(i),
                 )
-            table.cursor_type = "row"
+            table.cursor_type = "cell"
             self._update_status_bar()
 
     def _update_status_bar(self) -> None:
@@ -1165,8 +1165,13 @@ class DataViewScreen(Screen):
         if stack and stack.cursor > 0:
             step = stack.steps[stack.cursor - 1]
             step_info = f" | step {stack.cursor}/{len(stack.steps)} {step.verb}"
+        col_info = ""
+        cols = df.columns
+        idx = self._cursor_column_index
+        if 0 <= idx < len(cols):
+            col_info = f" | [{cols[idx]}]"
         self.query_one("#data-view-status", Static).update(
-            f" {label} \u2014 {len(df)} rows \u00d7 {len(df.columns)} cols{step_info}"
+            f" {label} \u2014 {len(df)} rows \u00d7 {len(cols)} cols{col_info}{step_info}"
         )
 
     def _render_error(self, message) -> None:
@@ -1395,13 +1400,11 @@ class DataViewScreen(Screen):
     def action_cursor_up(self) -> None:
         self.query_one("#data-view-table", DataTable).action_cursor_up()
 
-    def action_scroll_left(self) -> None:
-        self.query_one("#data-view-table", DataTable).action_scroll_left()
-        self._track_cursor_column()
+    def action_cursor_left(self) -> None:
+        self.query_one("#data-view-table", DataTable).action_cursor_left()
 
-    def action_scroll_right(self) -> None:
-        self.query_one("#data-view-table", DataTable).action_scroll_right()
-        self._track_cursor_column()
+    def action_cursor_right(self) -> None:
+        self.query_one("#data-view-table", DataTable).action_cursor_right()
 
     def action_scroll_top(self) -> None:
         table = self.query_one("#data-view-table", DataTable)
@@ -1412,14 +1415,12 @@ class DataViewScreen(Screen):
         if table.row_count > 0:
             table.move_cursor(row=table.row_count - 1)
 
-    def _track_cursor_column(self) -> None:
-        """Update tracked column index from DataTable cursor position."""
-        if self._df is None:
-            return
-        table = self.query_one("#data-view-table", DataTable)
-        col = table.cursor_column
-        if 0 <= col < len(self._df.columns):
+    @on(DataTable.CellHighlighted, "#data-view-table")
+    def _on_cell_highlighted(self, event: DataTable.CellHighlighted) -> None:
+        col = event.coordinate.column
+        if self._df is not None and 0 <= col < len(self._df.columns):
             self._cursor_column_index = col
+            self._update_status_bar()
 
     # --- Stack browser ---
 


### PR DESCRIPTION
## Summary

Builds on #1797 — adds interactive expression composition in a full-screen data view.

- **DataViewScreen**: full-screen explorer opened with `e` from the catalog, with VisiData-style column cursor (`h/j/k/l`), column sort (`[`/`]`), and drop column (`d`).
- **ExprStack**: immutable undo/redo stack that chains Ibis ops into a single evaluable expression. Each step is wrapped as `(lambda source: step_code)(prior)` so every `source` identifier inside a step binds to the prior step's result.
- **`:` freeform prompt**: one input accepts any Ibis expression (e.g. `source.filter(source.x > 1)`). Column names and Ibis `Table` methods (introspected at runtime) tab-complete via `SuggestFromList`.
- **Stack browser** (`s`), **undo** (`u`), **redo** (`ctrl+r`).
- **Persist** (`w`) saves the composed expression via `xorq catalog compose` subprocess; execution goes through `xorq catalog run -c`, serialized with `@work(exclusive=True)` and a stack-identity guard so rapid keystrokes cancel prior workers and stale results never clobber newer state.
- **Errors** from the subprocess surface as Textual notifications, not inside the command input.
- **Layout**: unified panel borders (muted teal, brightening on `:focus-within`) and decluttered footer (nav/duplicate-quit hidden, view toggles moved to the end).

## Test plan
- [x] ExprStack push/undo/redo/fork and code-chaining semantics, including inner-`source` rebinding across steps
- [x] `:` opens the freeform prompt and `escape` closes it
- [x] Column-cursor navigation, sort, and drop bindings
- [x] Stack browser toggle (`s`)
- [x] Persist round-trip through `xorq catalog compose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)