### PR TITLE
ref: migrate dask_normalize_expr.py functions to `__dask_tokenize__`

### DIFF
--- a/docs/adr/0009-dask-tokenize-refactoring.md
+++ b/docs/adr/0009-dask-tokenize-refactoring.md
@@ -1,0 +1,160 @@
+# ADR-0009: Move dask normalize functions into `__dask_tokenize__` class methods
+
+- **Status:** Proposed
+- **Date:** 2026-04-22
+- **Context area:** `python/xorq/common/utils/dask_normalize/dask_normalize_expr.py`
+
+## Context
+
+xorq uses `dask.base.tokenize` to derive cache keys for every expression graph. The current design concentrates all normalization logic in a single 740-line module (`dask_normalize_expr.py`) that registers standalone functions via `@dask.base.normalize_token.register()`. Three problems arise:
+
+**Discovery.** A reader of `rel.Read` or `rel.CachedNode` has no indication that a normalization function exists. Finding the rule requires knowing to look in `dask_normalize_expr.py` and scanning for the `@register` decorator — there is no co-location signal.
+
+**Coupling.** `SnapshotStrategy` imports `normalize_backend`, `normalize_read`, and `normalize_remote_table` by name and re-exposes them as static methods. Any rename or refactor in `dask_normalize_expr.py` silently breaks the caching strategy.
+
+**Brittleness.** The dispatch logic in `normalize_databasetable` and `normalize_backend` identifies backends by `dt.source.name` / `con.name` string literals. Every backend rename requires hunting down and updating scattered string guards across the file — and guards can be missed. The xorq backend has been renamed three times:
+
+| Commit             | Rename                                    |
+|--------------------|-------------------------------------------|
+| `65d6857d` (#1450) | `"let"` → `"xorq"`                        |
+| `fc4ff21c` (#1837) | `"xorq"` → `"xorq-datafusion"`            |
+| `9db3be53` (#1851) | `"xorq-datafusion"` → `"xorq_datafusion"` |
+
+Each rename required manual edits to `dask_normalize_expr.py`. Commit `125b9c42` (#1842) shows how this fails: `SnapshotStrategy.normalize_backend` in `strategy.py` missed the `"xorq-datafusion"` rename and required a separate fix four days later.
+
+### How dask dispatches `normalize_token`
+
+The `dask.base.normalize_token` object is a `Dispatch` instance. When `normalize_token(obj)` is called, it:
+
+1. Walks `type(obj).__mro__` and checks `normalize_token._lookup` (the registered-function dict) for each class in the MRO.
+2. If a match is found in `_lookup`, that function is called.
+3. If no match is found anywhere in the MRO, falls through to `normalize_object` (registered for `object`).
+4. `normalize_object` checks `obj.__dask_tokenize__` and calls it if present.
+
+Consequence: a `_lookup` entry (including one injected by `patch_normalize_token`) **always takes priority over `__dask_tokenize__`**. This means `SnapshotStrategy.normalization_context` continues to work correctly after the migration, because the context manager patches `_lookup` directly.
+
+### Vendored ibis
+
+xorq maintains a forked copy of ibis under `python/xorq/vendor/ibis/`. This copy is already diverged from upstream — it carries xorq-specific operations (`Tag`, `HashingTag`, `FlightExpr`, etc.) that will never be upstreamed. Upstream ibis have a steady, low-pace cadence that makes tracking manageable, particularly with LLM-assisted diff review. Adding `__dask_tokenize__` to vendored classes is equivalent to any other targeted modification of the vendor layer.
+
+## Decision drivers
+
+- Normalization logic must be co-located with the type it normalizes.
+- The `SnapshotStrategy` patching mechanism (`patch_normalize_token` via `_lookup`) must continue to work without modification.
+- Backend renames must not require edits to `dask_normalize_expr.py` or any centralized dispatch table.
+- Migration should be incremental and independently testable.
+- `normalize_op` must remain importable from its current module path — `patch_normalize_op_caching` patches it by module attribute reference.
+
+## Decision
+
+### Core principle
+
+Every type with a standalone registered function gets a `__dask_tokenize__` method. For types that dispatch to backend-specific logic (specifically `ir.DatabaseTable` and `ibis.backends.BaseBackend`), the dispatch is pushed all the way to each backend class — eliminating any centralized string-keyed or instance-checked dispatch table.
+
+### `DatabaseTable` and the `tokenize_table` protocol
+
+`ir.DatabaseTable.__dask_tokenize__` delegates entirely to the backend:
+
+```python
+def __dask_tokenize__(self):
+    return self.source.tokenize_table(self)
+```
+
+`BaseBackend` gains a `tokenize_table(self, dt)` protocol method (raises `NotImplementedError` by default). Each xorq backend class in `python/xorq/backends/` implements it with the logic currently in the corresponding `normalize_X_databasetable` function. There is no dispatch dict, no string comparison, no `isinstance` check — Python's method resolution handles dispatch.
+
+`BaseBackend.__dask_tokenize__` moves the connection-identity logic from `normalize_backend` into the base class, with each backend overriding as needed.
+
+### Target classes
+
+**xorq-owned** (`python/xorq/expr/` and `python/xorq/expr/`):
+
+| Standalone function                | Class                       | File                             |
+|------------------------------------|-----------------------------|----------------------------------|
+| `normalize_read`                   | `rel.Read`                  | `python/xorq/expr/relations.py`  |
+| `normalize_remote_table`           | `rel.RemoteTable`           | `python/xorq/expr/relations.py`  |
+| `normalize_cached_node`            | `rel.CachedNode`            | `python/xorq/expr/relations.py`  |
+| `normalize_named_scalar_parameter` | `xops.NamedScalarParameter` | `python/xorq/expr/operations.py` |
+| `normalize_ibis_datatype`          | `dat.DataType`              | `python/xorq/expr/datatypes.py`  |
+
+**Vendored ibis** (`python/xorq/vendor/ibis/`):
+
+| Standalone function       | Class                  | File                                                   |
+|---------------------------|------------------------|--------------------------------------------------------|
+| `normalize_schema`        | `ir.Schema`            | `python/xorq/vendor/ibis/expr/schema.py`               |
+| `normalize_namespace`     | `ir.Namespace`         | `python/xorq/vendor/ibis/expr/operations/relations.py` |
+| `normalize_scalar_udf`    | `ScalarUDF`            | `python/xorq/vendor/ibis/expr/operations/udf.py`       |
+| `normalize_agg_udf`       | `AggUDF`               | `python/xorq/vendor/ibis/expr/operations/udf.py`       |
+| `normalize_expr`          | `ibis.expr.types.Expr` | `python/xorq/vendor/ibis/expr/types/core.py`           |
+| `normalize_databasetable` | `ir.DatabaseTable`     | `python/xorq/vendor/ibis/expr/operations/relations.py` |
+| `normalize_backend`       | `BaseBackend`          | `python/xorq/vendor/ibis/backends/__init__.py`         |
+
+**Backend `tokenize_table` implementations** (`python/xorq/backends/`):
+
+| Current function                     | Backend class             | File                                                      |
+|--------------------------------------|---------------------------|-----------------------------------------------------------|
+| `normalize_pandas_databasetable`     | `pandas.Backend`          | `python/xorq/backends/pandas/__init__.py`                 |
+| `normalize_datafusion_databasetable` | `datafusion.Backend`      | `python/xorq/backends/datafusion/__init__.py`             |
+| `normalize_postgres_databasetable`   | `postgres.Backend`        | `python/xorq/backends/postgres/__init__.py`               |
+| `normalize_snowflake_databasetable`  | `snowflake.Backend`       | `python/xorq/backends/snowflake/__init__.py`              |
+| `normalize_xorq_databasetable`       | `xorq_datafusion.Backend` | `python/xorq/backends/xorq_datafusion/__init__.py`        |
+| `normalize_duckdb_databasetable`     | `duckdb.Backend`          | `python/xorq/backends/duckdb/__init__.py`                 |
+| `normalize_remote_databasetable`     | `trino.Backend`           | `python/xorq/backends/trino/__init__.py`                  |
+| `normalize_remote_databasetable`     | `gizmosql.Backend`        | `python/xorq/backends/gizmosql/__init__.py`               |
+| `normalize_bigquery_databasetable`   | `bigquery.Backend`        | `python/xorq/vendor/ibis/backends/bigquery/__init__.py` ¹ |
+| `normalize_pyiceberg_database_table` | `pyiceberg.Backend`       | `python/xorq/backends/pyiceberg/__init__.py`              |
+| `normalize_sqlite_database_table`    | `sqlite.Backend`          | `python/xorq/backends/sqlite/__init__.py`                 |
+
+¹ `bigquery` has no xorq-owned subclass; `tokenize_table` is added directly to the vendored ibis backend.
+
+### Out of scope
+
+**`normalize_module`.** `types.ModuleType` is a stdlib type; adding a method to it is not possible. The `@normalize_token.register(types.ModuleType)` decorator stays.
+
+**`normalize_op` and `opaque_node_replacer`.** Internal helpers called by `normalize_expr`, not registered for specific types. They remain as module-level helpers in `dask_normalize_expr.py`. `patch_normalize_op_caching` patches `normalize_op` by module attribute reference and must continue to find it at `xorq.common.utils.dask_normalize.dask_normalize_expr.normalize_op`.
+
+### `SnapshotStrategy` import update
+
+After migrating, update `python/xorq/caching/strategy.py`:
+
+- Remove the three named imports (`normalize_backend`, `normalize_read`, `normalize_remote_table`).
+- `cached_normalize_read`: `normalize_read(op)` → `dask.base.normalize_token(op)`.
+- `normalize_databasetable`: `normalize_remote_table(dt)` → `dask.base.normalize_token(dt)`.
+- `normalize_backend` fallback: `normalize_backend(con)` → `dask.base.normalize_token(con)`.
+
+## Alternatives considered
+
+### Keep all normalize functions as registered module-level functions
+
+Rejected: normalization logic remains invisible from the class definition, `SnapshotStrategy` stays coupled to internal helper names, and every backend rename forces edits to `dask_normalize_expr.py`.
+
+### Replace string dispatch with `isinstance`-based dispatch in `normalize_databasetable`
+
+Rejected: still a centralized dispatch table, still requires editing one file when a new backend is added. Pushing dispatch to the backend class eliminates the centralized table entirely.
+
+### Exclude vendored-ibis classes from the migration
+
+Deferred initially on vendor-maintenance grounds. Rejected on reexamination: xorq's vendor copy is already a diverged fork; adding `__dask_tokenize__` and `tokenize_table` is no different from existing targeted modifications.
+
+## Consequences
+
+### Positive
+
+- Normalization logic is co-located with the type it describes — a reader of `postgres.Backend` sees `tokenize_table` directly.
+- Adding a new backend only requires implementing `tokenize_table` on the new backend class; `dask_normalize_expr.py` is not touched.
+- Backend renames do not affect tokenization code at all.
+- `SnapshotStrategy` no longer imports named helpers from `dask_normalize_expr.py`.
+- `dask_normalize_expr.py` shrinks to `normalize_op`, `opaque_node_replacer`, `normalize_module`, `normalize_inmemorytable`, and their private helpers.
+
+### Negative
+
+- Vendored ibis files diverge further from upstream. Accepted: upstream pace is low and LLM-assisted diff review makes periodic reconciliation tractable.
+- `bigquery` lacks a xorq-owned `Backend` subclass; its `tokenize_table` goes into the vendored copy. A future xorq-owned bigquery subclass would be the natural resolution.
+- `normalize_op` must stay at its current module path.
+
+## References
+
+- `python/xorq/common/utils/dask_normalize/dask_normalize_expr.py` — current normalize functions
+- `python/xorq/caching/strategy.py` — `SnapshotStrategy.normalization_context` and named imports
+- `python/xorq/expr/relations.py` lines 119–160 — `Tag` and `HashingTag.__dask_tokenize__` (existing template)
+- Commits `65d6857d`, `fc4ff21c`, `9db3be53`, `125b9c42` — backend rename churn in `dask_normalize_expr.py`
+- dask 2025.1.0 `dask/tokenize.py` — `normalize_object` shows `__dask_tokenize__` is checked only when no `_lookup` entry exists

--- a/python/xorq/backends/databricks/__init__.py
+++ b/python/xorq/backends/databricks/__init__.py
@@ -117,6 +117,28 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
     name = "databricks"
     compiler = sc.databricks.compiler
 
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            caller="normalize_remote_databasetable",
+        )
+
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            self.name, (self._server_hostname, self._http_path)
+        )
+
     @property
     def current_catalog(self) -> str:
         with self._safe_raw_sql(sg.select(self.compiler.f.current_catalog())) as cur:

--- a/python/xorq/backends/datafusion/__init__.py
+++ b/python/xorq/backends/datafusion/__init__.py
@@ -22,6 +22,46 @@ if TYPE_CHECKING:
 
 
 class Backend(IbisDatafusionBackend):
+    def tokenize_table(self, dt):
+        import re  # noqa: PLC0415
+
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            _extract_plan_file_paths,
+            _normalize_path_stat,
+            normalize_memory_databasetable,
+            normalize_seq_with_caller,
+        )
+
+        table = dt.source.con.table(dt.name)
+        ep_str = str(table.execution_plan())
+        if ep_str.startswith(("ParquetExec:", "CsvExec:")) or re.match(
+            r"DataSourceExec:.+file_type=(csv|parquet)", ep_str
+        ):
+            paths = _extract_plan_file_paths(ep_str)
+            if paths:
+                file_metadata = tuple(
+                    (p, _normalize_path_stat(p)) for p in sorted(paths)
+                )
+                return normalize_seq_with_caller(
+                    dt.schema.to_pandas(),
+                    file_metadata,
+                )
+            else:
+                raise ValueError(
+                    f"no parquet/csv paths extractable from execution plan: {ep_str!r}"
+                )
+        elif ep_str.startswith(("MemoryExec:", "DataSourceExec:")):
+            return normalize_memory_databasetable(dt)
+        elif "PyRecordBatchProviderExec" in ep_str:
+            return normalize_seq_with_caller(
+                dt.schema.to_pandas(),
+                dt.name,
+            )
+        elif ep_str.startswith("EmptyExec"):
+            raise ValueError("No data to cache")
+        else:
+            raise ValueError(f"unrecognized DataFusion execution plan: {ep_str!r}")
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         self.con.from_arrow(op.data.to_pyarrow(op.schema), op.name)
 

--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -8,6 +8,30 @@ from xorq.vendor.ibis.util import gen_name
 
 
 class Backend(IbisDuckDBBackend):
+    def tokenize_table(self, dt):
+        import re  # noqa: PLC0415
+
+        import sqlglot as sg  # noqa: PLC0415
+
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_duckdb_file_read,
+            normalize_memory_databasetable,
+        )
+
+        name = sg.table(dt.name, quoted=dt.source.compiler.quoted).sql(
+            dialect=dt.source.name
+        )
+        ((_, plan),) = dt.source.raw_sql(f"EXPLAIN SELECT * FROM {name}").fetchall()
+        scan_line = plan.split("\n")[1]
+        execution_plan_name = r"\s*│\s*(\w+)\s*│\s*"
+        match re.match(execution_plan_name, scan_line).group(1):
+            case "ARROW_SCAN" | "PANDAS_SCAN":
+                return normalize_memory_databasetable(dt)
+            case "READ_PARQUET" | "READ_CSV" | "SEQ_SCAN":
+                return normalize_duckdb_file_read(dt)
+            case _:
+                raise NotImplementedError(scan_line)
+
     def execute(
         self,
         expr: ir.Expr,

--- a/python/xorq/backends/gizmosql/__init__.py
+++ b/python/xorq/backends/gizmosql/__init__.py
@@ -8,6 +8,19 @@ from xorq.vendor.ibis.util import gen_name
 
 
 class Backend(IbisGizmoSQLBackend):
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            caller="normalize_remote_databasetable",
+        )
+
     def execute(
         self,
         expr: ir.Expr,

--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -305,6 +305,13 @@ class BasePandasBackend(BaseBackend, NoUrl):
 class Backend(BasePandasBackend):
     name = "pandas"
 
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_memory_databasetable,
+        )
+
+        return normalize_memory_databasetable(dt)
+
     def execute(self, query, params=None, limit="default", **kwargs):
         from xorq.backends.pandas.executor import PandasExecutor  # noqa: PLC0415
 

