### PR TITLE
fix(catalog): prevent hang when annex content is missing with no remote

### DIFF
--- a/python/xorq/catalog/backend.py
+++ b/python/xorq/catalog/backend.py
@@ -9,7 +9,7 @@ from attr import (
 from attr.validators import instance_of
 from git import Repo
 
-from xorq.catalog.annex import Annex
+from xorq.catalog.annex import Annex, AnnexError
 
 
 class CatalogBackend(abc.ABC):
@@ -106,6 +106,19 @@ class GitAnnexBackend(CatalogBackend):
         p = Path(path)
         return p.exists() and not (p.is_symlink() and not p.resolve().exists())
 
+    def _has_any_remote(self):
+        """True if the repo has any git remote or annex special remote."""
+        if self.annex.remote_name is not None:
+            return True
+        return bool(self.repo.remotes)
+
     def fetch_content(self, *paths):
+        if not self._has_any_remote():
+            missing = [p for p in paths if not self.is_content_local(p)]
+            if missing:
+                raise AnnexError(
+                    f"Content not local and no remote configured: {missing}"
+                )
+            return
         relpaths = [self.get_relpath(p) for p in paths]
         self.annex.get(*relpaths)

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -12,6 +12,7 @@ from xorq.caching import ParquetSnapshotCache
 from xorq.catalog.annex import (
     LOCAL_ANNEX,
     Annex,
+    AnnexError,
     DirectoryRemoteConfig,
     S3RemoteConfig,
     _do_inside,
@@ -861,3 +862,23 @@ def test_base_path_is_silently_dropped_through_catalog_round_trip(catalog, tmp_p
     ck = entry.parquet_snapshot_cache_keys[0]
     assert ck.relative_path == "my_cache"
     assert ck.key
+
+
+def test_annex_fetch_content_no_remote_raises(tmpdir):
+    """fetch_content raises instead of hanging when no remote is configured."""
+    repo_path = Path(tmpdir) / "no-remote"
+    repo = Catalog.init_repo_path(repo_path, annex=LOCAL_ANNEX)
+    backend = GitAnnexBackend(repo=repo, annex=Annex(repo_path=repo_path))
+    catalog = Catalog(backend=backend)
+
+    expr = xo.memtable({"x": [1, 2, 3]})
+    entry = catalog.add(expr, sync=False)
+
+    # Drop the annex content so is_content_local returns False
+    backend.annex.drop(backend.get_relpath(entry.catalog_path))
+
+    assert not backend.is_content_local(entry.catalog_path)
+    assert not backend._has_any_remote()
+
+    with pytest.raises(AnnexError, match="no remote configured"):
+        backend.fetch_content(entry.catalog_path)


### PR DESCRIPTION
## Summary

`GitAnnexBackend.fetch_content` now checks for configured remotes before calling `git-annex get`. With no git remotes and no annex special remote, `git-annex get` blocks indefinitely waiting for content that has no source. The guard raises `AnnexError` instead.

## Test plan

- [x] `test_annex_fetch_content_no_remote_raises` — drops annex content, verifies `fetch_content` raises instead of blocking
- [x] All 92 catalog tests pass (verified in main worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)