### PR TITLE
feat(xorq-datafusion): rename backend to xorq-datafusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ docs = [
 ]
 
 [project.entry-points."xorq.backends"]
-xorq = "xorq.backends.xorq"
+xorq-datafusion = "xorq.backends.xorq"
 postgres = "xorq.backends.postgres"
 snowflake = "xorq.backends.snowflake"
 datafusion = "xorq.backends.datafusion"

--- a/python/xorq/backends/tests/test_backend.py
+++ b/python/xorq/backends/tests/test_backend.py
@@ -26,7 +26,7 @@ def get_method(connect_parts):
         ("postgres", "connect_env"),
         ("datafusion", "connect"),
         (
-            "xorq",
+            "xorq-datafusion",
             "connect",
         ),
         ("pandas", "connect"),
@@ -58,7 +58,7 @@ def test_con_equality(connect_parts):
             ],
         ),
         (
-            "xorq",
+            "xorq-datafusion",
             "connect",
         ),
         ("pandas", "connect"),

--- a/python/xorq/backends/xorq/__init__.py
+++ b/python/xorq/backends/xorq/__init__.py
@@ -36,7 +36,7 @@ def _get_datafusion_dataframe(con, expr, **kwargs):
 
 
 class Backend(DataFusionBackend):
-    name = "xorq"
+    name = "xorq-datafusion"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -418,7 +418,7 @@ def normalize_backend(con):
         con_details = {k: con_dct[k] for k in ("host", "port", "dbname")}
     elif name == "pandas":
         con_details = id(con.dictionary)
-    elif name in ("datafusion", "duckdb", "xorq", "gizmosql"):
+    elif name in ("datafusion", "duckdb", "xorq-datafusion", "gizmosql"):
         con_details = (con._profile.con_name, con._profile.kwargs_tuple)
     elif name == "trino":
         con_details = con.con.host

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -271,7 +271,7 @@ def normalize_xorq_databasetable(dt):
         )
     native_source = dt.source._sources.get_backend(dt)
 
-    if native_source.name == "xorq":
+    if native_source.name == "xorq-datafusion":
         return normalize_datafusion_databasetable(dt)
     new_dt = rel.make_native_op(dt)
     return dask.base.normalize_token(new_dt)

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -51,7 +51,13 @@ def normalize_inmemorytable(dt):
 
 
 def normalize_memory_databasetable(dt):
