### PR TITLE
fix(logging): wire RotatingFileHandler so xorq.log actually rotates

### DIFF
--- a/docs/api_reference/backends/env_variables.qmd
+++ b/docs/api_reference/backends/env_variables.qmd
@@ -90,7 +90,8 @@ Core XORQ application settings.
 | `XORQ_DEFAULT_RELATIVE_PATH` | Default relative path for data | No | `parquet` | 
 | `XORQ_PROFILE_DIR` | Directory for storing profiles | No | `~/.config/xorq/profiles` | 
 | `XORQ_DEBUG` | Enable debug mode | No | `False` | 
-| `XORQ_CACHE_KEY_PREFIX` | Prefix for cache keys | No | `letsql_cache-` | 
+| `XORQ_CACHE_KEY_PREFIX` | Prefix for cache keys | No | `letsql_cache-` |
+| `XORQ_LOG_LEVEL` | Log level for file logging (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, or `OFF` to disable) | No | `INFO` |
 
 **Note:** These variables use `export` statements in the template, indicating they should be set as shell environment variables.
 

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -97,15 +97,29 @@ def get_print_logger():
 # https://betterstack.com/community/guides/logging/structlog/
 log_path = get_log_path(log_path=default_log_path)
 log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper())
-rfh = logging.handlers.RotatingFileHandler(log_path, maxBytes=50 * 2**20)
+
+_xorq_logger = logging.getLogger("xorq")
+_xorq_logger.setLevel(log_level)
+_rfh = logging.handlers.RotatingFileHandler(
+    log_path, maxBytes=50 * 2**20, backupCount=3
+)
+_rfh.setFormatter(
+    structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+)
+_xorq_logger.addHandler(_rfh)
+
 structlog.configure(
-    logger_factory=structlog.WriteLoggerFactory(rfh._open()),
     processors=[
         structlog.processors.add_log_level,
         structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.dict_tracebacks,
-        structlog.processors.JSONRenderer(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.make_filtering_bound_logger(log_level),
 )
 get_logger = structlog.get_logger

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -2,7 +2,6 @@ import datetime
 import hashlib
 import json
 import logging.handlers
-import os
 import pathlib
 import subprocess
 import tempfile
@@ -22,8 +21,15 @@ import structlog
 from attr import field, frozen
 from attr.validators import instance_of
 
+from xorq.common.utils.env_utils import EnvConfigable, env_templates_dir
+
 
 default_log_path = pathlib.Path("~/.config/xorq/xorq.log").expanduser()
+
+_log_env_config = EnvConfigable.subclass_from_env_file(
+    env_templates_dir.joinpath(".env.xorq.template"),
+    prefix="XORQ_",
+).from_env()
 
 
 def _git_is_present(cwd=None):
@@ -96,22 +102,26 @@ def get_print_logger():
 
 # https://betterstack.com/community/guides/logging/structlog/
 log_path = get_log_path(log_path=default_log_path)
-log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper())
+_log_level_str = _log_env_config.log_level.upper()
 
-_xorq_logger = logging.getLogger("xorq")
-_xorq_logger.setLevel(log_level)
-_rfh = logging.handlers.RotatingFileHandler(
-    log_path, maxBytes=50 * 2**20, backupCount=3
-)
-_rfh.setFormatter(
-    structlog.stdlib.ProcessorFormatter(
-        processors=[
-            structlog.processors.dict_tracebacks,
-            structlog.processors.JSONRenderer(),
-        ],
+if _log_level_str != "OFF":
+    log_level = getattr(logging, _log_level_str)
+    _xorq_logger = logging.getLogger("xorq")
+    _xorq_logger.setLevel(log_level)
+    _rfh = logging.handlers.RotatingFileHandler(
+        log_path, maxBytes=50 * 2**20, backupCount=3
     )
-)
-_xorq_logger.addHandler(_rfh)
+    _rfh.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            processors=[
+                structlog.processors.dict_tracebacks,
+                structlog.processors.JSONRenderer(),
+            ],
+        )
+    )
+    _xorq_logger.addHandler(_rfh)
+else:
+    log_level = logging.CRITICAL
 
 structlog.configure(
     processors=[
@@ -123,7 +133,9 @@ structlog.configure(
     wrapper_class=structlog.make_filtering_bound_logger(log_level),
 )
 get_logger = structlog.get_logger
-log_initial_state()
+
+if _log_level_str != "OFF":
+    log_initial_state()
 
 
 # ---------------------------------------------------------------------------

--- a/python/xorq/common/utils/tests/test_logging.py
+++ b/python/xorq/common/utils/tests/test_logging.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import logging.handlers
 import pathlib
 from unittest.mock import MagicMock
 
@@ -139,6 +141,42 @@ def test_from_expr_hash_finalizes_with_span_context(tmp_path):
     meta = json.loads((rl.run_dir / "meta.json").read_text())
     assert meta["status"] == "ok"
     assert "otel_trace_id" in meta
+
+
+def test_rotating_file_handler_rotates(tmp_path):
+    log_file = tmp_path / "xorq.log"
+    max_bytes = 1024
+
+    handler = logging.handlers.RotatingFileHandler(
+        log_file, maxBytes=max_bytes, backupCount=3
+    )
+    handler.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            processors=[structlog.processors.JSONRenderer()],
+        )
+    )
+    test_logger = logging.getLogger("test_rotation")
+    test_logger.setLevel(logging.DEBUG)
+    test_logger.addHandler(handler)
+
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG),
+    )
+
+    logger = structlog.get_logger("test_rotation")
+    for i in range(200):
+        logger.info("padding", i=i, data="x" * 50)
+
+    assert log_file.exists()
+    assert (tmp_path / "xorq.log.1").exists()
+
+    test_logger.removeHandler(handler)
+    handler.close()
 
 
 def test_null_run_logger_is_noop():

