### PR TITLE
feat(plot): add PlotNode support via UDAF + Tag

### DIFF
--- a/python/xorq/common/utils/plot_utils.py
+++ b/python/xorq/common/utils/plot_utils.py
@@ -1,0 +1,14 @@
+from xorq.expr import udf
+
+
+PLOT_TAG = "plot"
+
+
+def make_plot_expr(table, plot_fn, return_type, *, name="plot"):
+    plot_udaf = udf.agg.pandas_df(
+        plot_fn,
+        table.schema(),
+        return_type,
+        name=name,
+    )
+    return table.agg(plot_udaf.on_expr(table).name(name)).tag(PLOT_TAG)

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -947,6 +947,16 @@ class LETSQLAccessor:
         return find_all_sources(self.expr)
 
     @property
+    def is_plot(self):
+        from xorq.common.utils.node_utils import find_by_expr_tag
+        from xorq.common.utils.plot_utils import PLOT_TAG
+
+        return any(
+            any(dtype.is_binary() for dtype in node.schema.values())
+            for node in find_by_expr_tag(self.expr, PLOT_TAG)
+        )
+
+    @property
     def is_multiengine(self):
         (_, *rest) = set(self.backends)
         return bool(rest)


### PR DESCRIPTION
Plot expressions are created by wrapping a plot function as a UDAF (via make_plot_expr) and tagging the result with PLOT_TAG. This keeps plots in the expression graph as regular table operations, with PNG/SVG bytes stored in binary columns of the cached parquet result.

The tag is a standalone constant ("plot"), not a CatalogTag variant, because plot-ness is orthogonal to catalog composition roles. Detection is via expr.ls.is_plot on the LETSQLAccessor, which checks both the tag and that the schema contains a binary column.