### PR TITLE
feat(catalog): add replay --rebuild to regenerate entries under current code

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -840,7 +840,7 @@ class CatalogAddition:
                 raise ValueError(f"Entry '{self.name}' already exists in catalog")
             for catalog_alias in self.catalog_aliases:
                 catalog_alias._add()
-            return None
+            return CatalogEntry(self.name, self.catalog, require_exists=True)
         self.ensure_dirs()
         catalog_entry = self.catalog_entry
         catalog_entry.metadata_path.write_text(yaml12.format_yaml(self.metadata))

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -846,9 +846,10 @@ def compose(ctx, entries, code, alias, cache_dir, dry_run, raw_rename_params):
             entry_name = build_path.name
             aliases = (alias,) if alias else ()
             alias_existed = alias and catalog.catalog_yaml.contains_alias(alias)
-            catalog_entry = catalog.add(build_path, aliases=aliases, exist_ok=True)
+            entry_existed = catalog.contains(entry_name)
+            catalog.add(build_path, aliases=aliases, exist_ok=True)
             label = alias or entry_name
-            if catalog_entry is None:
+            if entry_existed:
                 if alias and not alias_existed:
                     click.echo(
                         f"Entry {entry_name!r} already exists; alias {alias!r} added",

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -559,6 +559,19 @@ def log(ctx, as_json):
 @click.option(
     "--dry-run", is_flag=True, help="Show what would be replayed without executing."
 )
+@click.option(
+    "--rebuild",
+    is_flag=True,
+    help=(
+        "Rebuild each entry under current code. Entries with no catalog "
+        "references are re-added from their stored expression; entries "
+        "containing catalog references (Composed, or ExprBuilder wrapping a "
+        "composition) have the catalog subtree recomposed against their "
+        "(already rebuilt) dependencies in the target catalog — outer "
+        "builder wrappings pass through untouched. Updates build_metadata "
+        "and entry hashes. Fetches annex content for every entry."
+    ),
+)
 @click.pass_context
 def replay(
     ctx,
@@ -570,6 +583,7 @@ def replay(
     preserve_commits,
     force,
     dry_run,
+    rebuild,
 ):
     """Replay catalog operations into a target catalog."""
     from xorq.catalog.catalog import Catalog
@@ -577,12 +591,12 @@ def replay(
 
     with click_context_catalog(ctx):
         source = ctx.obj.make_catalog(init=False)
-        replayer = Replayer(from_catalog=source)
+        replayer = Replayer(from_catalog=source, rebuild=rebuild)
         if dry_run:
             replayer.print_plan()
             return
         annex = _resolve_annex_option(env_file, env_prefix, gcs)
-        target = Catalog.from_repo_path(target_path, init=True, annex=annex)
+        target = Catalog.from_repo_path(target_path, annex=annex)
         replayer.replay(target, preserve_commits=preserve_commits)
         click.echo(f"Replayed {len(replayer.ops)} operations into {target_path}")
         if remote_url:

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -562,15 +562,7 @@ def log(ctx, as_json):
 @click.option(
     "--rebuild",
     is_flag=True,
-    help=(
-        "Rebuild each entry under current code. Entries with no catalog "
-        "references are re-added from their stored expression; entries "
-        "containing catalog references (Composed, or ExprBuilder wrapping a "
-        "composition) have the catalog subtree recomposed against their "
-        "(already rebuilt) dependencies in the target catalog — outer "
-        "builder wrappings pass through untouched. Updates build_metadata "
-        "and entry hashes. Fetches annex content for every entry."
-    ),
+    help="Rebuild each entry under current code (refreshes build_metadata and entry hashes).",
 )
 @click.pass_context
 def replay(
@@ -585,7 +577,15 @@ def replay(
     dry_run,
     rebuild,
 ):
-    """Replay catalog operations into a target catalog."""
+    """Replay catalog operations into a target catalog.
+
+    With ``--rebuild``, each entry is re-added under current code:
+    entries with no catalog references are re-added from their stored
+    expression; entries containing catalog references (Composed, or
+    ExprBuilder wrapping a composition) have the catalog subtree
+    recomposed against their already-rebuilt dependencies in the
+    target catalog. Outer builder wrappings pass through untouched.
+    """
     from xorq.catalog.catalog import Catalog
     from xorq.catalog.replay import Replayer
 

--- a/python/xorq/catalog/composer.py
+++ b/python/xorq/catalog/composer.py
@@ -51,6 +51,40 @@ class ExprComposer:
 
         return current
 
+    def with_inputs_translated(self, remap, to_catalog):
+        """Return a new ExprComposer with catalog inputs translated through *remap*.
+
+        ``source`` and each entry in ``transforms`` is rewritten to the
+        corresponding entry in *to_catalog* (following *remap*). ``code``
+        is preserved byte-for-byte. ``alias`` is pinned explicitly when
+        the original was ``None`` so the rebuilt source tag's alias
+        metadata is independent of aliases-list ordering drift across
+        catalogs.
+        """
+
+        def lookup(old_name):
+            new_name = remap.get(old_name, old_name) if remap else old_name
+            if new_name not in to_catalog.list():
+                raise RuntimeError(
+                    f"rebuild: recipe references {old_name!r} which has not been "
+                    f"rebuilt in target (translated to {new_name!r}). This indicates "
+                    f"a non-topological op ordering or a reference to an entry "
+                    f"outside the source catalog."
+                )
+            return to_catalog.get_catalog_entry(new_name)
+
+        new_source = lookup(self.source.name)
+        pinned_alias = self.alias
+        if pinned_alias is None and new_source.aliases:
+            pinned_alias = new_source.aliases[0].alias
+
+        return ExprComposer(
+            source=new_source,
+            transforms=tuple(lookup(t.name) for t in self.transforms),
+            code=self.code,
+            alias=pinned_alias,
+        )
+
     @classmethod
     def from_expr(cls, expr, catalog):
         """Recover an ExprComposer from a tagged expression.

--- a/python/xorq/catalog/composer.py
+++ b/python/xorq/catalog/composer.py
@@ -68,8 +68,8 @@ class ExprComposer:
                 raise RuntimeError(
                     f"rebuild: recipe references {old_name!r} which has not been "
                     f"rebuilt in target (translated to {new_name!r}). This indicates "
-                    f"a non-topological op ordering or a reference to an entry "
-                    f"outside the source catalog."
+                    f"a reference to an entry outside the source catalog, or — "
+                    f"less commonly — a non-topological op ordering."
                 )
             return to_catalog.get_catalog_entry(new_name)
 

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -8,19 +8,147 @@ Parses the four commit-message formats produced by xorq's Catalog API:
 
 The :class:`Replayer` replays these operations in order against a target
 catalog, reproducing the source catalog's state.
+
+Rebuild mode (``rebuild=True``) re-executes each ``AddEntry`` against the
+target catalog under the current code. Entries whose expression contains no
+catalog references are re-added from their stored ``lazy_expr``. Entries
+with catalog references (``Composed``, or ``ExprBuilder`` wrapping a
+composed subtree) have the catalog subtree *recomposed*: the composition
+recipe (``source [+ transforms*] [+ code]``) is recovered via
+``ExprComposer.from_expr``, each referenced entry is translated to its
+already-rebuilt counterpart in the target catalog, the subtree is rebuilt
+via ``ExprComposer.expr``, and the fresh subtree is spliced back under any
+outer wrapping (e.g., builder tags). Any composition shape outside the
+sanctioned ``SOURCE [TRANSFORM*] [CODE]`` arrangement raises.
 """
 
 from __future__ import annotations
 
 import os
 import re
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from functools import cached_property
 
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, optional
 
 from xorq.catalog.constants import CATALOG_YAML_NAME, CatalogInfix
+
+
+# Only exercised on rebuild=True — translates old catalog names to rebuilt ones.
+def _translate(name, remap):
+    return remap.get(name, name) if remap else name
+
+
+def _rebuild_expr_for_target(source_entry, to_catalog, remap):
+    """Return an expression for re-adding source_entry into to_catalog.
+
+    Entries with no catalog tags (raw expressions, pure builders over
+    non-catalog sources, bare memtables) are re-added via their stored
+    lazy_expr. Entries containing catalog tags (Composed, or ExprBuilder
+    wrapping a composed subtree) have their catalog subtree recovered
+    via ExprComposer.from_expr, translated through remap, rebuilt via
+    ExprComposer.expr, and spliced back into the outer expression.
+    """
+    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
+    from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
+    from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
+    from xorq.expr.relations import HashingTag  # noqa: PLC0415
+
+    expr = source_entry.lazy_expr
+    catalog_tags = frozenset(CatalogTag)
+    # INVARIANT: walk_nodes is outermost-first (graph_utils.py:73, DFS from
+    # root). composer.py:72 also depends on this. The first HashingTag with
+    # a catalog tag is therefore the outermost catalog tag — i.e., the
+    # composition root. If walk_nodes ordering changes, this must be
+    # reworked.
+    composition_root = next(
+        (
+            ht
+            for ht in walk_nodes(HashingTag, expr)
+            if ht.metadata.get("tag") in catalog_tags
+        ),
+        None,
+    )
+    if composition_root is None:
+        return expr
+
+    try:
+        recipe = ExprComposer.from_expr(
+            composition_root.to_expr(), source_entry.catalog
+        )
+    except ValueError as e:
+        raise RuntimeError(
+            f"rebuild: cannot recover composition recipe for entry "
+            f"{source_entry.name!r}: {e}. Only bind()/ExprComposer-produced "
+            f"composition shapes can be rebuilt."
+        ) from e
+
+    fresh = _translate_recipe(recipe, to_catalog, remap).expr
+
+    if expr.op() is composition_root:
+        return fresh
+    return _splice(expr, old=composition_root, new=fresh.op())
+
+
+def _translate_recipe(recipe, to_catalog, remap):
+    """Remap recipe's source and transforms into to_catalog entries.
+
+    Pins the source alias explicitly: if the original recipe had
+    alias=None, ``_make_source_tag`` would fall back to
+    ``entry.aliases[0]``, whose ordering is not guaranteed stable
+    across catalogs. Capturing the source's first alias here makes
+    the rebuilt source tag's ``alias`` metadata independent of
+    aliases-list ordering drift.
+    """
+    from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
+
+    def lookup(old_name):
+        new_name = _translate(old_name, remap)
+        if new_name not in to_catalog.list():
+            raise RuntimeError(
+                f"rebuild: recipe references {old_name!r} which has not been "
+                f"rebuilt in target (translated to {new_name!r}). This indicates "
+                f"a non-topological op ordering or a reference to an entry "
+                f"outside the source catalog."
+            )
+        return to_catalog.get_catalog_entry(new_name)
+
+    new_source = lookup(recipe.source.name)
+    pinned_alias = recipe.alias
+    if pinned_alias is None and new_source.aliases:
+        pinned_alias = new_source.aliases[0].alias
+
+    return ExprComposer(
+        source=new_source,
+        transforms=tuple(lookup(t.name) for t in recipe.transforms),
+        code=recipe.code,
+        alias=pinned_alias,
+    )
+
+
+def _splice(expr, *, old, new):
+    """Return expr with node `old` replaced by `new`, rebuilding parents.
+
+    PRECONDITION: `new` must have the same schema and node type as `old`.
+    `replace_nodes` rebuilds every parent of `old` with `new` as its
+    child, so any parent validator that checks schema/type compatibility
+    (e.g. builder tags that pre-computed schema-dependent metadata) will
+    reject a mismatched substitution. This holds by construction for
+    bind()-produced composition recovered via ExprComposer — a future
+    composition shape with schema-transforming outer wrappers would need
+    a different splice strategy.
+    """
+    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
+
+    def replacer(node, kwargs):
+        if node is old:
+            return new
+        if kwargs:
+            return node.__recreate__(kwargs)
+        return node
+
+    return replace_nodes(replacer, expr).to_expr()
 
 
 # -- Commit metadata ----------------------------------------------------------
@@ -122,7 +250,7 @@ class InitCatalog:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
         pass
 
     @staticmethod
@@ -148,7 +276,7 @@ class AddCatalogYAML:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
         pass
 
     @staticmethod
@@ -186,14 +314,27 @@ class AddEntry:
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[add]   {sha}  entry={self.entry_hash}  aliases=[{alias_str}]"
 
-    def do(self, from_catalog, to_catalog):
-        catalog_entry = from_catalog.get_catalog_entry(self.entry_hash)
-        to_catalog.add(
-            catalog_entry.catalog_path,
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+        if not rebuild:
+            catalog_entry = from_catalog.get_catalog_entry(self.entry_hash)
+            to_catalog.add(
+                catalog_entry.catalog_path,
+                sync=False,
+                aliases=self.aliases,
+                exist_ok=True,
+            )
+            return
+
+        source_entry = from_catalog.get_catalog_entry(self.entry_hash)
+        expr = _rebuild_expr_for_target(source_entry, to_catalog, remap)
+        new_entry = to_catalog.add(
+            expr,
             sync=False,
             aliases=self.aliases,
             exist_ok=True,
         )
+        if remap is not None:
+            remap[self.entry_hash] = new_entry.name
 
     def verify_commit(self, commit):
         paths = _changed_paths(commit)
@@ -231,8 +372,9 @@ class AddAlias:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[alias] {sha}  {self.alias} -> {self.entry_name}"
 
-    def do(self, from_catalog, to_catalog):
-        to_catalog.add_alias(self.entry_name, self.alias, sync=False)
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+        entry_name = _translate(self.entry_name, remap) if rebuild else self.entry_name
+        to_catalog.add_alias(entry_name, self.alias, sync=False)
 
     def verify_commit(self, commit):
         paths = _changed_paths(commit)
@@ -271,8 +413,9 @@ class RemoveEntry:
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[rm]    {sha}  entry={self.entry_name}  aliases=[{alias_str}]"
 
-    def do(self, from_catalog, to_catalog):
-        to_catalog.remove(self.entry_name, sync=False)
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+        entry_name = _translate(self.entry_name, remap) if rebuild else self.entry_name
+        to_catalog.remove(entry_name, sync=False)
 
     def verify_commit(self, commit):
         paths = _changed_paths(commit)
@@ -304,7 +447,7 @@ class RemoveAlias:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[rm-a]  {sha}  alias={self.alias}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
         from xorq.catalog.catalog import CatalogAlias  # noqa: PLC0415
 
         CatalogAlias.from_name(self.alias, to_catalog).remove()
@@ -339,7 +482,12 @@ class UnknownOp:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[???]   {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+        if rebuild:
+            raise RuntimeError(
+                f"Cannot rebuild unknown op at commit {self.hexsha[:8]}: {self.message!r}. "
+                "Rebuild requires all ops be recognized catalog operations."
+            )
         patch = from_catalog.repo.git.format_patch("-1", self.hexsha, stdout=True)
         to_catalog.repo.git.am(input=patch)
 
@@ -377,6 +525,39 @@ def parse_commit(commit, *, verify=True) -> CatalogOp:
 # -- Replayer -----------------------------------------------------------------
 
 
+def _rewrite_noop_commits(repo, noop_ops):
+    """Rewrite the first N commits so their timestamps match the source catalog.
+
+    InitCatalog and AddCatalogYAML are no-ops during replay because
+    Catalog.from_repo_path(init=True) already created those commits.
+    This function rewrites them with the correct author/committer metadata
+    using ``git commit-tree``, then rebases the remaining history on top.
+    """
+    all_commits = list(repo.iter_commits(reverse=True))
+    n = len(noop_ops)
+
+    prev_sha = None
+    for commit, op in zip(all_commits[:n], noop_ops):
+        if op.commit_metadata is None:
+            prev_sha = commit.hexsha
+            continue
+        parent_args = ["-p", prev_sha] if prev_sha else []
+        with op.commit_metadata.git_env():
+            new_sha = repo.git.commit_tree(
+                str(commit.tree), *parent_args, m=commit.message.strip()
+            )
+        prev_sha = new_sha
+
+    if prev_sha is None:
+        return
+
+    if n < len(all_commits):
+        old_base = all_commits[n - 1].hexsha
+        repo.git.rebase("--onto", prev_sha, old_base)
+    else:
+        repo.git.update_ref(f"refs/heads/{repo.active_branch.name}", prev_sha)
+
+
 def _parse_catalog_ops(catalog, *, verify=True) -> tuple[CatalogOp, ...]:
     commits = tuple(catalog.repo.iter_commits(reverse=True))
     return tuple(parse_commit(c, verify=verify) for c in commits)
@@ -386,6 +567,7 @@ def _parse_catalog_ops(catalog, *, verify=True) -> tuple[CatalogOp, ...]:
 class Replayer:
     from_catalog: object = field()  # Catalog — avoid import-time dep
     verify: bool = field(default=True)
+    rebuild: bool = field(default=False)
 
     @cached_property
     def ops(self) -> tuple[CatalogOp, ...]:
@@ -400,6 +582,8 @@ class Replayer:
         return counts
 
     def print_plan(self) -> None:
+        header = "--- rebuild plan ---" if self.rebuild else "--- replay plan ---"
+        print(header)
         for op in self.ops:
             print(op)
         print("\n--- summary ---")
@@ -408,10 +592,18 @@ class Replayer:
         print(f"  total commits: {len(self.ops)}")
 
     def replay(self, to_catalog, *, preserve_commits=True) -> None:
+        remap: dict[str, str] = {}
+        noop_ops: list[CatalogOp] = []
         for op in self.ops:
-            if preserve_commits and op.commit_metadata is not None:
-                with op.commit_metadata.git_env():
-                    op.do(self.from_catalog, to_catalog)
-            else:
-                op.do(self.from_catalog, to_catalog)
+            ctx = (
+                op.commit_metadata.git_env()
+                if preserve_commits and op.commit_metadata is not None
+                else nullcontext()
+            )
+            with ctx:
+                op.do(self.from_catalog, to_catalog, rebuild=self.rebuild, remap=remap)
+            if isinstance(op, (InitCatalog, AddCatalogYAML)) and preserve_commits:
+                noop_ops.append(op)
+        if noop_ops:
+            _rewrite_noop_commits(to_catalog.repo, noop_ops)
         to_catalog.assert_consistency()

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -34,15 +34,57 @@ import tempfile
 from contextlib import contextmanager, nullcontext
 from functools import cached_property, partial
 
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from strenum import StrEnum
+
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, optional
 
 from xorq.catalog.constants import CATALOG_YAML_NAME, CatalogInfix
 
 
-# Only exercised on rebuild=True — translates old catalog names to rebuilt ones.
+class OnUnrebuiltBuilder(StrEnum):
+    """Policy when a builder tag has no rebuild protocol registered."""
+
+    RAISE = "raise"
+    WARN = "warn"
+
+
+@frozen
+class RebuildContext:
+    """Per-replay rebuild parameters threaded through ``CatalogOp.do()``.
+
+    A default-constructed context (``rebuild=False``, empty ``remap``) is
+    what plain replay uses; rebuild mode constructs one with
+    ``rebuild=True``. ``remap`` is a mutable dict: ``AddEntry`` writes
+    ``old_hash -> new_hash`` entries into it during rebuild, and
+    ``AddAlias`` / ``RemoveEntry`` read from it via :func:`_translate`.
+
+    Each call to ``Replayer.replay`` constructs its own context so the
+    ``remap`` dict is not shared across replays.
+    """
+
+    rebuild: bool = field(default=False, validator=instance_of(bool))
+    on_unrebuilt_builder: OnUnrebuiltBuilder = field(
+        default=OnUnrebuiltBuilder.RAISE,
+        converter=OnUnrebuiltBuilder,
+        validator=instance_of(OnUnrebuiltBuilder),
+    )
+    remap: dict = field(factory=dict, validator=instance_of(dict))
+
+
 def _translate(name, remap):
-    return remap.get(name, name) if remap else name
+    """Translate an old catalog name through *remap*, falling back to identity.
+
+    Lax by design: callers that pass the result to ``to_catalog.add_alias`` /
+    ``to_catalog.remove`` rely on those mutators to surface "no such entry"
+    errors with full provenance. The strict equivalent on the recipe-rebuild
+    path is :meth:`ExprComposer.with_inputs_translated`'s ``lookup``.
+    """
+    return remap.get(name, name) if remap is not None else name
 
 
 @contextmanager
@@ -61,9 +103,7 @@ def _tempfile_patch(patch_text):
         os.unlink(path)
 
 
-def _rebuild_expr_for_target(
-    source_entry, to_catalog, remap, on_unrebuilt_builder="raise"
-):
+def _rebuild_expr_for_target(source_entry, to_catalog, ctx):
     """Return an expression for re-adding *source_entry* into *to_catalog*.
 
     Thin wrapper around :func:`_rebuild_subexpr` that reads ``lazy_expr``
@@ -73,18 +113,15 @@ def _rebuild_expr_for_target(
         source_entry.lazy_expr,
         from_catalog=source_entry.catalog,
         to_catalog=to_catalog,
-        remap=remap,
-        on_unrebuilt_builder=on_unrebuilt_builder,
+        ctx=ctx,
     )
 
 
-def _rebuild_subexpr(
-    expr, *, from_catalog, to_catalog, remap, on_unrebuilt_builder="raise"
-):
+def _rebuild_subexpr(expr, *, from_catalog, to_catalog, ctx):
     """Rebuild every outermost rebuildable tag in *expr* under current code.
 
     Walks tags outermost-first and collects all outermost rebuildable
-    tags — those with no rebuildable tag among their ancestors. Each is
+    tags (those with no rebuildable tag among their ancestors). Each is
     rebuilt atomically and spliced back, so parallel rebuildable
     subtrees (e.g., a ``FittedPipeline``'s training subtree reached via
     fit UDF, and its predict-input subtree reached via the direct tree
@@ -102,6 +139,8 @@ def _rebuild_subexpr(
 
     Returns *expr* unchanged when no rebuildable tag is found.
     """
+    import warnings  # noqa: PLC0415
+
     from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
     from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
     from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
@@ -116,8 +155,7 @@ def _rebuild_subexpr(
         _rebuild_subexpr,
         from_catalog=from_catalog,
         to_catalog=to_catalog,
-        remap=remap,
-        on_unrebuilt_builder=on_unrebuilt_builder,
+        ctx=ctx,
     )
 
     def _is_catalog_tag(node):
@@ -133,18 +171,25 @@ def _rebuild_subexpr(
                     "Only bind()/ExprComposer-produced composition shapes "
                     "can be rebuilt."
                 ) from e
-            return composer.with_inputs_translated(remap, to_catalog).expr
+            return composer.with_inputs_translated(ctx.remap, to_catalog).expr
         dispatch = get_rebuild_dispatch(tag)
         if dispatch is None:
             return None
-        if callable(dispatch):
-            return dispatch(rebuild_subexpr)
-        _, builder = dispatch
-        return builder.with_inputs_translated(remap, to_catalog).expr
+        return dispatch(rebuild_subexpr, ctx.remap, to_catalog)
 
-    # Collect outermost rebuildable tags. walk_nodes yields outermost-first,
-    # so a tag is "outermost rebuildable" iff no already-collected
-    # rebuildable tag contains it in its subtree.
+    # Collect outermost rebuildable tags. We rely on walk_nodes yielding
+    # any node before its descendants (DFS via list-pop, root pushed
+    # first). When a tag is selected we add its whole subtree to
+    # `claimed`, so any descendant tag encountered later is skipped.
+    # Sibling order is unspecified but irrelevant: siblings can never be
+    # in each other's subtrees.
+    #
+    # Correctness DOES depend on parent-before-descendant order. If a
+    # descendant were yielded first, both it and its ancestor would land
+    # in `outermost`; splicing the descendant first then rebuilds the
+    # ancestor node (replace_nodes rebuilds parents on a changed child),
+    # so the second splice can no longer find its `old` target by
+    # identity and silently no-ops, leaving the ancestor unrebuilt.
     outermost = []
     claimed = set()
     for tag in walk_nodes((Tag, HashingTag), expr):
@@ -158,10 +203,8 @@ def _rebuild_subexpr(
                     "protocol (handler.reemit, object.reemit, or "
                     "object.with_inputs_translated)"
                 )
-                if on_unrebuilt_builder == "raise":
+                if ctx.on_unrebuilt_builder is OnUnrebuiltBuilder.RAISE:
                     raise RuntimeError(msg)
-                import warnings  # noqa: PLC0415
-
                 warnings.warn(msg, stacklevel=2)
             continue
         outermost.append(tag)
@@ -179,17 +222,29 @@ def _rebuild_subexpr(
 
 
 def _assert_schema_preserved(tag_node, fresh):
+    """Raise ``RuntimeError`` if *fresh* has a different schema than *tag_node*'s subtree.
+
+    Splice precondition: parents of the tag (e.g. outer builder tags that
+    pre-computed schema-dependent metadata) are rebuilt by ``replace_nodes``
+    on substitution, so a schema-incompatible replacement would either be
+    rejected by parent validators or silently produce wrong metadata.
+    """
     old_schema = tag_node.to_expr().schema()
     new_schema = fresh.schema()
     if old_schema != new_schema:
         raise RuntimeError(
-            f"rebuild: schema changed for tag {tag_node.metadata.get('tag')!r} — "
+            f"rebuild: schema changed for tag {tag_node.metadata.get('tag')!r}; "
             f"old: {dict(old_schema.items())}, new: {dict(new_schema.items())}. "
             "Remove and re-add the entry manually under current code."
         )
 
 
 def _splice_or_return(expr, *, old, new):
+    """Replace *old* with *new* in *expr*; return *new* if *expr*'s root is *old*.
+
+    Skips the ``replace_nodes`` walk in the root-replacement case where
+    there are no parents to rebuild.
+    """
     if expr.op() is old:
         return new
     return _splice(expr, old=old, new=new.op())
@@ -299,7 +354,7 @@ def _parse_aliases(raw):
 def _changed_paths(commit):
     """Return the set of file paths changed by a commit."""
     if not commit.parents:
-        # initial commit — all files are new
+        # initial commit: all files are new
         return {item.path for item in commit.tree.traverse()}
     parent = commit.parents[0]
     return {diff.b_path or diff.a_path for diff in parent.diff(commit)}
@@ -309,6 +364,7 @@ _CATALOG_PREFIXES = tuple(f"{infix.value}/" for infix in CatalogInfix)
 
 
 def _is_catalog_path(path):
+    """True iff *path* is a catalog-managed path (catalog.yaml or under a catalog infix)."""
     if path == CATALOG_YAML_NAME:
         return True
     return any(path.startswith(prefix) for prefix in _CATALOG_PREFIXES)
@@ -325,15 +381,7 @@ class InitCatalog:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
+    def do(self, from_catalog, to_catalog, ctx):
         pass
 
     @staticmethod
@@ -359,15 +407,7 @@ class AddCatalogYAML:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
+    def do(self, from_catalog, to_catalog, ctx):
         pass
 
     @staticmethod
@@ -405,16 +445,8 @@ class AddEntry:
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[add]   {sha}  entry={self.entry_hash}  aliases=[{alias_str}]"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
-        if not rebuild:
+    def do(self, from_catalog, to_catalog, ctx):
+        if not ctx.rebuild:
             catalog_entry = from_catalog.get_catalog_entry(self.entry_hash)
             to_catalog.add(
                 catalog_entry.catalog_path,
@@ -430,21 +462,19 @@ class AddEntry:
                 source_entry.lazy_expr,
                 from_catalog=from_catalog,
                 to_catalog=to_catalog,
-                remap=remap,
-                on_unrebuilt_builder=on_unrebuilt_builder,
+                ctx=ctx,
             )
-        except RuntimeError as e:
+            new_entry = to_catalog.add(
+                expr,
+                sync=False,
+                aliases=self.aliases,
+                exist_ok=True,
+            )
+        except Exception as e:
             raise RuntimeError(
                 f"rebuild: failed to rebuild entry {source_entry.name!r}: {e}"
             ) from e
-        new_entry = to_catalog.add(
-            expr,
-            sync=False,
-            aliases=self.aliases,
-            exist_ok=True,
-        )
-        if remap is not None:
-            remap[self.entry_hash] = new_entry.name
+        ctx.remap[self.entry_hash] = new_entry.name
 
     def verify_commit(self, commit):
         paths = _changed_paths(commit)
@@ -482,17 +512,12 @@ class AddAlias:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[alias] {sha}  {self.alias} -> {self.entry_name}"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
-        entry_name = _translate(self.entry_name, remap) if rebuild else self.entry_name
-        to_catalog.add_alias(entry_name, self.alias, sync=False)
+    def do(self, from_catalog, to_catalog, ctx):
+        # _translate falls through to identity on an empty remap, so the same
+        # call works in plain replay (ctx.remap is empty) and rebuild mode.
+        to_catalog.add_alias(
+            _translate(self.entry_name, ctx.remap), self.alias, sync=False
+        )
 
     def verify_commit(self, commit):
         paths = _changed_paths(commit)
@@ -531,17 +556,8 @@ class RemoveEntry:
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[rm]    {sha}  entry={self.entry_name}  aliases=[{alias_str}]"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
-        entry_name = _translate(self.entry_name, remap) if rebuild else self.entry_name
-        to_catalog.remove(entry_name, sync=False)
+    def do(self, from_catalog, to_catalog, ctx):
+        to_catalog.remove(_translate(self.entry_name, ctx.remap), sync=False)
 
     def verify_commit(self, commit):
         paths = _changed_paths(commit)
@@ -573,15 +589,7 @@ class RemoveAlias:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[rm-a]  {sha}  alias={self.alias}"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
+    def do(self, from_catalog, to_catalog, ctx):
         from xorq.catalog.catalog import CatalogAlias  # noqa: PLC0415
 
         CatalogAlias.from_name(self.alias, to_catalog).remove()
@@ -616,25 +624,27 @@ class UnknownOp:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[???]   {sha}  {self.message}"
 
-    def do(
-        self,
-        from_catalog,
-        to_catalog,
-        *,
-        rebuild=False,
-        remap=None,
-        on_unrebuilt_builder="raise",
-    ):
-        if rebuild:
+    def do(self, from_catalog, to_catalog, ctx):
+        if ctx.rebuild:
             commit = from_catalog.repo.commit(self.hexsha)
             if any(_is_catalog_path(p) for p in _changed_paths(commit)):
                 raise RuntimeError(
-                    f"Cannot rebuild unknown op at commit {self.hexsha[:8]}: {self.message!r}. "
-                    "Rebuild requires all ops be recognized catalog operations."
+                    f"rebuild: cannot rebuild unknown op at commit "
+                    f"{self.hexsha[:8]}: {self.message!r}. Rebuild requires "
+                    "all ops be recognized catalog operations."
                 )
         patch = from_catalog.repo.git.format_patch("-1", self.hexsha, stdout=True)
         with _tempfile_patch(patch) as path:
-            to_catalog.repo.git.am(path)
+            try:
+                to_catalog.repo.git.am(path)
+            except Exception:
+                # `git am` failure leaves .git/rebase-apply behind; abort so
+                # the working tree returns to its pre-am state.
+                try:
+                    to_catalog.repo.git.am("--abort")
+                except Exception:
+                    pass
+                raise
 
     def verify_commit(self, commit):
         pass
@@ -670,6 +680,26 @@ def parse_commit(commit, *, verify=True) -> CatalogOp:
 # -- Replayer -----------------------------------------------------------------
 
 
+def _assert_target_pristine(to_catalog):
+    """Refuse to replay into a catalog that already contains real history.
+
+    `_rewrite_noop_commits` assumes the first N commits of the target are the
+    InitCatalog/AddCatalogYAML pair created by ``Catalog.from_repo_path``;
+    if the target already has prior commits, those would get rewritten with
+    the source's init metadata, corrupting unrelated history. The previous
+    CLI used ``init=True`` (which raised on any existing path) to enforce
+    this; now we enforce it directly so library callers and reused targets
+    cannot bypass it.
+    """
+    ops = _parse_catalog_ops(to_catalog, verify=False)
+    if not all(isinstance(op, (InitCatalog, AddCatalogYAML)) for op in ops):
+        raise RuntimeError(
+            "replay target is not pristine: it already contains catalog "
+            "history beyond the initial commit + catalog.yaml. Replay into "
+            "a fresh target (or an empty directory) instead."
+        )
+
+
 def _rewrite_noop_commits(repo, noop_ops):
     """Rewrite the first N commits so their timestamps match the source catalog.
 
@@ -698,7 +728,17 @@ def _rewrite_noop_commits(repo, noop_ops):
 
     if n < len(all_commits):
         old_base = all_commits[n - 1].hexsha
-        repo.git.rebase("--onto", prev_sha, old_base)
+        try:
+            repo.git.rebase("--onto", prev_sha, old_base)
+        except Exception:
+            # Leave the working tree clean rather than mid-rebase. The caller
+            # gets the original error; the catalog state is unchanged-on-failure
+            # rather than half-rewritten.
+            try:
+                repo.git.rebase("--abort")
+            except Exception:
+                pass
+            raise
     else:
         repo.git.update_ref(f"refs/heads/{repo.active_branch.name}", prev_sha)
 
@@ -710,11 +750,13 @@ def _parse_catalog_ops(catalog, *, verify=True) -> tuple[CatalogOp, ...]:
 
 @frozen(hash=False)
 class Replayer:
-    from_catalog: object = field()  # Catalog — avoid import-time dep
-    verify: bool = field(default=True)
-    rebuild: bool = field(default=False)
-    on_unrebuilt_builder: str = field(
-        default="raise", validator=validators.in_(("raise", "warn"))
+    from_catalog: object = field()  # Catalog; avoid import-time dep.
+    verify: bool = field(default=True, validator=instance_of(bool))
+    rebuild: bool = field(default=False, validator=instance_of(bool))
+    on_unrebuilt_builder: OnUnrebuiltBuilder = field(
+        default=OnUnrebuiltBuilder.RAISE,
+        converter=OnUnrebuiltBuilder,
+        validator=instance_of(OnUnrebuiltBuilder),
     )
 
     @cached_property
@@ -740,22 +782,20 @@ class Replayer:
         print(f"  total commits: {len(self.ops)}")
 
     def replay(self, to_catalog, *, preserve_commits=True) -> None:
-        remap: dict[str, str] = {}
+        _assert_target_pristine(to_catalog)
+        ctx = RebuildContext(
+            rebuild=self.rebuild,
+            on_unrebuilt_builder=self.on_unrebuilt_builder,
+        )
         noop_ops: list[CatalogOp] = []
         for op in self.ops:
-            ctx = (
+            commit_env = (
                 op.commit_metadata.git_env()
                 if preserve_commits and op.commit_metadata is not None
                 else nullcontext()
             )
-            with ctx:
-                op.do(
-                    self.from_catalog,
-                    to_catalog,
-                    rebuild=self.rebuild,
-                    remap=remap,
-                    on_unrebuilt_builder=self.on_unrebuilt_builder,
-                )
+            with commit_env:
+                op.do(self.from_catalog, to_catalog, ctx)
             if isinstance(op, (InitCatalog, AddCatalogYAML)) and preserve_commits:
                 noop_ops.append(op)
         if noop_ops:

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -11,23 +11,28 @@ catalog, reproducing the source catalog's state.
 
 Rebuild mode (``rebuild=True``) re-executes each ``AddEntry`` against the
 target catalog under the current code. Entries whose expression contains no
-catalog references are re-added from their stored ``lazy_expr``. Entries
-with catalog references (``Composed``, or ``ExprBuilder`` wrapping a
-composed subtree) have the catalog subtree *recomposed*: the composition
-recipe (``source [+ transforms*] [+ code]``) is recovered via
-``ExprComposer.from_expr``, each referenced entry is translated to its
-already-rebuilt counterpart in the target catalog, the subtree is rebuilt
-via ``ExprComposer.expr``, and the fresh subtree is spliced back under any
-outer wrapping (e.g., builder tags). Any composition shape outside the
-sanctioned ``SOURCE [TRANSFORM*] [CODE]`` arrangement raises.
+rebuildable tags are re-added from their stored ``lazy_expr``. Entries
+containing rebuildable tags walk outermost-first: the first ``CatalogTag``
+(SOURCE / TRANSFORM / CODE) goes through :class:`ExprComposer` as a
+single-output builder; any other tag registered via a ``TagHandler``
+goes through the handler's rebuild protocol. The fresh subtree is spliced
+back under any outer wrapping.
+
+Rebuild protocols (see ``xorq.expr.builders.get_rebuild_dispatch``):
+  1. Handler-level ``reemit`` callable on the ``TagHandler``.
+  2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
+     (multi-output builders like ``FittedPipeline``).
+  3. Domain-object ``with_inputs_translated(remap, to_catalog)`` +
+     ``expr`` (single-output builders like ``ExprComposer``).
 """
 
 from __future__ import annotations
 
 import os
 import re
+import tempfile
 from contextlib import contextmanager, nullcontext
-from functools import cached_property
+from functools import cached_property, partial
 
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, optional
@@ -40,91 +45,154 @@ def _translate(name, remap):
     return remap.get(name, name) if remap else name
 
 
-def _rebuild_expr_for_target(source_entry, to_catalog, remap):
-    """Return an expression for re-adding source_entry into to_catalog.
+@contextmanager
+def _tempfile_patch(patch_text):
+    """Write *patch_text* to a temp file and yield its path.
 
-    Entries with no catalog tags (raw expressions, pure builders over
-    non-catalog sources, bare memtables) are re-added via their stored
-    lazy_expr. Entries containing catalog tags (Composed, or ExprBuilder
-    wrapping a composed subtree) have their catalog subtree recovered
-    via ExprComposer.from_expr, translated through remap, rebuilt via
-    ExprComposer.expr, and spliced back into the outer expression.
+    GitPython's ``repo.git.am(input=...)`` passes ``--input=`` as a flag
+    instead of piping to stdin, so we write to a file and pass the path.
+    """
+    fd, path = tempfile.mkstemp(suffix=".patch")
+    try:
+        os.write(fd, patch_text.encode())
+        os.close(fd)
+        yield path
+    finally:
+        os.unlink(path)
+
+
+def _rebuild_expr_for_target(
+    source_entry, to_catalog, remap, on_unrebuilt_builder="raise"
+):
+    """Return an expression for re-adding *source_entry* into *to_catalog*.
+
+    Thin wrapper around :func:`_rebuild_subexpr` that reads ``lazy_expr``
+    and ``catalog`` from *source_entry*.
+    """
+    return _rebuild_subexpr(
+        source_entry.lazy_expr,
+        from_catalog=source_entry.catalog,
+        to_catalog=to_catalog,
+        remap=remap,
+        on_unrebuilt_builder=on_unrebuilt_builder,
+    )
+
+
+def _rebuild_subexpr(
+    expr, *, from_catalog, to_catalog, remap, on_unrebuilt_builder="raise"
+):
+    """Rebuild every outermost rebuildable tag in *expr* under current code.
+
+    Walks tags outermost-first and collects all outermost rebuildable
+    tags — those with no rebuildable tag among their ancestors. Each is
+    rebuilt atomically and spliced back, so parallel rebuildable
+    subtrees (e.g., a ``FittedPipeline``'s training subtree reached via
+    fit UDF, and its predict-input subtree reached via the direct tree
+    path) all get rebuilt in one pass.
+
+    - Catalog tag (``ExprKind.Composed``): recovers the full
+      ``SOURCE [TRANSFORM*] [CODE]`` chain via ``ExprComposer.from_expr``
+      and rebuilds it atomically via ``with_inputs_translated``. Inner
+      catalog tags inside the chain are rebuilt as part of the same
+      composition.
+    - Registered builder tag (``ExprKind.ExprBuilder``): dispatches via
+      the handler protocol. The handler's ``reemit`` recursively
+      rebuilds its own inputs via the ``rebuild_subexpr`` closure
+      passed in; outer processing does not re-enter its subtree.
+
+    Returns *expr* unchanged when no rebuildable tag is found.
     """
     from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
     from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
     from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
-    from xorq.expr.relations import HashingTag  # noqa: PLC0415
+    from xorq.expr.builders import (  # noqa: PLC0415
+        _get_from_tag_node_registry,
+        get_rebuild_dispatch,
+    )
+    from xorq.expr.relations import HashingTag, Tag  # noqa: PLC0415
 
-    expr = source_entry.lazy_expr
     catalog_tags = frozenset(CatalogTag)
-    # INVARIANT: walk_nodes is outermost-first (graph_utils.py:73, DFS from
-    # root). composer.py:72 also depends on this. The first HashingTag with
-    # a catalog tag is therefore the outermost catalog tag — i.e., the
-    # composition root. If walk_nodes ordering changes, this must be
-    # reworked.
-    composition_root = next(
-        (
-            ht
-            for ht in walk_nodes(HashingTag, expr)
-            if ht.metadata.get("tag") in catalog_tags
-        ),
-        None,
+    rebuild_subexpr = partial(
+        _rebuild_subexpr,
+        from_catalog=from_catalog,
+        to_catalog=to_catalog,
+        remap=remap,
+        on_unrebuilt_builder=on_unrebuilt_builder,
     )
-    if composition_root is None:
-        return expr
 
-    try:
-        recipe = ExprComposer.from_expr(
-            composition_root.to_expr(), source_entry.catalog
-        )
-    except ValueError as e:
+    def _is_catalog_tag(node):
+        return isinstance(node, HashingTag) and node.metadata.get("tag") in catalog_tags
+
+    def _rebuild_tag(tag):
+        if _is_catalog_tag(tag):
+            try:
+                composer = ExprComposer.from_expr(tag.to_expr(), from_catalog)
+            except ValueError as e:
+                raise RuntimeError(
+                    f"rebuild: cannot recover composition recipe: {e}. "
+                    "Only bind()/ExprComposer-produced composition shapes "
+                    "can be rebuilt."
+                ) from e
+            return composer.with_inputs_translated(remap, to_catalog).expr
+        dispatch = get_rebuild_dispatch(tag)
+        if dispatch is None:
+            return None
+        if callable(dispatch):
+            return dispatch(rebuild_subexpr)
+        _, builder = dispatch
+        return builder.with_inputs_translated(remap, to_catalog).expr
+
+    # Collect outermost rebuildable tags. walk_nodes yields outermost-first,
+    # so a tag is "outermost rebuildable" iff no already-collected
+    # rebuildable tag contains it in its subtree.
+    outermost = []
+    claimed = set()
+    for tag in walk_nodes((Tag, HashingTag), expr):
+        if id(tag) in claimed:
+            continue
+        if not (_is_catalog_tag(tag) or get_rebuild_dispatch(tag) is not None):
+            tag_name = tag.metadata.get("tag")
+            if tag_name and tag_name in _get_from_tag_node_registry():
+                msg = (
+                    f"rebuild: handler for tag {tag_name!r} has no rebuild "
+                    "protocol (handler.reemit, object.reemit, or "
+                    "object.with_inputs_translated)"
+                )
+                if on_unrebuilt_builder == "raise":
+                    raise RuntimeError(msg)
+                import warnings  # noqa: PLC0415
+
+                warnings.warn(msg, stacklevel=2)
+            continue
+        outermost.append(tag)
+        for descendant in walk_nodes((Tag, HashingTag), tag.to_expr()):
+            claimed.add(id(descendant))
+
+    for tag in outermost:
+        fresh = _rebuild_tag(tag)
+        if fresh is None:
+            continue
+        _assert_schema_preserved(tag, fresh)
+        expr = _splice_or_return(expr, old=tag, new=fresh)
+
+    return expr
+
+
+def _assert_schema_preserved(tag_node, fresh):
+    old_schema = tag_node.to_expr().schema()
+    new_schema = fresh.schema()
+    if old_schema != new_schema:
         raise RuntimeError(
-            f"rebuild: cannot recover composition recipe for entry "
-            f"{source_entry.name!r}: {e}. Only bind()/ExprComposer-produced "
-            f"composition shapes can be rebuilt."
-        ) from e
-
-    fresh = _translate_recipe(recipe, to_catalog, remap).expr
-
-    if expr.op() is composition_root:
-        return fresh
-    return _splice(expr, old=composition_root, new=fresh.op())
+            f"rebuild: schema changed for tag {tag_node.metadata.get('tag')!r} — "
+            f"old: {dict(old_schema.items())}, new: {dict(new_schema.items())}. "
+            "Remove and re-add the entry manually under current code."
+        )
 
 
-def _translate_recipe(recipe, to_catalog, remap):
-    """Remap recipe's source and transforms into to_catalog entries.
-
-    Pins the source alias explicitly: if the original recipe had
-    alias=None, ``_make_source_tag`` would fall back to
-    ``entry.aliases[0]``, whose ordering is not guaranteed stable
-    across catalogs. Capturing the source's first alias here makes
-    the rebuilt source tag's ``alias`` metadata independent of
-    aliases-list ordering drift.
-    """
-    from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
-
-    def lookup(old_name):
-        new_name = _translate(old_name, remap)
-        if new_name not in to_catalog.list():
-            raise RuntimeError(
-                f"rebuild: recipe references {old_name!r} which has not been "
-                f"rebuilt in target (translated to {new_name!r}). This indicates "
-                f"a non-topological op ordering or a reference to an entry "
-                f"outside the source catalog."
-            )
-        return to_catalog.get_catalog_entry(new_name)
-
-    new_source = lookup(recipe.source.name)
-    pinned_alias = recipe.alias
-    if pinned_alias is None and new_source.aliases:
-        pinned_alias = new_source.aliases[0].alias
-
-    return ExprComposer(
-        source=new_source,
-        transforms=tuple(lookup(t.name) for t in recipe.transforms),
-        code=recipe.code,
-        alias=pinned_alias,
-    )
+def _splice_or_return(expr, *, old, new):
+    if expr.op() is old:
+        return new
+    return _splice(expr, old=old, new=new.op())
 
 
 def _splice(expr, *, old, new):
@@ -134,10 +202,8 @@ def _splice(expr, *, old, new):
     `replace_nodes` rebuilds every parent of `old` with `new` as its
     child, so any parent validator that checks schema/type compatibility
     (e.g. builder tags that pre-computed schema-dependent metadata) will
-    reject a mismatched substitution. This holds by construction for
-    bind()-produced composition recovered via ExprComposer — a future
-    composition shape with schema-transforming outer wrappers would need
-    a different splice strategy.
+    reject a mismatched substitution. Schema preservation is enforced by
+    :func:`_assert_schema_preserved` before calling this function.
     """
     from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
@@ -239,6 +305,15 @@ def _changed_paths(commit):
     return {diff.b_path or diff.a_path for diff in parent.diff(commit)}
 
 
+_CATALOG_PREFIXES = tuple(f"{infix.value}/" for infix in CatalogInfix)
+
+
+def _is_catalog_path(path):
+    if path == CATALOG_YAML_NAME:
+        return True
+    return any(path.startswith(prefix) for prefix in _CATALOG_PREFIXES)
+
+
 @frozen
 class InitCatalog:
     """First commit: bare repo initialization."""
@@ -250,7 +325,15 @@ class InitCatalog:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         pass
 
     @staticmethod
@@ -276,7 +359,15 @@ class AddCatalogYAML:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         pass
 
     @staticmethod
@@ -314,7 +405,15 @@ class AddEntry:
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[add]   {sha}  entry={self.entry_hash}  aliases=[{alias_str}]"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         if not rebuild:
             catalog_entry = from_catalog.get_catalog_entry(self.entry_hash)
             to_catalog.add(
@@ -326,7 +425,18 @@ class AddEntry:
             return
 
         source_entry = from_catalog.get_catalog_entry(self.entry_hash)
-        expr = _rebuild_expr_for_target(source_entry, to_catalog, remap)
+        try:
+            expr = _rebuild_subexpr(
+                source_entry.lazy_expr,
+                from_catalog=from_catalog,
+                to_catalog=to_catalog,
+                remap=remap,
+                on_unrebuilt_builder=on_unrebuilt_builder,
+            )
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"rebuild: failed to rebuild entry {source_entry.name!r}: {e}"
+            ) from e
         new_entry = to_catalog.add(
             expr,
             sync=False,
@@ -372,7 +482,15 @@ class AddAlias:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[alias] {sha}  {self.alias} -> {self.entry_name}"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         entry_name = _translate(self.entry_name, remap) if rebuild else self.entry_name
         to_catalog.add_alias(entry_name, self.alias, sync=False)
 
@@ -413,7 +531,15 @@ class RemoveEntry:
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[rm]    {sha}  entry={self.entry_name}  aliases=[{alias_str}]"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         entry_name = _translate(self.entry_name, remap) if rebuild else self.entry_name
         to_catalog.remove(entry_name, sync=False)
 
@@ -447,7 +573,15 @@ class RemoveAlias:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[rm-a]  {sha}  alias={self.alias}"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         from xorq.catalog.catalog import CatalogAlias  # noqa: PLC0415
 
         CatalogAlias.from_name(self.alias, to_catalog).remove()
@@ -482,14 +616,25 @@ class UnknownOp:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[???]   {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog, *, rebuild=False, remap=None):
+    def do(
+        self,
+        from_catalog,
+        to_catalog,
+        *,
+        rebuild=False,
+        remap=None,
+        on_unrebuilt_builder="raise",
+    ):
         if rebuild:
-            raise RuntimeError(
-                f"Cannot rebuild unknown op at commit {self.hexsha[:8]}: {self.message!r}. "
-                "Rebuild requires all ops be recognized catalog operations."
-            )
+            commit = from_catalog.repo.commit(self.hexsha)
+            if any(_is_catalog_path(p) for p in _changed_paths(commit)):
+                raise RuntimeError(
+                    f"Cannot rebuild unknown op at commit {self.hexsha[:8]}: {self.message!r}. "
+                    "Rebuild requires all ops be recognized catalog operations."
+                )
         patch = from_catalog.repo.git.format_patch("-1", self.hexsha, stdout=True)
-        to_catalog.repo.git.am(input=patch)
+        with _tempfile_patch(patch) as path:
+            to_catalog.repo.git.am(path)
 
     def verify_commit(self, commit):
         pass
@@ -568,6 +713,9 @@ class Replayer:
     from_catalog: object = field()  # Catalog — avoid import-time dep
     verify: bool = field(default=True)
     rebuild: bool = field(default=False)
+    on_unrebuilt_builder: str = field(
+        default="raise", validator=validators.in_(("raise", "warn"))
+    )
 
     @cached_property
     def ops(self) -> tuple[CatalogOp, ...]:
@@ -601,7 +749,13 @@ class Replayer:
                 else nullcontext()
             )
             with ctx:
-                op.do(self.from_catalog, to_catalog, rebuild=self.rebuild, remap=remap)
+                op.do(
+                    self.from_catalog,
+                    to_catalog,
+                    rebuild=self.rebuild,
+                    remap=remap,
+                    on_unrebuilt_builder=self.on_unrebuilt_builder,
+                )
             if isinstance(op, (InitCatalog, AddCatalogYAML)) and preserve_commits:
                 noop_ops.append(op)
         if noop_ops:

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -211,6 +211,15 @@ def _rebuild_subexpr(expr, *, from_catalog, to_catalog, ctx):
         for descendant in walk_nodes((Tag, HashingTag), tag.to_expr()):
             claimed.add(id(descendant))
 
+    assert all(
+        id(a) not in {id(d) for d in walk_nodes((Tag, HashingTag), b.to_expr())}
+        for i, a in enumerate(outermost)
+        for b in outermost[i + 1 :]
+    ), (
+        "walk_nodes yielded a descendant before its ancestor — "
+        "parent-before-descendant order invariant violated"
+    )
+
     for tag in outermost:
         fresh = _rebuild_tag(tag)
         if fresh is None:

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -84,7 +84,7 @@ def _translate(name, remap):
     errors with full provenance. The strict equivalent on the recipe-rebuild
     path is :meth:`ExprComposer.with_inputs_translated`'s ``lookup``.
     """
-    return remap.get(name, name) if remap is not None else name
+    return remap.get(name, name)
 
 
 @contextmanager
@@ -740,6 +740,11 @@ def _rewrite_noop_commits(repo, noop_ops):
                 pass
             raise
     else:
+        if repo.head.is_detached:
+            raise RuntimeError(
+                "replay: cannot rewrite noop commits on a detached HEAD; "
+                "check out a branch in the target catalog before replaying."
+            )
         repo.git.update_ref(f"refs/heads/{repo.active_branch.name}", prev_sha)
 
 

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -17,7 +17,8 @@ import re
 from contextlib import contextmanager
 from functools import cached_property
 
-from attr import field, frozen, validators
+from attr import field, frozen
+from attr.validators import deep_iterable, instance_of, optional
 
 from xorq.catalog.constants import CATALOG_YAML_NAME, CatalogInfix
 
@@ -27,11 +28,11 @@ from xorq.catalog.constants import CATALOG_YAML_NAME, CatalogInfix
 
 @frozen
 class CommitMetadata:
-    sha: str = field(validator=validators.instance_of(str))
-    author_name: str = field(validator=validators.instance_of(str))
-    author_email: str = field(validator=validators.instance_of(str))
-    authored_date: str = field(validator=validators.instance_of(str))
-    committed_date: str = field(validator=validators.instance_of(str))
+    sha: str = field(validator=instance_of(str))
+    author_name: str = field(validator=instance_of(str))
+    author_email: str = field(validator=instance_of(str))
+    authored_date: str = field(validator=instance_of(str))
+    committed_date: str = field(validator=instance_of(str))
 
     @contextmanager
     def git_env(self):
@@ -91,7 +92,7 @@ _RM_ALIAS_RE = re.compile(r"^rm alias: (?P<alias>.+)$")
 def _make_commit_metadata_field():
     return field(
         default=None,
-        validator=validators.optional(validators.instance_of(CommitMetadata)),
+        validator=optional(instance_of(CommitMetadata)),
     )
 
 
@@ -114,7 +115,7 @@ def _changed_paths(commit):
 class InitCatalog:
     """First commit: bare repo initialization."""
 
-    message: str = field(validator=validators.instance_of(str))
+    message: str = field(validator=instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
     def __str__(self):
@@ -140,7 +141,7 @@ class InitCatalog:
 class AddCatalogYAML:
     """Second commit: catalog.yaml creation."""
 
-    message: str = field(validator=validators.instance_of(str))
+    message: str = field(validator=instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
     def __str__(self):
@@ -171,11 +172,11 @@ class AddCatalogYAML:
 class AddEntry:
     """catalog.add(build_dir, aliases=(...))"""
 
-    entry_hash: str = field(validator=validators.instance_of(str))
+    entry_hash: str = field(validator=instance_of(str))
     aliases: tuple[str, ...] = field(
-        validator=validators.deep_iterable(
-            member_validator=validators.instance_of(str),
-            iterable_validator=validators.instance_of(tuple),
+        validator=deep_iterable(
+            member_validator=instance_of(str),
+            iterable_validator=instance_of(tuple),
         )
     )
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
@@ -222,8 +223,8 @@ class AddEntry:
 class AddAlias:
     """catalog.add_alias(entry, alias)"""
 
-    alias: str = field(validator=validators.instance_of(str))
-    entry_name: str = field(validator=validators.instance_of(str))
+    alias: str = field(validator=instance_of(str))
+    entry_name: str = field(validator=instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
     def __str__(self):
@@ -256,11 +257,11 @@ class AddAlias:
 class RemoveEntry:
     """catalog.remove(entry) -- removes entry and its aliases."""
 
-    entry_name: str = field(validator=validators.instance_of(str))
+    entry_name: str = field(validator=instance_of(str))
     aliases: tuple[str, ...] = field(
-        validator=validators.deep_iterable(
-            member_validator=validators.instance_of(str),
-            iterable_validator=validators.instance_of(tuple),
+        validator=deep_iterable(
+            member_validator=instance_of(str),
+            iterable_validator=instance_of(tuple),
         )
     )
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
@@ -296,7 +297,7 @@ class RemoveEntry:
 class RemoveAlias:
     """CatalogAlias.remove()"""
 
-    alias: str = field(validator=validators.instance_of(str))
+    alias: str = field(validator=instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
     def __str__(self):
@@ -330,8 +331,8 @@ class RemoveAlias:
 class UnknownOp:
     """Commit that doesn't match any known catalog operation."""
 
-    message: str = field(validator=validators.instance_of(str))
-    hexsha: str = field(validator=validators.instance_of(str))
+    message: str = field(validator=instance_of(str))
+    hexsha: str = field(validator=instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
     def __str__(self):

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -96,8 +96,10 @@ def _tempfile_patch(patch_text):
     """
     fd, path = tempfile.mkstemp(suffix=".patch")
     try:
-        os.write(fd, patch_text.encode())
-        os.close(fd)
+        try:
+            os.write(fd, patch_text.encode())
+        finally:
+            os.close(fd)
         yield path
     finally:
         os.unlink(path)

--- a/python/xorq/catalog/tests/conftest.py
+++ b/python/xorq/catalog/tests/conftest.py
@@ -21,6 +21,7 @@ from xorq.catalog.catalog import (
 )
 from xorq.catalog.constants import MAIN_BRANCH, CatalogInfix
 from xorq.catalog.expr_utils import build_expr_context_zip
+from xorq.catalog.replay import Replayer
 from xorq.catalog.zip_utils import with_pure_suffix
 from xorq.ibis_yaml.enums import DumpFiles
 from xorq.ibis_yaml.packager import (
@@ -29,6 +30,16 @@ from xorq.ibis_yaml.packager import (
     find_file_upwards,
 )
 from xorq.vendor.ibis.expr import operations as ops
+
+
+def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
+    target = Catalog.from_repo_path(target_path, init=True)
+    Replayer(
+        from_catalog=source_catalog_obj,
+        rebuild=True,
+        on_unrebuilt_builder=on_unrebuilt_builder,
+    ).replay(target)
+    return target
 
 
 # Fake wheel name for tests that construct synthetic archives.

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -1,0 +1,444 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import xorq.api as xo
+from xorq.catalog.backend import GitBackend
+from xorq.catalog.bind import CatalogTag, bind
+from xorq.catalog.catalog import Catalog
+from xorq.catalog.cli import cli
+from xorq.catalog.composer import ExprComposer
+from xorq.catalog.replay import Replayer
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import HashingTag
+from xorq.vendor.ibis.expr import operations as ops
+
+
+@pytest.fixture
+def source_catalog(tmpdir):
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("source-repo"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    source_expr = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    source_entry = catalog.add(source_expr, aliases=("my-source",))
+    unbound = ops.UnboundTable(
+        name="placeholder", schema=source_expr.schema()
+    ).to_expr()
+    transform_expr = unbound.filter(unbound.amount > 0).select("user_id", "amount")
+    transform_entry = catalog.add(transform_expr, aliases=("my-transform",))
+    bound = bind(source_entry, transform_entry)
+    bound_entry = catalog.add(bound, aliases=("bound1",))
+    return catalog, source_entry, transform_entry, bound_entry
+
+
+@pytest.fixture
+def target_path(tmpdir):
+    return Path(tmpdir).joinpath("target-repo")
+
+
+@pytest.fixture
+def saved_registry():
+    """Save and restore the builder handler registry around a test."""
+    import xorq.expr.builders as _builders_mod  # noqa: PLC0415
+    from xorq.expr.builders import _FROM_TAG_NODE_REGISTRY  # noqa: PLC0415
+
+    saved = dict(_FROM_TAG_NODE_REGISTRY)
+    saved_keys = _builders_mod._BUILTIN_KEYS
+    saved_init = _builders_mod._initialized
+    yield
+    _FROM_TAG_NODE_REGISTRY.clear()
+    _FROM_TAG_NODE_REGISTRY.update(saved)
+    _builders_mod._BUILTIN_KEYS = saved_keys
+    _builders_mod._initialized = saved_init
+
+
+def _replay_rebuild(source_catalog_obj, target_path):
+    target = Catalog.from_repo_path(target_path, init=True)
+    Replayer(from_catalog=source_catalog_obj, rebuild=True).replay(target)
+    return target
+
+
+def test_rebuild_produces_consistent_target(source_catalog, target_path):
+    catalog, *_ = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+    assert len(target.list()) == len(catalog.list())
+    assert set(target.list_aliases()) == set(catalog.list_aliases())
+    target.assert_consistency()
+
+
+def test_rebuild_preserves_composed_from_linkage(source_catalog, target_path):
+    catalog, source_entry, transform_entry, bound_entry = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+
+    new_bound = target.get_catalog_entry("bound1", maybe_alias=True)
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+    new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)
+
+    composed_entry_names = {c["entry_name"] for c in new_bound.composed_from}
+    assert new_source.name in composed_entry_names
+    assert new_transform.name in composed_entry_names
+    for name in composed_entry_names:
+        assert name in target.list(), (
+            f"bound composed_from refers to {name} which is not in target"
+        )
+
+
+def test_rebuild_rewrites_remote_expr_not_just_metadata(source_catalog, target_path):
+    catalog, _source, _transform, _bound = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+    new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)
+    new_bound = target.get_catalog_entry("bound1", maybe_alias=True)
+
+    # Strong invariant: the rebuilt expression's recovered recipe references
+    # target entries by name. ExprComposer.from_expr walks HashingTag.metadata
+    # only, so this is independent of RemoteTable.name (gen_name-tainted) and
+    # of remote_expr op identity (which can shift across code versions).
+    recovered = ExprComposer.from_expr(new_bound.lazy_expr, target)
+    assert recovered.source.name == new_source.name
+    assert tuple(t.name for t in recovered.transforms) == (new_transform.name,)
+    assert recovered.code is None
+
+
+def test_rebuild_expr_for_target_returns_input_when_no_catalog_tags(source_catalog):
+    from types import SimpleNamespace  # noqa: PLC0415
+
+    from xorq.catalog.replay import _rebuild_expr_for_target  # noqa: PLC0415
+
+    catalog, _source, _transform, _bound = source_catalog
+    # Stub a minimal source_entry so lazy_expr is a stable object — the
+    # real CatalogEntry.lazy_expr reloads from zip on each access, which
+    # defeats identity comparison.
+    expr = xo.memtable({"x": [1, 2, 3]})
+    stub = SimpleNamespace(lazy_expr=expr, catalog=catalog, name="stub")
+    result = _rebuild_expr_for_target(stub, catalog, remap={})
+    assert result is expr
+
+
+def test_bind_is_hash_deterministic(source_catalog, tmpdir):
+    # Use two separate catalogs: Catalog.add(exist_ok=True) returns None when
+    # an entry already exists, so a second add into the same catalog can't
+    # reveal the hash. Scratch catalogs populated with the same source and
+    # transform will produce matching hashes iff bind() is deterministic.
+    _, source_entry, transform_entry, _ = source_catalog
+    a_cat = Catalog.from_repo_path(Path(tmpdir).joinpath("det-a"), init=True)
+    a_src = a_cat.add(source_entry.lazy_expr)
+    a_tr = a_cat.add(transform_entry.lazy_expr)
+    a = a_cat.add(bind(a_src, a_tr))
+    b_cat = Catalog.from_repo_path(Path(tmpdir).joinpath("det-b"), init=True)
+    b_src = b_cat.add(source_entry.lazy_expr)
+    b_tr = b_cat.add(transform_entry.lazy_expr)
+    b = b_cat.add(bind(b_src, b_tr))
+    assert a.name == b.name, (
+        "bind() is non-deterministic — gen_name is leaking into entry hash"
+    )
+
+
+def test_rebuild_matches_fresh_bind(source_catalog, target_path, tmpdir):
+    catalog, *_ = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+    new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)
+    new_bound = target.get_catalog_entry("bound1", maybe_alias=True)
+
+    # Re-add into a SCRATCH catalog so add()'s exist_ok-collision behavior
+    # cannot mask a name mismatch. Sanity-check that source/transform hash
+    # is content-pure first — otherwise the bind comparison below is moot.
+    # Aliases must match too: _make_source_tag falls back to the first
+    # alias of the source entry, and rebuild pins that alias explicitly.
+    scratch = Catalog.from_repo_path(Path(tmpdir).joinpath("scratch"), init=True)
+    scratch_source = scratch.add(new_source.lazy_expr, aliases=("my-source",))
+    scratch_transform = scratch.add(new_transform.lazy_expr, aliases=("my-transform",))
+    assert scratch_source.name == new_source.name
+    assert scratch_transform.name == new_transform.name
+
+    fresh = bind(scratch_source, scratch_transform)
+    fresh_entry = scratch.add(fresh)
+    assert fresh_entry.name == new_bound.name
+
+
+def test_rebuild_chained_bind_of_bind(tmpdir):
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    source_expr = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    source_entry = catalog.add(source_expr, aliases=("my-source",))
+
+    # First transform keeps schema (filter + select).
+    u1 = ops.UnboundTable(name="p1", schema=source_expr.schema()).to_expr()
+    t1 = u1.filter(u1.amount > 0).select("user_id", "amount")
+    t1_entry = catalog.add(t1, aliases=("t1",))
+
+    # Second transform keeps schema too.
+    u2 = ops.UnboundTable(name="p2", schema=source_expr.schema()).to_expr()
+    t2 = u2.select("user_id", "amount")
+    t2_entry = catalog.add(t2, aliases=("t2",))
+
+    # bound1 = bind(source, t1); bound2 = bind(bound1_as_source, t2) via a
+    # fresh source entry — the interesting case is chained transforms in
+    # one bind() call, which ExprComposer handles as transforms=(t1, t2).
+    bound = bind(source_entry, t1_entry, t2_entry)
+    catalog.add(bound, aliases=("chained",))
+
+    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    new_chained = target.get_catalog_entry("chained", maybe_alias=True)
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+    new_t1 = target.get_catalog_entry("t1", maybe_alias=True)
+    new_t2 = target.get_catalog_entry("t2", maybe_alias=True)
+
+    recovered = ExprComposer.from_expr(new_chained.lazy_expr, target)
+    assert recovered.source.name == new_source.name
+    assert tuple(t.name for t in recovered.transforms) == (new_t1.name, new_t2.name)
+    assert recovered.code is None
+
+
+def test_rebuild_code_only_composition(tmpdir):
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    source_expr = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    source_entry = catalog.add(source_expr, aliases=("my-source",))
+
+    composed = ExprComposer(
+        source=source_entry,
+        code="source.filter(source.amount > 0)",
+    )
+    catalog.add(composed.expr, aliases=("code-only",))
+
+    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    new_code_only = target.get_catalog_entry("code-only", maybe_alias=True)
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+
+    # (a) rebuilt entry has a CODE tag with the expected code metadata
+    code_tags = tuple(
+        ht
+        for ht in walk_nodes(HashingTag, new_code_only.lazy_expr)
+        if ht.metadata.get("tag") == CatalogTag.CODE
+    )
+    assert len(code_tags) == 1
+    assert code_tags[0].metadata["code"] == "source.filter(source.amount > 0)"
+
+    # (b) every catalog-tag entry_name is in target.list()
+    tag_names = {
+        ht.metadata["entry_name"]
+        for ht in walk_nodes(HashingTag, new_code_only.lazy_expr)
+        if ht.metadata.get("tag") in frozenset(CatalogTag)
+        and ht.metadata.get("entry_name")
+    }
+    assert tag_names <= set(target.list())
+
+    # (c) recovered recipe matches
+    recovered = ExprComposer.from_expr(new_code_only.lazy_expr, target)
+    assert recovered.source.name == new_source.name
+    assert recovered.transforms == ()
+    assert recovered.code == "source.filter(source.amount > 0)"
+
+
+def test_rebuild_source_transform_code_composition(source_catalog, target_path):
+    catalog, source_entry, transform_entry, _bound = source_catalog
+
+    composed = ExprComposer(
+        source=source_entry,
+        transforms=(transform_entry,),
+        code="source.select('user_id')",
+    )
+    catalog.add(composed.expr, aliases=("full-recipe",))
+
+    target = _replay_rebuild(catalog, target_path)
+    new_full = target.get_catalog_entry("full-recipe", maybe_alias=True)
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+    new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)
+
+    code_tags = tuple(
+        ht
+        for ht in walk_nodes(HashingTag, new_full.lazy_expr)
+        if ht.metadata.get("tag") == CatalogTag.CODE
+    )
+    assert len(code_tags) == 1
+    assert code_tags[0].metadata["code"] == "source.select('user_id')"
+
+    tag_names = {
+        ht.metadata["entry_name"]
+        for ht in walk_nodes(HashingTag, new_full.lazy_expr)
+        if ht.metadata.get("tag") in frozenset(CatalogTag)
+        and ht.metadata.get("entry_name")
+    }
+    assert tag_names <= set(target.list())
+
+    recovered = ExprComposer.from_expr(new_full.lazy_expr, target)
+    assert recovered.source.name == new_source.name
+    assert tuple(t.name for t in recovered.transforms) == (new_transform.name,)
+    assert recovered.code == "source.select('user_id')"
+
+
+def test_rebuild_preserves_outer_builder_wrapping(tmpdir, saved_registry):
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+    from xorq.expr.relations import Tag  # noqa: PLC0415
+    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_rebuild_builder",),
+            extract_metadata=lambda tag_node: {"type": "test_rebuild_builder"},
+        )
+    )
+
+    # Build a fresh catalog that has no pre-existing bound entry — Tag is
+    # transparent to dask.tokenize, so composed.tag(...) and composed hash
+    # to the same entry name; if bound were pre-added, the Tag-wrapped
+    # expression would collide.
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    source_expr = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    source_entry = catalog.add(source_expr, aliases=("my-source",))
+    unbound = ops.UnboundTable(name="p", schema=source_expr.schema()).to_expr()
+    transform_entry = catalog.add(
+        unbound.filter(unbound.amount > 0).select("user_id", "amount"),
+        aliases=("my-transform",),
+    )
+    composed = bind(source_entry, transform_entry)
+    builder_expr = composed.tag("test_rebuild_builder")
+    catalog.add(builder_expr, aliases=("builder1",))
+
+    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    new_builder = target.get_catalog_entry("builder1", maybe_alias=True)
+    new_source = target.get_catalog_entry("my-source", maybe_alias=True)
+    new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)
+
+    # Outer wrapping preserved.
+    assert new_builder.kind == ExprKind.ExprBuilder
+    outer = new_builder.lazy_expr.op()
+    assert isinstance(outer, Tag)
+    assert outer.metadata["tag"] == "test_rebuild_builder"
+
+    # Inner catalog refs translated. Recover recipe from the inner
+    # composition subtree.
+    inner_root = next(
+        ht
+        for ht in walk_nodes(HashingTag, new_builder.lazy_expr)
+        if ht.metadata.get("tag") in frozenset(CatalogTag)
+    )
+    recovered = ExprComposer.from_expr(inner_root.to_expr(), target)
+    assert recovered.source.name == new_source.name
+    assert tuple(t.name for t in recovered.transforms) == (new_transform.name,)
+
+
+def test_rebuild_pure_builder_without_catalog_refs(tmpdir, saved_registry):
+    import dask.base  # noqa: PLC0415
+
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_pure_builder",),
+            extract_metadata=lambda tag_node: {"type": "test_pure_builder"},
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    # Pure builder: no catalog refs anywhere.
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_pure_builder")
+    catalog.add(raw, aliases=("pure",))
+
+    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    new_pure = target.get_catalog_entry("pure", maybe_alias=True)
+    src_entry = catalog.get_catalog_entry("pure", maybe_alias=True)
+    # Same content hash — no catalog-tag rewrite should have run.
+    assert dask.base.tokenize(new_pure.lazy_expr) == dask.base.tokenize(
+        src_entry.lazy_expr
+    )
+    assert new_pure.name == src_entry.name
+
+
+def test_rebuild_raises_when_recipe_references_unknown_target_entry(
+    source_catalog, target_path
+):
+    from xorq.catalog.replay import AddEntry  # noqa: PLC0415
+
+    catalog, _source, _transform, bound_entry = source_catalog
+    target = Catalog.from_repo_path(target_path, init=True)
+
+    op = AddEntry(entry_hash=bound_entry.name, aliases=("bound1",))
+    with pytest.raises(RuntimeError, match="not been rebuilt in target"):
+        op.do(catalog, target, rebuild=True, remap={})
+
+
+def test_rebuild_preserves_aliases(source_catalog, target_path):
+    catalog, *_ = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+
+    for alias in ("my-source", "my-transform", "bound1"):
+        target_entry = target.get_catalog_entry(alias, maybe_alias=True)
+        assert target_entry.exists()
+        assert target_entry.name in target.list()
+
+
+def test_remove_entry_translates_via_remap(tmpdir):
+    from xorq.catalog.replay import RemoveEntry  # noqa: PLC0415
+
+    src_repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    src = Catalog(backend=GitBackend(repo=src_repo))
+    tgt_repo = Catalog.init_repo_path(Path(tmpdir).joinpath("tgt"))
+    tgt = Catalog(backend=GitBackend(repo=tgt_repo))
+    entry = tgt.add(xo.memtable({"a": [1]}))
+
+    op = RemoveEntry(entry_name="OLD_HASH", aliases=())
+    op.do(src, tgt, rebuild=True, remap={"OLD_HASH": entry.name})
+    assert entry.name not in tgt.list()
+
+
+def test_add_alias_translates_via_remap(tmpdir):
+    from xorq.catalog.replay import AddAlias  # noqa: PLC0415
+
+    src_repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    src = Catalog(backend=GitBackend(repo=src_repo))
+    tgt_repo = Catalog.init_repo_path(Path(tmpdir).joinpath("tgt"))
+    tgt = Catalog(backend=GitBackend(repo=tgt_repo))
+    entry = tgt.add(xo.memtable({"a": [1]}))
+
+    op = AddAlias(alias="my-alias", entry_name="OLD_HASH")
+    op.do(src, tgt, rebuild=True, remap={"OLD_HASH": entry.name})
+    resolved = tgt.get_catalog_entry("my-alias", maybe_alias=True)
+    assert resolved.name == entry.name
+
+
+def test_rebuild_preserves_commit_metadata(source_catalog, target_path):
+    catalog, *_ = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+
+    src_commits = list(catalog.repo.iter_commits(reverse=True))
+    tgt_commits = list(target.repo.iter_commits(reverse=True))
+    assert len(src_commits) == len(tgt_commits)
+    for s, t in zip(src_commits, tgt_commits):
+        assert s.author.name == t.author.name
+        assert s.author.email == t.author.email
+        assert s.authored_date == t.authored_date
+
+
+def test_rebuild_raises_on_unknown_op(tmpdir):
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    (Path(repo.working_dir) / "stray.txt").write_text("hello")
+    repo.index.add(["stray.txt"])
+    repo.index.commit("not a catalog op")
+
+    target_path = Path(tmpdir).joinpath("target")
+    target = Catalog.from_repo_path(target_path, init=True)
+    replayer = Replayer(from_catalog=catalog, rebuild=True, verify=False)
+    with pytest.raises(RuntimeError, match="Cannot rebuild unknown op"):
+        replayer.replay(target)
+
+
+def test_cli_replay_rebuild_smoke(source_catalog, tmpdir):
+    catalog, *_ = source_catalog
+    target = str(Path(tmpdir).joinpath("cli-target"))
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--path", str(catalog.repo_path), "replay", target, "--rebuild"],
+    )
+    assert result.exit_code == 0, result.output
+    target_catalog = Catalog.from_repo_path(target, init=False)
+    target_catalog.assert_consistency()
+    assert set(target_catalog.list_aliases()) == set(catalog.list_aliases())

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from click.testing import CliRunner
 
@@ -68,6 +69,20 @@ def test_rebuild_produces_consistent_target(source_catalog, target_path):
     assert len(target.list()) == len(catalog.list())
     assert set(target.list_aliases()) == set(catalog.list_aliases())
     target.assert_consistency()
+
+    # Execution-equivalence: every aliased entry must execute to the same data
+    # in source and target. Structural checks (schema/recipe/hash) can line up
+    # while a broken rebuild silently returns wrong rows.
+    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
+
+    for alias in ("my-source", "my-transform", "bound1"):
+        src_entry = catalog.get_catalog_entry(alias, maybe_alias=True)
+        tgt_entry = target.get_catalog_entry(alias, maybe_alias=True)
+        if src_entry.kind == ExprKind.UnboundExpr:
+            continue
+        src_df = src_entry.expr.execute().reset_index(drop=True)
+        tgt_df = tgt_entry.expr.execute().reset_index(drop=True)
+        pd.testing.assert_frame_equal(src_df, tgt_df)
 
 
 def test_rebuild_preserves_composed_from_linkage(source_catalog, target_path):
@@ -459,6 +474,71 @@ def test_rebuild_applies_non_catalog_unknown_op(tmpdir):
     assert (Path(target.repo.working_dir) / "README.md").read_text() == "hello"
 
 
+def test_rebuild_applies_changed_reemit(tmpdir, saved_registry):
+    """Simulate a code change between catalog.add and replay --rebuild: swap
+    the handler's reemit so it produces a different (but schema-compatible)
+    expression. Asserts (a) the rebuilt entry has a new hash, (b) ``remap``
+    records the old → new translation, (c) the rebuilt entry executes with
+    the v2 behavior. This is the only test where rebuild is not a no-op.
+    """
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    # v1 handler: reemit keeps every row with amount > 0.
+    def reemit_v1(tag_node, rebuild_subexpr):
+        inner = tag_node.parent.to_expr()
+        return inner.filter(inner.amount > 0)
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("cc_handler",),
+            extract_metadata=lambda tag_node: {"type": "cc_handler"},
+            reemit=reemit_v1,
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    raw = xo.memtable({"user_id": [1, 2, 3], "amount": [-5.0, 10.0, 20.0]})
+    src_entry = catalog.add(raw.tag("cc_handler"), aliases=("cc",))
+
+    # Swap to v2 — same schema, different filter (> 15 instead of > 0).
+    def reemit_v2(tag_node, rebuild_subexpr):
+        inner = tag_node.parent.to_expr()
+        return inner.filter(inner.amount > 15)
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("cc_handler",),
+            extract_metadata=lambda tag_node: {"type": "cc_handler"},
+            reemit=reemit_v2,
+        ),
+        override=True,
+    )
+
+    # Drive replay manually so we can inspect the remap built during rebuild.
+    target_path = Path(tmpdir).joinpath("tgt")
+    target = Catalog.from_repo_path(target_path, init=True)
+    replayer = Replayer(from_catalog=catalog, rebuild=True)
+    remap: dict = {}
+    for op in replayer.ops:
+        op.do(catalog, target, rebuild=True, remap=remap)
+    target.assert_consistency()
+
+    tgt_entry = target.get_catalog_entry("cc", maybe_alias=True)
+
+    # (a) Entry hash changed: the rebuilt zip encodes v2's filter expression,
+    #     not the stored tag wrapper, so md5sum differs from source.
+    assert tgt_entry.name != src_entry.name
+
+    # (b) Remap records the translation, and the translated name is in target.
+    assert remap.get(src_entry.name) == tgt_entry.name
+    assert tgt_entry.name in target.list()
+
+    # (c) Execution reflects v2 behavior: only the single row with amount > 15.
+    result = tgt_entry.expr.execute().reset_index(drop=True)
+    assert list(result["amount"]) == [20.0]
+
+
 def test_cli_replay_rebuild_smoke(source_catalog, tmpdir):
     catalog, *_ = source_catalog
     target = str(Path(tmpdir).joinpath("cli-target"))
@@ -471,3 +551,60 @@ def test_cli_replay_rebuild_smoke(source_catalog, tmpdir):
     target_catalog = Catalog.from_repo_path(target, init=False)
     target_catalog.assert_consistency()
     assert set(target_catalog.list_aliases()) == set(catalog.list_aliases())
+
+
+def test_cli_replay_rebuild_is_not_silently_ignored(tmpdir, saved_registry):
+    """Discriminating CLI test: if ``--rebuild`` were silently dropped, plain
+    replay would copy the source zip byte-for-byte and the target entry's
+    executed output would still match v1 behavior. Rebuild must re-emit the
+    expression under the v2 handler, so the target executes with v2 rows.
+    """
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    def reemit_v1(tag_node, rebuild_subexpr):
+        inner = tag_node.parent.to_expr()
+        return inner.filter(inner.amount > 0)
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("cli_cc_handler",),
+            extract_metadata=lambda tag_node: {"type": "cli_cc_handler"},
+            reemit=reemit_v1,
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    source = Catalog(backend=GitBackend(repo=repo))
+    raw = xo.memtable({"user_id": [1, 2, 3], "amount": [-5.0, 10.0, 20.0]})
+    src_entry = source.add(raw.tag("cli_cc_handler"), aliases=("cli_cc",))
+
+    def reemit_v2(tag_node, rebuild_subexpr):
+        inner = tag_node.parent.to_expr()
+        return inner.filter(inner.amount > 15)
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("cli_cc_handler",),
+            extract_metadata=lambda tag_node: {"type": "cli_cc_handler"},
+            reemit=reemit_v2,
+        ),
+        override=True,
+    )
+
+    target_path = str(Path(tmpdir).joinpath("cli-target"))
+    result = CliRunner().invoke(
+        cli,
+        ["--path", str(source.repo_path), "replay", target_path, "--rebuild"],
+    )
+    assert result.exit_code == 0, result.output
+
+    target_catalog = Catalog.from_repo_path(target_path, init=False)
+    tgt_entry = target_catalog.get_catalog_entry("cli_cc", maybe_alias=True)
+
+    # Under plain replay the target zip equals the source zip, so the target
+    # entry would have src_entry.name. Rebuild must have produced a new zip.
+    assert tgt_entry.name != src_entry.name
+
+    # Execution reflects v2 (amount > 15), not v1 (amount > 0): one row, 20.0.
+    rows = tgt_entry.expr.execute()["amount"].tolist()
+    assert rows == [20.0]

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -52,9 +52,13 @@ def saved_registry():
     _builders_mod._initialized = saved_init
 
 
-def _replay_rebuild(source_catalog_obj, target_path):
+def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
     target = Catalog.from_repo_path(target_path, init=True)
-    Replayer(from_catalog=source_catalog_obj, rebuild=True).replay(target)
+    Replayer(
+        from_catalog=source_catalog_obj,
+        rebuild=True,
+        on_unrebuilt_builder=on_unrebuilt_builder,
+    ).replay(target)
     return target
 
 
@@ -300,7 +304,9 @@ def test_rebuild_preserves_outer_builder_wrapping(tmpdir, saved_registry):
     builder_expr = composed.tag("test_rebuild_builder")
     catalog.add(builder_expr, aliases=("builder1",))
 
-    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    target = _replay_rebuild(
+        catalog, Path(tmpdir).joinpath("tgt"), on_unrebuilt_builder="warn"
+    )
     new_builder = target.get_catalog_entry("builder1", maybe_alias=True)
     new_source = target.get_catalog_entry("my-source", maybe_alias=True)
     new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)
@@ -341,7 +347,9 @@ def test_rebuild_pure_builder_without_catalog_refs(tmpdir, saved_registry):
     raw = xo.memtable({"x": [1, 2, 3]}).tag("test_pure_builder")
     catalog.add(raw, aliases=("pure",))
 
-    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    target = _replay_rebuild(
+        catalog, Path(tmpdir).joinpath("tgt"), on_unrebuilt_builder="warn"
+    )
     new_pure = target.get_catalog_entry("pure", maybe_alias=True)
     src_entry = catalog.get_catalog_entry("pure", maybe_alias=True)
     # Same content hash — no catalog-tag rewrite should have run.
@@ -416,11 +424,13 @@ def test_rebuild_preserves_commit_metadata(source_catalog, target_path):
         assert s.authored_date == t.authored_date
 
 
-def test_rebuild_raises_on_unknown_op(tmpdir):
+def test_rebuild_raises_on_unknown_op_touching_catalog_paths(tmpdir):
     repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
     catalog = Catalog(backend=GitBackend(repo=repo))
-    (Path(repo.working_dir) / "stray.txt").write_text("hello")
-    repo.index.add(["stray.txt"])
+    stray = Path(repo.working_dir) / "entries" / "fake.zip"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    stray.write_text("corrupt")
+    repo.index.add(["entries/fake.zip"])
     repo.index.commit("not a catalog op")
 
     target_path = Path(tmpdir).joinpath("target")
@@ -428,6 +438,25 @@ def test_rebuild_raises_on_unknown_op(tmpdir):
     replayer = Replayer(from_catalog=catalog, rebuild=True, verify=False)
     with pytest.raises(RuntimeError, match="Cannot rebuild unknown op"):
         replayer.replay(target)
+
+
+def test_rebuild_applies_non_catalog_unknown_op(tmpdir):
+    from xorq.catalog.replay import UnknownOp  # noqa: PLC0415
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    (Path(repo.working_dir) / "README.md").write_text("hello")
+    repo.index.add(["README.md"])
+    commit = repo.index.commit("add readme")
+
+    target_path = Path(tmpdir).joinpath("target")
+    target = Catalog.from_repo_path(target_path, init=True)
+    op = UnknownOp(
+        message="add readme",
+        hexsha=commit.hexsha,
+    )
+    op.do(catalog, target, rebuild=True, remap={})
+    assert (Path(target.repo.working_dir) / "README.md").read_text() == "hello"
 
 
 def test_cli_replay_rebuild_smoke(source_catalog, tmpdir):

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -37,22 +37,6 @@ def target_path(tmpdir):
     return Path(tmpdir).joinpath("target-repo")
 
 
-@pytest.fixture
-def saved_registry():
-    """Save and restore the builder handler registry around a test."""
-    import xorq.expr.builders as _builders_mod  # noqa: PLC0415
-    from xorq.expr.builders import _FROM_TAG_NODE_REGISTRY  # noqa: PLC0415
-
-    saved = dict(_FROM_TAG_NODE_REGISTRY)
-    saved_keys = _builders_mod._BUILTIN_KEYS
-    saved_init = _builders_mod._initialized
-    yield
-    _FROM_TAG_NODE_REGISTRY.clear()
-    _FROM_TAG_NODE_REGISTRY.update(saved)
-    _builders_mod._BUILTIN_KEYS = saved_keys
-    _builders_mod._initialized = saved_init
-
-
 def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
     target = Catalog.from_repo_path(target_path, init=True)
     Replayer(
@@ -123,15 +107,18 @@ def test_rebuild_rewrites_remote_expr_not_just_metadata(source_catalog, target_p
 def test_rebuild_expr_for_target_returns_input_when_no_catalog_tags(source_catalog):
     from types import SimpleNamespace  # noqa: PLC0415
 
-    from xorq.catalog.replay import _rebuild_expr_for_target  # noqa: PLC0415
+    from xorq.catalog.replay import (  # noqa: PLC0415
+        RebuildContext,
+        _rebuild_expr_for_target,
+    )
 
     catalog, _source, _transform, _bound = source_catalog
-    # Stub a minimal source_entry so lazy_expr is a stable object — the
+    # Stub a minimal source_entry so lazy_expr is a stable object; the
     # real CatalogEntry.lazy_expr reloads from zip on each access, which
     # defeats identity comparison.
     expr = xo.memtable({"x": [1, 2, 3]})
     stub = SimpleNamespace(lazy_expr=expr, catalog=catalog, name="stub")
-    result = _rebuild_expr_for_target(stub, catalog, remap={})
+    result = _rebuild_expr_for_target(stub, catalog, RebuildContext(rebuild=True))
     assert result is expr
 
 
@@ -150,7 +137,7 @@ def test_bind_is_hash_deterministic(source_catalog, tmpdir):
     b_tr = b_cat.add(transform_entry.lazy_expr)
     b = b_cat.add(bind(b_src, b_tr))
     assert a.name == b.name, (
-        "bind() is non-deterministic — gen_name is leaking into entry hash"
+        "bind() is non-deterministic; gen_name is leaking into entry hash"
     )
 
 
@@ -164,7 +151,7 @@ def test_rebuild_matches_fresh_bind(source_catalog, target_path, tmpdir):
 
     # Re-add into a SCRATCH catalog so add()'s exist_ok-collision behavior
     # cannot mask a name mismatch. Sanity-check that source/transform hash
-    # is content-pure first — otherwise the bind comparison below is moot.
+    # is content-pure first; otherwise the bind comparison below is moot.
     # Aliases must match too: _make_source_tag falls back to the first
     # alias of the source entry, and rebuild pins that alias explicitly.
     scratch = Catalog.from_repo_path(Path(tmpdir).joinpath("scratch"), init=True)
@@ -195,7 +182,7 @@ def test_rebuild_chained_bind_of_bind(tmpdir):
     t2_entry = catalog.add(t2, aliases=("t2",))
 
     # bound1 = bind(source, t1); bound2 = bind(bound1_as_source, t2) via a
-    # fresh source entry — the interesting case is chained transforms in
+    # fresh source entry. The interesting case is chained transforms in
     # one bind() call, which ExprComposer handles as transforms=(t1, t2).
     bound = bind(source_entry, t1_entry, t2_entry)
     catalog.add(bound, aliases=("chained",))
@@ -302,7 +289,7 @@ def test_rebuild_preserves_outer_builder_wrapping(tmpdir, saved_registry):
         )
     )
 
-    # Build a fresh catalog that has no pre-existing bound entry — Tag is
+    # Build a fresh catalog that has no pre-existing bound entry. Tag is
     # transparent to dask.tokenize, so composed.tag(...) and composed hash
     # to the same entry name; if bound were pre-added, the Tag-wrapped
     # expression would collide.
@@ -367,7 +354,7 @@ def test_rebuild_pure_builder_without_catalog_refs(tmpdir, saved_registry):
     )
     new_pure = target.get_catalog_entry("pure", maybe_alias=True)
     src_entry = catalog.get_catalog_entry("pure", maybe_alias=True)
-    # Same content hash — no catalog-tag rewrite should have run.
+    # Same content hash: no catalog-tag rewrite should have run.
     assert dask.base.tokenize(new_pure.lazy_expr) == dask.base.tokenize(
         src_entry.lazy_expr
     )
@@ -377,14 +364,14 @@ def test_rebuild_pure_builder_without_catalog_refs(tmpdir, saved_registry):
 def test_rebuild_raises_when_recipe_references_unknown_target_entry(
     source_catalog, target_path
 ):
-    from xorq.catalog.replay import AddEntry  # noqa: PLC0415
+    from xorq.catalog.replay import AddEntry, RebuildContext  # noqa: PLC0415
 
     catalog, _source, _transform, bound_entry = source_catalog
     target = Catalog.from_repo_path(target_path, init=True)
 
     op = AddEntry(entry_hash=bound_entry.name, aliases=("bound1",))
     with pytest.raises(RuntimeError, match="not been rebuilt in target"):
-        op.do(catalog, target, rebuild=True, remap={})
+        op.do(catalog, target, RebuildContext(rebuild=True))
 
 
 def test_rebuild_preserves_aliases(source_catalog, target_path):
@@ -398,7 +385,7 @@ def test_rebuild_preserves_aliases(source_catalog, target_path):
 
 
 def test_remove_entry_translates_via_remap(tmpdir):
-    from xorq.catalog.replay import RemoveEntry  # noqa: PLC0415
+    from xorq.catalog.replay import RebuildContext, RemoveEntry  # noqa: PLC0415
 
     src_repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
     src = Catalog(backend=GitBackend(repo=src_repo))
@@ -407,12 +394,12 @@ def test_remove_entry_translates_via_remap(tmpdir):
     entry = tgt.add(xo.memtable({"a": [1]}))
 
     op = RemoveEntry(entry_name="OLD_HASH", aliases=())
-    op.do(src, tgt, rebuild=True, remap={"OLD_HASH": entry.name})
+    op.do(src, tgt, RebuildContext(rebuild=True, remap={"OLD_HASH": entry.name}))
     assert entry.name not in tgt.list()
 
 
 def test_add_alias_translates_via_remap(tmpdir):
-    from xorq.catalog.replay import AddAlias  # noqa: PLC0415
+    from xorq.catalog.replay import AddAlias, RebuildContext  # noqa: PLC0415
 
     src_repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
     src = Catalog(backend=GitBackend(repo=src_repo))
@@ -421,7 +408,7 @@ def test_add_alias_translates_via_remap(tmpdir):
     entry = tgt.add(xo.memtable({"a": [1]}))
 
     op = AddAlias(alias="my-alias", entry_name="OLD_HASH")
-    op.do(src, tgt, rebuild=True, remap={"OLD_HASH": entry.name})
+    op.do(src, tgt, RebuildContext(rebuild=True, remap={"OLD_HASH": entry.name}))
     resolved = tgt.get_catalog_entry("my-alias", maybe_alias=True)
     assert resolved.name == entry.name
 
@@ -451,12 +438,12 @@ def test_rebuild_raises_on_unknown_op_touching_catalog_paths(tmpdir):
     target_path = Path(tmpdir).joinpath("target")
     target = Catalog.from_repo_path(target_path, init=True)
     replayer = Replayer(from_catalog=catalog, rebuild=True, verify=False)
-    with pytest.raises(RuntimeError, match="Cannot rebuild unknown op"):
+    with pytest.raises(RuntimeError, match="rebuild: cannot rebuild unknown op"):
         replayer.replay(target)
 
 
 def test_rebuild_applies_non_catalog_unknown_op(tmpdir):
-    from xorq.catalog.replay import UnknownOp  # noqa: PLC0415
+    from xorq.catalog.replay import RebuildContext, UnknownOp  # noqa: PLC0415
 
     repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
     catalog = Catalog(backend=GitBackend(repo=repo))
@@ -470,8 +457,23 @@ def test_rebuild_applies_non_catalog_unknown_op(tmpdir):
         message="add readme",
         hexsha=commit.hexsha,
     )
-    op.do(catalog, target, rebuild=True, remap={})
+    op.do(catalog, target, RebuildContext(rebuild=True))
     assert (Path(target.repo.working_dir) / "README.md").read_text() == "hello"
+
+
+def test_replay_refuses_non_pristine_target(source_catalog, tmpdir):
+    """Replaying into a target that already has its own catalog history would
+    cause `_rewrite_noop_commits` to overwrite unrelated commits with the
+    source's init metadata. Replayer must refuse before any rewriting runs.
+    """
+    catalog, *_ = source_catalog
+    target_path = Path(tmpdir).joinpath("target-with-history")
+    target = Catalog.from_repo_path(target_path, init=True)
+    # Add a real entry to the target so it's no longer pristine.
+    target.add(xo.memtable({"x": [1]}), aliases=("preexisting",))
+
+    with pytest.raises(RuntimeError, match="not pristine"):
+        Replayer(from_catalog=catalog).replay(target)
 
 
 def test_rebuild_applies_changed_reemit(tmpdir, saved_registry):
@@ -501,7 +503,7 @@ def test_rebuild_applies_changed_reemit(tmpdir, saved_registry):
     raw = xo.memtable({"user_id": [1, 2, 3], "amount": [-5.0, 10.0, 20.0]})
     src_entry = catalog.add(raw.tag("cc_handler"), aliases=("cc",))
 
-    # Swap to v2 — same schema, different filter (> 15 instead of > 0).
+    # Swap to v2: same schema, different filter (> 15 instead of > 0).
     def reemit_v2(tag_node, rebuild_subexpr):
         inner = tag_node.parent.to_expr()
         return inner.filter(inner.amount > 15)
@@ -516,12 +518,14 @@ def test_rebuild_applies_changed_reemit(tmpdir, saved_registry):
     )
 
     # Drive replay manually so we can inspect the remap built during rebuild.
+    from xorq.catalog.replay import RebuildContext  # noqa: PLC0415
+
     target_path = Path(tmpdir).joinpath("tgt")
     target = Catalog.from_repo_path(target_path, init=True)
     replayer = Replayer(from_catalog=catalog, rebuild=True)
-    remap: dict = {}
+    ctx = RebuildContext(rebuild=True)
     for op in replayer.ops:
-        op.do(catalog, target, rebuild=True, remap=remap)
+        op.do(catalog, target, ctx)
     target.assert_consistency()
 
     tgt_entry = target.get_catalog_entry("cc", maybe_alias=True)
@@ -531,7 +535,7 @@ def test_rebuild_applies_changed_reemit(tmpdir, saved_registry):
     assert tgt_entry.name != src_entry.name
 
     # (b) Remap records the translation, and the translated name is in target.
-    assert remap.get(src_entry.name) == tgt_entry.name
+    assert ctx.remap.get(src_entry.name) == tgt_entry.name
     assert tgt_entry.name in target.list()
 
     # (c) Execution reflects v2 behavior: only the single row with amount > 15.

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -15,6 +15,8 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.relations import HashingTag
 from xorq.vendor.ibis.expr import operations as ops
 
+from .conftest import _replay_rebuild
+
 
 @pytest.fixture
 def source_catalog(tmpdir):
@@ -35,16 +37,6 @@ def source_catalog(tmpdir):
 @pytest.fixture
 def target_path(tmpdir):
     return Path(tmpdir).joinpath("target-repo")
-
-
-def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
-    target = Catalog.from_repo_path(target_path, init=True)
-    Replayer(
-        from_catalog=source_catalog_obj,
-        rebuild=True,
-        on_unrebuilt_builder=on_unrebuilt_builder,
-    ).replay(target)
-    return target
 
 
 def test_rebuild_produces_consistent_target(source_catalog, target_path):

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -362,6 +362,54 @@ def test_rebuild_pure_builder_without_catalog_refs(tmpdir, saved_registry):
     assert new_pure.name == src_entry.name
 
 
+def test_rebuild_handles_dag_shared_catalog_tag(source_catalog, target_path):
+    """Same catalog-tagged subexpression reached via multiple paths in one
+    rebuild input. ``walk_nodes`` dedupes by node equality and ``claimed``
+    uses identity; ``replace_nodes`` then replaces every occurrence by
+    identity. The contract holds *because* an identity-shared tag is also
+    equality-shared, so both walk-side dedupe and splice-side replacement
+    converge on the same node.
+
+    Note: when source/transform content is unchanged, the rebuilt entry
+    hashes equal the originals (content-addressing). So we can't assert
+    "old names absent"; we assert "every catalog tag in the rebuilt
+    expression resolves to a real target entry, with no orphans."
+    """
+    from xorq.catalog.replay import RebuildContext, _rebuild_subexpr  # noqa: PLC0415
+
+    catalog, *_ = source_catalog
+    _, _, _, bound_entry = source_catalog
+    target = _replay_rebuild(catalog, target_path)
+
+    src_to_tgt = {
+        catalog.get_catalog_entry(
+            alias, maybe_alias=True
+        ).name: target.get_catalog_entry(alias, maybe_alias=True).name
+        for alias in ("my-source", "my-transform", "bound1")
+    }
+
+    # Reference the same loaded bound expression twice so the catalog tag is
+    # reached by both children of the union.
+    bound = bound_entry.lazy_expr
+    shared = bound.filter(bound.amount > 0).union(bound.filter(bound.amount > 1))
+
+    ctx = RebuildContext(rebuild=True, remap=src_to_tgt)
+    rebuilt = _rebuild_subexpr(shared, from_catalog=catalog, to_catalog=target, ctx=ctx)
+
+    rebuilt_tag_names = {
+        ht.metadata.get("entry_name")
+        for ht in walk_nodes(HashingTag, rebuilt)
+        if ht.metadata.get("tag") in frozenset(CatalogTag)
+        and ht.metadata.get("entry_name")
+    }
+    assert rebuilt_tag_names, "expected at least one catalog tag in rebuilt expr"
+    # Every catalog tag in the rebuilt expression points at a real target
+    # entry — no orphan references.
+    assert rebuilt_tag_names <= set(target.list())
+    # The rebuilt expression must still execute (proves no half-spliced state).
+    rebuilt.execute()
+
+
 def test_rebuild_raises_when_recipe_references_unknown_target_entry(
     source_catalog, target_path
 ):

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -123,10 +123,11 @@ def test_rebuild_expr_for_target_returns_input_when_no_catalog_tags(source_catal
 
 
 def test_bind_is_hash_deterministic(source_catalog, tmpdir):
-    # Use two separate catalogs: Catalog.add(exist_ok=True) returns None when
-    # an entry already exists, so a second add into the same catalog can't
-    # reveal the hash. Scratch catalogs populated with the same source and
-    # transform will produce matching hashes iff bind() is deterministic.
+    # Use two separate catalogs: re-adding the same content into one catalog
+    # would raise (exist_ok=False) or no-op against the existing entry, so a
+    # second add can't independently reveal the hash. Scratch catalogs
+    # populated with the same source and transform will produce matching
+    # hashes iff bind() is deterministic.
     _, source_entry, transform_entry, _ = source_catalog
     a_cat = Catalog.from_repo_path(Path(tmpdir).joinpath("det-a"), init=True)
     a_src = a_cat.add(source_entry.lazy_expr)
@@ -612,3 +613,68 @@ def test_cli_replay_rebuild_is_not_silently_ignored(tmpdir, saved_registry):
     # Execution reflects v2 (amount > 15), not v1 (amount > 0): one row, 20.0.
     rows = tgt_entry.expr.execute()["amount"].tolist()
     assert rows == [20.0]
+
+
+def test_rebuild_collision_records_remap_to_existing_entry(tmpdir, saved_registry):
+    """A code change that collapses two source entries to the same content
+    must not crash rebuild and must leave both remap entries pointing at the
+    one surviving target entry. Without the fix, the second AddEntry's
+    `to_catalog.add(...)` returned None and `new_entry.name` raised
+    AttributeError; even patched, an unrecorded remap would break any later
+    AddAlias for the colliding source."""
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    # v1 reemit preserves the parent expression, so distinct source data
+    # produces distinct rebuilt content.
+    def reemit_v1(tag_node, rebuild_subexpr):
+        return tag_node.parent.to_expr()
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("collide_handler",),
+            extract_metadata=lambda tag_node: {"type": "collide_handler"},
+            reemit=reemit_v1,
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    raw_a = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    raw_b = xo.memtable({"user_id": [4, 5, 6], "amount": [40.0, 50.0, 60.0]})
+    src_a = catalog.add(raw_a.tag("collide_handler"), aliases=("ca",))
+    src_b = catalog.add(raw_b.tag("collide_handler"), aliases=("cb",))
+    assert src_a.name != src_b.name  # distinct under v1
+
+    # v2 reemit collapses every input to the same canonical literal. Both
+    # rebuilt entries now share the same content hash.
+    canonical = xo.memtable({"user_id": [0], "amount": [0.0]})
+
+    def reemit_v2(tag_node, rebuild_subexpr):
+        return canonical
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("collide_handler",),
+            extract_metadata=lambda tag_node: {"type": "collide_handler"},
+            reemit=reemit_v2,
+        ),
+        override=True,
+    )
+
+    # Drive replay manually so we can inspect the remap.
+    from xorq.catalog.replay import RebuildContext  # noqa: PLC0415
+
+    target_path = Path(tmpdir).joinpath("tgt")
+    target = Catalog.from_repo_path(target_path, init=True)
+    replayer = Replayer(from_catalog=catalog, rebuild=True)
+    ctx = RebuildContext(rebuild=True)
+    for op in replayer.ops:
+        op.do(catalog, target, ctx)
+    target.assert_consistency()
+
+    tgt_a = target.get_catalog_entry("ca", maybe_alias=True)
+    tgt_b = target.get_catalog_entry("cb", maybe_alias=True)
+    assert tgt_a.name == tgt_b.name
+    assert ctx.remap[src_a.name] == tgt_a.name
+    assert ctx.remap[src_b.name] == tgt_b.name
+    assert {"ca", "cb"} <= set(target.list_aliases())

--- a/python/xorq/catalog/tests/test_replay_rebuild_builders.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild_builders.py
@@ -333,3 +333,62 @@ def test_rebuild_refuses_missing_protocol_silent_passthrough(tmpdir, saved_regis
         and ht.metadata.get("entry_name")
     }
     assert inner_names <= set(target.list())
+
+
+# ---------------------------------------------------------------------------
+# Real FittedPipeline rebuild integration (sklearn-gated)
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_fitted_pipeline_roundtrip_predictions_match(tmpdir):
+    """End-to-end rebuild of a real sklearn FittedPipeline catalog entry.
+
+    Covers the multi-output-builder rebuild path:
+      1. ``FittedPipeline`` is recovered from the PREDICT tag via the builtin
+         ``from_tag_node`` handler.
+      2. Its ``reemit`` method is dispatched by the rebuild driver, which
+         refits the pipeline and re-stamps the tag with fresh kwargs.
+      3. The rebuilt entry executes and produces predictions equal to the
+         source's predictions.
+
+    Without this, the FittedPipeline rebuild path is only covered by dispatch-
+    table string checks; nothing fits a real model and compares outputs.
+    """
+    pytest.importorskip("sklearn")
+    import pandas as pd  # noqa: PLC0415
+    from sklearn.linear_model import LinearRegression  # noqa: PLC0415
+    from sklearn.pipeline import make_pipeline  # noqa: PLC0415
+    from sklearn.preprocessing import StandardScaler  # noqa: PLC0415
+
+    from xorq.expr.ml.pipeline_lib import Pipeline  # noqa: PLC0415
+    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
+
+    train = xo.memtable(
+        {
+            "feature_0": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "feature_1": [5.0, 4.0, 3.0, 2.0, 1.0],
+            "target": [0.0, 1.0, 0.0, 1.0, 0.0],
+        },
+        name="ml_train",
+    )
+    sk_pipe = make_pipeline(StandardScaler(), LinearRegression())
+    pipeline = Pipeline.from_instance(sk_pipe)
+    fitted = pipeline.fit(train, target="target")
+    predict_expr = fitted.predict(train)
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    src_entry = catalog.add(predict_expr, aliases=("preds",))
+    assert src_entry.kind == ExprKind.ExprBuilder
+
+    src_df = src_entry.expr.execute().reset_index(drop=True)
+
+    target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    tgt_entry = target.get_catalog_entry("preds", maybe_alias=True)
+
+    # The rebuilt entry is still an ExprBuilder — the outer PREDICT tag was
+    # preserved (re-emitted with refreshed kwargs), not stripped.
+    assert tgt_entry.kind == ExprKind.ExprBuilder
+
+    tgt_df = tgt_entry.expr.execute().reset_index(drop=True)
+    pd.testing.assert_frame_equal(src_df, tgt_df, check_exact=False)

--- a/python/xorq/catalog/tests/test_replay_rebuild_builders.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild_builders.py
@@ -23,22 +23,6 @@ from xorq.expr.relations import HashingTag
 from xorq.vendor.ibis.expr import operations as ops
 
 
-@pytest.fixture
-def saved_registry():
-    """Save and restore the builder handler registry around a test."""
-    import xorq.expr.builders as _builders_mod  # noqa: PLC0415
-    from xorq.expr.builders import _FROM_TAG_NODE_REGISTRY  # noqa: PLC0415
-
-    saved = dict(_FROM_TAG_NODE_REGISTRY)
-    saved_keys = _builders_mod._BUILTIN_KEYS
-    saved_init = _builders_mod._initialized
-    yield
-    _FROM_TAG_NODE_REGISTRY.clear()
-    _FROM_TAG_NODE_REGISTRY.update(saved)
-    _builders_mod._BUILTIN_KEYS = saved_keys
-    _builders_mod._initialized = saved_init
-
-
 def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
     target = Catalog.from_repo_path(target_path, init=True)
     Replayer(
@@ -49,9 +33,7 @@ def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise
     return target
 
 
-# ---------------------------------------------------------------------------
-# FittedPipeline dispatch-table coverage (no catalog integration needed)
-# ---------------------------------------------------------------------------
+# -- FittedPipeline dispatch-table coverage (no catalog integration needed) --
 
 
 @pytest.mark.parametrize(
@@ -65,16 +47,16 @@ def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise
     ],
 )
 def test_fitted_pipeline_reemit_table_coverage(tag_key_name, method_name):
-    """The reemit dispatch table maps every entry point to a real method."""
+    """Every reemit entry point names a real FittedPipeline method."""
     pytest.importorskip("sklearn")
     from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
     from xorq.expr.ml.pipeline_lib import (  # noqa: PLC0415
-        _FITTED_PIPELINE_REEMIT_METHODS,
+        _FITTED_PIPELINE_REEMIT_TAGS,
         FittedPipeline,
     )
 
     tag_key = FittedPipelineTagKey[tag_key_name]
-    assert _FITTED_PIPELINE_REEMIT_METHODS[tag_key] == method_name
+    assert tag_key in _FITTED_PIPELINE_REEMIT_TAGS
     assert callable(getattr(FittedPipeline, method_name))
 
 
@@ -83,16 +65,14 @@ def test_fitted_pipeline_training_reserved_from_reemit():
     pytest.importorskip("sklearn")
     from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
     from xorq.expr.ml.pipeline_lib import (  # noqa: PLC0415
-        _FITTED_PIPELINE_REEMIT_METHODS,
+        _FITTED_PIPELINE_REEMIT_TAGS,
     )
 
-    assert FittedPipelineTagKey.TRAINING not in _FITTED_PIPELINE_REEMIT_METHODS
-    assert FittedPipelineTagKey.ALL_STEPS not in _FITTED_PIPELINE_REEMIT_METHODS
+    assert FittedPipelineTagKey.TRAINING not in _FITTED_PIPELINE_REEMIT_TAGS
+    assert FittedPipelineTagKey.ALL_STEPS not in _FITTED_PIPELINE_REEMIT_TAGS
 
 
-# ---------------------------------------------------------------------------
-# Protocol dispatch tests using test-only builders (no sklearn / no FittedPipeline)
-# ---------------------------------------------------------------------------
+# -- Protocol dispatch tests using test-only builders (no sklearn / no FittedPipeline) --
 
 
 def test_get_rebuild_dispatch_returns_none_without_handler(saved_registry):
@@ -133,27 +113,30 @@ def test_get_rebuild_dispatch_handler_level_reemit_wins(saved_registry):
     dispatch = get_rebuild_dispatch(raw.op())
     assert callable(dispatch)
     # Calling the dispatch invokes the handler-level reemit, not from_tag_node.
-    dispatch(lambda expr: expr)
+    dispatch(lambda expr: expr, {}, None)
     assert calls["reemit"] == 1
     assert calls["from_tag_node"] == 0
 
 
-def test_get_rebuild_dispatch_single_output_sentinel(saved_registry):
-    """A domain object with with_inputs_translated + expr returns the single-output sentinel."""
+def test_get_rebuild_dispatch_single_output_returns_callable(saved_registry):
+    """A domain object with with_inputs_translated + expr returns a callable
+    that delegates to with_inputs_translated and reads `.expr`."""
     from attr import field, frozen  # noqa: PLC0415
 
     from xorq.expr.builders import (  # noqa: PLC0415
-        _SINGLE_OUTPUT_DISPATCH,
         TagHandler,
         get_rebuild_dispatch,
         register_tag_handler,
     )
+
+    calls = {"with_inputs_translated": 0}
 
     @frozen
     class FakeBuilder:
         tag = field()
 
         def with_inputs_translated(self, remap, to_catalog):
+            calls["with_inputs_translated"] += 1
             return self
 
         @property
@@ -170,10 +153,9 @@ def test_get_rebuild_dispatch_single_output_sentinel(saved_registry):
 
     raw = xo.memtable({"x": [1, 2, 3]}).tag("test_single_out")
     dispatch = get_rebuild_dispatch(raw.op())
-    assert isinstance(dispatch, tuple)
-    sentinel, builder = dispatch
-    assert sentinel == _SINGLE_OUTPUT_DISPATCH
-    assert isinstance(builder, FakeBuilder)
+    assert callable(dispatch)
+    dispatch(lambda expr: expr, {}, None)
+    assert calls["with_inputs_translated"] == 1
 
 
 def test_get_rebuild_dispatch_domain_object_reemit(saved_registry):
@@ -202,7 +184,7 @@ def test_get_rebuild_dispatch_domain_object_reemit(saved_registry):
     raw = xo.memtable({"x": [1, 2, 3]}).tag("test_multi_out")
     dispatch = get_rebuild_dispatch(raw.op())
     assert callable(dispatch)
-    dispatch(lambda expr: expr)
+    dispatch(lambda expr: expr, {}, None)
     assert calls["reemit"] == 1
 
 
@@ -227,9 +209,7 @@ def test_get_rebuild_dispatch_no_protocol_returns_none(saved_registry):
     assert get_rebuild_dispatch(raw.op()) is None
 
 
-# ---------------------------------------------------------------------------
-# Integration tests via catalog rebuild + handler-level reemit
-# ---------------------------------------------------------------------------
+# -- Integration tests via catalog rebuild + handler-level reemit --
 
 
 def test_rebuild_dispatches_handler_level_reemit(tmpdir, saved_registry):
@@ -324,7 +304,7 @@ def test_rebuild_refuses_missing_protocol_silent_passthrough(tmpdir, saved_regis
     assert isinstance(outer, Tag)
     assert outer.metadata["tag"] == "test_bare"
 
-    # Inner catalog refs were translated — same check as the preserves-builder
+    # Inner catalog refs were translated; same check as the preserves-builder
     # test in test_replay_rebuild.py.
     inner_names = {
         ht.metadata["entry_name"]
@@ -335,9 +315,7 @@ def test_rebuild_refuses_missing_protocol_silent_passthrough(tmpdir, saved_regis
     assert inner_names <= set(target.list())
 
 
-# ---------------------------------------------------------------------------
-# Real FittedPipeline rebuild integration (sklearn-gated)
-# ---------------------------------------------------------------------------
+# -- Real FittedPipeline rebuild integration (sklearn-gated) --
 
 
 def test_rebuild_fitted_pipeline_roundtrip_predictions_match(tmpdir):
@@ -386,9 +364,47 @@ def test_rebuild_fitted_pipeline_roundtrip_predictions_match(tmpdir):
     target = _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
     tgt_entry = target.get_catalog_entry("preds", maybe_alias=True)
 
-    # The rebuilt entry is still an ExprBuilder — the outer PREDICT tag was
+    # The rebuilt entry is still an ExprBuilder; the outer PREDICT tag was
     # preserved (re-emitted with refreshed kwargs), not stripped.
     assert tgt_entry.kind == ExprKind.ExprBuilder
 
     tgt_df = tgt_entry.expr.execute().reset_index(drop=True)
     pd.testing.assert_frame_equal(src_df, tgt_df, check_exact=False)
+
+
+def test_rebuild_rejects_fitted_pipeline_with_catalog_training(tmpdir):
+    """When the FittedPipeline's training subtree contains catalog refs,
+    rebuild must refuse rather than silently produce an entry whose model
+    UDF closes over stale source-catalog reads."""
+    pytest.importorskip("sklearn")
+    from sklearn.linear_model import LinearRegression  # noqa: PLC0415
+    from sklearn.pipeline import make_pipeline  # noqa: PLC0415
+    from sklearn.preprocessing import StandardScaler  # noqa: PLC0415
+
+    from xorq.expr.ml.pipeline_lib import Pipeline  # noqa: PLC0415
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+
+    # Build training data through the catalog (training sees a CatalogTag).
+    raw = xo.memtable(
+        {
+            "feature_0": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "feature_1": [5.0, 4.0, 3.0, 2.0, 1.0],
+            "target": [0.0, 1.0, 0.0, 1.0, 0.0],
+        }
+    )
+    raw_entry = catalog.add(raw, aliases=("raw",))
+    unbound = ops.UnboundTable(name="p", schema=raw.schema()).to_expr()
+    identity = catalog.add(unbound.select(*raw.columns), aliases=("identity",))
+    train = bind(raw_entry, identity)
+
+    sk_pipe = make_pipeline(StandardScaler(), LinearRegression())
+    pipeline = Pipeline.from_instance(sk_pipe)
+    fitted = pipeline.fit(train, target="target")
+    predict_expr = fitted.predict(train)
+    catalog.add(predict_expr, aliases=("preds",))
+
+    target = Catalog.from_repo_path(Path(tmpdir).joinpath("tgt"), init=True)
+    with pytest.raises(RuntimeError, match="training subtree contains catalog"):
+        Replayer(from_catalog=catalog, rebuild=True).replay(target)

--- a/python/xorq/catalog/tests/test_replay_rebuild_builders.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild_builders.py
@@ -22,15 +22,7 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.relations import HashingTag
 from xorq.vendor.ibis.expr import operations as ops
 
-
-def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
-    target = Catalog.from_repo_path(target_path, init=True)
-    Replayer(
-        from_catalog=source_catalog_obj,
-        rebuild=True,
-        on_unrebuilt_builder=on_unrebuilt_builder,
-    ).replay(target)
-    return target
+from .conftest import _replay_rebuild
 
 
 # -- FittedPipeline dispatch-table coverage (no catalog integration needed) --

--- a/python/xorq/catalog/tests/test_replay_rebuild_builders.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild_builders.py
@@ -1,0 +1,335 @@
+"""Tests for builder-subtree rebuild (ExprBuilder via TagHandler).
+
+Covers the generalized ``catalog replay --rebuild`` capability that
+delegates to registered ``TagHandler`` rebuild protocols:
+  1. Handler-level ``reemit`` callable.
+  2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
+     (multi-output builders like ``FittedPipeline``).
+  3. Domain-object ``with_inputs_translated`` + ``expr`` (single-output
+     builders like ``ExprComposer``).
+"""
+
+from pathlib import Path
+
+import pytest
+
+import xorq.api as xo
+from xorq.catalog.backend import GitBackend
+from xorq.catalog.bind import CatalogTag, bind
+from xorq.catalog.catalog import Catalog
+from xorq.catalog.replay import Replayer
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import HashingTag
+from xorq.vendor.ibis.expr import operations as ops
+
+
+@pytest.fixture
+def saved_registry():
+    """Save and restore the builder handler registry around a test."""
+    import xorq.expr.builders as _builders_mod  # noqa: PLC0415
+    from xorq.expr.builders import _FROM_TAG_NODE_REGISTRY  # noqa: PLC0415
+
+    saved = dict(_FROM_TAG_NODE_REGISTRY)
+    saved_keys = _builders_mod._BUILTIN_KEYS
+    saved_init = _builders_mod._initialized
+    yield
+    _FROM_TAG_NODE_REGISTRY.clear()
+    _FROM_TAG_NODE_REGISTRY.update(saved)
+    _builders_mod._BUILTIN_KEYS = saved_keys
+    _builders_mod._initialized = saved_init
+
+
+def _replay_rebuild(source_catalog_obj, target_path, on_unrebuilt_builder="raise"):
+    target = Catalog.from_repo_path(target_path, init=True)
+    Replayer(
+        from_catalog=source_catalog_obj,
+        rebuild=True,
+        on_unrebuilt_builder=on_unrebuilt_builder,
+    ).replay(target)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# FittedPipeline dispatch-table coverage (no catalog integration needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tag_key_name, method_name",
+    [
+        ("TRANSFORM", "transform"),
+        ("PREDICT", "predict"),
+        ("PREDICT_PROBA", "predict_proba"),
+        ("DECISION_FUNCTION", "decision_function"),
+        ("FEATURE_IMPORTANCES", "feature_importances"),
+    ],
+)
+def test_fitted_pipeline_reemit_table_coverage(tag_key_name, method_name):
+    """The reemit dispatch table maps every entry point to a real method."""
+    pytest.importorskip("sklearn")
+    from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
+    from xorq.expr.ml.pipeline_lib import (  # noqa: PLC0415
+        _FITTED_PIPELINE_REEMIT_METHODS,
+        FittedPipeline,
+    )
+
+    tag_key = FittedPipelineTagKey[tag_key_name]
+    assert _FITTED_PIPELINE_REEMIT_METHODS[tag_key] == method_name
+    assert callable(getattr(FittedPipeline, method_name))
+
+
+def test_fitted_pipeline_training_reserved_from_reemit():
+    """TRAINING and ALL_STEPS are interior tags, not reemit entry points."""
+    pytest.importorskip("sklearn")
+    from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
+    from xorq.expr.ml.pipeline_lib import (  # noqa: PLC0415
+        _FITTED_PIPELINE_REEMIT_METHODS,
+    )
+
+    assert FittedPipelineTagKey.TRAINING not in _FITTED_PIPELINE_REEMIT_METHODS
+    assert FittedPipelineTagKey.ALL_STEPS not in _FITTED_PIPELINE_REEMIT_METHODS
+
+
+# ---------------------------------------------------------------------------
+# Protocol dispatch tests using test-only builders (no sklearn / no FittedPipeline)
+# ---------------------------------------------------------------------------
+
+
+def test_get_rebuild_dispatch_returns_none_without_handler(saved_registry):
+    from xorq.expr.builders import get_rebuild_dispatch  # noqa: PLC0415
+
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("no_such_handler")
+    assert get_rebuild_dispatch(raw.op()) is None
+
+
+def test_get_rebuild_dispatch_handler_level_reemit_wins(saved_registry):
+    """When TagHandler.reemit is set, it's used without calling from_tag_node."""
+    from xorq.expr.builders import (  # noqa: PLC0415
+        TagHandler,
+        get_rebuild_dispatch,
+        register_tag_handler,
+    )
+
+    calls = {"reemit": 0, "from_tag_node": 0}
+
+    def handler_reemit(tag_node, rebuild_subexpr):
+        calls["reemit"] += 1
+        return tag_node.parent.to_expr()
+
+    def from_tag_node(tag_node):
+        calls["from_tag_node"] += 1
+        return object()
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_handler_reemit",),
+            extract_metadata=lambda tag_node: {"type": "test_handler_reemit"},
+            from_tag_node=from_tag_node,
+            reemit=handler_reemit,
+        )
+    )
+
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_handler_reemit")
+    dispatch = get_rebuild_dispatch(raw.op())
+    assert callable(dispatch)
+    # Calling the dispatch invokes the handler-level reemit, not from_tag_node.
+    dispatch(lambda expr: expr)
+    assert calls["reemit"] == 1
+    assert calls["from_tag_node"] == 0
+
+
+def test_get_rebuild_dispatch_single_output_sentinel(saved_registry):
+    """A domain object with with_inputs_translated + expr returns the single-output sentinel."""
+    from attr import field, frozen  # noqa: PLC0415
+
+    from xorq.expr.builders import (  # noqa: PLC0415
+        _SINGLE_OUTPUT_DISPATCH,
+        TagHandler,
+        get_rebuild_dispatch,
+        register_tag_handler,
+    )
+
+    @frozen
+    class FakeBuilder:
+        tag = field()
+
+        def with_inputs_translated(self, remap, to_catalog):
+            return self
+
+        @property
+        def expr(self):
+            return self.tag.parent.to_expr()
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_single_out",),
+            extract_metadata=lambda tag_node: {"type": "test_single_out"},
+            from_tag_node=lambda tag_node: FakeBuilder(tag=tag_node),
+        )
+    )
+
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_single_out")
+    dispatch = get_rebuild_dispatch(raw.op())
+    assert isinstance(dispatch, tuple)
+    sentinel, builder = dispatch
+    assert sentinel == _SINGLE_OUTPUT_DISPATCH
+    assert isinstance(builder, FakeBuilder)
+
+
+def test_get_rebuild_dispatch_domain_object_reemit(saved_registry):
+    """A domain object with a reemit method returns a callable."""
+    from xorq.expr.builders import (  # noqa: PLC0415
+        TagHandler,
+        get_rebuild_dispatch,
+        register_tag_handler,
+    )
+
+    calls = {"reemit": 0}
+
+    class FakeBuilder:
+        def reemit(self, tag_node, rebuild_subexpr):
+            calls["reemit"] += 1
+            return tag_node.parent.to_expr()
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_multi_out",),
+            extract_metadata=lambda tag_node: {"type": "test_multi_out"},
+            from_tag_node=lambda tag_node: FakeBuilder(),
+        )
+    )
+
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_multi_out")
+    dispatch = get_rebuild_dispatch(raw.op())
+    assert callable(dispatch)
+    dispatch(lambda expr: expr)
+    assert calls["reemit"] == 1
+
+
+def test_get_rebuild_dispatch_no_protocol_returns_none(saved_registry):
+    """A domain object with neither reemit nor with_inputs_translated returns None."""
+    from xorq.expr.builders import (  # noqa: PLC0415
+        TagHandler,
+        get_rebuild_dispatch,
+        register_tag_handler,
+    )
+
+    class Bare:
+        pass
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_bare",),
+            from_tag_node=lambda tag_node: Bare(),
+        )
+    )
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_bare")
+    assert get_rebuild_dispatch(raw.op()) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via catalog rebuild + handler-level reemit
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_dispatches_handler_level_reemit(tmpdir, saved_registry):
+    """End-to-end: handler-level reemit on a catalog entry gets invoked."""
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    calls = {"handler_reemit": 0}
+
+    def handler_reemit(tag_node, rebuild_subexpr):
+        calls["handler_reemit"] += 1
+        return tag_node.parent.to_expr().tag("test_handler_reemit")
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_handler_reemit",),
+            extract_metadata=lambda tag_node: {"type": "test_handler_reemit"},
+            reemit=handler_reemit,
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_handler_reemit")
+    catalog.add(raw, aliases=("hre",))
+
+    _replay_rebuild(catalog, Path(tmpdir).joinpath("tgt"))
+    assert calls["handler_reemit"] >= 1
+
+
+def test_rebuild_refuses_schema_change(tmpdir, saved_registry):
+    """Builder reemit that returns a schema-different expression is refused."""
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    def bad_reemit(tag_node, rebuild_subexpr):
+        return xo.memtable({"completely": [1], "different": [2]})
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_schema_change",),
+            extract_metadata=lambda tag_node: {"type": "test_schema_change"},
+            reemit=bad_reemit,
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    raw = xo.memtable({"x": [1, 2, 3]}).tag("test_schema_change")
+    entry = catalog.add(raw, aliases=("schematest",))
+
+    target = Catalog.from_repo_path(Path(tmpdir).joinpath("tgt"), init=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        Replayer(from_catalog=catalog, rebuild=True).replay(target)
+    message = str(excinfo.value)
+    assert entry.name in message
+    assert "schema changed" in message
+
+
+def test_rebuild_refuses_missing_protocol_silent_passthrough(tmpdir, saved_registry):
+    """When the outer handler returns a bare object with no protocol, the tag
+    is treated as non-rebuildable: the inner catalog composition is still
+    rebuilt (by the driver's outermost-first walk), and the outer tag
+    passes through on the rebuilt subtree."""
+    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
+
+    class Bare:
+        pass
+
+    register_tag_handler(
+        TagHandler(
+            tag_names=("test_bare",),
+            from_tag_node=lambda tag_node: Bare(),
+        )
+    )
+
+    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    source_expr = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    source_entry = catalog.add(source_expr, aliases=("src",))
+    unbound = ops.UnboundTable(name="p", schema=source_expr.schema()).to_expr()
+    transform_entry = catalog.add(unbound.select("user_id", "amount"), aliases=("tx",))
+    composed = bind(source_entry, transform_entry).tag("test_bare")
+    catalog.add(composed, aliases=("bare_entry",))
+
+    target = _replay_rebuild(
+        catalog, Path(tmpdir).joinpath("tgt"), on_unrebuilt_builder="warn"
+    )
+    new_bare = target.get_catalog_entry("bare_entry", maybe_alias=True)
+
+    from xorq.expr.relations import Tag  # noqa: PLC0415
+
+    outer = new_bare.lazy_expr.op()
+    assert isinstance(outer, Tag)
+    assert outer.metadata["tag"] == "test_bare"
+
+    # Inner catalog refs were translated — same check as the preserves-builder
+    # test in test_replay_rebuild.py.
+    inner_names = {
+        ht.metadata["entry_name"]
+        for ht in walk_nodes(HashingTag, new_bare.lazy_expr)
+        if ht.metadata.get("tag") in frozenset(CatalogTag)
+        and ht.metadata.get("entry_name")
+    }
+    assert inner_names <= set(target.list())

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -71,7 +71,9 @@ def bfs(node):
 
 
 def walk_nodes(node_types, expr):
-    """DFS walk yielding matching nodes in parent-before-descendant order.
+    """DFS walk yielding matching nodes in parent-before-descendant order
+    for tree-shaped expressions; shared (DAG) nodes may appear before a
+    non-matching ancestor.
 
     Callers (e.g. ``_rebuild_subexpr``) depend on ancestors appearing before
     their descendants.  Changing traversal strategy (BFS, reverse, etc.) will

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -71,7 +71,12 @@ def bfs(node):
 
 
 def walk_nodes(node_types, expr):
-    # TODO should this function use an ordered set
+    """DFS walk yielding matching nodes in parent-before-descendant order.
+
+    Callers (e.g. ``_rebuild_subexpr``) depend on ancestors appearing before
+    their descendants.  Changing traversal strategy (BFS, reverse, etc.) will
+    break that invariant.
+    """
     visited = set()
     to_visit = [to_node(expr)]
     result = ()

--- a/python/xorq/conftest.py
+++ b/python/xorq/conftest.py
@@ -6,6 +6,27 @@ import pandas as pd
 import pytest
 
 import xorq.api as xo
+from xorq.expr.builders import _FROM_TAG_NODE_REGISTRY
+
+
+@pytest.fixture
+def saved_registry():
+    """Snapshot the builder ``TagHandler`` registry around a test.
+
+    Tests that call ``register_tag_handler`` mutate process-global state in
+    ``xorq.expr.builders``; this fixture restores that state afterward so
+    tests don't leak handlers into each other or into builtin lookups.
+    """
+    import xorq.expr.builders as _builders_mod  # noqa: PLC0415
+
+    saved = dict(_FROM_TAG_NODE_REGISTRY)
+    saved_keys = _builders_mod._BUILTIN_KEYS
+    saved_init = _builders_mod._initialized
+    yield
+    _FROM_TAG_NODE_REGISTRY.clear()
+    _FROM_TAG_NODE_REGISTRY.update(saved)
+    _builders_mod._BUILTIN_KEYS = saved_keys
+    _builders_mod._initialized = saved_init
 
 
 # ensure registration of numpy and pandas objects for tokenization purposes

--- a/python/xorq/expr/builders/__init__.py
+++ b/python/xorq/expr/builders/__init__.py
@@ -54,6 +54,7 @@ class TagHandler:
     from_tag_node: Optional[Callable] = field(
         default=None, validator=optional(is_callable())
     )
+    reemit: Optional[Callable] = field(default=None, validator=optional(is_callable()))
 
     def __attrs_post_init__(self):
         if not self.tag_names:
@@ -159,6 +160,48 @@ def extract_builder_metadata(tag_node):
     if handler.extract_metadata is not None:
         return handler.extract_metadata(tag_node)
     return {"type": tag_name}
+
+
+_SINGLE_OUTPUT_DISPATCH = "single_output"
+
+
+def get_rebuild_dispatch(tag_node):
+    """Return a rebuild dispatch for *tag_node*, or ``None``.
+
+    Dispatch order:
+      1. Handler-level ``reemit`` callable (e.g., BSL-shape builders whose
+         ``from_tag_node`` does not carry the full recipe).
+      2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
+         (multi-output builders like ``FittedPipeline``).
+      3. Domain-object ``with_inputs_translated(remap, to_catalog)`` +
+         ``expr`` (single-output builders like ``ExprComposer``).
+
+    Returns
+    -------
+    callable | tuple | None
+        - ``callable(rebuild_subexpr) -> Expr`` for paths 1 and 2.
+        - ``(_SINGLE_OUTPUT_DISPATCH, builder)`` sentinel for path 3; the
+          driver must supply ``remap`` / ``to_catalog``.
+        - ``None`` when no handler matches or no rebuild path is available.
+    """
+    registry = _get_from_tag_node_registry()
+    handler = registry.get(tag_node.metadata.get("tag"))
+    if handler is None:
+        return None
+    if callable(handler.reemit):
+        return lambda rebuild_subexpr: handler.reemit(tag_node, rebuild_subexpr)
+    if handler.from_tag_node is None:
+        return None
+    builder = handler.from_tag_node(tag_node)
+    if builder is None:
+        return None
+    if callable(getattr(builder, "reemit", None)):
+        return lambda rebuild_subexpr: builder.reemit(tag_node, rebuild_subexpr)
+    if callable(getattr(builder, "with_inputs_translated", None)) and hasattr(
+        builder, "expr"
+    ):
+        return (_SINGLE_OUTPUT_DISPATCH, builder)
+    return None
 
 
 def _resolve_builder_from_tag(expr):

--- a/python/xorq/expr/builders/__init__.py
+++ b/python/xorq/expr/builders/__init__.py
@@ -1,19 +1,23 @@
-"""from_tag_node registry — recover domain objects from expression tags.
+"""from_tag_node registry: recover domain objects from expression tags.
 
 An ExprBuilder is an expression whose tags carry domain-specific metadata.
 Handlers are ``TagHandler`` instances that declare their ``tag_names`` and
-provide:
+provide one or more of these optional callbacks:
 
-- ``extract_metadata(tag_node) → dict`` — sidecar metadata for the catalog
-- ``from_tag_node(tag_node) → object``  — recover a live domain object
+- ``extract_metadata(tag_node) -> dict``: sidecar metadata for the catalog.
+- ``from_tag_node(tag_node) -> object``: recover a live domain object.
+- ``reemit(tag_node, rebuild_subexpr) -> Expr``: handler-level rebuild hook,
+  used by ``catalog replay --rebuild`` and dispatched by
+  :func:`get_rebuild_dispatch`.
 
-Both callbacks are optional (but at least one is required).  If only
-``from_tag_node`` is provided, a minimal metadata dict ``{"type": tag_name}``
-is generated automatically.
+At least one of ``extract_metadata`` or ``from_tag_node`` is required.  If
+only ``from_tag_node`` is provided, a minimal metadata dict
+``{"type": tag_name}`` is generated automatically. ``reemit`` is purely
+opt-in.
 
 Built-in handlers (ML pipeline) are declared in ``_builtin_handlers()``.
 Third-party packages register via the ``"xorq.from_tag_node"`` entry point
-group — the loaded object must be a ``TagHandler``.
+group; the loaded object must be a ``TagHandler``.
 
 Entry point example (pyproject.toml)::
 
@@ -162,11 +166,8 @@ def extract_builder_metadata(tag_node):
     return {"type": tag_name}
 
 
-_SINGLE_OUTPUT_DISPATCH = "single_output"
-
-
 def get_rebuild_dispatch(tag_node):
-    """Return a rebuild dispatch for *tag_node*, or ``None``.
+    """Return a rebuild dispatch callable for *tag_node*, or ``None``.
 
     Dispatch order:
       1. Handler-level ``reemit`` callable (e.g., BSL-shape builders whose
@@ -176,31 +177,40 @@ def get_rebuild_dispatch(tag_node):
       3. Domain-object ``with_inputs_translated(remap, to_catalog)`` +
          ``expr`` (single-output builders like ``ExprComposer``).
 
-    Returns
-    -------
-    callable | tuple | None
-        - ``callable(rebuild_subexpr) -> Expr`` for paths 1 and 2.
-        - ``(_SINGLE_OUTPUT_DISPATCH, builder)`` sentinel for path 3; the
-          driver must supply ``remap`` / ``to_catalog``.
-        - ``None`` when no handler matches or no rebuild path is available.
+    All three paths are normalized to a single calling convention:
+    ``dispatch(rebuild_subexpr, remap, to_catalog) -> Expr``. Closures
+    for paths 1 and 2 ignore ``remap``/``to_catalog`` (their reemit
+    method recurses through ``rebuild_subexpr`` instead); the closure
+    for path 3 ignores ``rebuild_subexpr`` (``with_inputs_translated``
+    walks the recipe directly). The driver passes all three regardless.
+
+    Returns ``None`` when no handler matches or no rebuild path is available.
     """
     registry = _get_from_tag_node_registry()
     handler = registry.get(tag_node.metadata.get("tag"))
     if handler is None:
         return None
     if callable(handler.reemit):
-        return lambda rebuild_subexpr: handler.reemit(tag_node, rebuild_subexpr)
+        return lambda rebuild_subexpr, remap, to_catalog: handler.reemit(
+            tag_node, rebuild_subexpr
+        )
     if handler.from_tag_node is None:
         return None
     builder = handler.from_tag_node(tag_node)
     if builder is None:
         return None
     if callable(getattr(builder, "reemit", None)):
-        return lambda rebuild_subexpr: builder.reemit(tag_node, rebuild_subexpr)
+        return lambda rebuild_subexpr, remap, to_catalog: builder.reemit(
+            tag_node, rebuild_subexpr
+        )
     if callable(getattr(builder, "with_inputs_translated", None)) and hasattr(
         builder, "expr"
     ):
-        return (_SINGLE_OUTPUT_DISPATCH, builder)
+        return (
+            lambda rebuild_subexpr, remap, to_catalog: builder.with_inputs_translated(
+                remap, to_catalog
+            ).expr
+        )
     return None
 
 

--- a/python/xorq/expr/builders/tests/test_builders.py
+++ b/python/xorq/expr/builders/tests/test_builders.py
@@ -38,21 +38,6 @@ from xorq.vendor.ibis.expr.types.core import (
 
 
 @pytest.fixture
-def saved_registry():
-    """Save and restore the handler registry around a test."""
-    import xorq.expr.builders as _builders_mod  # noqa: PLC0415
-
-    saved = dict(_FROM_TAG_NODE_REGISTRY)
-    saved_keys = _builders_mod._BUILTIN_KEYS
-    saved_init = _builders_mod._initialized
-    yield
-    _FROM_TAG_NODE_REGISTRY.clear()
-    _FROM_TAG_NODE_REGISTRY.update(saved)
-    _builders_mod._BUILTIN_KEYS = saved_keys
-    _builders_mod._initialized = saved_init
-
-
-@pytest.fixture
 def con():
     return xo.connect()
 

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -961,6 +961,17 @@ class Pipeline:
         return self.__class__.from_instance(remapped)
 
 
+_FITTED_PIPELINE_REEMIT_METHODS: dict[FittedPipelineTagKey, str] = {
+    FittedPipelineTagKey.TRANSFORM: "transform",
+    FittedPipelineTagKey.PREDICT: "predict",
+    FittedPipelineTagKey.PREDICT_PROBA: "predict_proba",
+    FittedPipelineTagKey.DECISION_FUNCTION: "decision_function",
+    FittedPipelineTagKey.FEATURE_IMPORTANCES: "feature_importances",
+}
+# ALL_STEPS and TRAINING are interior tags stamped as side-effects of
+# Pipeline.fit — not reemit entry points.
+
+
 @frozen
 class FittedPipeline:
     fitted_steps = field(
@@ -1015,6 +1026,40 @@ class FittedPipeline:
         if not pipeline_tags:
             raise ValueError("No FittedPipeline tag found on expr")
         return cls.from_tag_node(pipeline_tags[0])
+
+    def reemit(self, tag_node, rebuild_subexpr):
+        """Re-emit *tag_node*'s subtree under current code.
+
+        Refits the pipeline on the rebuilt training subtree so the
+        outer tag's ``training_hash`` and step kwargs refresh, rebuilds
+        catalog subtrees inside the tag's parent (so inner Reads
+        resolve to the target catalog's files), and re-stamps the outer
+        pipeline tag on the rebuilt parent with fresh kwargs from the
+        refitted pipeline.
+
+        The internal transform/predict expression structure is
+        preserved — we do not re-invoke the response method, since the
+        original predict/transform input is not recoverable from the
+        tag subtree alone.
+        """
+        tag_key = FittedPipelineTagKey(tag_node.metadata["tag"])
+        if tag_key not in _FITTED_PIPELINE_REEMIT_METHODS:
+            raise RuntimeError(
+                f"rebuild: FittedPipeline tag {tag_key!r} is not a reemit entry point"
+            )
+
+        new_training = rebuild_subexpr(self.expr)
+        refitted = self.pipeline.fit(
+            new_training,
+            features=self.fitted_steps[0].features,
+            target=self.fitted_steps[0].target,
+            cache=self.fitted_steps[0].cache,
+        )
+        new_parent = rebuild_subexpr(tag_node.parent.to_expr())
+        new_kwargs = refitted.get_tag_kwargs(tag_key) | refitted.get_tag_kwargs(
+            FittedPipelineTagKey.ALL_STEPS
+        )
+        return new_parent.tag(str(tag_key), **new_kwargs)
 
     @property
     def pipeline(self):

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -961,15 +961,17 @@ class Pipeline:
         return self.__class__.from_instance(remapped)
 
 
-_FITTED_PIPELINE_REEMIT_METHODS: dict[FittedPipelineTagKey, str] = {
-    FittedPipelineTagKey.TRANSFORM: "transform",
-    FittedPipelineTagKey.PREDICT: "predict",
-    FittedPipelineTagKey.PREDICT_PROBA: "predict_proba",
-    FittedPipelineTagKey.DECISION_FUNCTION: "decision_function",
-    FittedPipelineTagKey.FEATURE_IMPORTANCES: "feature_importances",
-}
 # ALL_STEPS and TRAINING are interior tags stamped as side-effects of
-# Pipeline.fit — not reemit entry points.
+# Pipeline.fit, not reemit entry points.
+_FITTED_PIPELINE_REEMIT_TAGS: frozenset[FittedPipelineTagKey] = frozenset(
+    {
+        FittedPipelineTagKey.TRANSFORM,
+        FittedPipelineTagKey.PREDICT,
+        FittedPipelineTagKey.PREDICT_PROBA,
+        FittedPipelineTagKey.DECISION_FUNCTION,
+        FittedPipelineTagKey.FEATURE_IMPORTANCES,
+    }
+)
 
 
 @frozen
@@ -1038,14 +1040,46 @@ class FittedPipeline:
         refitted pipeline.
 
         The internal transform/predict expression structure is
-        preserved — we do not re-invoke the response method, since the
+        preserved; we do not re-invoke the response method, since the
         original predict/transform input is not recoverable from the
         tag subtree alone.
         """
+        from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
+        from xorq.expr.relations import HashingTag  # noqa: PLC0415
+
         tag_key = FittedPipelineTagKey(tag_node.metadata["tag"])
-        if tag_key not in _FITTED_PIPELINE_REEMIT_METHODS:
+        if tag_key not in _FITTED_PIPELINE_REEMIT_TAGS:
             raise RuntimeError(
                 f"rebuild: FittedPipeline tag {tag_key!r} is not a reemit entry point"
+            )
+
+        # Refuse rebuild when the training subtree itself contains catalog
+        # refs. The model UDFs in `tag_node.parent` close over the original
+        # training expression via `computed_kwargs_expr`, and rebuild_subexpr
+        # only translates Reads it can reach by graph walk; it does not
+        # descend into UDF closures. So if we proceed:
+        #   - new_training would be the catalog-translated training expr,
+        #   - refitted's tag_kwargs would advertise a fresh training_hash,
+        #   - but the model UDF inside new_parent would still reference the
+        #     OLD training expression (whose Reads point at source-catalog
+        #     paths that may not exist in the target).
+        # The result is silent provenance/execution divergence. Doing this
+        # correctly requires recursively rebuilding inside ScalarUDF
+        # closures, punted to a follow-up.
+        catalog_tags = frozenset(CatalogTag)
+        training_catalog_tags = tuple(
+            n
+            for n in walk_nodes((HashingTag,), self.expr)
+            if n.metadata.get("tag") in catalog_tags
+        )
+        if training_catalog_tags:
+            raise RuntimeError(
+                "rebuild: FittedPipeline whose training subtree contains "
+                "catalog references is not yet supported. Model UDFs close "
+                "over the original training expression and rebuild_subexpr "
+                "does not descend into UDF closures, so the rebuilt entry "
+                "would fit on the translated training data but still "
+                "reference the source catalog's reads at execution time."
             )
 
         new_training = rebuild_subexpr(self.expr)

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -961,8 +961,6 @@ class Pipeline:
         return self.__class__.from_instance(remapped)
 
 
-# ALL_STEPS and TRAINING are interior tags stamped as side-effects of
-# Pipeline.fit, not reemit entry points.
 _FITTED_PIPELINE_REEMIT_TAGS: frozenset[FittedPipelineTagKey] = frozenset(
     {
         FittedPipelineTagKey.TRANSFORM,

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -1080,6 +1080,12 @@ class FittedPipeline:
                 "reference the source catalog's reads at execution time."
             )
 
+        # Asymmetry note: the catalog-refs guard above only walks `self.expr`
+        # (training), but rebuild *does* translate catalog refs in the predict
+        # input — that subtree is reached via `tag_node.parent` and rebuilt by
+        # the `rebuild_subexpr` call below. Training is the path that's
+        # unreachable through the graph walk (it's bound into the model UDF
+        # closure), which is why it's the one we refuse rather than translate.
         new_training = rebuild_subexpr(self.expr)
         refitted = self.pipeline.fit(
             new_training,


### PR DESCRIPTION
## Summary

Add `catalog replay --rebuild` to regenerate catalog entries under current code, plus supporting infrastructure for builder-aware rebuild.

> Split out of this PR (do not block on; can land independently):
> - Annex `fileprefix` namespacing → #1895
> - Tokenize-tolerant `normalize_read` via `read_path` → #1917
> - `Profile.validate_con_name` informative error → #1914
> - Downstream BSL CI workflow → #1915

### `replay --rebuild` core (`replay.py`, `composer.py`)
- Rebuild mode loads each entry's `lazy_expr`, rewrites `HashingTag` catalog refs via a remap dict keyed by old entry hash, and re-adds the fresh expr to the target so new hashes reflect current `build_metadata`
- `ExprComposer.with_inputs_translated(remap, to_catalog)` performs the recipe translation: source + transforms get rewritten to the target catalog's entries, `code` is preserved byte-for-byte, alias is pinned to the source-side selection
- `AddAlias` / `RemoveEntry` translate entry names via the same remap; `UnknownOp` inspects changed paths and raises only when catalog-managed paths are touched — non-catalog patches (e.g. README, scripts) are applied via `format-patch`/`am`
- Preserves source commit metadata (author, email, timestamps) — initial commits created by `Catalog.from_repo_path(init=True)` are rewritten via `git commit-tree` so `authored_date` matches the source. The post-rewrite `git rebase --onto` and the `UnknownOp` `git am` paths abort cleanly on failure rather than leaving the target catalog mid-rebase / mid-am.
- `_rewrite_noop_commits` refuses on a detached HEAD with an actionable error rather than letting `active_branch.name` raise a confusing `TypeError`.

### Builder-aware rebuild (`builders/__init__.py`, `pipeline_lib.py`)
- `TagHandler` gains an optional `reemit` field; `get_rebuild_dispatch` picks handler-level `reemit`, then domain-object `reemit(tag_node, rebuild_subexpr)` (multi-output, e.g. `FittedPipeline`), then `with_inputs_translated(remap, to_catalog) + .expr` (single-output, e.g. `ExprComposer`)
- `_rebuild_subexpr` collects all outermost rebuildable tags in one pass and splices each — so a builder subtree with parallel catalog compositions (e.g. training + predict input) gets every composition rebuilt
- Registered builder tags with no rebuild protocol raise `RuntimeError` by default; pass `on_unrebuilt_builder="warn"` to `Replayer` (or `_rebuild_subexpr` directly) to downgrade to a warning and pass through unchanged
- `FittedPipeline.reemit` refits on rebuilt training data, refreshing `training_hash` and step kwargs, and re-stamps the outer pipeline tag. Refuses (rather than silently producing stale UDFs) when the training subtree itself contains catalog refs, since model UDFs close over the original training expression and `rebuild_subexpr` does not descend into UDF closures.
- Schema-preservation is enforced per splice

### CLI (`cli.py`)
- `catalog replay <target> --rebuild` flag wired through Click

### API change (`catalog.py`)
- `CatalogAddition` now returns a `CatalogEntry` on the existing-entry branch (previously `None`). Required by `AddEntry.do` to access `new_entry.name` for remap recording on rebuild. The one in-tree caller affected is `cli compose`, which now uses `catalog.contains(name)` before `add()` to detect collisions instead of testing the return value.

## Test plan

- [x] `test_replay_rebuild.py` — 20 tests covering consistent target, composed_from linkage, expr rewrite, hash determinism, fresh-bind match, chained bind, code-only/full-recipe composition, outer builder wrapping, pure builder passthrough, alias preservation, remap translation, commit metadata preservation, unknown-op error, non-catalog unknown-op passthrough, content-collision remap, DAG-shared catalog tag, CLI smoke (rebuild and discriminating-vs-replay)
- [x] `test_replay_rebuild_builders.py` — 10 tests covering FittedPipeline reemit table coverage, training reservation, rebuild dispatch (handler-level, domain-object, single-output, no-protocol raise), handler-level reemit integration, schema-change refusal, missing-protocol passthrough, real-sklearn FittedPipeline roundtrip, catalog-training refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)