### PR TITLE
chore(cli): split uv into its own subcommand group (XOR-287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The manifest is roundtrippable and machine-writeable. Git-diff
 your pipelines. Code review your features. Track python dependencies. Rebuild from YAML alone.
 
 ```bash
-$ xorq uv-build expr.py
+$ xorq uv build expr.py
 builds/28ecab08754e/
 
 $ ls builds/28ecab08754e/*.tar.gz

--- a/docs/api_reference/cli/index.qmd
+++ b/docs/api_reference/cli/index.qmd
@@ -10,9 +10,9 @@ Xorq provides command-line tools for building, running, and managing your data a
 |--------------------------------------------|--------------------------------------------------------------------------------------|
 | [init](init.qmd)                           | Create a Xorq project.                                                               |
 | [build](build.qmd)                         | Compile a Xorq expression into a reusable artifact that can be executed later.       |
-| [uv-build](uv-build.qmd)                   | Build a Xorq expression using uv for dependency management.                          |
+| [uv build](uv-build.qmd)                   | Build a Xorq expression using uv for dependency management.                          |
 | [run](run.qmd)                             | Executes a built expression artifact and outputs the results in your desired format. |
-| [uv-run](uv-run.qmd)                       | Run a built expression artifact using uv for dependency management.                  |
+| [uv run](uv-run.qmd)                       | Run a built expression artifact using uv for dependency management.                  |
 
 ### Serving and deployment
 

--- a/docs/api_reference/cli/serve-unbound.qmd
+++ b/docs/api_reference/cli/serve-unbound.qmd
@@ -12,7 +12,7 @@ xorq serve-unbound <build_path> [options]
 
 ## Arguments
 
-- **build_path**: Path to the build directory produced by `xorq build`/`uv-build`.
+- **build_path**: Path to the build directory produced by `xorq build`/`uv build`.
 
 ## Options
 

--- a/docs/api_reference/cli/uv-build.qmd
+++ b/docs/api_reference/cli/uv-build.qmd
@@ -1,13 +1,13 @@
 ---
-title: 'uv-build'
+title: 'uv build'
 ---
 
-The `xorq uv-build` command builds an expression in an isolated, reproducible environment using uv tooling. It mirrors `xorq build` but executes via the packaged sdist to ensure dependency fidelity.
+The `xorq uv build` command builds an expression in an isolated, reproducible environment using uv tooling. It mirrors `xorq build` but executes via the packaged sdist to ensure dependency fidelity.
 
 ## Usage
 
 ```bash
-xorq uv-build <script_path> [options]
+xorq uv build <script_path> [options]
 ```
 
 ## Arguments
@@ -23,7 +23,7 @@ xorq uv-build <script_path> [options]
 ## Example
 
 ```bash
-xorq uv-build examples/penguins_example/expr.py -e expr --builds-dir builds
+xorq uv build examples/penguins_example/expr.py -e expr --builds-dir builds
 ```
 
 This writes the build artifacts to the specified `builds` directory and prints the build path to stdout.

--- a/docs/api_reference/cli/uv-run.qmd
+++ b/docs/api_reference/cli/uv-run.qmd
@@ -1,18 +1,18 @@
 ---
-title: 'uv-run'
+title: 'uv run'
 ---
 
-The `xorq uv-run` command executes a built expression in an isolated uv environment using the packaged sdist. It mirrors `xorq run` while ensuring the runtime matches the packaged dependencies.
+The `xorq uv run` command executes a built expression in an isolated uv environment using the packaged sdist. It mirrors `xorq run` while ensuring the runtime matches the packaged dependencies.
 
 ## Usage
 
 ```bash
-xorq uv-run <build_path> [options]
+xorq uv run <build_path> [options]
 ```
 
 ## Arguments
 
-- **build_path**: Path to the compiled build directory or file produced by `xorq build`/`uv-build`.
+- **build_path**: Path to the compiled build directory or file produced by `xorq build`/`uv build`.
 
 ## Options
 
@@ -24,13 +24,13 @@ xorq uv-run <build_path> [options]
 
 ```bash
 # Run and preview results
-xorq uv-run builds/7061dd65ff3c
+xorq uv run builds/7061dd65ff3c
 
 # Save to parquet
-xorq uv-run builds/7061dd65ff3c -o results.parquet
+xorq uv run builds/7061dd65ff3c -o results.parquet
 
 # Stream JSON to stdout
-xorq uv-run builds/7061dd65ff3c -f json -o -
+xorq uv run builds/7061dd65ff3c -f json -o -
 ```
 
 

--- a/docs/concepts/core_concepts/reproducible_environments_uv.qmd
+++ b/docs/concepts/core_concepts/reproducible_environments_uv.qmd
@@ -10,7 +10,7 @@ You will understand how to ensure consistent execution across development and pr
 
 **What you'll learn:**
 - Why uv matters for Xorq
-- How uv-build works
+- How uv build works
 - Dependency locking
 - Environment reproducibility
 

--- a/python/xorq/backends/xorq/tests/test_cli_compat.py
+++ b/python/xorq/backends/xorq/tests/test_cli_compat.py
@@ -20,10 +20,12 @@ def test_output_formats_enum():
     sys.version_info > (3, 10), reason="compatibility test for Python 3.10"
 )
 @pytest.mark.xorq
-@pytest.mark.parametrize("cmd", ["run", "run-cached", "uv-run", "run-unbound"])
+@pytest.mark.parametrize(
+    "cmd", [["run"], ["run-cached"], ["uv", "run"], ["run-unbound"]]
+)
 def test_output_format_choices_in_help(cmd):
     runner = CliRunner()
-    result = runner.invoke(cli, [cmd, "--help"])
+    result = runner.invoke(cli, cmd + ["--help"])
     assert result.exit_code == 0, result.output
     for fmt in OutputFormats:
         assert fmt.value in result.output

--- a/python/xorq/backends/xorq/tests/test_cli_compat.py
+++ b/python/xorq/backends/xorq/tests/test_cli_compat.py
@@ -21,11 +21,20 @@ def test_output_formats_enum():
 )
 @pytest.mark.xorq
 @pytest.mark.parametrize(
-    "cmd", [["run"], ["run-cached"], ["uv", "run"], ["run-unbound"]]
+    "cmd",
+    [
+        ("run",),
+        ("run-cached",),
+        (
+            "uv",
+            "run",
+        ),
+        ("run-unbound",),
+    ],
 )
 def test_output_format_choices_in_help(cmd):
     runner = CliRunner()
-    result = runner.invoke(cli, cmd + ["--help"])
+    result = runner.invoke(cli, [*cmd, "--help"])
     assert result.exit_code == 0, result.output
     for fmt in OutputFormats:
         assert fmt.value in result.output

--- a/python/xorq/backends/xorq/tests/test_cli_compat.py
+++ b/python/xorq/backends/xorq/tests/test_cli_compat.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 from click.testing import CliRunner
 
-from xorq.cli import OutputFormats, cli
+from xorq.cli import OutputFormats, cli, uv_group
 
 
 @pytest.mark.skipif(
@@ -14,6 +14,19 @@ def test_output_formats_enum():
     for fmt in OutputFormats:
         assert OutputFormats(fmt.value) == fmt
     assert OutputFormats.default == OutputFormats.parquet
+
+
+@pytest.mark.skipif(
+    sys.version_info > (3, 10), reason="compatibility test for Python 3.10"
+)
+@pytest.mark.xorq
+def test_uv_group_shows_help_without_subcommand():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["uv"])
+    assert result.exit_code == 0, result.output
+    assert "Commands that use uv" in result.output
+    for name in uv_group.commands:
+        assert name in result.output
 
 
 @pytest.mark.skipif(

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -749,7 +749,13 @@ def cli(use_pdb, pdb_runcall):
     pass
 
 
-@cli.command("uv-build")
+@cli.group("uv")
+def uv_group():
+    """Commands that use uv to manage a custom Python environment."""
+    pass
+
+
+@uv_group.command("build")
 @click.argument("script_path")
 @click.option(
     "-e",
@@ -770,7 +776,7 @@ def uv_build(script_path, expr_name, builds_dir, cache_dir):
     uv_build_command(script_path, expr_name, builds_dir, cache_dir)
 
 
-@cli.command("uv-run")
+@uv_group.command("run")
 @click.argument("build_path")
 @click.option(
     "--cache-dir",

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -749,10 +749,12 @@ def cli(use_pdb, pdb_runcall):
     pass
 
 
-@cli.group("uv")
-def uv_group():
+@cli.group("uv", invoke_without_command=True)
+@click.pass_context
+def uv_group(ctx):
     """Commands that use uv to manage a custom Python environment."""
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @uv_group.command("build")

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -750,7 +750,8 @@ def test_init_uv_build_uv_run(template, tmpdir):
 
     build_args = (
         "xorq",
-        "uv-build",
+        "uv",
+        "build",
         str(path.joinpath("expr.py")),
     )
     (returncode, stdout, stderr) = subprocess_run(build_args, text=True)
@@ -761,7 +762,8 @@ def test_init_uv_build_uv_run(template, tmpdir):
     output_path = tmpdir.joinpath("output")
     run_args = (
         "xorq",
-        "uv-run",
+        "uv",
+        "run",
         "--output-path",
         str(output_path),
         str(build_path),


### PR DESCRIPTION
Replace top-level `xorq uv-build` / `xorq uv-run` commands with a `uv` subgroup so the interface becomes `xorq uv build` / `xorq uv run`. Update tests, README, and docs accordingly.