--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -312,6 +312,13 @@ class Backend(BasePandasBackend):
 
         return normalize_memory_databasetable(dt)
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.name, id(self.dictionary))
+
     def execute(self, query, params=None, limit="default", **kwargs):
         from xorq.backends.pandas.executor import PandasExecutor  # noqa: PLC0415
 

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -40,6 +40,15 @@ class Backend(IbisPostgresBackend):
             caller="normalize_postgres_databasetable",
         )
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        con_dct = self.con.info.get_parameters() | {"port": self.con.info.port}
+        con_details = {k: con_dct[k] for k in ("host", "port", "dbname")}
+        return normalize_seq_with_caller(self.name, con_details)
+
     compiler = compiler
 
     @classmethod

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -22,6 +22,24 @@ from xorq.vendor.ibis.util import (
 
 class Backend(IbisPostgresBackend):
     _top_level_methods = ("connect_examples", "connect_env")
+
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+        from xorq.common.utils.postgres_utils import (  # noqa: PLC0415
+            get_postgres_n_reltuples,
+        )
+
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            get_postgres_n_reltuples(dt),
+            caller="normalize_postgres_databasetable",
+        )
+
     compiler = compiler
 
     @classmethod

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -72,6 +72,17 @@ class Backend(SQLBackend):
             caller="normalize_pyiceberg_databasetable",
         )
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        catalog_params = self.catalog_params
+        con_details = (self.catalog.name,) + tuple(
+            catalog_params[k] for k in ("type", "uri", "warehouse")
+        )
+        return normalize_seq_with_caller(self.name, con_details)
+
     @property
     def version(self):
         import importlib.metadata  # noqa: PLC0415

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -55,6 +55,23 @@ class Backend(SQLBackend):
     dialect = PyIceberg
     compiler = postgres_compiler
 
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+        from xorq.common.utils.pyiceberg_utils import (  # noqa: PLC0415
+            get_iceberg_snapshots_ids,
+        )
+
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            get_iceberg_snapshots_ids(dt),
+            caller="normalize_pyiceberg_databasetable",
+        )
+
     @property
     def version(self):
         import importlib.metadata  # noqa: PLC0415

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -113,6 +113,13 @@ class Backend(IbisSnowflakeBackend):
             caller="normalize_snowflake_databasetable",
         )
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.name, self.con._host)
+
     def table(self, *args, **kwargs):
         table = super().table(*args, **kwargs)
         op = table.op()

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -96,6 +96,23 @@ class Backend(IbisSnowflakeBackend):
         toolz.curry(connect_env, authenticator=SnowflakeAuthenticator.keypair)
     )
 
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+        from xorq.common.utils.snowflake_utils import (  # noqa: PLC0415
+            get_snowflake_last_modification_time,
+        )
+
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            get_snowflake_last_modification_time(dt).tobytes(),
+            caller="normalize_snowflake_databasetable",
+        )
+
     def table(self, *args, **kwargs):
         table = super().table(*args, **kwargs)
         op = table.op()

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -19,6 +19,24 @@ if TYPE_CHECKING:
 
 
 class Backend(IbisSQLiteBackend):
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_memory_databasetable,
+            normalize_seq_with_caller,
+        )
+        from xorq.common.utils.sqlite_utils import get_sqlite_stats  # noqa: PLC0415
+
+        if dt.source.is_in_memory():
+            return normalize_memory_databasetable(dt)
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            get_sqlite_stats(dt),
+            caller="normalize_sqlite_database_table",
+        )
+
     def read_record_batches(
         self,
         record_batches: pa.RecordBatchReader,

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -37,6 +37,11 @@ class Backend(IbisSQLiteBackend):
             caller="normalize_sqlite_database_table",
         )
 
