### PR TITLE
fix(worktree): preserve symlinks when copying envrc secrets

### DIFF
--- a/.gitignore.template
+++ b/.gitignore.template
@@ -1,6 +1,8 @@
 .gitignore
 /target
 
+.claude
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 .pytest_cache/
@@ -88,3 +90,4 @@ ci/ibis_testing.db
 .codspeed
 
 .envrc.secrets
+.envrcs/.worktree-symlinks

--- a/dev/cleanup-worktree
+++ b/dev/cleanup-worktree
@@ -3,26 +3,18 @@ set -euo pipefail
 
 here=$(git rev-parse --show-toplevel)
 main=$(git worktree list --porcelain | head -1 | cut -d' ' -f2)
-
-# Support both old and new manifest locations
-manifest="$here/.worktree-manifest"
-if [ ! -f "$manifest" ]; then
-    manifest="$here/.envrcs/.worktree-manifest"
-fi
+manifest="$here/.envrcs/.worktree-manifest"
 
 if [ -f "$manifest" ]; then
     cd "$here"
     xargs rm -v < "$manifest"
+    # Remove any empty parent directories created by setup
     while IFS= read -r entry; do
         dir=$(dirname "$entry")
         rmdir -p "$dir" 2>/dev/null || true
     done < "$manifest"
     rm -v "$manifest"
 fi
-
-# Restore all git-tracked files that were replaced by symlinks
-cd "$here"
-git checkout -- . 2>/dev/null || true
 
 cd "$main"
 git worktree remove "$here"

--- a/dev/cleanup-worktree
+++ b/dev/cleanup-worktree
@@ -3,18 +3,26 @@ set -euo pipefail
 
 here=$(git rev-parse --show-toplevel)
 main=$(git worktree list --porcelain | head -1 | cut -d' ' -f2)
-manifest="$here/.envrcs/.worktree-manifest"
+
+# Support both old and new manifest locations
+manifest="$here/.worktree-manifest"
+if [ ! -f "$manifest" ]; then
+    manifest="$here/.envrcs/.worktree-manifest"
+fi
 
 if [ -f "$manifest" ]; then
     cd "$here"
     xargs rm -v < "$manifest"
-    # Remove any empty parent directories created by setup
     while IFS= read -r entry; do
         dir=$(dirname "$entry")
         rmdir -p "$dir" 2>/dev/null || true
     done < "$manifest"
     rm -v "$manifest"
 fi
+
+# Restore all git-tracked files that were replaced by symlinks
+cd "$here"
+git checkout -- . 2>/dev/null || true
 
 cd "$main"
 git worktree remove "$here"

--- a/dev/setup-worktree
+++ b/dev/setup-worktree
@@ -9,18 +9,13 @@ if [ "$main" = "$here" ]; then
     exit 0
 fi
 
-manifest="$here/.worktree-manifest"
+manifest="$here/.envrcs/.worktree-manifest"
 : > "$manifest"
 
-# Remove git's .envrc and .envrcs so we can replace them with symlinks
-# to the main worktree (where the sops secret symlinks live).
-for target in .envrc .envrcs dev; do
-    if [ -e "$here/$target" ] && [ ! -L "$here/$target" ]; then
-        rm -rf "$here/$target"
-    fi
-    if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
-        ln -sv "$main/$target" "$here/$target"
-        echo "$target" >> "$manifest"
+for f in "$main"/.envrcs/.envrc.secrets "$main"/.envrcs/.envrc.user "$main"/.envrcs/.env.*; do
+    if [ -e "$f" ]; then
+        cp -Pv "$f" "$here/.envrcs/"
+        echo ".envrcs/$(basename "$f")" >> "$manifest"
     fi
 done
 
@@ -48,5 +43,5 @@ if [ -f "$extra" ]; then
     done < "$extra"
 fi
 
-echo "Manifest written to .worktree-manifest"
+echo "Manifest written to .envrcs/.worktree-manifest"
 echo "To remove: dev/cleanup-worktree"

--- a/dev/setup-worktree
+++ b/dev/setup-worktree
@@ -9,13 +9,18 @@ if [ "$main" = "$here" ]; then
     exit 0
 fi
 
-manifest="$here/.envrcs/.worktree-manifest"
+manifest="$here/.worktree-manifest"
 : > "$manifest"
 
-for f in "$main"/.envrcs/.envrc.secrets "$main"/.envrcs/.envrc.user "$main"/.envrcs/.env.*; do
-    if [ -f "$f" ]; then
-        cp -v "$f" "$here/.envrcs/"
-        echo ".envrcs/$(basename "$f")" >> "$manifest"
+# Remove git's .envrc and .envrcs so we can replace them with symlinks
+# to the main worktree (where the sops secret symlinks live).
+for target in .envrc .envrcs dev; do
+    if [ -e "$here/$target" ] && [ ! -L "$here/$target" ]; then
+        rm -rf "$here/$target"
+    fi
+    if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
+        ln -sv "$main/$target" "$here/$target"
+        echo "$target" >> "$manifest"
     fi
 done
 
@@ -43,5 +48,5 @@ if [ -f "$extra" ]; then
     done < "$extra"
 fi
 
-echo "Manifest written to .envrcs/.worktree-manifest"
+echo "Manifest written to .worktree-manifest"
 echo "To remove: dev/cleanup-worktree"


### PR DESCRIPTION
## Summary
- Use `cp -Pv` instead of `cp -v` in `dev/setup-worktree` so symlinks like `.envrc.secrets` → `~/.config/xorq/envrcs/.envrc.secrets` are preserved as symlinks rather than dereferenced into regular files
- Check `-e` instead of `-f` so symlinks are detected correctly
- Add `.claude` and `.envrcs/.worktree-symlinks` to `.gitignore.template` to keep worktree noise out of `git status`

## Test plan
- [x] Create a worktree and verify `.envrcs/.envrc.secrets` and `.envrcs/.envrc.user` are symlinks (not regular files)
- [x] Verify `git status` in the worktree is clean (no modifications to tracked files)
- [x] Verify `direnv allow` loads secrets correctly in the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)