### PR TITLE
ci: add faulthandler_timeout, verbose output, and step timeout

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -139,7 +139,8 @@ jobs:
         run: just up-ci ${{ matrix.backend.services }}
 
       - name: pytest
-        run: uv run --no-sync pytest --import-mode=importlib --cov --cov-report=xml -m ${{ matrix.backend.name }} -k 'not script_execution and not slow'${{ matrix.backend.parallel && ' -n auto --dist=loadfile' || '' }}
+        timeout-minutes: 20
+        run: uv run --no-sync pytest --import-mode=importlib --cov --cov-report=xml -m ${{ matrix.backend.name }} -k 'not script_execution and not slow' -v --durations=20${{ matrix.backend.parallel && ' -n auto --dist=loadfile' || '' }}
         working-directory: ${{ github.workspace }}
         env:
           POSTGRES_PASSWORD: postgres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ ignore-regex = '\b(DOUB|i[if]f|I[IF]F|lamduh|AFE|crate|ba|fpr)\b'
 builtin = "clear,rare,names"
 
 [tool.pytest.ini_options]
+faulthandler_timeout = 300
 filterwarnings = [
     # pandas 2.2 warnings
     'ignore:DataFrameGroupBy\.apply operated on the grouping columns\. This behavior is deprecated:DeprecationWarning',


### PR DESCRIPTION
## Summary

- `faulthandler_timeout = 300` in pyproject.toml — dumps thread tracebacks if any test blocks >5 min
- `-v` on pytest invocation — streams test names in real time (essential for xdist debugging)
- `--durations=20` — surfaces the 20 slowest tests at the end
- `timeout-minutes: 20` on pytest step — kills hung steps so logs are always available

These were essential for diagnosing the Rich infinite recursion hang in #1805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)