+    def __dask_tokenize__(self):
+        if self.is_in_memory():
+            return id(self.con)
+        return self.uri
+
     def read_record_batches(
         self,
         record_batches: pa.RecordBatchReader,

--- a/python/xorq/backends/trino/__init__.py
+++ b/python/xorq/backends/trino/__init__.py
@@ -2,4 +2,15 @@ from xorq.vendor.ibis.backends.trino import Backend as IbisTrinoBackend
 
 
 class Backend(IbisTrinoBackend):
-    pass
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            caller="normalize_remote_databasetable",
+        )

--- a/python/xorq/backends/trino/__init__.py
+++ b/python/xorq/backends/trino/__init__.py
@@ -14,3 +14,10 @@ class Backend(IbisTrinoBackend):
             dt.namespace,
             caller="normalize_remote_databasetable",
         )
+
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.name, self.con.host)

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -38,6 +38,48 @@ def _get_datafusion_dataframe(con, expr, **kwargs):
 class Backend(DataFusionBackend):
     name = "xorq_datafusion"
 
+    def tokenize_table(self, dt):
+        import dask  # noqa: PLC0415
+
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            rename_unbound_static,
+        )
+        from xorq.expr.relations import (  # noqa: PLC0415
+            FlightExpr,
+            FlightUDXF,
+            make_native_op,
+        )
+
+        if isinstance(dt, FlightExpr):
+            return dask.base.normalize_token(
+                (
+                    "normalize_xorq_databasetable",
+                    dt.input_expr,
+                    rename_unbound_static(dt.unbound_expr.op()).to_expr(),
+                    dt.make_connection,
+                )
+            )
+        elif isinstance(dt, FlightUDXF):
+            return dask.base.normalize_token(
+                (
+                    "normalize_xorq_databasetable",
+                    dt.input_expr,
+                    dt.udxf.exchange_f,
+                    dt.make_connection,
+                )
+            )
+        native_source = dt.source._sources.get_backend(dt)
+        if native_source.name == "xorq_datafusion":
+            # table lives in this backend's own datafusion context;
+            # delegate to datafusion execution-plan tokenization
+            from xorq.backends.datafusion import (  # noqa: PLC0415
+                Backend as _DataFusionBackend,
+            )
+
+            return _DataFusionBackend.tokenize_table(self, dt)
+        new_dt = make_native_op(dt)
+        return dask.base.normalize_token(new_dt)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._sources = SourceDict()

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -13,11 +13,6 @@ from attr import (
 
 import xorq.common.utils.dask_normalize  # noqa: F401
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.common.utils.dask_normalize.dask_normalize_expr import (
-    normalize_backend,
-    normalize_read,
-    normalize_remote_table,
-)
 from xorq.common.utils.dask_normalize.dask_normalize_utils import (
     patch_normalize_op_caching,
     patch_normalize_token,
@@ -76,7 +71,7 @@ class SnapshotStrategy(CacheStrategy):
     @staticmethod
     @functools.cache
     def cached_normalize_read(op):
-        return normalize_read(op)
+        return op.__dask_tokenize__()
 
     @staticmethod
     @functools.cache
@@ -111,7 +106,7 @@ class SnapshotStrategy(CacheStrategy):
         if name in ("pandas", "duckdb", "datafusion", "xorq_datafusion"):
             return (name, None)
         else:
-            return normalize_backend(con)
+            return con.__dask_tokenize__()
 
     @staticmethod
     def normalize_databasetable(dt):
@@ -119,7 +114,7 @@ class SnapshotStrategy(CacheStrategy):
             # one alternative is to explicitly iterate over the fields name, schema, source, namespace
             # but explicit is better than implicit, additionally the name is not a safe bet for caching
             # RemoteTable
-            return normalize_remote_table(dt)
+            return dt.__dask_tokenize__()
         else:
             keys = ["name", "schema", "source", "namespace"]
             return dask.tokenize._normalize_seq_func(

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -498,7 +498,6 @@ def normalize_named_scalar_parameter(node):
     )
 
 
-@dask.base.normalize_token.register(ibis.backends.BaseBackend)
 def normalize_backend(con):
     name = con.name
     if name == "snowflake":
@@ -680,7 +679,6 @@ def opaque_node_replacer(node, kwargs):
     return new_node
 
 
-@dask.base.normalize_token.register(ibis.expr.types.Expr)
 def normalize_expr(expr):
     from xorq.expr.api import get_compiler  # noqa: PLC0415
 

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -2,7 +2,6 @@ import itertools
 import pathlib
 import re
 import types
-import urllib.error
 import urllib.request
 
 import dask
@@ -101,12 +100,6 @@ def normalize_memory_databasetable(dt):
     )
 
 
-def normalize_pandas_databasetable(dt):
-    if dt.source.name != "pandas":
-        raise ValueError(f"expected pandas backend, got {dt.source.name!r}")
-    return normalize_memory_databasetable(dt)
-
-
 _REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
 
 
@@ -171,159 +164,6 @@ def _extract_duckdb_file_paths(sql_ddl):
     return parquet_paths + csv_paths
 
 
-def normalize_datafusion_databasetable(dt):
-    if dt.source.name not in ("datafusion", "xorq_datafusion"):
-        raise ValueError(f"expected datafusion/xorq backend, got {dt.source.name!r}")
-    table = dt.source.con.table(dt.name)
-    ep_str = str(table.execution_plan())
-    if ep_str.startswith(("ParquetExec:", "CsvExec:")) or re.match(
-        r"DataSourceExec:.+file_type=(csv|parquet)", ep_str
-    ):
-        paths = _extract_plan_file_paths(ep_str)
-        if paths:
-            file_metadata = tuple((p, _normalize_path_stat(p)) for p in sorted(paths))
-            return normalize_seq_with_caller(
-                dt.schema.to_pandas(),
-                file_metadata,
-            )
-        else:
-            raise ValueError(
-                f"no parquet/csv paths extractable from execution plan: {ep_str!r}"
-            )
-    elif ep_str.startswith(("MemoryExec:", "DataSourceExec:")):
-        return normalize_memory_databasetable(dt)
-    elif "PyRecordBatchProviderExec" in ep_str:
-        return normalize_seq_with_caller(
-            dt.schema.to_pandas(),
-            dt.name,
-        )
-    elif ep_str.startswith("EmptyExec"):
-        raise ValueError("No data to cache")
-    else:
-        raise ValueError(f"unrecognized DataFusion execution plan: {ep_str!r}")
-
-
-def normalize_remote_databasetable(dt):
-    return normalize_seq_with_caller(
-        dt.name,
-        dt.schema,
-        dt.source,
-        dt.namespace,
-        caller="normalize_remote_databasetable",
-    )
-
-
-def normalize_postgres_databasetable(dt):
-    from xorq.common.utils.postgres_utils import (  # noqa: PLC0415
-        get_postgres_n_reltuples,
-    )
-
-    if dt.source.name != "postgres":
-        raise ValueError(f"expected postgres backend, got {dt.source.name!r}")
-    return normalize_seq_with_caller(
-        dt.name,
-        dt.schema,
-        dt.source,
-        dt.namespace,
-        get_postgres_n_reltuples(dt),
-        caller="normalize_postgres_databasetable",
-    )
-
-
-def normalize_pyiceberg_database_table(dt):
-    from xorq.common.utils.pyiceberg_utils import (  # noqa: PLC0415
-        get_iceberg_snapshots_ids,
-    )
-
-    if dt.source.name != "pyiceberg":
-        raise ValueError(f"expected pyiceberg backend, got {dt.source.name!r}")
-
-    return normalize_seq_with_caller(
-        dt.name,
-        dt.schema,
-        dt.source,
-        dt.namespace,
-        get_iceberg_snapshots_ids(dt),
-        caller="normalize_pyiceberg_databasetable",
-    )
-
-
-def normalize_snowflake_databasetable(dt):
-    from xorq.common.utils.snowflake_utils import (  # noqa: PLC0415
-        get_snowflake_last_modification_time,
-    )
-
-    if dt.source.name != "snowflake":
-        raise ValueError(f"expected snowflake backend, got {dt.source.name!r}")
-    return normalize_seq_with_caller(
-        dt.name,
-        dt.schema,
-        dt.source,
-        dt.namespace,
-        get_snowflake_last_modification_time(dt).tobytes(),
-        caller="normalize_snowflake_databasetable",
-    )
-
-
-def normalize_bigquery_databasetable(dt):
-    # https://stackoverflow.com/questions/44288261/get-the-last-modified-date-for-all-bigquery-tables-in-a-bigquery-project/44290543#44290543
-    if dt.source.name != "bigquery":
-        raise ValueError(f"expected bigquery backend, got {dt.source.name!r}")
-    # https://stackoverflow.com/a/44290543
-    query = f"""
-    SELECT last_modified_time
-    FROM `{dt.namespace.database}.__TABLES__` where table_id = '{dt.name}'
-    """
-    ((last_modified_time,),) = dt.source.raw_sql(query).to_dataframe()
-    return normalize_seq_with_caller(
-        dt.name,
-        dt.schema,
-        dt.source,
-        dt.namespace,
-        last_modified_time,
-    )
-
-
-def normalize_duckdb_databasetable(dt):
-    if dt.source.name != "duckdb":
-        raise ValueError(f"expected duckdb backend, got {dt.source.name!r}")
-    name = sg.table(dt.name, quoted=dt.source.compiler.quoted).sql(
-        dialect=dt.source.name
-    )
-
-    ((_, plan),) = dt.source.raw_sql(f"EXPLAIN SELECT * FROM {name}").fetchall()
-    scan_line = plan.split("\n")[1]
-    execution_plan_name = r"\s*│\s*(\w+)\s*│\s*"
-    match re.match(execution_plan_name, scan_line).group(1):
-        case "ARROW_SCAN" | "PANDAS_SCAN":
-            return normalize_memory_databasetable(dt)
-        case "READ_PARQUET" | "READ_CSV" | "SEQ_SCAN":
-            return normalize_duckdb_file_read(dt)
-        case _:
-            raise NotImplementedError(scan_line)
-
-
-def normalize_sqlite_database_table(dt):
-    from xorq.common.utils.sqlite_utils import get_sqlite_stats  # noqa: PLC0415
-
-    if dt.source.name != "sqlite":
-        raise ValueError(f"expected sqlite backend, got {dt.source.name!r}")
-
-    if dt.source.is_in_memory():
-        return normalize_memory_databasetable(dt)
-    else:
-        return normalize_seq_with_caller(
-            dt.name,
-            dt.schema,
-            dt.source,
-            dt.namespace,
-            get_sqlite_stats(dt),
-            caller="normalize_sqlite_database_table",
-        )
-
-    pass
-
-
 def normalize_duckdb_file_read(dt):
     name = sg.exp.convert(dt.name).sql(dialect=dt.source.name)
     (sql_ddl_statement,) = dt.source.con.sql(
@@ -360,189 +200,12 @@ def rename_unbound_static(op, prefix="static-name"):
     return op.replace(rename_unbound)
 
 
-def normalize_xorq_databasetable(dt):
-    if dt.source.name != "xorq_datafusion":
-        raise ValueError(f"expected xorq backend, got {dt.source.name!r}")
-    if isinstance(dt, rel.FlightExpr):
-        return dask.base.normalize_token(
-            (
-                "normalize_xorq_databasetable",
-                dt.input_expr,
-                # we need to "stabilize" the name of the tables in the unbound expr
-                rename_unbound_static(dt.unbound_expr.op()).to_expr(),
-                dt.make_connection,
-            )
-        )
-    elif isinstance(dt, rel.FlightUDXF):
-        return dask.base.normalize_token(
-            (
-                "normalize_xorq_databasetable",
-                dt.input_expr,
-                dt.udxf.exchange_f,
-                dt.make_connection,
-            )
-        )
-    native_source = dt.source._sources.get_backend(dt)
-
-    if native_source.name == "xorq_datafusion":
-        return normalize_datafusion_databasetable(dt)
-    new_dt = rel.make_native_op(dt)
-    return dask.base.normalize_token(new_dt)
-
-
 @dask.base.normalize_token.register(types.ModuleType)
 def normalize_module(module):
     return normalize_seq_with_caller(
         module.__name__,
         module.__package__,
         caller="normalize_module",
-    )
-
-
-def normalize_ibis_datatype(datatype):
-    return normalize_seq_with_caller(datatype.name.lower(), *datatype.args)
-
-
-@dask.base.normalize_token.register(rel.Read)
-def normalize_read(read):
-    read_kwargs = dict(read.read_kwargs)
-    path = read_kwargs["hash_path"]
-    if isinstance(path, (list, tuple)):
-        # normalize_filenames may have converted a single path to a list
-        path = path[0] if len(path) == 1 else path
-    if isinstance(path, (str, pathlib.Path)):
-        path = str(path)
-        if path.startswith(("http://", "https://")):
-            tpls = _normalize_path_stat(path)
-        elif path.startswith(("s3://", "gs://", "gcs://")):
-            tpls = _normalize_path_stat(
-                path, **{k: v for k, v in read_kwargs.items() if k != "hash_path"}
-            )
-        elif not pathlib.Path(path).is_absolute() and path == read_kwargs.get(
-            "read_path"
-        ):
-            # Build-bundled Read whose hash_path was rewritten to the relative
-            # read_path for deterministic YAML (see common.py register_node).
-            # The filename is already a content hash, so use it directly.
-            tpls = (("build-relative-path", path),)
-        elif (path := pathlib.Path(path)).exists():
-            tpls = read.normalize_method(path)
-        else:
-            raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    elif isinstance(path, (list, tuple)) and all(isinstance(el, str) for el in path):
-        raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    else:
-        raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    tpls += tuple(
-        (k, v)
-        for k, v in read.read_kwargs
-        if k
-        in (
-            "mode",
-            "schema",
-            "temporary",
-        )
-    )
-    return normalize_seq_with_caller(
-        read.schema,
-        tpls,
-        caller="normalize_read",
-    )
-
-
-def normalize_databasetable(dt):
-    dct = {
-        "pandas": normalize_pandas_databasetable,
-        "datafusion": normalize_datafusion_databasetable,
-        "postgres": normalize_postgres_databasetable,
-        "snowflake": normalize_snowflake_databasetable,
-        "xorq_datafusion": normalize_xorq_databasetable,
-        "duckdb": normalize_duckdb_databasetable,
-        "trino": normalize_remote_databasetable,
-        "gizmosql": normalize_remote_databasetable,
-        "bigquery": normalize_bigquery_databasetable,
-        "pyiceberg": normalize_pyiceberg_database_table,
-        "sqlite": normalize_sqlite_database_table,
-    }
-    f = dct[dt.source.name]
-    return f(dt)
-
-
-def normalize_remote_table(dt):
-    if not isinstance(dt, rel.RemoteTable):
-        raise ValueError(f"expected RemoteTable, got {type(dt)}")
-
-    return normalize_seq_with_caller(
-        ("schema", dt.schema),
-        ("expr", dt.remote_expr),
-        # only thing that matters is the type of source its going into
-        ("source", dt.source.name),
-        caller="normalize_remote_table",
-    )
-
-
-def normalize_cached_node(node):
-    return normalize_seq_with_caller(
-        node.parent,
-        node.cache,
-        caller="normalize_cached_node",
-    )
-
-
-def normalize_named_scalar_parameter(node):
-    return normalize_seq_with_caller(
-        node.label,
-        node.dtype,
-        node.default,
-        caller="normalize_named_scalar_parameter",
-    )
-
-
-def normalize_backend(con):
-    name = con.name
-    if name == "snowflake":
-        con_details = con.con._host
-    elif name == "postgres":
-        con_dct = con.con.info.get_parameters() | {"port": con.con.info.port}
-        con_details = {k: con_dct[k] for k in ("host", "port", "dbname")}
-    elif name == "pandas":
-        con_details = id(con.dictionary)
-    elif name in ("datafusion", "duckdb", "xorq_datafusion", "gizmosql"):
-        con_details = (con._profile.con_name, con._profile.kwargs_tuple)
-    elif name == "trino":
-        con_details = con.con.host
-    elif name == "bigquery":
-        con_details = (
-            con.project_id,
-            con.dataset_id,
-        )
-    elif name == "pyiceberg":
-        catalog_params = con.catalog_params
-        con_details = (con.catalog.name,) + tuple(
-            catalog_params[k] for k in ("type", "uri", "warehouse")
-        )
-    elif name == "sqlite":
-        return id(con.con) if con.is_in_memory() else con.uri
-    elif name == "databricks":
-        con_details = (con._server_hostname, con._http_path)
-    else:
-        raise ValueError(f"no normalization rule for backend {name!r}")
-    return normalize_seq_with_caller(
-        name,
-        con_details,
-    )
-
-
-def normalize_schema(schema):
-    return normalize_seq_with_caller(
-        schema.to_pandas(),
-    )
-
-
-def normalize_namespace(ns):
-    return normalize_seq_with_caller(
-        ns.catalog,
-        ns.database,
     )
 
 
@@ -585,37 +248,6 @@ def _normalize_computed_kwargs_expr(cke):
         reads,
         cached,
         caller="normalize_computed_kwargs_expr",
-    )
-
-
-def normalize_scalar_udf(udf):
-    typs = tuple(arg.dtype for arg in udf.args)
-    computed_kwargs_expr = udf.__config__.get("computed_kwargs_expr")
-    if computed_kwargs_expr is not None:
-        computed_kwargs_token = _normalize_computed_kwargs_expr(computed_kwargs_expr)
-    else:
-        computed_kwargs_token = None
-    return normalize_seq_with_caller(
-        ScalarUDF,
-        typs,
-        udf.dtype,
-        udf.__func__,
-        computed_kwargs_token,
-        caller="normalize_scalar_udf",
-    )
-
-
-def normalize_agg_udf(udf):
-    (*args, where) = udf.args
-    if where is not None:
-        raise NotImplementedError
-    typs = tuple(arg.dtype for arg in args)
-    return normalize_seq_with_caller(
-        AggUDF,
-        typs,
-        udf.dtype,
-        udf.__func__,
-        caller="normalize_agg_udf",
     )
 
 
@@ -677,12 +309,6 @@ def opaque_node_replacer(node, kwargs):
             else:
                 new_node = node
     return new_node
-
-
-def normalize_expr(expr):
-    from xorq.expr.api import get_compiler  # noqa: PLC0415
-
-    return normalize_op(expr.op(), compiler=get_compiler(expr))
 
 
 def normalize_op(op, compiler=None):

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -9,7 +9,6 @@ import dask
 import sqlglot as sg
 import yaml12
 
-import xorq.expr.datatypes as dat
 import xorq.expr.operations as xops
 import xorq.expr.relations as rel
 import xorq.vendor.ibis.expr.operations.relations as ir
@@ -400,7 +399,6 @@ def normalize_module(module):
     )
 
 
