### PR TITLE
fix(cache): snapshot strategy uses path identity

### DIFF
--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import functools
 
 from attr import (
     field,
@@ -27,7 +26,6 @@ from xorq.caching.strategy import (
 )
 from xorq.common.exceptions import XorqError
 from xorq.common.utils.otel_utils import tracer
-from xorq.config import options
 from xorq.vendor.ibis.expr import types as ir
 
 
@@ -45,10 +43,6 @@ __all__ = [  # noqa: PLE0604
 class Cache:
     strategy = field(validator=instance_of(CacheStrategy))
     storage = field(validator=instance_of(CacheStorage))
-    key_prefix = field(
-        validator=instance_of(str),
-        factory=functools.partial(options.get, "cache.key_prefix"),
-    )
 
     strategy_typ = None
     storage_typ = None
@@ -70,7 +64,7 @@ class Cache:
         if expr.ls.is_cached and expr.ls.cache is self:
             expr = expr.ls.uncached_one
         expr = maybe_prevent_cross_source_caching(expr, self)
-        return self.strategy.calc_key(expr, self.key_prefix)
+        return self.strategy.calc_key(expr)
 
     def key_exists(self, key):
         return self.storage.exists(key)
@@ -119,7 +113,10 @@ class Cache:
         )
 
         return normalize_seq_with_caller(
-            self.strategy, self.storage, self.key_prefix, caller="normalize_cache"
+            self.strategy,
+            self.storage,
+            self.strategy.key_prefix,
+            caller="normalize_cache",
         )
 
     @classmethod

--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -54,16 +54,23 @@ class Cache:
     storage_typ = None
 
     def __attrs_post_init__(self):
-        assert isinstance(self.strategy, self.strategy_typ)
-        assert isinstance(self.storage, self.storage_typ)
+        if not isinstance(self.strategy, self.strategy_typ):
+            raise TypeError(
+                f"expected strategy of type {self.strategy_typ.__name__}, "
+                f"got {type(self.strategy).__name__}"
+            )
+        if not isinstance(self.storage, self.storage_typ):
+            raise TypeError(
+                f"expected storage of type {self.storage_typ.__name__}, "
+                f"got {type(self.storage).__name__}"
+            )
 
     def calc_key(self, expr):
         # the order here matters: must check is_cached before calling maybe_prevent_cross_source_caching
         if expr.ls.is_cached and expr.ls.cache is self:
             expr = expr.ls.uncached_one
         expr = maybe_prevent_cross_source_caching(expr, self)
-        # FIXME: let strategy solely determine key by giving it key_prefix
-        return self.key_prefix + self.strategy.calc_key(expr)
+        return self.strategy.calc_key(expr, self.key_prefix)
 
     def key_exists(self, key):
         return self.storage.exists(key)
@@ -204,8 +211,15 @@ class GCSCache(Cache):
     def __attrs_post_init__(self):
         from xorq.common.utils.gcloud_utils import GCStorage  # noqa: PLC0415
 
-        assert isinstance(self.strategy, self.strategy_typ)
-        assert isinstance(self.storage, GCStorage)
+        if not isinstance(self.strategy, self.strategy_typ):
+            raise TypeError(
+                f"expected strategy of type {self.strategy_typ.__name__}, "
+                f"got {type(self.strategy).__name__}"
+            )
+        if not isinstance(self.storage, GCStorage):
+            raise TypeError(
+                f"expected storage of type GCStorage, got {type(self.storage).__name__}"
+            )
 
     @classmethod
     def from_kwargs(cls, bucket_name, source):

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import pathlib
 from abc import (
     abstractmethod,
 )
@@ -15,10 +16,10 @@ import xorq.common.utils.dask_normalize  # noqa: F401
 import xorq.vendor.ibis.expr.operations as ops
 from xorq.common.utils.dask_normalize.dask_normalize_expr import (
     normalize_backend,
-    normalize_read,
     normalize_remote_table,
 )
 from xorq.common.utils.dask_normalize.dask_normalize_utils import (
+    normalize_seq_with_caller,
     patch_normalize_op_caching,
     patch_normalize_token,
 )
@@ -29,10 +30,51 @@ from xorq.expr.relations import (
 from xorq.vendor.ibis.expr import types as ir
 
 
+def snapshot_normalize_read(read):
+    """Normalize Read for snapshot caching using path identity only, not file modification stats."""
+    read_kwargs = dict(read.read_kwargs)
+    # Materialized build-bundle reads carry a content-hash-named read_path that is
+    # stable across environments. Their hash_path is an absolute tmpdir path that
+    # changes every run, so prefer read_path when available.
+    path = read_kwargs.get("read_path") or read_kwargs["hash_path"]
+    match path:
+        case list() | tuple() if len(path) == 1:
+            tpls = (("path", str(path[0])),)
+        case list() | tuple():
+            tpls = (("paths", tuple(str(p) for p in path)),)
+        case str() | pathlib.Path():
+            tpls = (("path", str(path)),)
+        case _:
+            raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+    tpls += tuple(
+        (k, v) for k, v in read.read_kwargs if k in ("mode", "schema", "temporary")
+    )
+    return normalize_seq_with_caller(
+        read.schema,
+        tpls,
+        caller="snapshot_normalize_read",
+    )
+
+
+def _rename_remote_table(node, kwargs):
+    if isinstance(node, RemoteTable):
+        # FIXME: how to verify that we're always within a normalization_context?
+        name = dask.base.tokenize(node)
+        return RemoteTable(
+            name=name,
+            schema=node.schema,
+            source=node.source,
+            remote_expr=node.remote_expr,
+            namespace=node.namespace,
+        )
+    # kwargs is None when no children were rewritten (graph.py convention)
+    return node.__recreate__(kwargs) if kwargs else node
+
+
 @frozen
 class CacheStrategy:
     @abstractmethod
-    def calc_key(self, expr):
+    def calc_key(self, expr, key_prefix=""):
         pass
 
     def __dask_tokenize__(self):
@@ -41,17 +83,17 @@ class CacheStrategy:
 
 @frozen
 class ModificationTimeStrategy(CacheStrategy):
-    def calc_key(self, expr: ir.Expr):
-        return expr.ls.tokenized
+    def calc_key(self, expr: ir.Expr, key_prefix=""):
+        return key_prefix + expr.ls.tokenized
 
 
 @frozen
 class SnapshotStrategy(CacheStrategy):
-    def calc_key(self, expr: ir.Expr):
+    def calc_key(self, expr: ir.Expr, key_prefix=""):
         with self.normalization_context(expr):
             replaced = self.replace_remote_table(expr)
             tokenized = replaced.ls.tokenized
-            return "-".join(("snapshot", tokenized))
+            return key_prefix + "-".join(("snapshot", tokenized))
 
     @contextlib.contextmanager
     def normalization_context(self, expr):
@@ -73,37 +115,21 @@ class SnapshotStrategy(CacheStrategy):
                     ):
                         yield
 
-    @staticmethod
-    @functools.cache
-    def cached_normalize_read(op):
-        return normalize_read(op)
-
-    @staticmethod
-    @functools.cache
-    def cached_replace_remote_table(op):
-        def rename_remote_table(node, kwargs):
-            if isinstance(node, RemoteTable):
-                # FIXME: how to verify that we're always within a self.normalization_context?
-                name = dask.base.tokenize(node)
-                rt = RemoteTable(
-                    name=name,
-                    schema=node.schema,
-                    source=node.source,
-                    remote_expr=node.remote_expr,
-                    namespace=node.namespace,
-                )
-                return rt
-            else:
-                # kwargs is None when no children were rewritten (graph.py convention)
-                return node.__recreate__(kwargs) if kwargs else node
-
-        return op.replace(rename_remote_table)
-
     def replace_remote_table(self, expr):
         """replace remote table with deterministic name ***strictly for key calculation***"""
         if expr.op().find(RemoteTable):
             expr = self.cached_replace_remote_table(expr.op()).to_expr()
         return expr
+
+    @staticmethod
+    @functools.cache
+    def cached_normalize_read(op):
+        return snapshot_normalize_read(op)
+
+    @staticmethod
+    @functools.cache
+    def cached_replace_remote_table(op):
+        return op.replace(_rename_remote_table)
 
     @staticmethod
     def normalize_backend(con):

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -9,7 +9,11 @@ from abc import (
 
 import dask
 from attr import (
+    field,
     frozen,
+)
+from attr.validators import (
+    instance_of,
 )
 
 import xorq.common.utils.dask_normalize  # noqa: F401
@@ -23,6 +27,7 @@ from xorq.common.utils.dask_normalize.dask_normalize_utils import (
     patch_normalize_op_caching,
     patch_normalize_token,
 )
+from xorq.config import options
 from xorq.expr.relations import (
     Read,
     RemoteTable,
@@ -73,8 +78,13 @@ def _rename_remote_table(node, kwargs):
 
 @frozen
 class CacheStrategy:
+    key_prefix = field(
+        validator=instance_of(str),
+        factory=functools.partial(options.get, "cache.key_prefix"),
+    )
+
     @abstractmethod
-    def calc_key(self, expr, key_prefix=""):
+    def calc_key(self, expr):
         pass
 
     def __dask_tokenize__(self):
@@ -83,17 +93,17 @@ class CacheStrategy:
 
 @frozen
 class ModificationTimeStrategy(CacheStrategy):
-    def calc_key(self, expr: ir.Expr, key_prefix=""):
-        return key_prefix + expr.ls.tokenized
+    def calc_key(self, expr: ir.Expr):
+        return self.key_prefix + expr.ls.tokenized
 
 
 @frozen
 class SnapshotStrategy(CacheStrategy):
-    def calc_key(self, expr: ir.Expr, key_prefix=""):
+    def calc_key(self, expr: ir.Expr):
         with self.normalization_context(expr):
             replaced = self.replace_remote_table(expr)
             tokenized = replaced.ls.tokenized
-            return key_prefix + "-".join(("snapshot", tokenized))
+            return self.key_prefix + "-".join(("snapshot", tokenized))
 
     @contextlib.contextmanager
     def normalization_context(self, expr):

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -88,7 +88,7 @@ class CacheStrategy:
         pass
 
     def __dask_tokenize__(self):
-        return (type(self).__name__,)
+        return (type(self).__name__, self.key_prefix)
 
 
 @frozen

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import functools
 import pathlib
 from abc import (
@@ -61,9 +62,21 @@ def snapshot_normalize_read(read):
     )
 
 
+# Tracks whether the caller is inside SnapshotStrategy.normalization_context.
+# _rename_remote_table calls dask.base.tokenize, which depends on the patched
+# normalizers that context installs; calling it outside would cache a wrong
+# RemoteTable name forever (cached_replace_remote_table is process-global).
+_in_normalization_context: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "xorq_snapshot_in_normalization_context", default=False
+)
+
+
 def _rename_remote_table(node, kwargs):
     if isinstance(node, RemoteTable):
-        # FIXME: how to verify that we're always within a normalization_context?
+        if not _in_normalization_context.get():
+            raise RuntimeError(
+                "_rename_remote_table called outside SnapshotStrategy.normalization_context"
+            )
         name = dask.base.tokenize(node)
         return RemoteTable(
             name=name,
@@ -113,17 +126,21 @@ class SnapshotStrategy(CacheStrategy):
         # normalize_scalar_udf recursively tokenizes computed_kwargs_expr, both
         # of which share sub-expressions that get re-tokenized without caching.
         typs = map(type, expr.ls.backends)
-        with patch_normalize_op_caching():
-            with patch_normalize_token(*typs, f=self.normalize_backend):
-                with patch_normalize_token(
-                    ops.DatabaseTable,
-                    f=self.normalize_databasetable,
-                ):
+        token = _in_normalization_context.set(True)
+        try:
+            with patch_normalize_op_caching():
+                with patch_normalize_token(*typs, f=self.normalize_backend):
                     with patch_normalize_token(
-                        Read,
-                        f=self.cached_normalize_read,
+                        ops.DatabaseTable,
+                        f=self.normalize_databasetable,
                     ):
-                        yield
+                        with patch_normalize_token(
+                            Read,
+                            f=self.cached_normalize_read,
+                        ):
+                            yield
+        finally:
+            _in_normalization_context.reset(token)
 
     def replace_remote_table(self, expr):
         """replace remote table with deterministic name ***strictly for key calculation***"""
@@ -134,6 +151,8 @@ class SnapshotStrategy(CacheStrategy):
     @staticmethod
     @functools.cache
     def cached_normalize_read(op):
+        # Wrapped function must be pure over `op` (no file I/O, no clock): the
+        # process-global cache assumes equal ops always produce equal results.
         return snapshot_normalize_read(op)
 
     @staticmethod

--- a/python/xorq/common/tests/test_cache.py
+++ b/python/xorq/common/tests/test_cache.py
@@ -48,4 +48,4 @@ def test_snapshot_strategy_calc_key_with_hashing_tag_over_remote_table():
 
     strategy = SnapshotStrategy()
     key = strategy.calc_key(tagged)
-    assert key.startswith("snapshot-")
+    assert key.startswith(f"{strategy.key_prefix}snapshot-")

--- a/python/xorq/common/tests/test_cache.py
+++ b/python/xorq/common/tests/test_cache.py
@@ -1,8 +1,10 @@
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 import xorq.api as xo
 from xorq.caching import ParquetCache
-from xorq.caching.strategy import SnapshotStrategy
+from xorq.caching.strategy import ModificationTimeStrategy, SnapshotStrategy
 from xorq.expr.relations import RemoteTable
 
 
@@ -40,6 +42,36 @@ def test_default_connection(tmp_path, parquet_dir):
     assert get_node.to_expr().execute is not None
 
 
+def test_snapshot_strategy_key_is_path_identity(tmp_path):
+    # Regression test: SnapshotStrategy must key on path identity only, not on
+    # mtime/size/inode. Without this, snapshot keys flip whenever the underlying
+    # file is rewritten, defeating the purpose of the strategy.
+    #
+    # SnapshotStrategy.cached_normalize_read is @functools.cache'd on op identity,
+    # which would mask the bug in a single process. Clear it between runs to
+    # simulate a fresh process — that is where the bug actually bit users.
+    path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"a": [1, 2, 3]}), path)
+
+    con = xo.connect()
+    snapshot = SnapshotStrategy()
+    mtime = ModificationTimeStrategy()
+
+    expr = xo.deferred_read_parquet(path, con=con, table_name="t")
+    snapshot_before = snapshot.calc_key(expr)
+    mtime_before = mtime.calc_key(expr)
+    SnapshotStrategy.cached_normalize_read.cache_clear()
+
+    pq.write_table(pa.table({"a": list(range(50))}), path)
+    expr = xo.deferred_read_parquet(path, con=con, table_name="t")
+
+    assert snapshot.calc_key(expr) == snapshot_before
+    # Sanity: ModificationTimeStrategy *should* notice the change. If it doesn't,
+    # the test setup isn't actually exercising stat sensitivity and the snapshot
+    # invariant above is vacuous.
+    assert mtime.calc_key(expr) != mtime_before
+
+
 def test_snapshot_strategy_calc_key_with_hashing_tag_over_remote_table():
     t = xo.memtable({"a": [1, 2, 3]})
     con = t._find_backend()