--- a/python/xorq/env_templates/.env.xorq.template
+++ b/python/xorq/env_templates/.env.xorq.template
@@ -3,5 +3,6 @@ XORQ_DEFAULT_RELATIVE_PATH=parquet
 XORQ_PROFILE_DIR=~/.config/xorq/profiles
 XORQ_DEBUG=False
 XORQ_CACHE_KEY_PREFIX=letsql_cache-
+XORQ_LOG_LEVEL=INFO
 XORQ_RUNS_LOGS_DIR=~/.local/share/xorq/runs
 XORQ_DEFAULT_CATALOG=


### PR DESCRIPTION
## Summary

Addresses https://github.com/boringdata/boring-semantic-layer/issues/233 — `~/.config/xorq/xorq.log` grows without bound.

- `RotatingFileHandler` was configured with `backupCount=0` (default), which disables rotation entirely
- `structlog.WriteLoggerFactory(rfh._open())` grabbed a raw file descriptor, bypassing the handler's `emit()` path — so `shouldRollover()` never ran even if `backupCount` were set
- Route structlog through stdlib logging via `ProcessorFormatter` so writes go through `emit()` → `shouldRollover()` → `doRollover()`
- Set `backupCount=3` to keep rotated backups (`xorq.log.1`, `.2`, `.3`), capping total disk usage at ~200 MiB
- Add `XORQ_LOG_LEVEL` env var (via `EnvConfigable` / `.env.xorq.template`). Set to `OFF` to disable file logging entirely
- Document `XORQ_LOG_LEVEL` in the env variables reference

## Test plan

- [x] Smoke test: `get_logger('test').info('msg', k='v')` writes JSON to `~/.config/xorq/xorq.log`
- [x] Log output format unchanged (JSON with `level`, `timestamp`, `event`, kwargs)
- [x] `XORQ_LOG_LEVEL=OFF` skips handler creation and log file writes
- [x] `ruff check` passes
- [x] Test that rotation triggers by writing >maxBytes and checking for `.log.1` backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)