### PR TITLE
fix(packaging): exclude env_templates from VCS scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 sources = ["python"]
+# Exclude env_templates from the normal VCS scan (git ls-files picks them up in
+# a git repo, but force-include below also adds them, causing duplicates in the
+# wheel ZIP).  By excluding here we ensure only force-include writes the files.
+exclude = [
+    "python/xorq/env_templates/**",
+]
 
 # .gitignore contains `.env.*` which hatchling treats as an exclusion pattern
 # in non-VCS contexts (sdist rebuilds, staging dirs, uv tool run).


### PR DESCRIPTION
 exclude env_templates from VCS scan to prevent duplicate wheel entries

In a git repo, hatchling includes env_templates/ via `git ls-files`, while force-include (added in 8975c28) also adds the same files — producing a ZIP with duplicate entries that PyPI rejects with HTTP 400.

Adding `exclude = ["python/xorq/env_templates/**"]` to the wheel target prevents the VCS scan from including these files, so force-include remains the single code path that writes them in both git and non-git contexts.