@@ -49,3 +81,17 @@ def test_snapshot_strategy_calc_key_with_hashing_tag_over_remote_table():
     strategy = SnapshotStrategy()
     key = strategy.calc_key(tagged)
     assert key.startswith(f"{strategy.key_prefix}snapshot-")
+
+
+def test_rename_remote_table_outside_normalization_context_raises():
+    # _rename_remote_table tokenizes via dask, which depends on the patched
+    # normalizers that normalization_context installs. Calling outside the
+    # context would poison cached_replace_remote_table forever, so we guard.
+    from xorq.caching.strategy import _rename_remote_table  # noqa: PLC0415
+
+    t = xo.memtable({"a": [1, 2, 3]})
+    con = t._find_backend()
+    rt_op = RemoteTable.from_expr(con, t)
+
+    with pytest.raises(RuntimeError, match="normalization_context"):
+        _rename_remote_table(rt_op, None)

--- a/python/xorq/common/utils/tests/snapshots/test_dask_normalize/test_duckdb_snapshot_key/duckdb_snapshot_key.txt
+++ b/python/xorq/common/utils/tests/snapshots/test_dask_normalize/test_duckdb_snapshot_key/duckdb_snapshot_key.txt
@@ -1,1 +1,1 @@
-snapshot-5d4d3239676c2df034a2d914e639bb4d
+letsql_cache-snapshot-5d4d3239676c2df034a2d914e639bb4d

