### PR TITLE
fix(worktree): copy .gitignore instead of symlinking

### DIFF
--- a/dev/setup-worktree
+++ b/dev/setup-worktree
@@ -19,8 +19,16 @@ for f in "$main"/.envrcs/.envrc.secrets "$main"/.envrcs/.envrc.user "$main"/.env
     fi
 done
 
-# Symlink shared dotfiles from main worktree
-for target in .gitignore .claude ci/ibis-testing-data; do
+# Copy files that git opens with O_NOFOLLOW (symlinks cause ELOOP)
+for target in .gitignore; do
+    if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
+        cp -v "$main/$target" "$here/$target"
+        echo "$target" >> "$manifest"
+    fi
+done
+
+# Symlink shared directories from main worktree
+for target in .claude ci/ibis-testing-data; do
     if [ -e "$main/$target" ] && [ ! -e "$here/$target" ]; then
         mkdir -p "$(dirname "$here/$target")"
         ln -sv "$main/$target" "$here/$target"


### PR DESCRIPTION
## Summary
- git opens `.gitignore` with `O_NOFOLLOW`, so a symlinked `.gitignore` always fails with ELOOP ("Too many levels of symbolic links")
- Changed `dev/setup-worktree` to copy `.gitignore` instead of symlinking it
- Other entries (`.claude`, `ci/ibis-testing-data`) remain symlinks — they're directories that git doesn't open with `O_NOFOLLOW`

## Test plan
- [x] Run `dev/setup-worktree` in a new worktree, verify `.gitignore` is a regular file
- [x] Run `git add` in the worktree, verify no ELOOP warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)