### PR TITLE
fix(compiler): use except_ in sge.Star to emit EXCLUDE clauses

### DIFF
--- a/python/xorq/vendor/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -1023,7 +1023,7 @@ class BigQueryCompiler(SQLGlotCompiler):
     def visit_DropColumns(self, op, *, parent, columns_to_drop):
         quoted = self.quoted
         excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
-        star = sge.Star(**{"except": excludes})
+        star = sge.Star(**{"except_": excludes})
         table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
         column = sge.Column(this=star, table=table)
         return sg.select(column).from_(parent)

--- a/python/xorq/vendor/ibis/backends/sql/compilers/clickhouse.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/clickhouse.py
@@ -688,7 +688,7 @@ class ClickHouseCompiler(SQLGlotCompiler):
     def visit_DropColumns(self, op, *, parent, columns_to_drop):
         quoted = self.quoted
         excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
-        star = sge.Star(**{"except": excludes})
+        star = sge.Star(**{"except_": excludes})
         table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
         column = sge.Column(this=star, table=table)
         return sg.select(column).from_(parent)

--- a/python/xorq/vendor/ibis/backends/sql/compilers/duckdb.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/duckdb.py
@@ -619,7 +619,7 @@ class DuckDBCompiler(SQLGlotCompiler):
         #
         # then that means "exclude all columns named `a`"
         excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
-        star = sge.Star(**{"except": excludes})
+        star = sge.Star(**{"except_": excludes})
         table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
         column = sge.Column(this=star, table=table)
         return sg.select(column).from_(parent)

--- a/python/xorq/vendor/ibis/backends/sql/compilers/snowflake.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/snowflake.py
@@ -798,7 +798,7 @@ $$""",
     def visit_DropColumns(self, op, *, parent, columns_to_drop):
         quoted = self.quoted
         excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
-        star = sge.Star(**{"except": excludes})
+        star = sge.Star(**{"except_": excludes})
         table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
         column = sge.Column(this=star, table=table)
         return sg.select(column).from_(parent)

--- a/python/xorq/vendor/ibis/backends/sql/compilers/test_drop_columns.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/test_drop_columns.py
@@ -1,0 +1,91 @@
+import pytest
+import sqlglot.expressions as sge
+
+from xorq.vendor import ibis
+from xorq.vendor.ibis.backends.sql.compilers.duckdb import DuckDBCompiler
+from xorq.vendor.ibis.backends.sql.compilers.snowflake import SnowflakeCompiler
+
+
+def _wide_table(n_cols=10):
+    """Create an unbound table wide enough that DropColumns survives the rewrite.
+
+    The ``drop_columns_to_select`` rewrite converts DropColumns to an explicit
+    Select when >= 50% of columns are dropped. Using 10 columns and dropping 2
+    keeps the DropColumns node intact so the compiler's ``visit_DropColumns``
+    is exercised.
+    """
+    cols = {f"col_{i}": "int64" for i in range(n_cols)}
+    return ibis.table(cols, name="wide_table")
+
+
+@pytest.fixture(params=["duckdb", "snowflake"])
+def dialect_and_compiler(request):
+    compilers = {
+        "duckdb": DuckDBCompiler,
+        "snowflake": SnowflakeCompiler,
+    }
+    return request.param, compilers[request.param]()
+
+
+def _compile(compiler, expr):
+    queries = compiler.to_sqlglot(expr)
+    return queries[0].sql(dialect=compiler.dialect)
+
+
+def test_drop_columns_generates_exclude(dialect_and_compiler):
+    """visit_DropColumns must produce SELECT * EXCLUDE (...), not bare SELECT *."""
+    dialect, compiler = dialect_and_compiler
+    t = _wide_table()
+    expr = t.drop("col_0", "col_1")
+
+    sql = _compile(compiler, expr)
+    assert "EXCLUDE" in sql, (
+        f"{dialect}: DropColumns generated bare SELECT * without EXCLUDE clause: {sql}"
+    )
+
+
+def test_drop_columns_lists_all_dropped(dialect_and_compiler):
+    """Every dropped column must appear in the EXCLUDE clause."""
+    _, compiler = dialect_and_compiler
+    t = _wide_table()
+    to_drop = ["col_0", "col_3"]
+    expr = t.drop(*to_drop)
+
+    sql = _compile(compiler, expr)
+    for col in to_drop:
+        assert col in sql, f"Dropped column {col!r} missing from SQL: {sql}"
+
+
+def test_drop_columns_preserves_remaining(dialect_and_compiler):
+    """Dropped columns must NOT appear in the result schema."""
+    _, compiler = dialect_and_compiler
+    t = _wide_table()
+    to_drop = ["col_0", "col_1"]
+    expr = t.drop(*to_drop)
+
+    result_cols = set(expr.columns)
+    for col in to_drop:
+        assert col not in result_cols
+
+
+def test_sge_star_except_underscore():
+    """Regression: sge.Star must use 'except_' (with underscore), not 'except'.
+
+    'except' is silently ignored by sqlglot because the arg slot is named
+    'except_' (Python reserved word). This caused SELECT * EXCLUDE to render
+    as bare SELECT *, making DropColumns a no-op.
+    """
+    import sqlglot as sg
+
+    excludes = [sg.column("dropped_col", quoted=True)]
+
+    star_broken = sge.Star(**{"except": excludes})
+    star_fixed = sge.Star(**{"except_": excludes})
+
+    sql_broken = sge.Column(this=star_broken).sql()
+    sql_fixed = sge.Column(this=star_fixed).sql()
+
+    assert "dropped_col" not in sql_broken, (
+        "sqlglot now accepts 'except' — update the compiler if this changes"
+    )
+    assert "dropped_col" in sql_fixed


### PR DESCRIPTION
## Summary

- **Fix one-character typo** (`"except"` → `"except_"`) in `sge.Star()` across all four vendored compilers that override `visit_DropColumns`: DuckDB, Snowflake, BigQuery, and ClickHouse
- `except` is a Python reserved word; sqlglot names the arg slot `except_` — passing `"except"` was silently ignored, causing `SELECT * EXCLUDE (...)` to render as bare `SELECT *`
- This made `DropColumns` a no-op on wide tables, leading to column count mismatches downstream (e.g., `ArrowInvalid: tried to rename a table of 72 columns but only 70 names were provided`)
- Bug was inherited from upstream ibis when the vendor copy was created (0c806fdc, Feb 2025)

### Why it went undetected

The `drop_columns_to_select` rewrite converts `DropColumns` → explicit `Select` when ≥50% of columns are dropped. Most test tables are narrow (3–5 columns), so the rewrite always kicked in and `visit_DropColumns` was never exercised.

## Test plan

- [x] Added 7 regression tests in `test_drop_columns.py` using a 10-column table (dropping 2 = 20% < 50% threshold) to ensure `visit_DropColumns` runs
- [x] `test_drop_columns_generates_exclude` — SQL contains `EXCLUDE`, not bare `SELECT *`
- [x] `test_drop_columns_lists_all_dropped` — every dropped column appears in `EXCLUDE`
- [x] `test_drop_columns_preserves_remaining` — dropped columns absent from result schema
- [x] `test_sge_star_except_underscore` — regression guard proving `"except"` is silently ignored by sqlglot
- [x] Pre-commit passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)