### PR TITLE
feat(cli): add MCP server for Claude plugin integration

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -68,6 +68,7 @@ jobs:
               - --extra pyiceberg
               - --extra sqlite
               - --extra ibis
+              - --extra mcp
           - name: sqlite
             services: false
             extras:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ snowflake = [
 quickgrove = [
     "quickgrove>=0.1.2",
 ]
+mcp = [
+    "mcp>=1.5.0",
+]
 examples = [
     "pins[gcs]>=0.8.3,<1 ; python_version >= '3.10' and python_version < '4.0'",
     "xgboost >=1.6.1 ; python_version >= '3.10' and python_version < '4.0'",

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -714,14 +714,22 @@ def init_command(
 
 
 class PdbGroup(click.Group):
+    _lazy_loader_names = ("catalog", "mcp")
+
+    def _ensure_lazy(self, cmd_name):
+        if cmd_name in self._lazy_loader_names and cmd_name not in self.commands:
+            # Resolve loader function by name from the module globals.
+            loader = globals().get(f"_load_{cmd_name}_cli")
+            if loader:
+                loader()
+
     def get_command(self, ctx, cmd_name):
-        if cmd_name == "catalog" and "catalog" not in self.commands:
-            _load_catalog_cli()
+        self._ensure_lazy(cmd_name)
         return super().get_command(ctx, cmd_name)
 
     def list_commands(self, ctx):
-        if "catalog" not in self.commands:
-            _load_catalog_cli()
+        for name in self._lazy_loader_names:
+            self._ensure_lazy(name)
         return super().list_commands(ctx)
 
     def invoke(self, ctx):
@@ -1188,6 +1196,33 @@ def _load_catalog_cli():
     from xorq.catalog.cli import cli as _catalog_cli
 
     cli.add_command(_catalog_cli, "catalog")
+
+
+def _load_mcp_cli():
+    @cli.group("mcp", invoke_without_command=True)
+    @click.pass_context
+    def mcp_group(ctx):
+        """MCP (Model Context Protocol) server for Claude integrations."""
+        if ctx.invoked_subcommand is None:
+            click.echo(ctx.get_help())
+
+    @mcp_group.command("serve")
+    @click.option(
+        "--sse",
+        is_flag=True,
+        default=False,
+        help="Use SSE transport instead of stdio.",
+    )
+    def mcp_serve(sse):
+        """Start the xorq MCP server.
+
+        By default uses stdio transport (for Claude Desktop / Claude Code).
+        Pass --sse for HTTP Server-Sent Events transport.
+        """
+        from xorq.mcp import serve
+
+        transport = "sse" if sse else "stdio"
+        serve(transport=transport)
 
 
 def main():

--- a/python/xorq/mcp.py
+++ b/python/xorq/mcp.py
@@ -1,0 +1,337 @@
+"""MCP server exposing the xorq CLI as Claude-compatible tools.
+
+Wraps CLI commands via subprocess so that:
+- The heavy ``xorq.api`` import happens in the child process, not the server.
+- Every tool maps 1:1 to a CLI invocation the user already knows.
+
+Start with::
+
+    xorq mcp serve            # stdio transport (default, for Claude integrations)
+    xorq mcp serve --sse      # SSE transport (for debugging / remote)
+"""
+
+import asyncio
+
+from mcp.server.fastmcp import FastMCP
+
+
+mcp = FastMCP(
+    "xorq",
+    instructions=(
+        "xorq is a framework for building, versioning, and running "
+        "composable data expressions. Use the catalog tools to discover "
+        "available entries and inspect their schemas before running them."
+    ),
+)
+
+_XORQ_BIN = "xorq"
+
+
+async def _run_cli(*args: str, timeout: float = 120.0) -> str:
+    """Run ``xorq <args>`` and return combined stdout/stderr."""
+    cmd = [_XORQ_BIN, *args]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        return f"Error: command timed out after {timeout}s: {' '.join(cmd)}"
+
+    out = stdout.decode() if stdout else ""
+    err = stderr.decode() if stderr else ""
+
+    if proc.returncode != 0:
+        return f"Error (exit {proc.returncode}):\n{err or out}".strip()
+
+    return out or err
+
+
+def _catalog_args(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+) -> list[str]:
+    """Build the ``xorq catalog [--name N | --path P]`` prefix."""
+    args = ["catalog"]
+    if catalog_name:
+        args += ["--name", catalog_name]
+    elif catalog_path:
+        args += ["--path", catalog_path]
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Catalog tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def catalog_list(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+    show_kind: bool = False,
+) -> str:
+    """List all entries in a xorq catalog.
+
+    Returns one entry per line. Pass show_kind=True to include the entry kind
+    (source vs. partial/unbound).
+    """
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("list")
+    if show_kind:
+        args.append("--kind")
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_list_aliases(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+) -> str:
+    """List all aliases in a xorq catalog."""
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("list-aliases")
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_schema(
+    name: str,
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+    as_json: bool = False,
+) -> str:
+    """Show the schema (input/output columns and types) of a catalog entry.
+
+    The ``name`` argument can be an entry name or an alias.
+    Set as_json=True for machine-readable output.
+    """
+    args = _catalog_args(catalog_name, catalog_path)
+    args += ["schema", name]
+    if as_json:
+        args.append("--json")
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_info(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+) -> str:
+    """Show catalog metadata: path, current commit, remotes, entry/alias counts."""
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("info")
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_log(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+    as_json: bool = True,
+) -> str:
+    """Show catalog history as structured operations.
+
+    Returns JSON by default for easier parsing.
+    """
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("log")
+    if as_json:
+        args.append("--json")
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_check(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+) -> str:
+    """Validate catalog consistency. Returns 'OK' if healthy."""
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("check")
+    return await _run_cli(*args)
+
+
+# ---------------------------------------------------------------------------
+# Build / run tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def build(
+    script_path: str,
+    expr_name: str = "expr",
+    builds_dir: str = "builds",
+) -> str:
+    """Compile a xorq expression script into versioned build artifacts.
+
+    Parameters
+    ----------
+    script_path
+        Path to the Python script containing the expression.
+    expr_name
+        Name of the expression variable in the script.
+    builds_dir
+        Directory where build artifacts are written.
+    """
+    args = ["build", script_path, "-e", expr_name, "--builds-dir", builds_dir]
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def run(
+    build_path: str,
+    output_format: str = "json",
+    limit: int | None = None,
+    params: dict[str, str] | None = None,
+) -> str:
+    """Execute a built xorq expression and return results.
+
+    Parameters
+    ----------
+    build_path
+        Path to the build directory (output of ``build``).
+    output_format
+        One of: csv, json, parquet, arrow. Defaults to json for readability.
+    limit
+        Maximum number of rows to return.
+    params
+        Named parameters as key-value pairs (e.g. {"threshold": "0.5"}).
+    """
+    args = ["run", build_path, "-f", output_format, "-o", "/dev/stdout"]
+    if limit is not None:
+        args += ["--limit", str(limit)]
+    if params:
+        for k, v in params.items():
+            args += ["-p", f"{k}={v}"]
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def run_cached(
+    build_path: str,
+    output_format: str = "json",
+    limit: int | None = None,
+    cache_type: str = "modification-time",
+    ttl: int | None = None,
+    params: dict[str, str] | None = None,
+) -> str:
+    """Execute a built expression with caching for efficient repeated runs.
+
+    Parameters
+    ----------
+    build_path
+        Path to the build directory.
+    output_format
+        One of: csv, json, parquet, arrow.
+    limit
+        Maximum number of rows to return.
+    cache_type
+        'modification-time' (default) or 'snapshot'.
+    ttl
+        TTL in seconds for snapshot cache.
+    params
+        Named parameters as key-value pairs.
+    """
+    args = [
+        "run-cached",
+        build_path,
+        "-f",
+        output_format,
+        "-o",
+        "/dev/stdout",
+        "--cache-type",
+        cache_type,
+    ]
+    if limit is not None:
+        args += ["--limit", str(limit)]
+    if ttl is not None:
+        args += ["--ttl", str(ttl)]
+    if params:
+        for k, v in params.items():
+            args += ["-p", f"{k}={v}"]
+    return await _run_cli(*args)
+
+
+# ---------------------------------------------------------------------------
+# Catalog mutation tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def catalog_add(
+    paths: list[str],
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+    aliases: list[str] | None = None,
+    sync: bool = True,
+) -> str:
+    """Add build artifacts to a catalog.
+
+    Parameters
+    ----------
+    paths
+        Paths to archive files or build directories to add.
+    aliases
+        Optional aliases to assign to the added entries.
+    sync
+        Whether to push after adding (default True).
+    """
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("add")
+    if not sync:
+        args.append("--no-sync")
+    if aliases:
+        for alias in aliases:
+            args += ["--alias", alias]
+    args += paths
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_remove(
+    names: list[str],
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+    sync: bool = True,
+) -> str:
+    """Remove entries from a catalog by name.
+
+    Parameters
+    ----------
+    names
+        Entry names to remove.
+    sync
+        Whether to push after removing (default True).
+    """
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("remove")
+    if not sync:
+        args.append("--no-sync")
+    args += names
+    return await _run_cli(*args)
+
+
+@mcp.tool()
+async def catalog_sync(
+    catalog_name: str | None = None,
+    catalog_path: str | None = None,
+) -> str:
+    """Pull then push a catalog to its remote(s)."""
+    args = _catalog_args(catalog_name, catalog_path)
+    args.append("sync")
+    return await _run_cli(*args)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def serve(transport: str = "stdio"):
+    """Run the MCP server."""
+    mcp.run(transport=transport)

--- a/python/xorq/tests/test_mcp.py
+++ b/python/xorq/tests/test_mcp.py
@@ -1,0 +1,170 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+pytest.importorskip("mcp", reason="mcp extra not installed")
+
+import xorq.mcp as mcp_mod
+from xorq.common.utils.process_utils import subprocess_run
+from xorq.mcp import _catalog_args, _run_cli, mcp
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring (subprocess) — measures real cold-start
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_help():
+    returncode, stdout, stderr = subprocess_run(["xorq", "mcp", "--help"], text=True)
+    assert returncode == 0, stderr
+    assert "serve" in stdout
+
+
+def test_mcp_serve_help():
+    returncode, stdout, stderr = subprocess_run(
+        ["xorq", "mcp", "serve", "--help"], text=True
+    )
+    assert returncode == 0, stderr
+    assert "--sse" in stdout
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+EXPECTED_TOOLS = {
+    "catalog_list",
+    "catalog_list_aliases",
+    "catalog_schema",
+    "catalog_info",
+    "catalog_log",
+    "catalog_check",
+    "build",
+    "run",
+    "run_cached",
+    "catalog_add",
+    "catalog_remove",
+    "catalog_sync",
+}
+
+
+def test_all_tools_registered():
+    tools = mcp._tool_manager.list_tools()
+    names = {t.name for t in tools}
+    assert names == EXPECTED_TOOLS
+
+
+def test_tool_descriptions_non_empty():
+    tools = mcp._tool_manager.list_tools()
+    for tool in tools:
+        assert tool.description, f"tool {tool.name} has no description"
+
+
+# ---------------------------------------------------------------------------
+# _run_cli helper
+# ---------------------------------------------------------------------------
+
+
+def test_run_cli_success():
+    result = asyncio.run(_run_cli("--help"))
+    assert "build" in result
+    assert "run" in result
+    assert "Error" not in result
+
+
+def test_run_cli_failure():
+    result = asyncio.run(_run_cli("nonexistent-command-xyz"))
+    assert result.startswith("Error")
+
+
+def test_run_cli_timeout():
+    # sleep 10 with a 1s timeout should be killed
+    result = asyncio.run(_run_cli("run", "sleep-forever-not-a-real-path", timeout=0.5))
+    # Either times out or fails with a non-zero exit — both are errors
+    assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# Argument building
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_args_no_options():
+    assert _catalog_args() == ["catalog"]
+
+
+def test_catalog_args_name():
+    assert _catalog_args(catalog_name="my-cat") == ["catalog", "--name", "my-cat"]
+
+
+def test_catalog_args_path():
+    assert _catalog_args(catalog_path="/tmp/cat") == ["catalog", "--path", "/tmp/cat"]
+
+
+def test_catalog_args_name_takes_precedence():
+    # When both are given, name wins (matches the if/elif logic)
+    result = _catalog_args(catalog_name="n", catalog_path="/p")
+    assert result == ["catalog", "--name", "n"]
+
+
+@pytest.mark.parametrize(
+    "tool_func,kwargs,expected_fragments",
+    [
+        ("catalog_list", {}, ["catalog", "list"]),
+        ("catalog_list", {"show_kind": True}, ["--kind"]),
+        ("catalog_schema", {"name": "foo"}, ["catalog", "schema", "foo"]),
+        ("catalog_schema", {"name": "foo", "as_json": True}, ["--json"]),
+        ("catalog_info", {}, ["catalog", "info"]),
+        ("catalog_log", {}, ["catalog", "log", "--json"]),
+        ("catalog_log", {"as_json": False}, ["catalog", "log"]),
+        ("catalog_check", {}, ["catalog", "check"]),
+        ("build", {"script_path": "s.py"}, ["build", "s.py", "-e", "expr"]),
+        (
+            "build",
+            {"script_path": "s.py", "expr_name": "my_expr"},
+            ["-e", "my_expr"],
+        ),
+        ("run", {"build_path": "/b"}, ["run", "/b", "-f", "json"]),
+        (
+            "run",
+            {"build_path": "/b", "limit": 10, "params": {"k": "v"}},
+            ["--limit", "10", "-p", "k=v"],
+        ),
+        (
+            "run_cached",
+            {"build_path": "/b"},
+            ["run-cached", "/b", "-f", "json", "--cache-type", "modification-time"],
+        ),
+        (
+            "run_cached",
+            {"build_path": "/b", "ttl": 60, "cache_type": "snapshot"},
+            ["--ttl", "60", "--cache-type", "snapshot"],
+        ),
+        ("catalog_add", {"paths": ["/a", "/b"]}, ["catalog", "add", "/a", "/b"]),
+        (
+            "catalog_add",
+            {"paths": ["/a"], "sync": False, "aliases": ["x"]},
+            ["--no-sync", "--alias", "x"],
+        ),
+        ("catalog_remove", {"names": ["e1"]}, ["catalog", "remove", "e1"]),
+        ("catalog_sync", {}, ["catalog", "sync"]),
+    ],
+)
+def test_tool_builds_correct_args(tool_func, kwargs, expected_fragments):
+    """Verify each tool passes the right args to _run_cli."""
+    captured_args = []
+
+    async def fake_run_cli(*args, **kw):
+        captured_args.extend(args)
+        return "ok"
+
+    with patch.object(mcp_mod, "_run_cli", side_effect=fake_run_cli):
+        fn = getattr(mcp_mod, tool_func)
+        asyncio.run(fn(**kwargs))
+
+    for fragment in expected_fragments:
+        assert fragment in captured_args, (
+            f"expected {fragment!r} in args for {tool_func}, got {captured_args}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -5895,6 +5895,9 @@ gizmosql = [
 ibis = [
     { name = "ibis-framework" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 postgres = [
     { name = "adbc-driver-postgresql" },
     { name = "psycopg", extra = ["binary"] },
@@ -5984,6 +5987,7 @@ requires-dist = [
     { name = "ibis-framework", marker = "extra == 'ibis'", specifier = ">=10.5.0" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.8.0" },
     { name = "mcp", marker = "extra == 'examples'", specifier = ">=1.5.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.5.0" },
     { name = "openai", marker = "extra == 'examples'", specifier = ">=1.65.4" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.32.1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.32.1" },
@@ -6022,7 +6026,7 @@ requires-dist = [
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
 ]
-provides-extras = ["pyiceberg", "duckdb", "datafusion", "snowflake", "quickgrove", "examples", "postgres", "sqlite", "gizmosql", "ibis", "trino", "bsl"]
+provides-extras = ["pyiceberg", "duckdb", "datafusion", "snowflake", "quickgrove", "mcp", "examples", "postgres", "sqlite", "gizmosql", "ibis", "trino", "bsl"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add `xorq mcp serve` subcommand and MCP server module that exposes the xorq CLI as 12 tools via subprocess. Plugin packaging lives in the separate xorq-labs/claude-plugins repo.

- python/xorq/mcp.py: FastMCP server wrapping CLI commands
- `xorq mcp serve [--sse]` subcommand with lazy loading
- Generalize PdbGroup lazy-loading for multiple subcommand groups
- Add `mcp` optional dependency extra in pyproject.toml
- 29 tests: CLI wiring, tool registration, _run_cli helper, argument building for all 12 tools