### PR TITLE
docs: add Agentic workflows section with preview stubs

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -31,6 +31,8 @@ website:
         text: "Get started"
       - href: tutorials/ml_tutorials/split_data_for_training.qmd
         text: "Tutorials"
+      - href: agentic_workflows/index.qmd
+        text: "Agentic workflows"
       - href: guides/data_workflows/read_write_production_data.qmd
         text: "Guides"
       - href: concepts/understanding_xorq/overview.qmd
@@ -86,6 +88,19 @@ website:
             # - href: tutorials/analytics_tutorials/use_window_functions.qmd
             - href: tutorials/analytics_tutorials/work_with_schemas.qmd
 
+    - id: agentic-workflows
+      title: "Agentic workflows"
+      collapse-level: 1
+      pinned: true
+      contents:
+        - href: agentic_workflows/index.qmd
+          text: "Overview"
+        - href: agentic_workflows/faa_semantic_layer.qmd
+          text: "Semantic layer (FAA)"
+        - href: agentic_workflows/build_your_own_agent.qmd
+          text: "Build your own data agent"
+        - href: agentic_workflows/mcp_for_analysts.qmd
+          text: "MCP for data analysts"
 
     - id: guides
       title: "Guides"

--- a/docs/agentic_workflows/build_your_own_agent.qmd
+++ b/docs/agentic_workflows/build_your_own_agent.qmd
@@ -1,0 +1,29 @@
+---
+title: "Build your own data agent"
+description: "Skeleton for writing a domain-specific data agent against the xorq catalog, using Python and your framework of choice."
+status: "preview"
+draft: true
+---
+
+::: {.callout-warning}
+**Preview — not yet written.** This tutorial is a placeholder for a walkthrough of building a custom data agent on top of xorq.
+:::
+
+## What this tutorial will cover
+
+Not every agentic workflow belongs in Claude Code or an IDE. Teams often want a **domain-specific agent** — one that knows the shape of their data, speaks their business vocabulary, and runs unattended inside a product or pipeline.
+
+This tutorial will show how to build such an agent against the xorq catalog: how to expose catalog entries as tools, how to ground the agent in existing expressions, and how to let it write new expressions that land back in the catalog as reviewable commits.
+
+## Intended outline
+
+1. **The agent surface** — what a data agent actually needs: a schema view of the catalog, a way to compose new expressions, a way to execute and return results.
+2. **Wiring xorq to your agent framework** — a minimal example using pydantic-ai (or equivalent) with the catalog as a tool surface.
+3. **Grounding the agent** — catalog search as the first step of every turn; preferring existing entries over new computation.
+4. **Writing back** — new expressions land as catalog entries, versioned and reviewable, not as ephemeral outputs.
+5. **Guardrails** — input validation, lineage checks, and human-in-the-loop review before writes become permanent.
+
+## Related
+
+- [Agentic workflows overview](index.qmd)
+- [MCP for data analysts](mcp_for_analysts.qmd) — the turnkey version of this pattern

