### PR TITLE
fix(flight): reduce test flakiness from CI resource contention

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -620,10 +620,10 @@ def unbind_and_serve_command(
         xorq.flight.FlightServer,
         flight_url=flight_url,
     )
-    logger.info(f"Serving expression from '{expr_path}' on {flight_url.to_location()}")
     server, _ = xorq.expr.relations.flight_serve_unbound(
         unbound_expr, make_server=make_server
     )
+    logger.info(f"Serving expression from '{expr_path}' on {flight_url.to_location()}")
     server.wait()
 
 
@@ -701,8 +701,9 @@ def serve_command(
         host=host,
     )
     location = server.flight_url.to_location()
+    server.serve(block=False)
     logger.info(f"Serving expression '{expr_path.stem}' on {location}")
-    server.serve(block=True)
+    server.wait()
 
 
 @_lazy_span("cli.init_command")

--- a/python/xorq/flight/__init__.py
+++ b/python/xorq/flight/__init__.py
@@ -81,6 +81,8 @@ class FlightUrl:
         self._socket = self._bind_socket(self.host, self.port)
 
     def unbind_socket(self):
+        if self._socket is not None:
+            self._socket.close()
         self._socket = None
 
     def to_location(self):

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -32,7 +32,7 @@ class FlightClient:
         cert_chain=None,
         private_key=None,
         tls_root_certs=None,
-        healthcheck_n_tries=20,
+        healthcheck_n_tries=40,
         **kwargs,
     ):
         """
@@ -89,15 +89,12 @@ class FlightClient:
                 )
                 if any(to_match in str(e) for to_match in matches):
                     raise e
-                else:
-                    pass
             except pa.flight.FlightUnauthenticatedError:
                 return
             except Exception:
                 pass
-            finally:
-                logger.info(f"Flight server unavailable, sleeping {sleep_n} seconds")
-                time.sleep(sleep_n)
+            logger.info(f"Flight server unavailable, sleeping {sleep_n} seconds")
+            time.sleep(sleep_n)
         raise RuntimeError(f"failed to connect after {attempt_i} attempts")
 
     # FIXME: rename to execute_table, add execute that return pd.DataFrame

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -936,6 +936,7 @@ def hit_server(port, expr):
 
 
 @pytest.mark.slow(level=3)
+@pytest.mark.xdist_group(name="serve")
 @pytest.mark.parametrize("serve_hash", serve_hashes)
 def test_serve_unbound_hash(serve_hash, pipeline_https_build):
     lookup = {
@@ -975,6 +976,7 @@ serve_tags = (
 
 
 @pytest.mark.slow(level=3)
+@pytest.mark.xdist_group(name="serve")
 @pytest.mark.parametrize("serve_tag", serve_tags)
 def test_serve_unbound_tag(serve_tag, pipeline_https_build):
     expr = load_expr(pipeline_https_build)
@@ -999,6 +1001,7 @@ def test_serve_unbound_tag(serve_tag, pipeline_https_build):
 
 
 @pytest.mark.slow(level=1)
+@pytest.mark.xdist_group(name="serve")
 def test_serve_unbound_tag_get_exchange(pipeline_https_build, parquet_dir):
     batting_url = "https://storage.googleapis.com/letsql-pins/batting/20240711T171118Z-431ef/batting.parquet"
     serve_tag = "read-batting"
@@ -1027,6 +1030,7 @@ def test_serve_unbound_tag_get_exchange(pipeline_https_build, parquet_dir):
 
 
 @pytest.mark.slow(level=1)
+@pytest.mark.xdist_group(name="serve")
 def test_serve_unbound_tag_get_exchange_udf(fixture_dir, tmp_path):
     df = pd.DataFrame([float(v) for v in range(10)], columns=["x"])
 
@@ -1059,6 +1063,7 @@ def test_serve_unbound_tag_get_exchange_udf(fixture_dir, tmp_path):
 
 
 @pytest.mark.slow(level=3)
+@pytest.mark.xdist_group(name="serve")
 def test_serve_penguins_template(tmpdir, tmp_path):
     tmpdir = Path(tmpdir)
     path = tmpdir.joinpath("xorq-template-penguins")


### PR DESCRIPTION
## Summary

- Serialize all Flight server tests under `xdist_group("serve")` so they don't compete for CPU when pytest-xdist fans out across workers — the direct cause of `test_serve_unbound_tag_get_exchange_udf` timing out in CI
- Move port-announcement log lines in `unbind_and_serve_command` and `serve_command` to after the gRPC server is actually listening, so healthcheck retries aren't burned during server startup
- Fix `_wait_on_healthcheck` sleeping 1s unconditionally in a `finally` block (including after successful healthcheck)
- Explicitly close the reserved socket in `FlightUrl.unbind_socket` instead of relying on refcount/GC
- Double the default healthcheck budget from 20 to 40 attempts

## Test plan

- [ ] CI `ci-test` passes (specifically `test_serve_unbound_tag_get_exchange_udf` on split 1)
- [ ] `test_serve_command` still passes (affected by `serve_command` block→wait change)
- [ ] No regressions in other serve tests (`test_serve_unbound_hash`, `test_serve_unbound_tag`, `test_serve_penguins_template`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)