-@dask.base.normalize_token.register(dat.DataType)
 def normalize_ibis_datatype(datatype):
     return normalize_seq_with_caller(datatype.name.lower(), *datatype.args)
 

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -494,7 +494,6 @@ def normalize_cached_node(node):
     )
 
 
-@dask.base.normalize_token.register(xops.NamedScalarParameter)
 def normalize_named_scalar_parameter(node):
     return normalize_seq_with_caller(
         node.label,
@@ -731,7 +730,7 @@ def normalize_op(op, compiler=None):
         udfs,
         tuple(map(normalize_inmemorytable, mems)),
         *(
-            (tuple(map(normalize_named_scalar_parameter, named_params)),)
+            (tuple(map(dask.base.normalize_token, named_params)),)
             if named_params
             else ()
         ),

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -450,7 +450,6 @@ def normalize_read(read):
     )
 
 
-@dask.base.normalize_token.register(ir.DatabaseTable)
 def normalize_databasetable(dt):
     dct = {
         "pandas": normalize_pandas_databasetable,
@@ -469,7 +468,6 @@ def normalize_databasetable(dt):
     return f(dt)
 
 
-@dask.base.normalize_token.register(rel.RemoteTable)
 def normalize_remote_table(dt):
     if not isinstance(dt, rel.RemoteTable):
         raise ValueError(f"expected RemoteTable, got {type(dt)}")
@@ -483,7 +481,6 @@ def normalize_remote_table(dt):
     )
 
 
