### PR TITLE
perf(catalog): template-clone fixtures to cut annex test setup

### DIFF
--- a/python/xorq/catalog/tests/conftest.py
+++ b/python/xorq/catalog/tests/conftest.py
@@ -73,31 +73,23 @@ def compare_repo_and_catalog(repo, catalog):
     assert tuple(sorted(alias_names)) == tuple(sorted(catalog.list_aliases()))
 
 
-@pytest.fixture(params=["git", "annex"])
+@pytest.fixture(scope="session", params=["git", "annex"])
 def backend_type(request):
     return request.param
 
 
-@pytest.fixture
-def repo(tmpdir, backend_type):
-    annex = LOCAL_ANNEX if backend_type == "annex" else None
-    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("repo"), annex=annex)
-    yield repo
-
-
-@pytest.fixture
-def catalog(repo, backend_type):
+def _make_catalog_from_repo(repo, backend_type):
     repo_path = Path(repo.working_dir)
     if backend_type == "annex":
         backend = GitAnnexBackend(repo=repo, annex=Annex(repo_path=repo_path))
     else:
         backend = GitBackend(repo=repo)
-    yield Catalog(backend=backend)
+    return Catalog(backend=backend)
 
 
-@pytest.fixture
-def catalog_path(catalog):
-    yield str(catalog.repo_path)
+def _init_catalog_repo(repo_path, backend_type):
+    annex = LOCAL_ANNEX if backend_type == "annex" else None
+    return Catalog.init_repo_path(repo_path, annex=annex)
 
 
 def make_build_zip(tmpdir, name):
@@ -108,25 +100,67 @@ def make_build_zip(tmpdir, name):
         return target
 
 
-@pytest.fixture
-def data_dict(tmpdir):
-    data_dict = {}
-    for name in map(
+_DATA_DICT_NAMES = tuple(
+    map(
         chr,
         (
             *range(ord("a"), ord("c")),
             *range(ord("A"), ord("C")),
         ),
-    ):
-        target = make_build_zip(tmpdir, name)
-        data_dict[target.name] = target
-    yield data_dict
+    )
+)
+
+
+@pytest.fixture(scope="session")
+def _data_dict_template(tmp_path_factory):
+    root = tmp_path_factory.mktemp("data-dict-template")
+    return {
+        (target := make_build_zip(root, name)).name: target for name in _DATA_DICT_NAMES
+    }
 
 
 @pytest.fixture
-def catalog_populated(catalog, data_dict):
-    tuple(catalog.add(path) for path in data_dict.values())
-    yield catalog
+def data_dict(tmpdir, _data_dict_template):
+    dst_root = Path(tmpdir)
+    return {
+        name: Path(shutil.copy(src, dst_root.joinpath(name)))
+        for name, src in _data_dict_template.items()
+    }
+
+
+@pytest.fixture(scope="session")
+def _catalog_populated_template(tmp_path_factory, backend_type, _data_dict_template):
+    root = tmp_path_factory.mktemp(f"catalog-populated-template-{backend_type}")
+    repo_path = root / "repo"
+    repo = _init_catalog_repo(repo_path, backend_type)
+    catalog = _make_catalog_from_repo(repo, backend_type)
+    for path in _data_dict_template.values():
+        catalog.add(path)
+    return repo_path
+
+
+@pytest.fixture
+def repo(tmpdir, backend_type):
+    repo = _init_catalog_repo(Path(tmpdir).joinpath("repo"), backend_type)
+    yield repo
+
+
+@pytest.fixture
+def catalog(repo, backend_type):
+    yield _make_catalog_from_repo(repo, backend_type)
+
+
+@pytest.fixture
+def catalog_path(catalog):
+    yield str(catalog.repo_path)
+
+
+@pytest.fixture
+def catalog_populated(tmpdir, backend_type, _catalog_populated_template):
+    dst = Path(tmpdir).joinpath("repo")
+    shutil.copytree(_catalog_populated_template, dst, symlinks=True)
+    repo = Repo(dst)
+    yield _make_catalog_from_repo(repo, backend_type)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Make `data_dict` and `catalog_populated` session-scoped **templates**; each test gets a per-test `shutil.copy` / `shutil.copytree(..., symlinks=True)` from the template instead of rebuilding from scratch
- Eliminates the 4× `git annex add` + commit that every `[annex]` test paid in setup — the dominant cost in `python/xorq/catalog/tests/test_cli.py` under xdist `--dist=loadfile`

## Motivation

Analysis of [ci-test job 72022776701](https://github.com/xorq-labs/xorq/actions/runs/24632718743/job/72022776701) (10 min wall) showed:

| Worker | Cumulative | Dominant file |
|---|---|---|
| gw1 | **557.6 s** | `catalog/tests/test_cli.py` (entire worker) |
| gw0 | 416.2 s | `catalog/tests/test_catalog.py` (262 s) |
| gw2 | 404.1 s | `catalog/tests/test_tui.py` (182 s) |
| gw3 | 407.1 s | mixed |

Within `test_cli.py`: `[annex]` parametrization = 517 s, `[git]` = 40 s for the same 87 functions — a 13× gap. Slowest-20 durations on that job were 6–8 s of fixture **setup** per annex test. Root cause: the annex fixture chain builds 4 zip archives and runs `catalog.add()` (= `git annex add` + commit) on each, for every test.

## Local measurements

Running `pytest python/xorq/catalog/tests/ -k 'not script_execution and not slow and not benchmark' --no-cov -n auto --dist=loadfile`:

| | Baseline | After | Δ |
|---|---|---|---|
| Full `catalog/tests/` | 142.8 s | 116.9 s | **−18%** |
| `test_cli.py` (`-n 4`, mirrors CI worker count) | 139.8 s | 113.1 s | **−19%** |

Same pass/fail set both runs: 550 passed / 21 skipped / 8 pre-existing failures. No new regressions.

CI per-test setup (~8 s) is ~5× slower than local (~1.7 s), so CI impact should be meaningfully larger than the local 18%.

## Implementation notes

- `backend_type` is now `scope="session"` so session-scoped fixtures can depend on it while preserving `["git", "annex"]` parametrization.
- `_catalog_populated_template` builds one pristine annex/git repo per (session, backend); `catalog_populated` `copytree`s it per test and rebuilds the `Catalog` handle on the copy.
- `symlinks=True` is required — git-annex stores content via symlinks into `.git/annex/objects`, which must be copied verbatim.
- Templates share UUID/commit-SHA across copies within a session. No tests currently assert UUID uniqueness across catalog-populated instances; `repo_cloned_bare` still gets a fresh annex UUID via its own `git annex init`.

## Test plan

- [x] Full `catalog/tests/` passes with same pass/fail set as baseline
- [ ] CI `ci-test` green
- [ ] CI wall-time delta captured for comparison with the 606 s baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)