### PR TITLE
feat: add devcontainer with worktree support

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,2 @@
+README.md
+audit-report.py

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,78 @@
+# per-project: base image
+FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
+
+ARG USER_UID=1000
+ARG USER_GID=1000
+ARG HOST_USER=
+ARG CONTAINER_WORKSPACE
+
+RUN if [ "$USER_GID" != "1000" ]; then groupmod -g $USER_GID vscode; fi \
+    && if [ "$USER_UID" != "1000" ]; then usermod -u $USER_UID vscode; fi \
+    && chown -R $USER_UID:$USER_GID /home/vscode
+
+# per-project: system packages and toolchain
+# Node 20 LTS — EOL 2026-10-30, upgrade to setup_22.x when available
+ARG NODE_MAJOR=20
+ARG NODESOURCE_SHA256=2c4c6683a17b6f4128898a7b521e3c8bb725a99ffaf1b5e32ac97c6fa7d381be
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x -o /tmp/nodesource.sh \
+    && echo "$NODESOURCE_SHA256  /tmp/nodesource.sh" | sha256sum -c - \
+    && bash /tmp/nodesource.sh \
+    && rm /tmp/nodesource.sh \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        direnv \
+        nodejs \
+        gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# per-project: uv (Python package manager)
+ARG UV_VERSION=0.7.8
+ARG UV_INSTALLER_SHA256=3e3043ca08e1156fbe18d90a1a4def3ae795418857c8f4ed3f807ffc45e51c3d
+RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh -o /tmp/uv-install.sh \
+    && echo "$UV_INSTALLER_SHA256  /tmp/uv-install.sh" | sha256sum -c - \
+    && env UV_INSTALL_DIR=/usr/local/bin sh /tmp/uv-install.sh \
+    && rm /tmp/uv-install.sh
+
+# per-project: just (task runner)
+ARG JUST_VERSION=1.40.0
+ARG JUST_INSTALLER_SHA256=e68e568671780281964fe61bbe0396507fd690a7677fc5a42fcdc69e737dd54a
+RUN curl -sSf https://just.systems/install.sh -o /tmp/just-install.sh \
+    && echo "$JUST_INSTALLER_SHA256  /tmp/just-install.sh" | sha256sum -c - \
+    && bash /tmp/just-install.sh --to /usr/local/bin --tag $JUST_VERSION \
+    && rm /tmp/just-install.sh
+
+# per-project: sops (secrets management)
+ARG SOPS_VERSION=3.9.4
+ARG SOPS_SHA256=5488e32bc471de7982ad895dd054bbab3ab91c417a118426134551e9626e4e85
+RUN curl -LsSf https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64 \
+        -o /usr/local/bin/sops \
+    && echo "$SOPS_SHA256  /usr/local/bin/sops" | sha256sum -c - \
+    && chmod +x /usr/local/bin/sops
+
+ARG CLAUDE_CODE_VERSION=2.1.119
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+COPY setup-claude.py /usr/local/bin/setup-claude
+COPY audit-hook /usr/local/bin/audit-hook
+COPY setup-env.sh /usr/local/bin/setup-env
+RUN chmod +x /usr/local/bin/setup-claude /usr/local/bin/audit-hook /usr/local/bin/setup-env
+
+# per-project: cache directories for build tools
+RUN mkdir -p /home/vscode/.cache/uv /home/vscode/.ssh \
+    && chown -R vscode:vscode /home/vscode/.cache /home/vscode/.ssh \
+    && chmod 700 /home/vscode/.ssh
+
+RUN HOST_USER="$(basename "$HOST_USER")" && \
+    if [ -n "$HOST_USER" ] && [ "$HOST_USER" != "vscode" ]; then \
+        ln -s /home/vscode "/home/$HOST_USER"; \
+    fi
+
+# per-project: PATH additions for project tooling
+ENV PATH="${CONTAINER_WORKSPACE}/.venv/bin:$PATH"
+ENV HOME=/home/vscode

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,7 +2,14 @@
 
 As an alternative to setting up a local environment, you can use the dev container. It works with both the main checkout and git worktrees.
 
-**Prerequisites:** Docker, bash, git, and Python 3 on the host (the script must be run from inside a git repo). No other dependencies required (no Node, no uv). Linux x86_64 only — uses GNU coreutils and installs amd64 binaries.
+**Prerequisites (host):** Docker, bash, git, and Python 3. No other dependencies required (no Node, no uv). The script must be run from inside a git repo.
+
+> [!IMPORTANT]
+> **Linux x86_64 only.** Installs amd64 binaries and uses GNU coreutils. macOS and Windows are not supported.
+
+**Toolchain (container):** Python 3.12 with uv 0.7.8, just 1.40.0, sops 3.9.4, gh, direnv, Node 20, and Claude Code 2.1.119. Versions are pinned in `.devcontainer/Dockerfile`.
+
+**Setup:** The `devcontainer` script lives in `dev/`. Run `direnv allow` in the repo root to add it to your PATH, or invoke it directly as `./dev/devcontainer`.
 
 ```bash
 # start the container (builds on first run)
@@ -33,6 +40,12 @@ devcontainer status
 devcontainer logs
 ```
 
+**Notes:**
+- After the first `up`, subsequent `exec` and `claude` invocations auto-start the container if it isn't already running.
+- The container rebuilds automatically when the `Dockerfile` or compose config changes.
+- `down` prompts before stopping a running container; `reset` prompts before destroying volumes.
+- `exec` with no arguments opens a bash shell and requires an interactive TTY. With an explicit command (e.g. `exec uv run pytest -m core`), no TTY is needed.
+
 ## Worktrees
 
 To use from a **worktree**, pass `-w` or run the script from the worktree directory:
@@ -60,8 +73,6 @@ This file is gitignored. Both `devcontainer` and `new-worktree` source it when p
 - `MODEL_VERSION` — pins the Claude model inside the container (written into `~/.claude/settings.json` as `model`). Leave unset to use Claude Code's default.
 
 The container workspace is always `/workspaces/src` — this is threaded through compose, the Dockerfile, and setup-claude as `DEV_CONTAINER_WORKSPACE` so the value lives in one place, but changing it is not supported.
-
-**Note:** `exec` with no arguments opens a bash shell and requires an interactive terminal (TTY). With an explicit command (e.g., `exec pytest`), no TTY is needed.
 
 ## Tab completion
 
@@ -99,17 +110,32 @@ The two paths diverge in what they provide:
 | Dep sync on lockfile change | `sync_if_needed` in the script | Not applied |
 | Image staleness check | Content hash of Dockerfile, compose, and COPY'd files | Handled by VS Code |
 
