### PR TITLE
fix(graph): prevent Rich unbounded recursion in Node.__rich_repr__

### DIFF
--- a/python/xorq/vendor/ibis/common/graph.py
+++ b/python/xorq/vendor/ibis/common/graph.py
@@ -284,8 +284,17 @@ class Node(Hashable):
         return tuple(_flatten_collections(self.__args__))
 
     def __rich_repr__(self):
-        """Support for rich reprerentation of the node."""
-        return zip(self.__argnames__, self.__args__)
+        """Support for rich representation of the node.
+
+        Child Nodes are rendered as compact type summaries to prevent
+        unbounded recursion when Rich traverses deep expression graphs
+        (e.g. during structlog exception logging with show_locals=True).
+        """
+        for name, arg in zip(self.__argnames__, self.__args__):
+            if isinstance(arg, Node):
+                yield name, f"{type(arg).__name__}(...)"
+            else:
+                yield name, arg
 
     def map(self, fn: Callable, filter: Optional[Finder] = None) -> dict[Node, Any]:
         """Apply a function to all nodes in the graph.


### PR DESCRIPTION
## Summary
- `Node.__rich_repr__` yielded raw child Node objects, causing `rich.pretty.traverse` to recurse into the entire expression DAG without depth limit
- This hangs structlog when logging exceptions with `exc_info=True` — structlog's `to_repr` calls `rich.pretty.traverse` with no `max_depth` on frame-local variables
- Fix: yield compact `"TypeName(...)"` strings for child Node args; non-Node args (Schema, metadata dicts, TableProxy) still pass through normally

## Test plan
- [ ] Verify `structlog.warning("...", exc_info=True)` no longer hangs when frame locals include ibis expressions
- [ ] Existing builder and ibis vendor tests pass (46 + 59 tests verified locally)
- [ ] CI passes under pytest-xdist without `sys.setrecursionlimit(200)` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)