### PR TITLE
feat(catalog): add -p/--params to `catalog run`

### DIFF
--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -920,6 +920,13 @@ def _resolve_single_entry(catalog, entry, code, instream, rename_map, span):
     multiple=True,
     help="Rename a parameter: entry,old_name,new_name (repeatable).",
 )
+@click.option(
+    "-p",
+    "--params",
+    "raw_params",
+    multiple=True,
+    help="Parameter as key=value (repeatable). e.g. --params threshold=0.5",
+)
 @click.pass_context
 def run(
     ctx,
@@ -931,6 +938,7 @@ def run(
     instream,
     fuse,
     raw_rename_params,
+    raw_params,
 ):
     """Compose and execute catalog entries.
 
@@ -948,7 +956,7 @@ def run(
 
     To persist composed results, use 'compose'.
     """
-    from xorq.cli import arbitrate_output_format
+    from xorq.cli import _apply_cli_params, arbitrate_output_format
     from xorq.common.utils.logging_utils import RunLogger
     from xorq.common.utils.otel_utils import tracer
     from xorq.common.utils.profile_utils import timed
@@ -968,6 +976,7 @@ def run(
                 ("output_path", str(output_path)),
                 ("fuse", str(fuse)),
                 ("limit", limit),
+                ("params", ",".join(raw_params)),
             )
 
             with RunLogger.from_expr_hash(
@@ -998,6 +1007,8 @@ def run(
                         "catalog_run.expr_loaded",
                         {"elapsed_s": round(get_elapsed(), 3)},
                     )
+
+                expr = _apply_cli_params(expr, raw_params)
 
                 if fuse:
                     expr = expr.ls.fused

--- a/python/xorq/catalog/tests/test_cli.py
+++ b/python/xorq/catalog/tests/test_cli.py
@@ -1420,6 +1420,12 @@ def test_rename_params_unknown_entry(runner, catalog_with_parameterized_entries)
 # --- --params tests ---
 
 
+def _csv_data_rows(output):
+    """Return non-header, non-empty CSV lines from CLI output."""
+    lines = [ln for ln in output.splitlines() if ln.strip()]
+    return [ln for ln in lines if ln and ln[0].isdigit()]
+
+
 def test_run_with_params_single_entry(runner, catalog_with_parameterized_entries):
     """run with -p binds a NamedScalarParameter value before execution."""
     catalog_path, _, _ = catalog_with_parameterized_entries
@@ -1439,10 +1445,9 @@ def test_run_with_params_single_entry(runner, catalog_with_parameterized_entries
         ],
     )
     assert result.exit_code == 0, result.output
-    # threshold=25 filters amount > 25, leaving only user_id=3,amount=30
-    assert "3,30" in result.output
-    assert "1,10" not in result.output
-    assert "2,20" not in result.output
+    # threshold=25 filters amount > 25, leaving only user_id=3,amount=30,name=c
+    rows = _csv_data_rows(result.output)
+    assert rows == ['3,30,"c"']
 
 
 def test_run_params_after_rename(runner, catalog_with_parameterized_entries):
@@ -1469,8 +1474,38 @@ def test_run_params_after_rename(runner, catalog_with_parameterized_entries):
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "3,30" in result.output
-    assert "1,10" not in result.output
+    rows = _csv_data_rows(result.output)
+    assert rows == ["3,30"]
+
+
+def test_run_params_multiple_distinct(runner, catalog_path):
+    """Two distinct -p flags bind to their respective NamedScalarParameters."""
+    lo = xo.param("lo", "float64", default=0.0)
+    hi = xo.param("hi", "float64", default=1000.0)
+    t = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    expr = t.filter((t.amount > lo) & (t.amount < hi))
+    Catalog.from_kwargs(path=catalog_path, init=False).add(expr, aliases=("rng",))
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "rng",
+            "-p",
+            "lo=15.0",
+            "-p",
+            "hi=25.0",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    rows = _csv_data_rows(result.output)
+    assert rows == ["2,20"]
 
 
 def test_run_params_bad_format(runner, catalog_with_parameterized_entries):
@@ -1491,8 +1526,30 @@ def test_run_params_bad_format(runner, catalog_with_parameterized_entries):
             "csv",
         ],
     )
-    assert result.exit_code != 0
+    assert result.exit_code == 2
     assert "Expected key=value" in result.output
+
+
+def test_run_params_bad_value(runner, catalog_with_parameterized_entries):
+    """-p with a value that fails dtype coercion should error."""
+    catalog_path, _, _ = catalog_with_parameterized_entries
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "psrc",
+            "-p",
+            "threshold=not_a_float",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "not_a_float" in result.output
 
 
 def test_run_params_unknown_name(runner, catalog_with_parameterized_entries):
@@ -1513,9 +1570,34 @@ def test_run_params_unknown_name(runner, catalog_with_parameterized_entries):
             "csv",
         ],
     )