-@dask.base.normalize_token.register(rel.CachedNode)
 def normalize_cached_node(node):
     return normalize_seq_with_caller(
         node.parent,

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -592,13 +592,9 @@ def _normalize_computed_kwargs_expr(cke):
     )
 
 
-@dask.base.normalize_token.register(ScalarUDF)
 def normalize_scalar_udf(udf):
     typs = tuple(arg.dtype for arg in udf.args)
     computed_kwargs_expr = udf.__config__.get("computed_kwargs_expr")
-    # Normalize computed_kwargs_expr via content-stable decomposition
-    # rather than the default normalize_expr -> normalize_op -> SQL path,
-    # which includes session-dependent UDF class names.
     if computed_kwargs_expr is not None:
         computed_kwargs_token = _normalize_computed_kwargs_expr(computed_kwargs_expr)
     else:
@@ -608,22 +604,14 @@ def normalize_scalar_udf(udf):
         typs,
         udf.dtype,
         udf.__func__,
-        #
-        # ExprScalarUDF
         computed_kwargs_token,
-        # we are insensitive to these for now
-        # udf.__udf_namespace__,
-        # udf.__func_name__,
         caller="normalize_scalar_udf",
     )
 
 
-@dask.base.normalize_token.register(AggUDF)
 def normalize_agg_udf(udf):
     (*args, where) = udf.args
     if where is not None:
