### PR TITLE
fix(otel): collector probe

### DIFF
--- a/python/xorq/common/utils/otel_utils.py
+++ b/python/xorq/common/utils/otel_utils.py
@@ -1,5 +1,7 @@
 import os
+import socket
 import sys
+import urllib.parse
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -15,18 +17,26 @@ from xorq.common.utils.env_utils import (
 )
 
 
-def localhost_and_listening(uri):
-    import socket  # noqa: PLC0415
-    import urllib  # noqa: PLC0415
-
+def is_localhost_collector_listening(uri):
     parsed = urllib.parse.urlparse(uri)
     if parsed.hostname != "localhost":
-        return None
+        return False
+    if parsed.port is None:
+        return False
     try:
         with socket.create_connection((parsed.hostname, parsed.port), timeout=1):
             return True
-    except (OSError, TimeoutError):
+    except OSError:  # includes TimeoutError (subclass since 3.3)
         return False
+
+
+def _should_use_otlp_exporter(endpoint):
+    if not endpoint:
+        return False
+    parsed = urllib.parse.urlparse(endpoint)
+    if parsed.hostname != "localhost":
+        return True
+    return is_localhost_collector_listening(endpoint)
 
 
 # This is the only template loaded unconditionally at import time
@@ -93,7 +103,7 @@ provider = TracerProvider(resource=resource)
 
 traces_endpoint = otel_config.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 
-if traces_endpoint and localhost_and_listening(traces_endpoint):
+if _should_use_otlp_exporter(traces_endpoint):
     processor = BatchSpanProcessor(get_otlp_exporter())
 else:
     processor = BatchSpanProcessor(

--- a/python/xorq/common/utils/otel_utils.py
+++ b/python/xorq/common/utils/otel_utils.py
@@ -20,16 +20,13 @@ def localhost_and_listening(uri):
     import urllib  # noqa: PLC0415
 
     parsed = urllib.parse.urlparse(uri)
-    localhost = "localhost"
-    if parsed.hostname == localhost:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            s.bind((localhost, parsed.port))
-        except OSError:
+    if parsed.hostname != "localhost":
+        return None
+    try:
+        with socket.create_connection((parsed.hostname, parsed.port), timeout=1):
             return True
-        else:
-            return False
-    return None
+    except (OSError, TimeoutError):
+        return False
 
 
 # This is the only template loaded unconditionally at import time

--- a/python/xorq/common/utils/tests/test_otel_utils.py
+++ b/python/xorq/common/utils/tests/test_otel_utils.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+from xorq.common.utils.otel_utils import (
+    _should_use_otlp_exporter,
+    is_localhost_collector_listening,
+)
+
+
+# -- is_localhost_collector_listening ------------------------------------------
+
+
+@patch("socket.create_connection")
+def test_localhost_listening_returns_true_when_connection_succeeds(mock_conn):
+    mock_conn.return_value.__enter__ = MagicMock()
+    mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+    assert is_localhost_collector_listening("http://localhost:4318/v1/traces")
+
+
+@patch("socket.create_connection", side_effect=ConnectionRefusedError)
+def test_localhost_listening_returns_false_when_connection_refused(mock_conn):
+    assert not is_localhost_collector_listening("http://localhost:4318/v1/traces")
+
+
+@patch("socket.create_connection", side_effect=TimeoutError)
+def test_localhost_listening_returns_false_on_timeout(mock_conn):
+    assert not is_localhost_collector_listening("http://localhost:4318/v1/traces")
+
+
+def test_localhost_listening_returns_false_for_remote_host():
+    assert not is_localhost_collector_listening("http://remote:4318/v1/traces")
+
+
+def test_localhost_listening_returns_false_for_missing_port():
+    assert not is_localhost_collector_listening("http://localhost/v1/traces")
+
+
+def test_localhost_listening_returns_false_for_ip_address():
+    assert not is_localhost_collector_listening("http://127.0.0.1:4318/v1/traces")
+
+
+# -- _should_use_otlp_exporter ------------------------------------------------
+
+
+def test_should_use_otlp_returns_false_for_empty_endpoint():
+    assert not _should_use_otlp_exporter("")
+    assert not _should_use_otlp_exporter(None)
+
+
+@patch(
+    "xorq.common.utils.otel_utils.is_localhost_collector_listening",
+)
+def test_should_use_otlp_returns_true_for_remote_endpoint_without_probing(mock_probe):
+    assert _should_use_otlp_exporter("http://remote:4318/v1/traces")
+    mock_probe.assert_not_called()
+
+
+@patch(
+    "xorq.common.utils.otel_utils.is_localhost_collector_listening",
+    return_value=True,
+)
+def test_should_use_otlp_delegates_to_probe_for_localhost_running(mock_probe):
+    assert _should_use_otlp_exporter("http://localhost:4318/v1/traces")
+    mock_probe.assert_called_once_with("http://localhost:4318/v1/traces")
+
+
+@patch(
+    "xorq.common.utils.otel_utils.is_localhost_collector_listening",
+    return_value=False,
+)
+def test_should_use_otlp_delegates_to_probe_for_localhost_not_running(mock_probe):
+    assert not _should_use_otlp_exporter("http://localhost:4318/v1/traces")
+    mock_probe.assert_called_once_with("http://localhost:4318/v1/traces")


### PR DESCRIPTION
## Summary

- **`socket.bind()` → `socket.create_connection()`** — `bind()` checks if a port is free (server-side); `create_connection()` checks if a service is accepting connections (client-side). Adds 1s timeout and context manager to prevent socket leak.
- **Fix silent discard of remote OTLP endpoints** — `localhost_and_listening()` returned `None` for non-localhost URIs, which is falsy, so `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` pointing at a remote collector was silently ignored (traces sent to `/dev/null`). Split the logic into `is_localhost_collector_listening` (pure TCP probe) and `_should_use_otlp_exporter` (routing policy that trusts remote endpoints and only probes localhost).
- **Guard `parsed.port is None`** — prevents `TypeError` on portless URIs.
- **Add tests** — 10 tests covering the probe and routing functions.

## Test plan

- [x] `ruff check` passes
- [x] `pytest python/xorq/common/utils/tests/test_otel_utils.py` — 10/10 pass
- [ ] Set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to a remote endpoint and verify OTLP exporter is created
- [ ] Verify no collector on localhost falls back to console exporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)