### PR TITLE
fix(catalog): deterministic catalog entry zip bytes

### DIFF
--- a/python/xorq/catalog/zip_utils.py
+++ b/python/xorq/catalog/zip_utils.py
@@ -40,13 +40,25 @@ def test_zip(zip_path):
 
 @contextmanager
 def make_zip_context(build_dir):
+    # Determinism: fixed mtime, sorted iteration, fixed permissions. Two
+    # builds of the same expression with identical member bytes must produce
+    # byte-identical zip archives, so downstream content-addressed storage
+    # (git-annex, etc.) dedups them.
     path_prefix = (build_dir := Path(build_dir)).parent
+    fixed_date_time = (1980, 1, 1, 0, 0, 0)
+    fixed_external_attr = 0o644 << 16
     with tempfile.TemporaryDirectory() as td:
         zip_path = Path(td).joinpath(build_dir.name).with_suffix(PREFERRED_SUFFIX)
         with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-            for p in build_dir.rglob("*"):
+            for p in sorted(build_dir.rglob("*")):
                 if p.is_file():
-                    zf.write(p, arcname=p.relative_to(path_prefix))
+                    info = zipfile.ZipInfo(
+                        filename=str(p.relative_to(path_prefix)),
+                        date_time=fixed_date_time,
+                    )
+                    info.compress_type = zipfile.ZIP_DEFLATED
+                    info.external_attr = fixed_external_attr
+                    zf.writestr(info, p.read_bytes())
         yield zip_path
 
 

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -420,6 +420,13 @@ def normalize_read(read):
             tpls = _normalize_path_stat(
                 path, **{k: v for k, v in read_kwargs.items() if k != "hash_path"}
             )
+        elif not pathlib.Path(path).is_absolute() and path == read_kwargs.get(
+            "read_path"
+        ):
+            # Build-bundled Read whose hash_path was rewritten to the relative
+            # read_path for deterministic YAML (see common.py register_node).
+            # The filename is already a content hash, so use it directly.
+            tpls = (("build-relative-path", path),)
         elif (path := pathlib.Path(path)).exists():
             tpls = read.normalize_method(path)
         else:

--- a/python/xorq/ibis_yaml/common.py
+++ b/python/xorq/ibis_yaml/common.py
@@ -114,11 +114,18 @@ class Registry:
         op_name = node_dict.get("op", "unknown").lower()
         node_ref = f"@{op_name}_{node_hash[: config.hash_length]}"
         node_dict_with_hash = freeze(node_dict | {"snapshot_hash": node_hash})
-        if isinstance(node, Read) and "memtables" in dict(node.read_kwargs):
+        if isinstance(node, Read) and "read_path" in dict(node.read_kwargs):
+            # Reads whose parquet was materialized into the build bundle carry
+            # a build-relative `read_path`. The absolute `hash_path` assigned
+            # at build time embeds the tmpdir root, so serializing it verbatim
+            # would make expr.yaml bytes non-deterministic across rebuilds.
+            # The loader (ExprLoader.deferred_reads_to_memtables) overwrites
+            # hash_path with expr_path.joinpath(read_path) anyway, so rewriting
+            # the stored value to the relative read_path is lossless.
             from xorq.common.utils.node_utils import update_read_kwargs  # noqa: PLC0415
 
             old_read_kwargs = node_dict_with_hash["read_kwargs"]
-            new_path = Path("memtables", dict(old_read_kwargs)["hash_path"].name)
+            new_path = Path(dict(old_read_kwargs)["read_path"])
             modified_read_kwargs = update_read_kwargs(
                 old_read_kwargs, (("hash_path", new_path),)
             )


### PR DESCRIPTION
## Summary

Two sources of non-determinism made `catalog.add(expr)` produce a different zip on every run for the same expression, plus a downstream crash when UDF closures contained Read nodes with the newly-relative paths. After this change, two runs of a catalog addition produce byte-identical zips and normalize correctly.

### 1. `expr.yaml` leaked the build tempdir prefix

`read_kwargs.hash_path` was serialized as the absolute build-time path, e.g. `/tmp/tmpXXXX/<hash>/database_tables/...`. The existing rewrite in `Registry.register_node` only fired for `InMemoryTable` memtables (gated on `"memtables" in read_kwargs`), so `database_table` Reads leaked the tempdir prefix.

Fix: gate on `"read_path" in read_kwargs` (the builder-materialized marker introduced by ADR-0006) and set `hash_path = Path(read_path)`. Lossless because `ExprLoader.deferred_reads_to_memtables` overwrites `hash_path` with `expr_path.joinpath(read_path)` at load time whenever `read_path` is present.

### 2. Zip member mtimes came from the filesystem

`make_zip_context` used `zf.write(p, arcname=...)`, which captures each member's mtime and permissions. Switched to `zf.writestr(ZipInfo(..., date_time=(1980,1,1,0,0,0)), bytes)` with `external_attr=0o644<<16` and sorted `rglob` output for stable ordering.

### 3. `normalize_read` crashed on relative build-relative paths

The deterministic YAML serialization rewrites `hash_path` to a relative build-relative path for all Read nodes. When a UDF's pickled closure contains a Read, `deferred_reads_to_memtables` can't resolve it, so `normalize_read` encounters the relative path during tokenization and fails. Fixed by using the path string directly as the normalization token — the filename already embeds a content hash, so this is safe and deterministic.

## Test plan

- [x] `python/xorq/ibis_yaml/tests/` — 435 passed (5 pre-existing postgres-env failures unrelated)
- [x] `python/xorq/catalog/tests/test_catalog.py` + `test_git_backend.py` — 117 passed
- [x] Run `scripts/2026-04-17-paddy-issue.py` twice; assert resulting entry zip md5s match
- [x] Verify `expr.yaml` `hash_path` is now `database_tables/<hash>.parquet` (relative)
- [x] Verify zip member mtimes are `(1980, 1, 1, 0, 0, 0)`
- [x] UDF expressions with Read nodes in their closures normalize without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)