-        # TODO: determine if sql string already contains
-        #       the relevant information of `where`
         raise NotImplementedError
     typs = tuple(arg.dtype for arg in args)
     return normalize_seq_with_caller(
@@ -631,9 +619,6 @@ def normalize_agg_udf(udf):
         typs,
         udf.dtype,
         udf.__func__,
-        # we are insensitive to these for now
-        # udf.__udf_namespace__,
-        # udf.__func_name__,
         caller="normalize_agg_udf",
     )
 

--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -537,14 +537,12 @@ def normalize_backend(con):
     )
 
 
-@dask.base.normalize_token.register(ir.Schema)
 def normalize_schema(schema):
     return normalize_seq_with_caller(
         schema.to_pandas(),
     )
 
 
-@dask.base.normalize_token.register(ir.Namespace)
 def normalize_namespace(ns):
     return normalize_seq_with_caller(
         ns.catalog,

--- a/python/xorq/expr/operations.py
+++ b/python/xorq/expr/operations.py
@@ -71,3 +71,15 @@ class NamedScalarParameter(ScalarParameter):
     @property
     def name(self):
         return self.label
+
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            self.label,
+            self.dtype,
+            self.default,
+            caller="normalize_named_scalar_parameter",
+        )

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -180,6 +180,18 @@ gen_name = toolz.compose(
 class RemoteTable(DatabaseTableView):
     remote_expr: Expr
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            ("schema", self.schema),
+            ("expr", self.remote_expr),
+            ("source", self.source.name),
+            caller="normalize_remote_table",
+        )
+
     @classmethod
     def from_expr(cls, con, expr, name=None):
         name = name or gen_name()

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -168,6 +168,17 @@ class CachedNode(DatabaseTableView):
     parent: Any = None
     cache: Any = None
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            self.parent,
+            self.cache,
+            caller="normalize_cached_node",
+        )
+
 
 gen_name_namespace = "rbr-placeholder"
 gen_name = toolz.compose(

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -592,6 +592,52 @@ class Read(ops.DatabaseTable):
     read_kwargs: Any = ()
     normalize_method: Callable = None
 
+    def __dask_tokenize__(self):
+        import pathlib  # noqa: PLC0415
+
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            _normalize_path_stat,
+        )
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        read_kwargs = dict(self.read_kwargs)
+        path = read_kwargs["hash_path"]
+        if isinstance(path, (list, tuple)):
+            path = path[0] if len(path) == 1 else path
+        if isinstance(path, (str, pathlib.Path)):
+            path = str(path)
+            if path.startswith(("http://", "https://")):
+                tpls = _normalize_path_stat(path)
+            elif path.startswith(("s3://", "gs://", "gcs://")):
+                tpls = _normalize_path_stat(
+                    path,
+                    **{k: v for k, v in read_kwargs.items() if k != "hash_path"},
+                )
+            elif not pathlib.Path(path).is_absolute() and path == read_kwargs.get(
+                "read_path"
+            ):
+                tpls = (("build-relative-path", path),)
+            elif (path := pathlib.Path(path)).exists():
+                tpls = self.normalize_method(path)
+            else:
+                raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+        elif isinstance(path, (list, tuple)) and all(
+            isinstance(el, str) for el in path
+        ):
+            raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+        else:
+            raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+        tpls += tuple(
+            (k, v) for k, v in self.read_kwargs if k in ("mode", "schema", "temporary")
+        )
+        return normalize_seq_with_caller(
+            self.schema,
+            tpls,
+            caller="normalize_read",
+        )
+
     def make_dt(self):
         method = getattr(self.source, self.method_name)
         _exclude = ("hash_path", "read_path")