-    assert result.exit_code != 0
+    assert result.exit_code == 2
     assert "Unknown parameter" in result.output
     assert "threshold" in result.output
+
+
+def test_run_params_no_declared(runner, catalog_path):
+    """-p on an expr with no NamedScalarParameter reports 'Available: (none)'."""
+    plain = xo.memtable({"x": [1, 2, 3]})
+    Catalog.from_kwargs(path=catalog_path, init=False).add(plain, aliases=("plain",))
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "plain",
+            "-p",
+            "anything=1.0",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Unknown parameter" in result.output
+    assert "(none)" in result.output
 
 
 # --- run with ExprBuilder entries ---

--- a/python/xorq/catalog/tests/test_cli.py
+++ b/python/xorq/catalog/tests/test_cli.py
@@ -1417,6 +1417,107 @@ def test_rename_params_unknown_entry(runner, catalog_with_parameterized_entries)
     assert "Unknown entry" in result.output
 
 
+# --- --params tests ---
+
+
+def test_run_with_params_single_entry(runner, catalog_with_parameterized_entries):
+    """run with -p binds a NamedScalarParameter value before execution."""
+    catalog_path, _, _ = catalog_with_parameterized_entries
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "psrc",
+            "-p",
+            "threshold=25.0",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # threshold=25 filters amount > 25, leaving only user_id=3,amount=30
+    assert "3,30" in result.output
+    assert "1,10" not in result.output
+    assert "2,20" not in result.output
+
+
+def test_run_params_after_rename(runner, catalog_with_parameterized_entries):
+    """--params values bind to the renamed names, not the original."""
+    catalog_path, _, _ = catalog_with_parameterized_entries
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "psrc",
+            "ptrn",
+            "--rename-params",
+            "ptrn,threshold,trn_threshold",
+            "-p",
+            "trn_threshold=25.0",
+            "-p",
+            "threshold=5.0",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "3,30" in result.output
+    assert "1,10" not in result.output
+
+
+def test_run_params_bad_format(runner, catalog_with_parameterized_entries):
+    """-p without '=' should report a usage error."""
+    catalog_path, _, _ = catalog_with_parameterized_entries
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "psrc",
+            "-p",
+            "no_equals",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Expected key=value" in result.output
+
+
+def test_run_params_unknown_name(runner, catalog_with_parameterized_entries):
+    """-p with a name not in the expr should error with available names."""
+    catalog_path, _, _ = catalog_with_parameterized_entries
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            "psrc",
+            "-p",
+            "not_a_param=1.0",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Unknown parameter" in result.output
+    assert "threshold" in result.output
+
+
 # --- run with ExprBuilder entries ---
 
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -126,6 +126,16 @@ def _parse_cli_params(expr, raw_params: tuple) -> dict:
     return params
 
 
+def _apply_cli_params(expr, raw_params: tuple):
+    """Parse --params CLI strings and bind them to expr; no-op if empty."""
+    param_dict = _parse_cli_params(expr, raw_params)
+    if not param_dict:
+        return expr
+    from xorq.expr.api import bind_params  # noqa: PLC0415
+
+    return bind_params(expr, param_dict)
+
+
 def ensure_build_dir(expr_path):
     build_dir = Path(expr_path)
     if not build_dir.exists() or not build_dir.is_dir():
@@ -412,11 +422,7 @@ def run_cached_command(
 
         with timed() as get_elapsed:
             expr = load_expr(expr_path, cache_dir=cache_dir)
-            param_dict = _parse_cli_params(expr, raw_params)
-            if param_dict:
-                from xorq.expr.api import bind_params  # noqa: PLC0415
-
-                expr = bind_params(expr, param_dict)
+            expr = _apply_cli_params(expr, raw_params)
 
         rl.log_span_event(
             span, "run_cached.expr_loaded", {"elapsed_s": round(get_elapsed(), 3)}


### PR DESCRIPTION
## Summary
- Add repeatable `-p/--params key=value` to `xorq catalog run`, mirroring `xorq run`.
- Values are coerced via each `NamedScalarParameter`'s declared dtype, then bound after `--rename-params` is applied (so values bind to the renamed names).
- Extract a small `_apply_cli_params(expr, raw_params)` helper in `xorq.cli` and reuse it from `run_cached_command` and the new catalog `run` path.

## Example
```
xorq catalog run src trn \
  --rename-params src,threshold,src_threshold \
  -p src_threshold=0.5 -p year=2024 \
  -o out.csv -f csv
```

## Test plan
- [x] `xorq catalog run <entry> -p name=value` binds the value and executes.
- [x] `-p unknown=1` reports unknown parameter with available names.
- [x] `-p badint=nope` on an Int64 param reports a type-coercion error.
- [x] Composed multi-entry run binds params defined in any sub-entry.
- [x] `--rename-params` + `-p <new_name>=...` works end-to-end.
- [x] Existing `xorq run` / `xorq run-cached` still accept `-p` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)