--- a/python/xorq/common/utils/tests/snapshots/test_dask_normalize/test_pandas_snapshot_key/pandas_snapshot_key.txt
+++ b/python/xorq/common/utils/tests/snapshots/test_dask_normalize/test_pandas_snapshot_key/pandas_snapshot_key.txt
@@ -1,1 +1,1 @@
-snapshot-c48047b2547220de65a7bdbd1c5a2cca
+letsql_cache-snapshot-c48047b2547220de65a7bdbd1c5a2cca

--- a/python/xorq/common/utils/tests/test_hashing_tag.py
+++ b/python/xorq/common/utils/tests/test_hashing_tag.py
@@ -76,7 +76,7 @@ def test_find_by_expr_hash_works_for_hashing_tag():
     strategy = SnapshotStrategy()
     ht_hash = compute_expr_hash(ht, strategy=strategy)
 
-    found = find_by_expr_hash(ht, ht_hash, typs=(HashingTag,))
+    found = find_by_expr_hash(ht, ht_hash, typs=(HashingTag,), strategy=strategy)
     assert found is not None
     assert isinstance(found, HashingTag)
 

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
-  "build_dir_name": "66e4de23f826",
-  "expr.yaml": "d554cb87b2623dcab925dfad5ec2400f",
-  "expr_metadata.json": "355e405234525c1caeb885384ef76df3",
+  "build_dir_name": "14f28a7fe020",
+  "expr.yaml": "6ca64bf0d7c8813e95d6e92e02cb18cc",
+  "expr_metadata.json": "1a2e30847b8cf23d21dbb50b3f586672",
   "profiles.yaml": "8ce157f3b30e82f40d53d80397a2301c"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -4,8 +4,8 @@
   "d4c7b4371895.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "d9167e92b15e.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "19541e3c40591e62f6cc8a17fd54c6b7",