-`devcontainer.json` is kept for contributors who prefer the VS Code flow, but `dev/devcontainer` is the supported path — it handles worktrees, credential forwarding, and Claude isolation that `devcontainer.json` does not.
+## Troubleshooting
+
+- **`devcontainer: command not found`** — `dev/` isn't on PATH. Run `direnv allow` in the repo root, or invoke as `./dev/devcontainer`.
+- **`docker: command not found` or "Cannot connect to the Docker daemon"** — Docker isn't installed or the daemon isn't running. Start Docker (`systemctl --user start docker` or your distro's equivalent).
+- **`docker compose` reports "unknown command"** — you have Compose v1. Install Compose v2 (the script uses `docker compose`, not `docker-compose`).
+- **Build fails partway through `up`** — inspect with `devcontainer logs`, then `devcontainer clean && devcontainer up` to rebuild from scratch.
+- **Files in `.venv/` owned by root, or `Permission denied` writing to the workspace** — UID/GID drift between the host and the image. `devcontainer clean && devcontainer up` rebuilds with the current host UID/GID.
+- **`uv sync` runs every entry** — the lockfile is newer than `.venv/.last-sync`. Expected after `git pull`; harmless.
+- **Auto-rebuild prompt won't go away** — the content hash of `Dockerfile` / compose changed. Accept the rebuild, or `devcontainer clean` to reset state.
 
 ## Claude isolation & permission audit
 
-The container's `~/.claude` is isolated from the host. On each entry (`up`, `exec`, `claude`), the host's credentials and permission baseline are re-copied, so the container always reflects your current host permissions. This means any container-side Claude settings changes (e.g. permissions granted during a session) are overwritten on the next entry. Host hooks (global and project-level) are intentionally not copied — they reference host paths and binaries that don't exist inside the container. Only permissions are inherited.
+The container's `~/.claude` is isolated from the host. On each entry (`up`, `exec`, `claude`), `setup-claude` re-copies the following from the host so the container reflects your current host configuration:
+
+- **Credentials** — `~/.claude/.credentials.json`
+- **Global permissions and `CLAUDE.md`** — the `permissions` block from `~/.claude/settings.json`, plus `~/.claude/CLAUDE.md`
+- **Project permissions and memory** — the `permissions` block from `~/.claude/projects/<host-project-key>/settings.json` and `settings.local.json`, plus the project's `memory/` directory
+
+Container-side Claude settings changes (e.g. permissions granted mid-session) are overwritten on the next entry. Host hooks are intentionally **not** copied — they reference host paths and binaries that don't exist inside the container. Only permissions, memory, and credentials cross the boundary.
 
 A `PreToolUse` hook logs every tool invocation to `.claude/container-audit/audit.jsonl` in the workspace. Use the `audit` subcommand to review:
 
 ```bash
-# summary: tool counts, bash prefixes, permissions not in host baseline
+# summary (default): tool counts, bash prefixes, permissions not in host baseline
 devcontainer audit
+devcontainer audit --summary
 
 # just the new permission patterns (for piping into settings)
 devcontainer audit --new

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,124 @@
+# Dev container
+
+As an alternative to setting up a local environment, you can use the dev container. It works with both the main checkout and git worktrees.
+
+**Prerequisites:** Docker, bash, git, and Python 3 on the host (the script must be run from inside a git repo). No other dependencies required (no Node, no uv). Linux x86_64 only — uses GNU coreutils and installs amd64 binaries.
+
+```bash
+# start the container (builds on first run)
+devcontainer up
+
+# open a shell inside the container
+devcontainer exec
+
+# run claude
+devcontainer claude
+
+# run claude with --dangerously-skip-permissions
+devcontainer claude-dangerously-skip-permissions
+
+# stop the container
+devcontainer down
+
+# destroy container and all volumes (venv, uv cache) to start fresh
+devcontainer reset
+
+# reset + remove images and host-side artifacts
+devcontainer clean
+
+# check whether the container is running
+devcontainer status
+
+# view container logs
+devcontainer logs
+```
+
+## Worktrees
+
+To use from a **worktree**, pass `-w` or run the script from the worktree directory:
+
+```bash
+# from the main checkout, targeting a worktree
+devcontainer -w ../xorq-my-feature up
+
+# or from inside the worktree (direnv adds dev/ to PATH)
+devcontainer up
+```
+
+## Overriding project defaults
+
+`PROJECT_NAME` defaults to the basename of the main checkout (e.g. `xorq` if you cloned into `xorq/`, `src` if you cloned into `src/`). It scopes the container name and the shared docker volumes (`<PROJECT_NAME>-uv-cache`, `<PROJECT_NAME>-ibis-testing-data`). To override, copy the example and edit:
+
+```bash
+cp dev/project.env.example dev/project.env
+# edit dev/project.env
+```
+
+This file is gitignored. Both `devcontainer` and `new-worktree` source it when present. The container workspace is always `/workspaces/src` — this is threaded through compose, the Dockerfile, and setup-claude as `DEV_CONTAINER_WORKSPACE` so the value lives in one place, but changing it is not supported.
+
+**Note:** `exec` with no arguments opens a bash shell and requires an interactive terminal (TTY). With an explicit command (e.g., `exec pytest`), no TTY is needed.
+
+## Tab completion
+
+```bash
+# bash
+eval "$(devcontainer completions bash)"
+
+# zsh
+eval "$(devcontainer completions zsh)"
+
+# fish
+devcontainer completions fish | source
+```
+
+## `dev/devcontainer` vs `devcontainer.json`
+
+This project has two ways to start the container:
+
+1. **`dev/devcontainer`** (primary) — a shell script that calls `docker compose` directly. This is what the documentation above describes.
+2. **`devcontainer.json`** — consumed by VS Code's "Reopen in Container" and the official `devcontainer` CLI.
+
+The two paths diverge in what they provide:
+
+| Capability | `dev/devcontainer` | `devcontainer.json` (VS Code) |
+|---|---|---|
+| Build & run | `docker compose` via the script | VS Code / `devcontainer` CLI |
+| Toolchain (uv, just, sops, gh, node, claude) | Dockerfile — always applied | Dockerfile — always applied |
+| UID/GID matching | `DEV_UID`/`DEV_GID` build args | Not applied (uses image defaults) |
+| Git config, gh auth, Claude setup | `setup_git`, `setup_gh`, `setup_claude` in the script | Not applied |
+| Worktree support | Full (mount host `.git`, resolve worktree paths) | Not supported |
+| SSH agent forwarding | Mounted via compose env vars | Not applied |
+| sops age keys | Mounted read-only via compose | Not applied |
+| Port forwarding | Not handled (use `docker compose` ports) | `forwardPorts` in `devcontainer.json` |
+| VS Code extensions & settings | Not applied | `customizations.vscode` in `devcontainer.json` |
+| Dep sync on lockfile change | `sync_if_needed` in the script | Not applied |
+| Image staleness check | Content hash of Dockerfile, compose, and COPY'd files | Handled by VS Code |
+
+`devcontainer.json` is kept for contributors who prefer the VS Code flow, but `dev/devcontainer` is the supported path — it handles worktrees, credential forwarding, and Claude isolation that `devcontainer.json` does not.
+
+## Claude isolation & permission audit
+
+The container's `~/.claude` is isolated from the host. On each entry (`up`, `exec`, `claude`), the host's credentials and permission baseline are re-copied, so the container always reflects your current host permissions. This means any container-side Claude settings changes (e.g. permissions granted during a session) are overwritten on the next entry. Host hooks (global and project-level) are intentionally not copied — they reference host paths and binaries that don't exist inside the container. Only permissions are inherited.
+
+A `PreToolUse` hook logs every tool invocation to `.claude/container-audit/audit.jsonl` in the workspace. Use the `audit` subcommand to review:
+
+```bash
+# summary: tool counts, bash prefixes, permissions not in host baseline
+devcontainer audit
+
+# just the new permission patterns (for piping into settings)
+devcontainer audit --new
+
+# all observed patterns (including those already in baseline)
+devcontainer audit --all
+
+# clear the audit log
+devcontainer audit --clear
+```
+
+Container session logs are written to `.claude/container-sessions/` in the workspace, visible from the host.
+
+> [!NOTE]
+> **Volume persistence:** `down` stops the container but leaves Docker volumes intact, including the `claude-home` volume which contains copied credentials (API keys, gh token). Use `reset` to destroy all volumes and scrub credentials.
+>
+> **Host git access:** The host's `.git` directory is mounted read-write inside the container (required for git operations in worktrees). A container compromise could modify host git history, hooks, and refs.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -54,7 +54,12 @@ cp dev/project.env.example dev/project.env
 # edit dev/project.env
 ```
 
-This file is gitignored. Both `devcontainer` and `new-worktree` source it when present. The container workspace is always `/workspaces/src` — this is threaded through compose, the Dockerfile, and setup-claude as `DEV_CONTAINER_WORKSPACE` so the value lives in one place, but changing it is not supported.
+This file is gitignored. Both `devcontainer` and `new-worktree` source it when present. Recognised keys:
+
+- `PROJECT_NAME` — overrides the per-project namespace described above.
+- `MODEL_VERSION` — pins the Claude model inside the container (written into `~/.claude/settings.json` as `model`). Leave unset to use Claude Code's default.
+
+The container workspace is always `/workspaces/src` — this is threaded through compose, the Dockerfile, and setup-claude as `DEV_CONTAINER_WORKSPACE` so the value lives in one place, but changing it is not supported.
 
 **Note:** `exec` with no arguments opens a bash shell and requires an interactive terminal (TTY). With an explicit command (e.g., `exec pytest`), no TTY is needed.
 

--- a/.devcontainer/audit-hook
+++ b/.devcontainer/audit-hook
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""PreToolUse audit hook — appends one JSONL line per tool invocation."""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+log_path = sys.argv[1]
+err_path = Path(log_path).with_suffix(".errors")
+
+try:
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "tool": os.environ.get("CLAUDE_TOOL_NAME", ""),
+        "input": json.loads(os.environ.get("CLAUDE_TOOL_INPUT", "{}")),
+    }
+    with open(log_path, "a") as f:
+        json.dump(entry, f, separators=(",", ":"))
+        f.write("\n")
+except Exception as exc:
+    with open(err_path, "a") as f:
+        f.write(f"{datetime.now(timezone.utc).isoformat()} {exc}\n")

--- a/.devcontainer/audit-report.py
+++ b/.devcontainer/audit-report.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Analyze the container audit log and report tool usage."""
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def main():
+    audit_log = sys.argv[1]
+    mode = sys.argv[2] if len(sys.argv) > 2 else "--summary"
+
+    host_settings_path = Path.home() / ".claude" / "settings.json"
+    baseline = set()
+    try:
+        with open(host_settings_path) as f:
+            for perm in json.load(f).get("permissions", {}).get("allow", []):
+                baseline.add(perm)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    tool_counts = Counter()
+    bash_prefixes = Counter()
+    patterns = set()
+
+    with open(audit_log) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            tool = entry.get("tool", "")
+            inp = entry.get("input", {})
+            tool_counts[tool] += 1
+            if tool == "Bash":
+                cmd = inp.get("command", "")
+                parts = cmd.split()
+                if not parts:
+                    continue
+                prefix = parts[0]
+                # per-project: bash commands that use two-word prefixes
+                if (
+                    prefix in ("git", "env", "uv", "npm", "pytest", "pre-commit")
+                    and len(parts) > 1
+                ):
+                    prefix = f"{parts[0]} {parts[1]}"
+                bash_prefixes[prefix] += 1
+                patterns.add(f"Bash({prefix}:*)")
+            else:
+                patterns.add(tool)
+
+    if mode == "--summary":
+        print("Tool usage:")
+        for tool, count in tool_counts.most_common():
+            print(f"  {tool}: {count}")
+        if bash_prefixes:
+            print("\nBash command prefixes:")
+            for cmd, count in bash_prefixes.most_common():
+                print(f"  {cmd}: {count}")
+        new = sorted(patterns - baseline)
+        if new:
+            print(f"\nPermissions not in host baseline ({len(new)}):")
+            for p in new:
+                print(f"  {p}")
+        else:
+            print("\nAll observed patterns covered by host baseline.")
+    elif mode == "--new":
+        for p in sorted(patterns - baseline):
+            print(p)
+    elif mode == "--all":
+        for p in sorted(patterns):
+            print(p)
+    else:
+        print(f"Unknown audit mode: {mode}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  // per-project: container name
+  "name": "xorq",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/src",
+  "remoteUser": "vscode",
+  // per-project: forwarded ports and labels
+  "forwardPorts": [5432, 8080, 31337],
+  "portsAttributes": {
+    "5432": {"label": "PostgreSQL"},
+    "8080": {"label": "Trino"},
+    "31337": {"label": "GizmoSQL"}
+  },
+  // per-project: IDE extensions and settings
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "eamodio.gitlens",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/workspaces/src/.venv/bin/python"
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        USER_UID: "${DEV_UID:-1000}"
+        USER_GID: "${DEV_GID:-1000}"
+        HOST_USER: "${DEV_HOST_USER:-}"
+        CONTAINER_WORKSPACE: "${DEV_CONTAINER_WORKSPACE:?DEV_CONTAINER_WORKSPACE is required}"
+    user: vscode
+    working_dir: ${DEV_CONTAINER_WORKSPACE:?DEV_CONTAINER_WORKSPACE is required}
+    volumes:
+      - ${DEV_WORKSPACE:?DEV_WORKSPACE is required}:${DEV_CONTAINER_WORKSPACE:?DEV_CONTAINER_WORKSPACE is required}:cached
+      # mounted at its HOST path so worktree .git files (gitdir: /home/user/…)
+      # resolve inside the container without rewriting paths;
+      # must be writable — git write operations (add, commit, fetch) write to
+      # .git/worktrees/, .git/objects/, and .git/refs/
+      - ${DEV_MAIN_GIT:?DEV_MAIN_GIT is required}:${DEV_MAIN_GIT}:cached
+      - ${DEV_MAIN_TREE:?DEV_MAIN_TREE is required}:${DEV_MAIN_TREE}:cached
+      # per-project: cached build/dependency volumes
+      - uv-cache:/home/vscode/.cache/uv
+      - venv:${DEV_CONTAINER_WORKSPACE:?DEV_CONTAINER_WORKSPACE is required}/.venv
+      # per-project: persistent test data
+      - ibis-testing-data:${DEV_CONTAINER_WORKSPACE:?DEV_CONTAINER_WORKSPACE is required}/ci/ibis-testing-data
+      # SSH agent forwarding (empty dir when no agent on host)
+      - ${DEV_SSH_AUTH_SOCK}:/home/vscode/.ssh/agent.sock
+      # sops age key (no-op when dir doesn't exist on host)
+      - ${DEV_SOPS_AGE_DIR:-/dev/null}:/home/vscode/.config/sops/age:ro
+      # Claude: host config read-only for baseline inheritance
+      - ${HOME}/.claude:/home/vscode/.claude-host:ro
+      - ${HOME}/.claude.json:/home/vscode/.claude-host.json:ro
+      # Claude: container-isolated config (setup-claude copies baseline in)
+      - claude-home:/home/vscode/.claude
+    tmpfs:
+      - /home/vscode/.claude/shell-snapshots
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    # per-project: host services accessible via host.docker.internal
+    environment:
+      - POSTGRES_HOST=host.docker.internal
+      - SSH_AUTH_SOCK=/home/vscode/.ssh/agent.sock
+    command: sleep infinity
+
+volumes:
+  # per-project: shared across worktrees (content-addressed)
+  uv-cache:
+    name: ${DEV_PROJECT_NAME:?DEV_PROJECT_NAME is required}-uv-cache
+  # per-worktree: virtualenv paths are workspace-specific
+  venv:
+  # per-project: shared across worktrees (read-mostly test fixtures)
+  ibis-testing-data:
+    name: ${DEV_PROJECT_NAME:?DEV_PROJECT_NAME is required}-ibis-testing-data
+  # per-worktree: session symlinks and project keys are workspace-specific
+  claude-home:

--- a/.devcontainer/setup-claude.py
+++ b/.devcontainer/setup-claude.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Set up Claude Code config inside the dev container.
+
+Copies host baseline (credentials, permissions, memory) into the container's
+isolated ~/.claude, installs a PreToolUse audit hook, and symlinks sessions
+to the workspace for host log capture.
+
+Expected environment variables (set by dev/devcontainer):
+    DEV_CONTAINER_WORKSPACE  — container workspace path (e.g. /workspaces/src)
+    DEV_HOST_PROJECT_KEY     — mangled host workspace path (e.g. -home-dan-repos-github-xorq)
+    DEV_CONTAINER_PROJECT_KEY — mangled container workspace path (e.g. -workspaces-src)
+"""
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+HOST = Path("/home/vscode/.claude-host")
+HOME = Path("/home/vscode/.claude")
+HOST_PREFS = Path("/home/vscode/.claude-host.json")
+CONTAINER_PREFS = Path("/home/vscode/.claude.json")
+
+REQUIRED_VARS = (
+    "DEV_CONTAINER_WORKSPACE",
+    "DEV_HOST_PROJECT_KEY",
+    "DEV_CONTAINER_PROJECT_KEY",
+)
+
+
+def copy_credentials():
+    src = HOST / ".credentials.json"
+    if src.exists():
+        dst = HOME / ".credentials.json"
+        shutil.copy2(src, dst)
+        dst.chmod(0o600)
+
+
+def copy_global_instructions():
+    src = HOST / "CLAUDE.md"
+    if src.exists():
+        shutil.copy2(src, HOME / "CLAUDE.md")
+
+
+def copy_user_prefs(workspace):
+    prefs = {}
+    if HOST_PREFS.exists():
+        with open(HOST_PREFS) as f:
+            prefs = json.load(f)
+
+    projects = prefs.setdefault("projects", {})
+    ws_key = str(workspace)
+    projects.setdefault(ws_key, {})
+    projects[ws_key]["hasTrustDialogAccepted"] = True
+
+    with open(CONTAINER_PREFS, "w") as f:
+        json.dump(prefs, f, indent=2)
+
+
+def setup_settings(workspace, host_project_key):
+    host_settings = {}
+    src = HOST / "settings.json"
+    if src.exists():
+        with open(src) as f:
+            host_settings = json.load(f)
+
+    skipped_hooks = 0
+    for hook_list in host_settings.get("hooks", {}).values():
+        for matcher_group in hook_list:
+            skipped_hooks += len(matcher_group.get("hooks", []))
+
+    host_project_dir = HOST / "projects" / host_project_key
+    if host_project_dir.is_dir():
+        for name in ("settings.json", "settings.local.json"):
+            src = host_project_dir / name
+            if not src.exists():
+                continue
+            with open(src) as f:
+                proj = json.load(f)
+            for hook_list in proj.get("hooks", {}).values():
+                for matcher_group in hook_list:
+                    skipped_hooks += len(matcher_group.get("hooks", []))
+
+    if skipped_hooks:
+        print(f"note: skipping {skipped_hooks} host hook(s) (reference host paths)")
+
+    audit_log = workspace / ".claude" / "container-audit" / "audit.jsonl"
+
+    audit_cmd = f"python3 /usr/local/bin/audit-hook {audit_log}"
+
+    container_settings = {
+        "permissions": host_settings.get("permissions", {}),
+        "skipDangerousModePermissionPrompt": True,
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": audit_cmd},
+                    ],
+                }
+            ],
+        },
+    }
+
+    with open(HOME / "settings.json", "w") as f:
+        json.dump(container_settings, f, indent=2)
+
+
+def setup_project_settings(host_project_key, container_project_key):
+    host_project_dir = HOST / "projects" / host_project_key
+    container_project_dir = HOME / "projects" / container_project_key
+
+    if container_project_dir.is_symlink():
+        container_project_dir.unlink()
+
+    container_project_dir.mkdir(parents=True, exist_ok=True)
+
+    if not host_project_dir.is_dir():
+        return
+
+    for name in ("settings.json", "settings.local.json"):
+        src = host_project_dir / name
+        if not src.exists():
+            continue
+        with open(src) as f:
+            proj = json.load(f)
+        container_proj = {"permissions": proj.get("permissions", {})}
+        with open(container_project_dir / name, "w") as f:
+            json.dump(container_proj, f, indent=2)
+
+    host_memory = host_project_dir / "memory"
+    container_memory = container_project_dir / "memory"
+    if host_memory.is_dir() and not container_memory.exists():
+        shutil.copytree(host_memory, container_memory)
+
+
+def setup_sessions(workspace):
+    sessions_target = workspace / ".claude" / "container-sessions"
+    sessions_target.mkdir(parents=True, exist_ok=True)
+
+    sessions_link = HOME / "sessions"
+    if sessions_link.is_dir() and not sessions_link.is_symlink():
+        shutil.rmtree(sessions_link)
+    elif sessions_link.is_symlink() or sessions_link.exists():
+        sessions_link.unlink()
+    sessions_link.symlink_to(sessions_target)
+
+
+def setup_audit(workspace):
+    (workspace / ".claude" / "container-audit").mkdir(parents=True, exist_ok=True)
+
+
+def main():
+    missing = [v for v in REQUIRED_VARS if v not in os.environ]
+    if missing:
+        print(
+            f"error: missing environment variables: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        print(
+            "This script should be called via dev/devcontainer, not directly.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    workspace = Path(os.environ["DEV_CONTAINER_WORKSPACE"])
+    host_project_key = os.environ["DEV_HOST_PROJECT_KEY"]
+    container_project_key = os.environ["DEV_CONTAINER_PROJECT_KEY"]
+
+    HOME.mkdir(parents=True, exist_ok=True)
+
+    copy_credentials()
+    copy_global_instructions()
+    copy_user_prefs(workspace)
+    setup_settings(workspace, host_project_key)
+    setup_project_settings(host_project_key, container_project_key)
+    setup_sessions(workspace)
+    setup_audit(workspace)
+
+
+if __name__ == "__main__":
+    main()

--- a/.devcontainer/setup-claude.py
+++ b/.devcontainer/setup-claude.py
@@ -105,6 +105,10 @@ def setup_settings(workspace, host_project_key):
         },
     }
 
+    model_version = os.environ.get("DEV_MODEL_VERSION")
+    if model_version:
+        container_settings["model"] = model_version
+
     with open(HOME / "settings.json", "w") as f:
         json.dump(container_settings, f, indent=2)
 

--- a/.devcontainer/setup-env.sh
+++ b/.devcontainer/setup-env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# per-project: this entire script is project-specific — replace with your
+# project's dependency installation and environment setup commands
+set -euo pipefail
+
+echo "Installing dependencies..."
+uv sync --all-extras --all-groups
+touch .venv/.last-sync
+
+echo "Installing pre-commit hooks..."
+uv run pre-commit install 2>/dev/null || true
+
+if ! grep -q "direnv hook bash" ~/.bashrc 2>/dev/null; then
+    echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+fi
+
+mkdir -p ~/.config/direnv
+cat > ~/.config/direnv/direnv.toml <<'TOML'
+[whitelist]
+prefix = ["/workspaces/src"]
+TOML
+
+if [ -f .envrcs/.envrc.user.template ] && [ ! -e .envrcs/.envrc.user ] && [ ! -L .envrcs/.envrc.user ]; then
+    cp .envrcs/.envrc.user.template .envrcs/.envrc.user
+fi

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 watch_file pyproject.toml
 
 export direnv_root=$(pwd)
+PATH_add dev
 source_env_if_exists .envrcs/.envrc.secrets
 source_env_if_exists .envrcs/.envrc.user

--- a/.envrcs/.envrc.user.uv
+++ b/.envrcs/.envrc.user.uv
@@ -1,2 +1,2 @@
-uv sync --all-extras --all-groups && source ../.venv/bin/activate
+uv sync --all-extras --all-groups && source $direnv_root/.venv/bin/activate
 xorq install-completion 2>/dev/null || true

--- a/.envrcs/README.md
+++ b/.envrcs/README.md
@@ -26,6 +26,13 @@ These are created locally by copying templates or by other tooling. Never commit
 | `.env.catalog.*` | Catalog backend connection config |
 | `.env.user.*` | Per-developer dotenv overrides |
 
+## Path conventions
+
+- **`$direnv_root`** — exported by the root `.envrc`; points to the repo root. Use it for paths that must survive worktree copies (e.g. `$direnv_root/.venv`).
+- **`$this_dir`** — set locally via `this_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")` at the top of a fragment. Use it for paths relative to `.envrcs/` itself (e.g. `$this_dir/.env.secrets.concatenated.sops-encrypted`).
+
+Prefer these over bare relative paths like `../.venv` or `.env.foo`, which break when the evaluation directory isn't what you expect.
+
 ## How it fits together
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,19 @@ uv run pre-commit install
 > [!IMPORTANT]
 > Rename `.gitignore.template` to `.gitignore` 
 
+## Dev container
+
+As an alternative to setting up a local environment, you can use the dev container. It works with both the main checkout and git worktrees. See [`.devcontainer/README.md`](.devcontainer/README.md) for full usage, worktree setup, tab completion, and Claude isolation details.
+
+**Quick start** (Linux x86_64, requires Docker + bash + git + Python 3):
+
+```bash
+devcontainer up      # start (builds on first run)
+devcontainer exec    # open a shell
+devcontainer claude  # run claude
+devcontainer down    # stop
+```
+
 ## Running the test suite
 Install the [just](https://github.com/casey/just#installation) command runner, if needed.
 Download example data to run the tests successfully.

--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -62,6 +62,7 @@ export DEV_MAIN_TREE="$MAIN_TREE"
 export DEV_HOST_USER="$(whoami)"
 export DEV_PROJECT_NAME="$PROJECT_NAME"
 export DEV_CONTAINER_WORKSPACE="$CONTAINER_WORKSPACE"
+[ -n "${MODEL_VERSION:-}" ] && export DEV_MODEL_VERSION="$MODEL_VERSION"
 # SSH agent forwarding: the container can sign with any key loaded in the
 # host agent.  For tighter control, use `ssh-add -c` (confirm each use)
 # or load only the keys you need before starting the container.

--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "completions" ]; then
+    shift
+    exec "$(dirname "$0")/devcontainer-completions" "$@"
+fi
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "error: devcontainer requires Linux (uses GNU coreutils)" >&2
+    exit 1
+fi
+
+while [[ "${1:-}" == -* ]]; do
+    case "$1" in
+        -w|--workspace)
+            shift
+            if [ $# -eq 0 ]; then
+                echo "error: --workspace requires an argument" >&2
+                exit 1
+            fi
+            DEV_WORKSPACE="$1"; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+MAIN_TREE="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+COMPOSE_FILE="$MAIN_TREE/.devcontainer/docker-compose.yml"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+    echo "error: $COMPOSE_FILE not found" >&2
+    echo "The .devcontainer/ directory must exist in the main checkout: $MAIN_TREE" >&2
+    exit 1
+fi
+
+PROJECT_ENV="$MAIN_TREE/dev/project.env"
+[ -f "$PROJECT_ENV" ] && . "$PROJECT_ENV"
+PROJECT_NAME="${PROJECT_NAME:-$(basename "$MAIN_TREE")}"
+# not configurable — compose, Dockerfile, and setup-claude all assume this path
+CONTAINER_WORKSPACE="/workspaces/src"
+
+DEV_WORKSPACE="${DEV_WORKSPACE:-.}"
+_CMD="${1:-up}"
+
+if [[ "$_CMD" =~ ^(down|reset|clean|status|logs)$ ]]; then
+    if [ -d "$DEV_WORKSPACE" ]; then
+        export DEV_WORKSPACE="$(cd "$DEV_WORKSPACE" && pwd)"
+    else
+        export DEV_WORKSPACE="$(readlink -m "$DEV_WORKSPACE")"
+    fi
+else
+    if [ ! -d "$DEV_WORKSPACE" ]; then
+        echo "error: workspace directory does not exist: $DEV_WORKSPACE" >&2
+        exit 1
+    fi
+    export DEV_WORKSPACE="$(cd "$DEV_WORKSPACE" && pwd)"
+fi
+export DEV_UID="$(id -u)"
+export DEV_GID="$(id -g)"
+export DEV_MAIN_GIT="$MAIN_TREE/.git"
+export DEV_MAIN_TREE="$MAIN_TREE"
+export DEV_HOST_USER="$(whoami)"
+export DEV_PROJECT_NAME="$PROJECT_NAME"
+export DEV_CONTAINER_WORKSPACE="$CONTAINER_WORKSPACE"
+# SSH agent forwarding: the container can sign with any key loaded in the
+# host agent.  For tighter control, use `ssh-add -c` (confirm each use)
+# or load only the keys you need before starting the container.
+if [ -S "${SSH_AUTH_SOCK:-}" ]; then
+    export DEV_SSH_AUTH_SOCK="$SSH_AUTH_SOCK"
+else
+    DEV_SSH_AUTH_SOCK_EMPTY="/tmp/devcontainer-empty-ssh-sock"
+    mkdir -p "$DEV_SSH_AUTH_SOCK_EMPTY"
+    export DEV_SSH_AUTH_SOCK="$DEV_SSH_AUTH_SOCK_EMPTY"
+    echo "warning: no SSH agent detected — git over SSH won't work inside the container" >&2
+fi
+
+SOPS_AGE_DIR="${HOME}/.config/sops/age"
+if [ -d "$SOPS_AGE_DIR" ]; then
+    export DEV_SOPS_AGE_DIR="$SOPS_AGE_DIR"
+else
+    # mount an empty directory so the container sees a keyless dir, not a device file
+    DEV_SOPS_AGE_EMPTY="/tmp/devcontainer-empty-sops-age"
+    mkdir -p "$DEV_SOPS_AGE_EMPTY"
+    export DEV_SOPS_AGE_DIR="$DEV_SOPS_AGE_EMPTY"
+    echo "warning: no sops age key found — sops-encrypted envrc secrets won't decrypt inside the container" >&2
+fi
+
+if [ "$DEV_WORKSPACE" = "$MAIN_TREE" ]; then
+    export DEV_WORKTREE="main"
+else
+    export DEV_WORKTREE="$(basename "$DEV_WORKSPACE")"
+fi
+
+CONTAINER_NAME="${PROJECT_NAME}-dev-$(basename "$DEV_WORKSPACE")"
+LOCKFILE="/tmp/devcontainer-${CONTAINER_NAME}.lock"
+
+dc() {
+    docker compose -f "$COMPOSE_FILE" -p "$CONTAINER_NAME" "$@"
+}
+
+dc_exec() {
+    dc exec \
+        -e DEV_WORKTREE="$DEV_WORKTREE" \
+        app "$@"
+}
+
+is_running() {
+    dc ps --status running --format '{{.Service}}' 2>/dev/null | grep -q '^app$'
+}
+
+config_hash() {
+    local df="$MAIN_TREE/.devcontainer/Dockerfile"
+    [ -f "$df" ] || { echo "error: $df not found" >&2; return 1; }
+    cat "$df" "$COMPOSE_FILE" \
+        "$MAIN_TREE/.devcontainer/setup-claude.py" \
+        "$MAIN_TREE/.devcontainer/audit-hook" \
+        "$MAIN_TREE/.devcontainer/setup-env.sh" \
+    | sha256sum | cut -d' ' -f1
+}
+
+image_stale() {
+    local container_id
+    container_id="$(dc ps -q app 2>/dev/null | head -1)" || return 0
+    [ -z "$container_id" ] && return 0
+
+    local container_image tagged_image
+    container_image="$(docker inspect --format '{{.Image}}' "$container_id")" || return 0
+    tagged_image="$(docker image inspect --format '{{.ID}}' "${CONTAINER_NAME}:$(config_hash)" 2>/dev/null)" || return 0
+
+    [ "$container_image" != "$tagged_image" ]
+}
+
+tag_image() {
+    docker tag "$(dc images -q app)" "${CONTAINER_NAME}:$(config_hash)" \
+        || echo "warning: could not tag image — staleness check will re-trigger next run" >&2
+}
+
+require_tty() {
+    if [ ! -t 0 ]; then
+        echo "error: '$1' requires an interactive terminal (TTY)" >&2
+        exit 1
+    fi
+}
+
+setup_claude() {
+    local host_project_key container_project_key
+    host_project_key="$(echo "$DEV_WORKSPACE" | sed 's|/|-|g')"
+    container_project_key="$(echo "$CONTAINER_WORKSPACE" | sed 's|/|-|g')"
+
+    # named volume root is owned by root; fix so vscode can write
+    dc exec -u root app chown -R vscode:vscode /home/vscode/.claude
+
+    dc exec \
+        -e DEV_CONTAINER_WORKSPACE="$CONTAINER_WORKSPACE" \
+        -e DEV_HOST_PROJECT_KEY="$host_project_key" \
+        -e DEV_CONTAINER_PROJECT_KEY="$container_project_key" \
+        app python3 /usr/local/bin/setup-claude
+}
+
+setup_git() {
+    local name email
+    name="$(git config user.name 2>/dev/null || true)"
+    email="$(git config user.email 2>/dev/null || true)"
+    if [ -n "$name" ]; then
+        dc_exec git config --global user.name "$name"
+    fi
+    if [ -n "$email" ]; then
+        dc_exec git config --global user.email "$email"
+    fi
+}
+
+setup_gh() {
+    local hosts="$HOME/.config/gh/hosts.yml"
+    if [ -f "$hosts" ]; then
+        dc_exec mkdir -p /home/vscode/.config/gh
+        docker cp "$hosts" "$(dc ps -q app)":/home/vscode/.config/gh/hosts.yml
+    fi
+}
+
+# per-project: first-run setup — chown build artifacts, install deps
+setup() {
+    dc exec -u root app chown vscode:vscode "$CONTAINER_WORKSPACE/.venv"
+    dc exec app setup-env
+    echo "Dev container ready: $CONTAINER_NAME"
+}
+
+# per-project: re-sync dependencies when lockfile changes
+sync_if_needed() {
+    local lock_mtime stamp_mtime
+    lock_mtime="$(dc_exec stat -c %Y uv.lock 2>/dev/null)" || return 0
+    stamp_mtime="$(dc_exec stat -c %Y .venv/.last-sync 2>/dev/null)" || stamp_mtime=0
+    if [ "$lock_mtime" -gt "$stamp_mtime" ]; then
+        dc_exec bash -c 'uv sync --all-extras --all-groups && touch .venv/.last-sync'
+    fi
+}
+
+ensure_up() {
+    exec 9>"$LOCKFILE"
+    if ! flock -n 9; then
+        echo "Another devcontainer operation is in progress, waiting..."
+        flock 9
+    fi
+
+    if ! is_running; then
+        dc up --build -d
+        tag_image
+        setup
+    elif image_stale; then
+        read -rp "Devcontainer config changed. Running container will be stopped. Continue? [y/N] " answer
+        if [[ "$answer" != [yY]* ]]; then
+            exit 0
+        fi
+        dc down
+        dc up --build -d
+        tag_image
+        setup
+    fi
+    setup_git
+    setup_gh
+    setup_claude
+    sync_if_needed
+
+    exec 9>&-
+}
+
+case "${1:-up}" in
+    up)
+        ensure_up
+        ;;
+    down)
+        if is_running; then
+            read -rp "Running container will be stopped. Continue? [y/N] " answer
+            if [[ "$answer" != [yY]* ]]; then
+                exit 0
+            fi
+        fi
+        dc down
+        ;;
+    reset)
+        read -rp "This will destroy the container and all volumes (venv, uv cache). Continue? [y/N] " answer
+        if [[ "$answer" != [yY]* ]]; then
+            exit 0
+        fi
+        dc down --volumes
+        ;;
+    clean)
+        read -rp "This will destroy the container, volumes, images, and host-side artifacts. Continue? [y/N] " answer
+        if [[ "$answer" != [yY]* ]]; then
+            exit 0
+        fi
+        dc down --volumes --rmi local
+        docker images --format '{{.Repository}}:{{.Tag}}' \
+            | grep "^${CONTAINER_NAME}:" \
+            | xargs -r docker rmi 2>/dev/null || true
+        rm -rf "$DEV_WORKSPACE/.claude/container-audit"
+        rm -rf "$DEV_WORKSPACE/.claude/container-sessions"
+        echo "Cleaned: $CONTAINER_NAME"
+        ;;
+    exec)
+        shift
+        if [ $# -eq 0 ]; then
+            require_tty exec
+            set -- bash
+        fi
+        ensure_up
+        dc_exec "$@"
+        ;;
+    claude)
+        shift
+        require_tty claude
+        ensure_up
+        echo "Entering claude in $CONTAINER_NAME..."
+        dc_exec claude "$@"
+        ;;
+    claude-dangerously-skip-permissions)
+        shift
+        require_tty claude-dangerously-skip-permissions
+        ensure_up
+        echo "Entering claude in $CONTAINER_NAME (--dangerously-skip-permissions)..."
+        dc_exec claude --dangerously-skip-permissions "$@"
+        ;;
+    audit)
+        shift
+        audit_log="$DEV_WORKSPACE/.claude/container-audit/audit.jsonl"
+        if [ "${1:-}" = "--clear" ]; then
+            rm -f "$audit_log"
+            echo "Audit log cleared."
+            exit 0
+        fi
+        if [ ! -f "$audit_log" ]; then
+            echo "No audit log found at $audit_log"
+            exit 0
+        fi
+        python3 "$MAIN_TREE/.devcontainer/audit-report.py" "$audit_log" "${1:---summary}"
+        ;;
+    status)
+        if is_running; then
+            echo "running: $CONTAINER_NAME (workspace: $DEV_WORKSPACE)"
+        else
+            echo "stopped"
+        fi
+        ;;
+    logs)
+        shift
+        dc logs "$@"
+        ;;
+    *)
+        cat >&2 <<'USAGE'
+Usage: devcontainer [-w dir] <command>
+
+Commands:
+  up                                  start the dev container (default)
+  down                                stop the dev container
+  reset                               destroy container and all volumes
+  clean                               reset + remove images and host-side artifacts
+  status                              show whether the container is running
+  logs [args...]                      show container logs
+  exec [cmd...]                       run a command (default: bash)
+  claude [args...]                    run claude
+  claude-dangerously-skip-permissions run claude with --dangerously-skip-permissions
+  audit [--summary|--new|--all|--clear]  show permission audit log (default: --summary)
+  completions [bash|zsh|fish]         emit shell completions
+USAGE
+        exit 1
+        ;;
+esac

--- a/dev/devcontainer-completions
+++ b/dev/devcontainer-completions
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shell="${1:-bash}"
+
+case "$shell" in
+    bash)
+        cat <<'BASH'
+_devcontainer() {
+    local cur prev words cword
+    _init_completion || return
+
+    local subcmds="up down reset clean status logs exec claude claude-dangerously-skip-permissions audit completions"
+    local global_opts="-w --workspace"
+
+    local i=1 subcmd=""
+    while [ $i -lt $cword ]; do
+        case "${words[i]}" in
+            -w|--workspace) ((i+=2)); continue ;;
+            -*) ((i++)); continue ;;
+            *) subcmd="${words[i]}"; break ;;
+        esac
+    done
+
+    if [ -z "$subcmd" ]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W "$global_opts" -- "$cur"))
+        elif [[ "$prev" == -w || "$prev" == --workspace ]]; then
+            _filedir -d
+        else
+            COMPREPLY=($(compgen -W "$subcmds" -- "$cur"))
+        fi
+        return
+    fi
+
+    case "$subcmd" in
+        exec)
+            COMPREPLY=($(compgen -c -- "$cur"))
+            ;;
+        audit)
+            COMPREPLY=($(compgen -W "--summary --new --all --clear" -- "$cur"))
+            ;;
+        completions)
+            COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
+            ;;
+    esac
+}
+BASH
+        printf 'complete -F _devcontainer devcontainer\n'
+        ;;
+    zsh)
+        echo '#compdef devcontainer'
+        cat <<'ZSH'
+_devcontainer() {
+    local -a subcmds=(
+        'up:start the dev container'
+        'down:stop the dev container'
+        'reset:destroy container and all volumes'
+        'clean:reset + remove images and host-side artifacts'
+        'exec:run a command in the dev container'
+        'claude:run claude in the dev container'
+        'claude-dangerously-skip-permissions:run claude with --dangerously-skip-permissions'
+        'audit:show permission audit log'
+        'status:show whether the container is running'
+        'logs:show container logs'
+        'completions:emit shell completions'
+    )
+    _arguments -s \
+        '(-w --workspace)'{-w,--workspace}'[workspace directory]:dir:_directories' \
+        '1:subcommand:->subcmd' \
+        '*::arg:->args'
+    case $state in
+        subcmd) _describe 'subcommand' subcmds ;;
+        args)
+            case $words[1] in
+                exec) _command_names ;;
+                audit) _values 'mode' --summary --new --all --clear ;;
+                completions) _values 'shell' bash zsh fish ;;
+            esac
+            ;;
+    esac
+}
+_devcontainer "$@"
+ZSH
+        ;;
+    fish)
+        cat <<'FISH'
+set -l cmds up down reset clean status logs exec claude claude-dangerously-skip-permissions audit completions
+complete -c devcontainer -f
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -s w -l workspace -ra '(__fish_complete_directories)' -d 'workspace directory'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a up -d 'start the dev container'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a down -d 'stop the dev container'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a reset -d 'destroy container and all volumes'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a clean -d 'reset + remove images and host-side artifacts'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a exec -d 'run a command in the dev container'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a claude -d 'run claude in the dev container'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a claude-dangerously-skip-permissions -d 'run claude with --dangerously-skip-permissions'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a audit -d 'show permission audit log'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a status -d 'show whether the container is running'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a logs -d 'show container logs'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a completions -d 'emit shell completions'
+complete -c devcontainer -n "__fish_seen_subcommand_from audit" -a "--summary --new --all --clear"
+complete -c devcontainer -n "__fish_seen_subcommand_from completions" -a "bash zsh fish"
+FISH
+        ;;
+    *)
+        echo "Unsupported shell: $shell (try bash, zsh, or fish)" >&2
+        exit 1
+        ;;
+esac

--- a/dev/project.env
+++ b/dev/project.env
@@ -1,2 +1,0 @@
-# PROJECT_NAME=xorq
-# CONTAINER_WORKSPACE=/workspaces/xorq

--- a/dev/project.env.example
+++ b/dev/project.env.example
@@ -1,0 +1,3 @@
+# Copy to dev/project.env and uncomment to override defaults.
+# PROJECT_NAME defaults to the basename of the main checkout.
+# PROJECT_NAME=xorq

--- a/dev/project.env.example
+++ b/dev/project.env.example
@@ -1,3 +1,5 @@
 # Copy to dev/project.env and uncomment to override defaults.
 # PROJECT_NAME defaults to the basename of the main checkout.
 # PROJECT_NAME=xorq
+# MODEL_VERSION pins the Claude model used inside the container.
+# MODEL_VERSION=claude-opus-4-7

--- a/dev/setup-worktree
+++ b/dev/setup-worktree
@@ -12,6 +12,7 @@ fi
 manifest="$here/.envrcs/.worktree-manifest"
 : > "$manifest"
 
+# per-project: env/secrets files to copy into worktrees
 for f in "$main"/.envrcs/.envrc.secrets "$main"/.envrcs/.envrc.user "$main"/.envrcs/.env.*; do
     if [ -e "$f" ]; then
         cp -Pv "$f" "$here/.envrcs/"
@@ -27,7 +28,7 @@ for target in .gitignore; do
     fi
 done
 
-# Symlink shared directories from main worktree
+# per-project: shared directories to symlink from main worktree
 for target in .claude ci/ibis-testing-data; do
     if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
         mkdir -p "$(dirname "$here/$target")"


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/` config and `dev/devcontainer` wrapper script for running dev containers against the main checkout or any git worktree
- Container: Python 3.12, uv, just, sops, direnv, Node 20, Claude Code (versions pinned in `.devcontainer/Dockerfile`)
- All remote installs verified against pinned SHA-256 checksums
- Remaps container UID/GID to match host user; symlinks host homedir to `/home/vscode` so Claude Code resolves paths correctly
- Mounts main checkout's `.git` at its host path so worktree `.git` pointers resolve natively — no `GIT_DIR`/`GIT_WORK_TREE` env vars needed
- Named volumes for uv cache, `.venv` (isolated from host), and `ibis-testing-data`
- **Claude isolation:** host `~/.claude` and `~/.claude.json` are mounted read-only at `~/.claude-host{,.json}`; the container's `~/.claude` is an isolated `claude-home` volume. On each entry, `setup-claude` copies credentials, global/project permissions, `CLAUDE.md`, and project memory in — host **hooks are deliberately skipped** (they reference host paths). A `PreToolUse` audit hook logs every tool call to `.claude/container-audit/audit.jsonl`; review with `devcontainer audit`. Tmpfs over `shell-snapshots` prevents host env contamination.
- Uses `docker compose` directly — no Node/npx dependency on the host
- Auto-starts container on `exec`/`claude`; auto-rebuilds when `Dockerfile`, `docker-compose.yml`, `setup-claude.py`, `audit-hook`, or `setup-env.sh` change
- Confirms before stopping a running container (`down`) or destroying volumes (`reset`)

## `dev/devcontainer` subcommands
```bash
devcontainer up                                          # build & start
devcontainer down                                        # stop (prompts if running)
devcontainer reset                                       # destroy container + all volumes
devcontainer clean                                       # reset + remove images and host-side artifacts
devcontainer status                                      # show whether the container is running
devcontainer logs                                        # show container logs
devcontainer exec                                        # bash shell
devcontainer exec uv run pytest -m core                  # run a command
devcontainer claude                                      # run claude
devcontainer claude-dangerously-skip-permissions         # run claude unattended
devcontainer audit                                       # tool usage summary + new permissions
devcontainer completions bash                            # emit shell completions
devcontainer -w ../xorq-fix-foo claude                   # target a different worktree
```

Tab completion for bash/zsh/fish:
```bash
eval "$(devcontainer completions bash)"
```

## Project overrides

`dev/project.env` is gitignored; copy `dev/project.env.example` and edit to override:

- `PROJECT_NAME` — namespaces the container and shared docker volumes (defaults to the basename of the main checkout)
- `MODEL_VERSION` — pins the Claude model inside the container (written into `~/.claude/settings.json` as `model`); leave unset for the Claude Code default

## Commits
1. **refactor(direnv):** `PATH_add dev` in root `.envrc` so `devcontainer`/`new-worktree` are on PATH. Fix `../.venv` → `$direnv_root/.venv`. Document path conventions.
2. **feat(devcontainer):** Container infrastructure, wrapper script, completions, audit tooling, and Claude isolation setup.
3. **feat(devcontainer):** Allow model version override via `DEV_MODEL_VERSION` env var (sourced from `MODEL_VERSION` in `dev/project.env`).
4. **docs(devcontainer):** Clarify prerequisites, toolchain, and runtime behavior in `.devcontainer/README.md`.

## Test plan
- [ ] Build devcontainer from worktree, verify `uv sync` completes
- [ ] Verify Claude Code starts and can run bash commands
- [ ] Verify `git` commands work inside container (including `git clone` of unrelated repos)
- [ ] Verify host file edits are visible inside the container
- [ ] Modify Dockerfile, run `devcontainer exec bash` — verify auto-rebuild prompt
- [ ] Repeat for `setup-claude.py` / `audit-hook` / `setup-env.sh` edits
- [ ] Test from main checkout (non-worktree)
- [ ] Verify `devcontainer reset` destroys volumes
- [ ] Verify `devcontainer clean` removes images and host-side artifacts
- [ ] Verify tab completions work
- [ ] Set `MODEL_VERSION=...` in `dev/project.env`; verify it appears in container `~/.claude/settings.json`
- [ ] Verify `devcontainer audit` shows tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