-    if dt.source.name not in ("pandas", "xorq", "datafusion", "duckdb", "sqlite"):
+    if dt.source.name not in (
+        "pandas",
+        "xorq-datafusion",
+        "datafusion",
+        "duckdb",
+        "sqlite",
+    ):
         raise ValueError(f"expected in-memory backend, got {dt.source.name!r}")
     return normalize_seq_with_caller(
         # we are normalizing the data, we don't care about the connection
@@ -73,7 +79,7 @@ def normalize_pandas_databasetable(dt):
 
 
 def normalize_datafusion_databasetable(dt):
-    if dt.source.name not in ("datafusion", "xorq"):
+    if dt.source.name not in ("datafusion", "xorq-datafusion"):
         raise ValueError(f"expected datafusion/xorq backend, got {dt.source.name!r}")
     table = dt.source.con.table(dt.name)
     ep_str = str(table.execution_plan())
@@ -248,7 +254,7 @@ def rename_unbound_static(op, prefix="static-name"):
 
 
 def normalize_xorq_databasetable(dt):
-    if dt.source.name != "xorq":
+    if dt.source.name != "xorq-datafusion":
         raise ValueError(f"expected xorq backend, got {dt.source.name!r}")
     if isinstance(dt, rel.FlightExpr):
         return dask.base.normalize_token(
@@ -363,7 +369,7 @@ def normalize_databasetable(dt):
         "datafusion": normalize_datafusion_databasetable,
         "postgres": normalize_postgres_databasetable,
         "snowflake": normalize_snowflake_databasetable,
-        "xorq": normalize_xorq_databasetable,
+        "xorq-datafusion": normalize_xorq_databasetable,
         "duckdb": normalize_duckdb_databasetable,
         "trino": normalize_remote_databasetable,
         "gizmosql": normalize_remote_databasetable,

--- a/python/xorq/common/utils/tests/test_deferred_read.py
+++ b/python/xorq/common/utils/tests/test_deferred_read.py
@@ -356,7 +356,11 @@ def test_deferred_read_csv_multiple_paths(csv_dir):
 
 @pytest.fixture(scope="function")
 def backend(request, con):
-    lookup = {"duckdb": xo.duckdb.connect(), "postgres": con, "xorq": xo.connect()}
+    lookup = {
+        "duckdb": xo.duckdb.connect(),
+        "postgres": con,
+        "xorq-datafusion": xo.connect(),
+    }
 
     return lookup.get(request.param, con)
 
@@ -366,7 +370,7 @@ def backend(request, con):
     [
         pytest.param("duckdb", id="duckdb"),
         pytest.param("postgres", id="postgres"),
-        pytest.param("xorq", id="xorq"),
+        pytest.param("xorq-datafusion", id="xorq-datafusion"),
     ],
     indirect=True,
 )

--- a/python/xorq/common/utils/tests/test_replace_sources.py
+++ b/python/xorq/common/utils/tests/test_replace_sources.py
@@ -32,7 +32,7 @@ def parquet_path(parquet_dir):
     return parquet_dir / "batting.parquet"
 
 
-BACKEND_NAMES = ("xorq", "duckdb", "pandas")
+BACKEND_NAMES = ("xorq-datafusion", "duckdb", "pandas")
 
 
 def make_con(name):

--- a/python/xorq/expr/ml/tests/test_split_lib.py
+++ b/python/xorq/expr/ml/tests/test_split_lib.py
@@ -103,7 +103,7 @@ def test_train_test_split():
 @pytest.mark.parametrize(
     "con_name,unique_key",
     itertools.product(
-        (None, "pandas", "xorq", "sqlite"),
+        (None, "pandas", "xorq-datafusion", "sqlite"),
         (
             "key1",
             ("key1",),

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -100,11 +100,13 @@ def replace_source_factory(source: Any):
 
 def make_native_op(node):
     # FIXME: how to reference let.Backend.name?
-    if node.source.name != "xorq":
-        raise ValueError(f"Expected 'xorq' backend, but got {node.source.name!r}")
+    if node.source.name != "xorq-datafusion":
+        raise ValueError(
+            f"Expected 'xorq-datafusion' backend, but got {node.source.name!r}"
+        )
     sources = node.source._sources
     native_source = sources.get_backend(node)
-    if native_source.name == "xorq":
+    if native_source.name == "xorq-datafusion":
         raise ValueError("Expected a native backend, but got 'let' backend")
 
     def replace_table(_node, _kwargs):

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -367,7 +367,7 @@ def _extract_sql_queries(expr, kind) -> tuple[tuple[str, str, str], ...]:
     match kind:
         case ExprKind.UnboundExpr:
             sql = str(xorq_to_sql(clean)).strip()
-            return (("main", "xorq", sql),) if sql else ()
+            return (("main", "xorq-datafusion", sql),) if sql else ()
         case _:
             sql_plans, deferred_reads = generate_sql_plans(clean)
             return tuple(

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -83,7 +83,7 @@ def _ensure_translate_registered():
     import xorq.ibis_yaml.translate  # noqa: PLC0415, F401
 
 
-memory_backends = ("pandas", "duckdb", "datafusion", "xorq")
+memory_backends = ("pandas", "duckdb", "datafusion", "xorq-datafusion")
 table_like_ops = tuple(o for o in opaque_ops if issubclass(o, DatabaseTable))
 
 

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "66e4de23f826",
-  "expr.yaml": "2d10e348a8c01088dec95228429fa89f",
+  "expr.yaml": "828d64928f7353a9322433a1906fe9a4",
   "expr_metadata.json": "6fea1b671f31a55005df6277227ce9aa",
   "profiles.yaml": "8bfea0dc8692e7ce82757f11558829e1"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "66e4de23f826",
-  "expr.yaml": "cd48a885e9836839fbbc8c67c5813b1e",
-  "expr_metadata.json": "8cf9e2bbbbb71d9b3c4dc1a071692cf0",
-  "profiles.yaml": "5823d159cc022c8b36f837b3b7cbac1b"
+  "expr.yaml": "2d10e348a8c01088dec95228429fa89f",
+  "expr_metadata.json": "6fea1b671f31a55005df6277227ce9aa",
+  "profiles.yaml": "8bfea0dc8692e7ce82757f11558829e1"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -3,9 +3,9 @@
   "6c96e9dd3dae.sql": "64898e4816b436c2c6c5d534e2005d8f",
   "d4c7b4371895.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "d9167e92b15e.sql": "677d396e365f6dcbda3f20b588d6a064",
-  "deferred_reads.yaml": "6811bb93a1822db982f95a0197a43087",
-  "expr.yaml": "862644cbe7acb452b53a955456405590",
-  "expr_metadata.json": "f9d48ed2fc5e3992096b003aed5c482c",
-  "profiles.yaml": "f14d089ce2cc15b9d82868965637a755",
-  "sql.yaml": "84df0ac6ab484f0e8a438d1cb398dffb"
+  "deferred_reads.yaml": "cf49e5e9af39a392709e09937e2d11e1",
+  "expr.yaml": "908deb763ed7f2596deaf4a62dcca6cb",
+  "expr_metadata.json": "08622853efb32aa0b4c39ae09514e6dc",
+  "profiles.yaml": "5aa65a8060a4d018811002253149e363",
+  "sql.yaml": "1ae001bef4da654dd9b3f9fcb9b2421a"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -3,9 +3,9 @@
   "6c96e9dd3dae.sql": "64898e4816b436c2c6c5d534e2005d8f",
   "d4c7b4371895.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "d9167e92b15e.sql": "677d396e365f6dcbda3f20b588d6a064",
-  "deferred_reads.yaml": "91e65e1f3ae065269e5a25f2a68eb97c",
-  "expr.yaml": "645aa9e0a76387bebdf46ae6dcdefc82",
-  "expr_metadata.json": "80b06b1b30eb8bda554e6027aad40c23",
-  "profiles.yaml": "f14d089ce2cc15b9d82868965637a755",
-  "sql.yaml": "84df0ac6ab484f0e8a438d1cb398dffb"
+  "deferred_reads.yaml": "cda5e0150f9a2bd461e92beabf76a736",
+  "expr.yaml": "417de6ff028ae420ed8e6bfac77851e8",
+  "expr_metadata.json": "19ca405aecb1afdebaa9184b5e1ca746",
+  "profiles.yaml": "5aa65a8060a4d018811002253149e363",
+  "sql.yaml": "1ae001bef4da654dd9b3f9fcb9b2421a"
 }

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -623,7 +623,7 @@ def test_into_backend_with_array_filter(builds_dir):
     )
     roundtrip_expr = do_roundtrip_expr(expr, builds_dir=builds_dir, debug=False)
     assert_frame_equal(expr.execute(), roundtrip_expr.execute())
-    assert {"duckdb", "xorq"}.intersection(
+    assert {"duckdb", "xorq-datafusion"}.intersection(
         source.name for source in find_all_sources(roundtrip_expr)
     )
 

--- a/python/xorq/ibis_yaml/tests/test_sql.py
+++ b/python/xorq/ibis_yaml/tests/test_sql.py
@@ -13,7 +13,7 @@ def test_find_tables_simple():
     assert len(remote_tables) == 1
     table_name = next(iter(remote_tables))
     assert table_name.startswith("ibis_" + gen_name_namespace)
-    assert remote_tables[table_name]["engine"] == "xorq"
+    assert remote_tables[table_name]["engine"] == "xorq-datafusion"
 
 
 def test_find_tables_nested():

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -998,7 +998,7 @@ def test_serve_penguins_template(tmpdir, tmp_path):
     assert returncode == 0, stderr
 
     if match := re.search(f"{target_dir}/([0-9a-f]+)", stdout.decode("ascii")):
-        serve_hash = "e4122ce163e8680c757d6a5ed665440a"  # RemoteTable (test split)
+        serve_hash = "2eb9c1ed893765e42e514c717193b83f"  # RemoteTable (test split)
 
         serve_args = (
             "xorq",

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -643,7 +643,9 @@ def test_execution_expr_multiple_tables(ls_con, tables, request, mocker):
         "playerID",
     )
 
-    native_backend = left_backend is right_backend and left_backend.name != "xorq"
+    native_backend = (
+        left_backend is right_backend and left_backend.name != "xorq-datafusion"
+    )
     spy = mocker.spy(left_backend, "to_pyarrow_batches") if native_backend else None
 
     assert expr.execute() is not None

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -9,7 +9,7 @@ from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.backends.profiles import Profile, Profiles
 
 
-local_con_names = ("duckdb", "xorq", "datafusion", "pandas", "pyiceberg")
+local_con_names = ("duckdb", "xorq-datafusion", "datafusion", "pandas", "pyiceberg")
 remote_connectors = (lambda: xo.postgres.connect_env(),)
 local_connectors = tuple(
     lambda: getattr(xo, con_name).connect()  # noqa: B023


### PR DESCRIPTION
## Summary
- Rename the DataFusion-based backend's `name` from `"xorq"` to `"xorq-datafusion"` to distinguish it from other backends
- Update the entry point key in `pyproject.toml` and all string comparisons that check backend identity (`relations.py`, `dask_normalize_expr.py`, `compiler.py`, `test_into_backend.py`)
- No module path changes — `xorq.backends.xorq` remains the import path

## Test plan
- [ ] Verify `xo.connect().name` returns `"xorq-datafusion"`
- [ ] Run `pytest python/xorq/tests/test_into_backend.py -v`
- [ ] Run `pytest python/xorq/ibis_yaml/ -v`
- [ ] Verify `load_backend("xorq-datafusion")` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)