-  "expr.yaml": "6794366e2a90ddfc5b37b620cc16cd9c",
-  "expr_metadata.json": "8d3b0db233198828578d08c057ae65f4",
+  "expr.yaml": "146d2d9454ee8bf13483d0c0a8719c67",
+  "expr_metadata.json": "d8aca3a93ba67967de281e2d094b95a9",
   "profiles.yaml": "f466ae00fd29a8d8a4bb0a1badc3f1bc",
   "sql.yaml": "0622715aff78e58f75afe23246a64dda"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -4,8 +4,8 @@
   "d4c7b4371895.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "d9167e92b15e.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "934344b8a5c3facb0436cffffb3bccf7",
-  "expr.yaml": "48508fb71e16d7b174551682ca06194b",
-  "expr_metadata.json": "c95e2c383bbb45eed119fff3fb6eea89",
+  "expr.yaml": "dcc966f9da0db862c62669e85026b2f2",
+  "expr_metadata.json": "78d0fbc659903640b043ef6e33024e9b",
   "profiles.yaml": "f466ae00fd29a8d8a4bb0a1badc3f1bc",
   "sql.yaml": "0622715aff78e58f75afe23246a64dda"
 }

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -14,6 +14,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import xorq.api as xo
+from xorq.caching.strategy import SnapshotStrategy
 from xorq.cli import (
     OutputFormats,
     build_command,
@@ -868,10 +869,10 @@ def test_uv_build_with_extra(tmpdir):
 
 
 serve_hashes = (
-    "1e5f8b2b262dd841f1db1bc19ac6abc2",  # batting, rel.Read
-    "e210634ae2df82a56dd49d7cf7516d14",  # awards_players, rel.Read
-    "edaa2a90ba8df1688e67a24edb03964e",  # left, ops.Filter
-    "929550bdf9130ece976a83ae2cf285f8",  # right, ops.DropColumns
+    "0f76674432f4f2e88d98adf8cfa8b7b2",  # batting, rel.Read
+    "f2f7ee33ce2ff34ed8b11ca1e58aedcd",  # awards_players, rel.Read
+    "7adb47cba9c636e265af9710e5f805b5",  # left, ops.Filter
+    "b37e5c790be38823aca3a7bd151570d4",  # right, ops.DropColumns
 )
 
 
@@ -940,12 +941,14 @@ def hit_server(port, expr):
 @pytest.mark.parametrize("serve_hash", serve_hashes)
 def test_serve_unbound_hash(serve_hash, pipeline_https_build):
     lookup = {
-        "929550bdf9130ece976a83ae2cf285f8": "xorq.vendor.ibis.expr.operations.DropColumns",
-        "edaa2a90ba8df1688e67a24edb03964e": "xorq.vendor.ibis.expr.operations.Filter",
+        "b37e5c790be38823aca3a7bd151570d4": "xorq.vendor.ibis.expr.operations.DropColumns",
+        "7adb47cba9c636e265af9710e5f805b5": "xorq.vendor.ibis.expr.operations.Filter",
     }
     expr = load_expr(pipeline_https_build)
     typ = lookup.get(serve_hash)
-    subexpr = find_node(expr, hash=serve_hash, tag=None, typs=typ).to_expr()
+    subexpr = find_node(
+        expr, hash=serve_hash, tag=None, typs=typ, strategy=SnapshotStrategy()
+    ).to_expr()
 
     serve_args = (
         "xorq",
@@ -1097,7 +1100,7 @@ def test_serve_penguins_template(tmpdir, tmp_path):
     assert returncode == 0, stderr
 
     if match := re.search(f"{target_dir}/([0-9a-f]+)", stdout.decode("ascii")):
-        serve_hash = "d9cebcfbeeadc40f4a39814357716481"  # RemoteTable (test split)
+        serve_hash = "2e6380c0c379fbac0f8270a7418a590b"  # RemoteTable (test split)
 
         serve_args = (
             "xorq",


### PR DESCRIPTION
## Problem

SnapshotStrategy was delegating to `normalize_read`, which calls `normalize_read_path_stat` (mtime/size/inode), making snapshot keys sensitive to file changes — defeating the point of a snapshot strategy.

## Changes

**Core fix: path-identity normalization**
- Introduce `snapshot_normalize_read` that keys on path identity only (file path, mode, schema, temporary), ignoring mtime/size/inode.
- Prefer `read_path` over `hash_path` for materialized build-bundle reads, since `hash_path` is an absolute tmpdir path that changes every run.

**Push `key_prefix` down to `CacheStrategy`**
- Move `key_prefix` field from `Cache` to `CacheStrategy` base class so the strategy solely determines the full cache key.
- Remove the `FIXME` in `Cache.calc_key` — it no longer prepends `key_prefix` itself.
- Include `key_prefix` in `CacheStrategy.__dask_tokenize__` so strategies with different prefixes produce different tokens.

**Guard `_rename_remote_table` with `ContextVar`**
- Extract `_rename_remote_table` to module level and gate it behind an `_in_normalization_context` `ContextVar`.
- Raises `RuntimeError` if called outside `SnapshotStrategy.normalization_context`, resolving the previous `FIXME` about verifying context.

**Replace bare `assert` with `TypeError`**
- `Cache.__attrs_post_init__` and `GCSCache.__attrs_post_init__` now raise `TypeError` with a descriptive message instead of using `assert`.

**Tests**
- Add `test_snapshot_strategy_key_is_path_identity`: regression test proving snapshot keys are stable across file rewrites (clears `@functools.cache` between runs to simulate a fresh process).
- Add `test_rename_remote_table_outside_normalization_context_raises`: verifies the `ContextVar` guard.
- Fix `test_find_by_expr_hash_works_for_hashing_tag` to pass strategy consistently when computing and searching by hash.
- Update snapshot key fixtures and build-file-stability expected values.