### PR TITLE
feat: remove xo.read_csv and xo.read_parquet from top-level API

### DIFF
--- a/python/xorq/backends/xorq/tests/test_api.py
+++ b/python/xorq/backends/xorq/tests/test_api.py
@@ -5,34 +5,16 @@ import xorq.api as xo
 from xorq.api import SessionConfig
 
 
-def test_register_read_csv(csv_dir):
-    # this will use ls.options.backend: do we want to clear it out between function invocations?
-    api_batting = xo.read_csv(csv_dir / "batting.csv", table_name="api_batting")
-    result = xo.execute(api_batting)
-
-    assert result is not None
-
-
-def test_register_read_parquet(parquet_dir):
-    # this will use ls.options.backend: do we want to clear it out between function invocations?
-    api_batting = xo.read_parquet(
-        parquet_dir / "batting.parquet", table_name="api_batting"
-    )
-    result = xo.execute(api_batting)
-
-    assert result is not None
-
-
 @pytest.mark.xfail(reason="No purpose with no registration api")
 def test_executed_on_original_backend(parquet_dir, csv_dir, mocker):
     con = xo.config._backend_init()
     spy = mocker.spy(con, "execute")
 
-    parquet_table = xo.read_parquet(parquet_dir / "batting.parquet")[
+    parquet_table = con.read_parquet(parquet_dir / "batting.parquet")[
         lambda t: t.yearID == 2015
     ]
 
-    csv_table = xo.read_csv(csv_dir / "batting.csv")[lambda t: t.yearID == 2014]
+    csv_table = con.read_csv(csv_dir / "batting.csv")[lambda t: t.yearID == 2014]
 
     expr = parquet_table.join(
         csv_table,

--- a/python/xorq/backends/xorq/tests/test_cache.py
+++ b/python/xorq/backends/xorq/tests/test_cache.py
@@ -504,7 +504,7 @@ def test_parquet_ttl_snapshot_cache(ls_con, batting, tmp_path):
     path = tmp_path.joinpath("data.parquet")
     expr = batting[lambda t: t.yearID > 2014][lambda t: t.stint == 1]
     expr.to_parquet(all_rows_path)
-    assert xo.read_parquet(all_rows_path).count().execute() != n_rows
+    assert ls_con.read_parquet(all_rows_path).count().execute() != n_rows
     expr.limit(n_rows).to_parquet(n_rows_path)
     path.write_bytes(all_rows_path.read_bytes())
 

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -45,7 +45,6 @@ from xorq.vendor.ibis.expr.sql import SQLString
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from io import TextIOWrapper
     from pathlib import Path
 
@@ -56,8 +55,6 @@ if TYPE_CHECKING:
 __all__ = (
     "execute",
     "calc_split_column",
-    "read_csv",
-    "read_parquet",
     "read_postgres",
     "read_pyarrow_stream",
     "register",
@@ -89,121 +86,6 @@ def read_pyarrow_stream(
     con = con or _backend_init()
     rbr = pa.ipc.open_stream(source, **kwargs)
     return con.read_record_batches(rbr, table_name=table_name)
-
-
-def read_csv(
-    sources: str | Path | Sequence[str | Path],
-    table_name: str | None = None,
-    **kwargs: Any,
-) -> ir.Table:
-    """Lazily load a CSV or set of CSVs.
-
-    This function delegates to the `read_csv` method on the current default
-    backend (DuckDB or `xorq.config.default_backend`).
-
-    Parameters
-    ----------
-    sources
-        A filesystem path or URL or list of same.  Supports CSV and TSV files.
-    table_name
-        A name to refer to the table.  If not provided, a name will be generated.
-    kwargs
-        Backend-specific keyword arguments for the file type. For the DuckDB
-        backend used by default, please refer to:
-
-        * CSV/TSV: https://duckdb.org/docs/data/csv/overview.html#parameters.
-
-    Returns
-    -------
-    ir.Table
-        Table expression representing a file
-
-    Examples
-    --------
-    >>> import xorq.api as xo
-    >>> xo.options.interactive = True
-    >>> lines = '''a,b
-    ... 1,d
-    ... 2,
-    ... ,f
-    ... '''
-    >>> with open("/tmp/lines.csv", mode="w") as f:
-    ...     nbytes = f.write(lines)  # nbytes is unused
-    >>> t = xo.read_csv("/tmp/lines.csv")
-    >>> t
-    ┏━━━━━━━┳━━━━━━━━┓
-    ┃ a     ┃ b      ┃
-    ┡━━━━━━━╇━━━━━━━━┩
-    │ int64 │ string │
-    ├───────┼────────┤
-    │     1 │ d      │
-    │     2 │ NULL   │
-    │  NULL │ f      │
-    └───────┴────────┘
-
-    """
-    from xorq.config import _backend_init  # noqa: PLC0415
-
-    con = _backend_init()
-    return con.read_csv(sources, table_name=table_name, **kwargs)
-
-
-def read_parquet(
-    sources: str | Path | Sequence[str | Path],
-    table_name: str | None = None,
-    **kwargs: Any,
-) -> ir.Table:
-    """Lazily load a parquet file or set of parquet files.
-
-    This function delegates to the `read_parquet` method on the current default
-    backend (DuckDB or `ibis.config.default_backend`).
-
-    Parameters
-    ----------
-    sources
-        A filesystem path or URL or list of same.
-    table_name
-        A name to refer to the table.  If not provided, a name will be generated.
-    kwargs
-        Backend-specific keyword arguments for the file type. For the DuckDB
-        backend used by default, please refer to:
-
-        * Parquet: https://duckdb.org/docs/data/parquet
-
-    Returns
-    -------
-    ir.Table
-        Table expression representing a file
-
-    Examples
-    --------
-    >>> import xorq.api as xo
-    >>> import pandas as pd
-    >>> xo.options.interactive = True
-    >>> df = pd.DataFrame({"a": [1, 2, 3], "b": list("ghi")})
-    >>> df
-       a  b
-    0  1  g
-    1  2  h
-    2  3  i
-    >>> df.to_parquet("/tmp/data.parquet")
-    >>> t = xo.read_parquet("/tmp/data.parquet")
-    >>> t
-    ┏━━━━━━━┳━━━━━━━━┓
-    ┃ a     ┃ b      ┃
-    ┡━━━━━━━╇━━━━━━━━┩
-    │ int64 │ string │
-    ├───────┼────────┤
-    │     1 │ g      │
-    │     2 │ h      │
-    │     3 │ i      │
-    └───────┴────────┘
-
-    """
-    from xorq.config import _backend_init  # noqa: PLC0415
-
-    con = _backend_init()
-    return con.read_parquet(sources, table_name=table_name, **kwargs)
 
 
 def register(

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
 
+EXCLUDE = ("read_csv", "read_parquet")
 
 __all__ = (
     "execute",
@@ -71,7 +72,7 @@ __all__ = (
     "deferred_read_parquet",
     "get_object_metadata",
     "bind_params",
-    *api.__all__,
+    *(member for member in api.__all__ if member not in EXCLUDE),
 )
 
 

--- a/python/xorq/expr/datatypes/tests/test_large_string.py
+++ b/python/xorq/expr/datatypes/tests/test_large_string.py
@@ -59,7 +59,9 @@ def test_can_read_write_parquet(utf8_data, tmp_path):
     xo.to_parquet(t, names_parquet_path)
 
     # need to specify the schema when reading parquet because DataFusion transforms into StringView
-    t = xo.read_parquet(names_parquet_path, "names_parquet", schema=schema.to_pyarrow())
+    t = con.read_parquet(
+        names_parquet_path, "names_parquet", schema=schema.to_pyarrow()
+    )
     assert t.schema() == schema
 
     actual = xo.execute(t)

--- a/python/xorq/flight/tests/test_server.py
+++ b/python/xorq/flight/tests/test_server.py
@@ -208,7 +208,7 @@ def test_failed_auth(tls_kwargs):
     ],
 )
 def test_into_backend_flight_server(connection, port, parquet_dir):
-    batting = xo.read_parquet(parquet_dir / "batting.parquet")
+    batting = xo.connect().read_parquet(parquet_dir / "batting.parquet")
     flight_url = make_flight_url(port)
 
     with FlightServer(

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -547,7 +547,7 @@ def test_build_file_stability_and_relocatability(
         normalize_method=normalize_read_path_md5sum,
     )
     batting = xo.memtable(
-        xo.read_parquet(parquet_dir.joinpath("batting.parquet")).execute()
+        xo.connect().read_parquet(parquet_dir.joinpath("batting.parquet")).execute()
     )
     on = sorted(set(batting.columns).intersection(awards_players.columns))
     expr = awards_players.select(on).join(batting.select(on), predicates=on)

--- a/python/xorq/tests/test_api.py
+++ b/python/xorq/tests/test_api.py
@@ -100,33 +100,8 @@ def test_unbind(alltypes, expr_fn: Callable):
 
 
 @pytest.mark.parametrize(
-    ("extension", "method"),
-    [("parquet", xo.read_parquet), ("csv", xo.read_csv)],
-)
-def test_read(data_dir, extension, method):
-    table = method(
-        data_dir / extension / f"batting.{extension}", table_name=f"batting-{extension}"
-    )
-    assert table.execute() is not None
-
-
-@pytest.mark.parametrize(
     ("extension", "write", "read"),
     [
-        (
-            "parquet",
-            xo.to_parquet,
-            lambda path, schema: xo.read_parquet(
-                path, schema=schema.to_pyarrow()
-            ).execute(),
-        ),
-        (
-            "csv",
-            xo.to_csv,
-            lambda path, schema: xo.read_csv(
-                path, schema=schema.to_pyarrow()
-            ).execute(),
-        ),
         (
             "json",
             xo.to_json,

--- a/python/xorq/tests/test_register_read.py
+++ b/python/xorq/tests/test_register_read.py
@@ -66,28 +66,6 @@ def test_register_parquet(con, data_dir):
     assert table.count().execute() > 0
 
 
-def test_read_parquet_with_custom_file_extension(con, tmp_path):
-    parquet_path = (tmp_path / "data").with_suffix(".arquet")
-
-    expected = pd.DataFrame([{"maxitem": 43182839, "n": 1000}])
-    expected.to_parquet(parquet_path)
-
-    actual = xo.read_parquet(parquet_path).execute()
-
-    assert_frame_equal(expected, actual)
-
-
-def test_read_csv_with_custom_file_extension(con, tmp_path):
-    csv_path = (tmp_path / "data").with_suffix(".acsv")
-
-    expected = pd.DataFrame([{"maxitem": 43182839, "n": 1000}])
-    expected.to_csv(csv_path, index=False)
-
-    actual = xo.read_csv(csv_path).execute()
-
-    assert_frame_equal(expected, actual)
-
-
 def test_read_csv(con, data_dir):
     t = con.read_csv(data_dir / "csv" / "functional_alltypes.csv")
     assert t.count().execute()


### PR DESCRIPTION
Removes `xo.read_csv` and `xo.read_parquet` to steer users toward the preferred `xo.deferred_read_csv` and `xo.deferred_read_parquet`. Updates all test callsites to use backend-level `con.read_*` methods instead.

Closes #1830