--- a/python/xorq/vendor/ibis/backends/__init__.py
+++ b/python/xorq/vendor/ibis/backends/__init__.py
@@ -876,6 +876,15 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         self._profile = Profile.from_con(self, *args, **kwargs)
         super().__init__()
 
+    def tokenize_table(self, dt):
+        """Return a stable token for a DatabaseTable bound to this backend.
+
+        Subclasses must override this to provide backend-specific logic.
+        """
+        raise NotImplementedError(
+            f"tokenize_table is not implemented for backend {self.name!r}"
+        )
+
     @property
     @abc.abstractmethod
     def dialect(self) -> sg.Dialect | None:

--- a/python/xorq/vendor/ibis/backends/__init__.py
+++ b/python/xorq/vendor/ibis/backends/__init__.py
@@ -885,6 +885,16 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
             f"tokenize_table is not implemented for backend {self.name!r}"
         )
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(
+            self.name,
+            (self._profile.con_name, self._profile.kwargs_tuple),
+        )
+
     @property
     @abc.abstractmethod
     def dialect(self) -> sg.Dialect | None:

--- a/python/xorq/vendor/ibis/backends/bigquery/__init__.py
+++ b/python/xorq/vendor/ibis/backends/bigquery/__init__.py
@@ -161,6 +161,24 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     compiler = sc.bigquery.compiler
     supports_python_udfs = False
 
+    def tokenize_table(self, dt):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        query = f"""
+        SELECT last_modified_time
+        FROM `{dt.namespace.database}.__TABLES__` where table_id = '{dt.name}'
+        """
+        ((last_modified_time,),) = dt.source.raw_sql(query).to_dataframe()
+        return normalize_seq_with_caller(
+            dt.name,
+            dt.schema,
+            dt.source,
+            dt.namespace,
+            last_modified_time,
+        )
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.__session_dataset: bq.DatasetReference | None = None