--- a/docs/agentic_workflows/faa_semantic_layer.qmd
+++ b/docs/agentic_workflows/faa_semantic_layer.qmd
@@ -1,0 +1,36 @@
+---
+title: "Agents and the semantic layer: FAA flights on xorq"
+description: "Build a business semantic layer over the FAA on-time performance dataset and let agents query it through xorq expressions."
+status: "preview"
+draft: true
+---
+
+::: {.callout-warning}
+**Preview — not yet written.** This tutorial is an outline. The worked example lives in Hussain's head; the writeup is pending. TODO: **research BSL** — what's the current standard for expressing a semantic layer (Cube, dbt semantic layer, Malloy, LookML), and which primitive does xorq want to expose to agents?
+:::
+
+## What this tutorial will cover
+
+An agent can only reason about data as well as the vocabulary it's given. Give it raw flight records and it writes brittle SQL against column names it half-understands. Give it a **semantic layer** — named dimensions, measures, and relationships with known join paths — and it composes correct answers on the first try.
+
+This tutorial walks through building a minimal business semantic layer (BSL) on top of the FAA on-time performance dataset, registering it as xorq catalog entries, and letting an agent answer operational questions against it.
+
+## Intended outline
+
+1. **The dataset** — FAA BTS on-time performance (flights, carriers, airports). Why it's a good semantic-layer testbed: stable schema, well-known entities, questions a human analyst would actually ask.
+2. **Without a semantic layer** — let an agent loose on the raw CSVs. Watch it guess at column meanings (`DEP_DELAY` vs `DEP_DELAY_NEW`), miscount cancellations, double-count diverted flights.
+3. **Modeling the BSL** — entities (Flight, Carrier, Airport, Route), measures (on-time rate, avg delay, cancellation rate), dimensions (origin region, time of day, carrier size). TODO: **research BSL** conventions here — what shape does xorq want this to take in the catalog?
+4. **Registering the layer as xorq expressions** — each measure becomes a named, typed catalog entry with its aggregation logic baked in. Each dimension becomes a reusable grouping.
+5. **The agent with the semantic layer** — same agent, same prompts, now composing against named measures instead of raw columns. Show the accuracy delta.
+6. **What this generalizes to** — the BSL pattern isn't FAA-specific. Any domain with stable entities and analyst-style questions benefits from this shape.
+
+## Open questions
+
+- What's the minimum viable BSL primitive in xorq? Is it just a naming convention over existing expressions, or a new catalog entry type?
+- How does the BSL interact with input-addressed caching — do measure definitions become cache keys?
+- How does an agent *discover* the semantic layer? Through catalog search, an MCP resource, or a dedicated skill?
+
+## Related
+
+- [Orientation Over Reasoning](https://xorq.dev/blog/orientation-over-reasoning/) — the DABStep result that motivates this direction.
+- [Getting started with the xorq Claude plugin](recon_import.qmd) — the opposite end of the spectrum: no schema, agent discovers it.

--- a/docs/agentic_workflows/index.qmd
+++ b/docs/agentic_workflows/index.qmd
@@ -1,0 +1,22 @@
+---
+title: "Agentic workflows"
+description: "Tutorials for building and using xorq with AI agents — from unstructured data discovery to semantic layers and composable tools."
+---
+
+xorq is a **context engine for data agents**. It gives agents a persistent, typed, queryable surface to build on — one where expressions carry lineage, caching is input-addressed, and the catalog is shared memory across sessions.
+
+The tutorials below walk through different axes of agentic work with xorq: turning raw files into catalog entries, layering meaning on structured data, composing reusable tools, and exposing the catalog to analyst-facing agents.
+
+## Tutorials
+
+- [**Unstructured data with Claude**](#) — Use the xorq Claude plugin and `recon-import` to turn a directory of CSVs into a typed, versioned catalog in a few prompts. *(Preview — plugin not yet published.)*
+- [**Semantic layer with xorq (FAA)**](faa_semantic_layer.qmd) — Build a business semantic layer over the FAA on-time performance dataset so agents reason about *flights* and *carriers*, not raw columns. *(Preview — outline only.)*
+- [**Composing reusable tools**](#) — How to publish a catalog entry so other agents (and humans) can compose on it without re-deriving your work. *(Preview.)*
+- [**Build your own data agent**](build_your_own_agent.qmd) — Skeleton for writing a domain-specific data agent against the xorq catalog. *(Preview.)*
+- [**MCP for data analysts**](mcp_for_analysts.qmd) — The xorq MCP server as an analyst-facing endpoint — natural-language questions over the catalog. *(Preview.)*
+
+## Why agents need xorq
+
+Agents that write pandas against raw files produce answers that can't be verified, reused, or built on. Every session starts from zero. Give an agent a catalog of typed expressions with known schemas and join keys, and accuracy goes up while token spend goes down — the catalog routes reasoning through pre-computed structure instead of asking the model to re-derive it.
+
+See [Orientation Over Reasoning](https://xorq.dev/blog/orientation-over-reasoning/) for the benchmark result that motivates this direction: Haiku + catalog (85%) outperforms Sonnet baseline (75%) on DABStep.

--- a/docs/agentic_workflows/mcp_for_analysts.qmd
+++ b/docs/agentic_workflows/mcp_for_analysts.qmd
@@ -1,0 +1,29 @@
+---
+title: "MCP for data analysts"
+description: "Expose the xorq catalog as an MCP server so analyst-facing agents can answer natural-language questions against governed data."
+status: "preview"
+draft: true
+---
+
+::: {.callout-warning}
+**Preview — not yet written.** This tutorial is a placeholder for the analyst-facing MCP workflow.
+:::
+
+## What this tutorial will cover
+
+A data analyst doesn't want to write expressions. They want to ask a question in their own language and get an answer they can trust. The xorq MCP server exposes the catalog as an MCP-native tool surface, so any MCP-capable agent (Claude Desktop, Cursor, a custom harness) can search, compose, and execute catalog entries on the analyst's behalf.
+
+This tutorial will walk through standing up the MCP server against an existing catalog, connecting it to an agent, and asking questions that get answered by composing known-good expressions rather than generating SQL from scratch.
+
+## Intended outline
+
+1. **Why MCP** — the analyst-facing surface for a governed catalog. Agents get tools, analysts get answers, the catalog stays the source of truth.
+2. **Standing up the server** — `xorq mcp serve` against your catalog; what the default tool surface exposes (search, describe, execute, lineage).
+3. **Connecting Claude Desktop** — the five-line config change; verifying the catalog shows up as a tool.
+4. **The analyst experience** — example questions over a sample catalog (retail, flights, whatever the reference dataset ends up being); the agent's tool-call sequence; where the answers come from.
+5. **Governance and limits** — read-only mode, row-level filters, audit trails. What an analyst *can't* do through MCP by default.
+
+## Related
+
+- [Build your own data agent](build_your_own_agent.qmd) — the bespoke version of this pattern
+- [Build an MCP tool](/tutorials/ai_tutorials/build_an_mcp_tool.qmd) — the existing tutorial on building MCP tools with xorq


### PR DESCRIPTION
## Summary

- Adds a new **Agentic workflows** top-level section to the docs, mirroring the "context engine for data agents" messaging from [xorq-website PR 25](https://github.com/xorq-labs/xorq-website/pull/25).
- Wires a navbar entry + a dedicated sidebar into `_quarto.yml` — additive only, nothing moved or renamed.
- Lands four starter files: an overview `index.qmd` and three preview stubs (FAA semantic layer, Build your own data agent, MCP for analysts). Each stub outlines what the tutorial will cover so Hussain and others can fill them in incrementally.

The FAA stub includes a **research BSL** TODO marker for Hussain — the worked example lives in his head and the writeup needs a scoping pass.

## What's intentionally not in this PR

- **Claude plugin tutorial** (`recon_import.qmd`) — lives in [xorq-website PR 25](https://github.com/xorq-labs/xorq-website/pull/25); belongs here once the plugin is published. Not yet wired into the sidebar.
- **Composition tutorial** — real content, will land in a follow-up.
- Touching the existing `index.qmd` / `introduction.qmd` messaging — separate PR.

## Test plan

- [ ] `quarto preview docs` renders without errors
- [ ] "Agentic workflows" appears in the navbar between Tutorials and Guides
- [ ] Clicking the navbar entry lands on the overview page
- [ ] Sidebar shows all four entries; each one loads
- [ ] Preview callouts render visibly on the three stub pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)