--- a/python/xorq/vendor/ibis/backends/bigquery/__init__.py
+++ b/python/xorq/vendor/ibis/backends/bigquery/__init__.py
@@ -179,6 +179,13 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
             last_modified_time,
         )
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.name, (self.project_id, self.dataset_id))
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.__session_dataset: bq.DatasetReference | None = None

--- a/python/xorq/vendor/ibis/expr/datatypes/core.py
+++ b/python/xorq/vendor/ibis/expr/datatypes/core.py
@@ -461,6 +461,13 @@ class DataType(Concrete, Coercible):
         """Return true if an instance of a Variadic type."""
         return isinstance(self, Variadic)
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.name.lower(), *self.args)
+
 
 @public
 class Unknown(DataType, Singleton):

--- a/python/xorq/vendor/ibis/expr/operations/relations.py
+++ b/python/xorq/vendor/ibis/expr/operations/relations.py
@@ -399,6 +399,13 @@ class Namespace(Concrete):
     catalog: Optional[str] = None
     database: Optional[str] = None
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.catalog, self.database)
+
 
 @public
 class UnboundTable(PhysicalTable):

--- a/python/xorq/vendor/ibis/expr/operations/relations.py
+++ b/python/xorq/vendor/ibis/expr/operations/relations.py
@@ -423,6 +423,9 @@ class DatabaseTable(PhysicalTable):
     source: Any
     namespace: Namespace = Namespace()
 
+    def __dask_tokenize__(self):
+        return self.source.tokenize_table(self)
+
 
 @public
 class InMemoryTable(PhysicalTable):

--- a/python/xorq/vendor/ibis/expr/operations/udf.py
+++ b/python/xorq/vendor/ibis/expr/operations/udf.py
@@ -53,6 +53,30 @@ class InputType(enum.Enum):
 
 @public
 class ScalarUDF(ops.Value):
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            _normalize_computed_kwargs_expr,
+        )
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        typs = tuple(arg.dtype for arg in self.args)
+        computed_kwargs_expr = self.__config__.get("computed_kwargs_expr")
+        computed_kwargs_token = (
+            _normalize_computed_kwargs_expr(computed_kwargs_expr)
+            if computed_kwargs_expr is not None
+            else None
+        )
+        return normalize_seq_with_caller(
+            ScalarUDF,
+            typs,
+            self.dtype,
+            self.__func__,
+            computed_kwargs_token,
+            caller="normalize_scalar_udf",
+        )
+
     @attribute
     def shape(self):
         if not (args := getattr(self, "args")):  # noqa: B009
@@ -102,6 +126,23 @@ class AggUDF(ops.Reduction):
     where: Optional[ops.Value[dt.Boolean]] = None
 
     __reduce__ = reduce_udf
+
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        (*args, where) = self.args
+        if where is not None:
+            raise NotImplementedError
+        typs = tuple(arg.dtype for arg in args)
+        return normalize_seq_with_caller(
+            AggUDF,
+            typs,
+            self.dtype,
+            self.__func__,
+            caller="normalize_agg_udf",
+        )
 
 
 def _wrap(

--- a/python/xorq/vendor/ibis/expr/schema.py
+++ b/python/xorq/vendor/ibis/expr/schema.py
@@ -102,6 +102,13 @@ class Schema(Concrete, Coercible, MapSet):
             )
         return self == other
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
+            normalize_seq_with_caller,
+        )
+
+        return normalize_seq_with_caller(self.to_pandas())
+
     @classmethod
     def from_tuples(
         cls,

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -156,6 +156,14 @@ class Expr(Immutable, Coercible):
     def __hash__(self):
         return hash((self.__class__, self._arg))
 
+    def __dask_tokenize__(self):
+        from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
+            normalize_op,
+        )
+        from xorq.expr.api import get_compiler  # noqa: PLC0415
+
+        return normalize_op(self.op(), compiler=get_compiler(self))
+
     def equals(self, other):
         """Return whether this expression is _structurally_ equivalent to `other`.
 


### PR DESCRIPTION
Add `docs/adr/0009-dask-tokenize-refactoring.md`, which records the decision to move all `@dask.base.normalize_token.register()` handlers out of `dask_normalize_expr.py` into `__dask_tokenize__` methods on their respective classes, and introduces a `tokenize_table(self, dt)` protocol on `BaseBackend` to replace the string-keyed dispatch table in `normalize_databasetable`. The steps below are the agreed implementation sequence.

**Estimated effort:** ~2 days. Steps 1–7 are mechanical (one class at a time, run tests after each). Step 10 is the bulk — 11 backend `tokenize_table` implementations — but each is an isolated move of existing logic. Steps 11–13 are integration and cleanup.

1. **`rel.Read`** — add `Read.__dask_tokenize__`; leave `normalize_read` shim for `SnapshotStrategy.cached_normalize_read`.
2. **`rel.RemoteTable`** — add `RemoteTable.__dask_tokenize__`; leave shim.
3. **`rel.CachedNode`** — add `CachedNode.__dask_tokenize__`; no shim needed.
4. **`xops.NamedScalarParameter`** — add `__dask_tokenize__`; replace `map(normalize_named_scalar_parameter, ...)` in `normalize_op` with `map(dask.base.normalize_token, ...)`.
5. **`dat.DataType`** — add `DataType.__dask_tokenize__`.
6. **`ir.Schema`, `ir.Namespace`** — add `__dask_tokenize__` to vendored classes.
7. **`ScalarUDF`, `AggUDF`** — add `__dask_tokenize__` to vendored UDF classes.
8. **`tokenize_table` protocol** — add `BaseBackend.tokenize_table(self, dt)` raising `NotImplementedError`.
9. **`ir.DatabaseTable`** — replace `normalize_databasetable` with `__dask_tokenize__(self): return self.source.tokenize_table(self)`.
10. **Per-backend `tokenize_table`** — implement on each backend, moving logic from the corresponding `normalize_X_databasetable` function: `pandas`, `datafusion`, `postgres`, `snowflake`, `xorq_datafusion`, `duckdb`, `trino`, `gizmosql`, `bigquery` (vendored), `pyiceberg`, `sqlite`.
11. **`BaseBackend.__dask_tokenize__`, `Expr.__dask_tokenize__`** — move `normalize_backend` and `normalize_expr` logic into the vendored classes.
12. **`SnapshotStrategy`** — drop named imports; replace `normalize_read(op)`, `normalize_remote_table(dt)`, `normalize_backend(con)` with `dask.base.normalize_token(...)`. Remove shims.
13. **Cleanup** — remove all migrated `@register` decorators and dead functions from `dask_normalize_expr.py`.