### PR TITLE
refactor: consolidate default backend to xorq_datafusion 

### DIFF
--- a/python/xorq/backends/databricks/__init__.py
+++ b/python/xorq/backends/databricks/__init__.py
@@ -25,7 +25,7 @@ import xorq.vendor.ibis.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
 import xorq.vendor.ibis.expr.schema as sch
 import xorq.vendor.ibis.expr.types as ir
-from xorq.expr.api import read_parquet
+from xorq.config import _backend_init
 from xorq.vendor.ibis import util
 from xorq.vendor.ibis.backends import CanCreateDatabase, UrlFromPath
 from xorq.vendor.ibis.backends.sql import SQLBackend
@@ -521,7 +521,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
     ) -> ir.Table:
         if table_name is None:
             table_name = util.gen_name("ls-read-parquet")
-        record_batches = read_parquet(path).to_pyarrow_batches()
+        record_batches = _backend_init().read_parquet(path).to_pyarrow_batches()
         return self.read_record_batches(
             record_batches=record_batches,
             table_name=table_name,

--- a/python/xorq/backends/databricks/__init__.py
+++ b/python/xorq/backends/databricks/__init__.py
@@ -25,7 +25,7 @@ import xorq.vendor.ibis.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
 import xorq.vendor.ibis.expr.schema as sch
 import xorq.vendor.ibis.expr.types as ir
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.vendor.ibis import util
 from xorq.vendor.ibis.backends import CanCreateDatabase, UrlFromPath
 from xorq.vendor.ibis.backends.sql import SQLBackend
@@ -521,7 +521,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
     ) -> ir.Table:
         if table_name is None:
             table_name = util.gen_name("ls-read-parquet")
-        record_batches = _backend_init().read_parquet(path).to_pyarrow_batches()
+        record_batches = default_backend().read_parquet(path).to_pyarrow_batches()
         return self.read_record_batches(
             record_batches=record_batches,
             table_name=table_name,

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -12,7 +12,7 @@ from xorq.backends.postgres.compiler import compiler
 from xorq.common.utils.defer_utils import (
     read_csv_rbr,
 )
-from xorq.expr.api import read_parquet
+from xorq.config import _backend_init
 from xorq.vendor.ibis.backends.postgres import Backend as IbisPostgresBackend
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import (
@@ -125,7 +125,7 @@ class Backend(IbisPostgresBackend):
                 )
             else:
                 table_name = gen_name("ls-read-parquet")
-        record_batches = read_parquet(path).to_pyarrow_batches()
+        record_batches = _backend_init().read_parquet(path).to_pyarrow_batches()
         return self.read_record_batches(
             record_batches=record_batches,
             table_name=table_name,

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -12,7 +12,7 @@ from xorq.backends.postgres.compiler import compiler
 from xorq.common.utils.defer_utils import (
     read_csv_rbr,
 )
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.vendor.ibis.backends.postgres import Backend as IbisPostgresBackend
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import (
@@ -125,7 +125,7 @@ class Backend(IbisPostgresBackend):
                 )
             else:
                 table_name = gen_name("ls-read-parquet")
-        record_batches = _backend_init().read_parquet(path).to_pyarrow_batches()
+        record_batches = default_backend().read_parquet(path).to_pyarrow_batches()
         return self.read_record_batches(
             record_batches=record_batches,
             table_name=table_name,

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import sqlglot as sg
 import sqlglot.expressions as sge
 
-from xorq.expr.api import read_csv, read_parquet
+from xorq.config import _backend_init
 from xorq.vendor.ibis import Schema, util
 from xorq.vendor.ibis.backends.sqlite import Backend as IbisSQLiteBackend
 from xorq.vendor.ibis.backends.sqlite import _quote
@@ -95,7 +95,7 @@ class Backend(IbisSQLiteBackend):
         **kwargs: Any,
     ) -> ir.Table:
         table_name = table_name or gen_name("xo_read_parquet")
-        record_batches = read_parquet(path).to_pyarrow_batches()
+        record_batches = _backend_init().read_parquet(path).to_pyarrow_batches()
         return self.read_record_batches(record_batches, table_name, mode, **kwargs)
 
     def read_csv(
@@ -106,5 +106,5 @@ class Backend(IbisSQLiteBackend):
         **kwargs: Any,
     ) -> ir.Table:
         table_name = table_name or gen_name("xo_read_csv")
-        record_batches = read_csv(path).to_pyarrow_batches()
+        record_batches = _backend_init().read_csv(path).to_pyarrow_batches()
         return self.read_record_batches(record_batches, table_name, mode, **kwargs)

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import sqlglot as sg
 import sqlglot.expressions as sge
 
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.vendor.ibis import Schema, util
 from xorq.vendor.ibis.backends.sqlite import Backend as IbisSQLiteBackend
 from xorq.vendor.ibis.backends.sqlite import _quote
@@ -95,7 +95,7 @@ class Backend(IbisSQLiteBackend):
         **kwargs: Any,
     ) -> ir.Table:
         table_name = table_name or gen_name("xo_read_parquet")
-        record_batches = _backend_init().read_parquet(path).to_pyarrow_batches()
+        record_batches = default_backend().read_parquet(path).to_pyarrow_batches()
         return self.read_record_batches(record_batches, table_name, mode, **kwargs)
 
     def read_csv(
@@ -106,5 +106,5 @@ class Backend(IbisSQLiteBackend):
         **kwargs: Any,
     ) -> ir.Table:
         table_name = table_name or gen_name("xo_read_csv")
-        record_batches = _backend_init().read_csv(path).to_pyarrow_batches()
+        record_batches = default_backend().read_csv(path).to_pyarrow_batches()
         return self.read_record_batches(record_batches, table_name, mode, **kwargs)

--- a/python/xorq/backends/xorq_datafusion/tests/test_api.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_api.py
@@ -7,7 +7,7 @@ from xorq.api import SessionConfig
 
 @pytest.mark.xfail(reason="No purpose with no registration api")
 def test_executed_on_original_backend(parquet_dir, csv_dir, mocker):
-    con = xo.config._backend_init()
+    con = xo.config.default_backend()
     spy = mocker.spy(con, "execute")
 
     parquet_table = con.read_parquet(parquet_dir / "batting.parquet")[

--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -27,7 +27,7 @@ from xorq.common.utils.defer_utils import (
 from xorq.common.utils.func_utils import (
     if_not_none,
 )
-from xorq.config import _backend_init, options
+from xorq.config import default_backend, options
 from xorq.vendor import ibis
 
 
@@ -86,7 +86,7 @@ def _write_parquet(path, batch_reader, parquet_metadata=None):
 class ParquetStorage(CacheStorage):
     source = field(
         validator=instance_of(ibis.backends.BaseBackend),
-        factory=_backend_init,
+        factory=default_backend,
     )
     relative_path = field(
         validator=instance_of(Path),
@@ -186,7 +186,7 @@ class ParquetDummyStorage(ParquetStorage):
 class SourceStorage(CacheStorage):
     source = field(
         validator=instance_of(ibis.backends.BaseBackend),
-        factory=_backend_init,
+        factory=default_backend,
     )
 
     def __dask_tokenize__(self):

--- a/python/xorq/common/utils/caching_utils.py
+++ b/python/xorq/common/utils/caching_utils.py
@@ -45,9 +45,9 @@ def find_backend(op: ops.Node, use_default=False) -> tuple[BaseBackend, bool]:
             backends.add(table.source)
 
     if not backends and use_default:
-        from xorq.config import _backend_init  # noqa: PLC0415
+        from xorq.config import default_backend  # noqa: PLC0415
 
-        con = _backend_init()
+        con = default_backend()
         backends.add(con)
 
     return (

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -13,7 +13,7 @@ from xorq.backends.xorq_datafusion import connect as xo_connect
 from xorq.common.utils.inspect_utils import (
     get_arguments,
 )
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.expr.relations import (
     Read,
 )
@@ -170,7 +170,7 @@ def deferred_read_csv(
     deferred_read_csv.method_name = method_name = "read_csv"
 
     if con is None:
-        con = _backend_init()
+        con = default_backend()
 
     method = getattr(con, method_name)
 
@@ -242,7 +242,7 @@ def deferred_read_parquet(
 
     deferred_read_parquet.method_name = method_name = "read_parquet"
     if con is None:
-        con = _backend_init()
+        con = default_backend()
     method = getattr(con, method_name)
     if table_name is None:
         table_name = gen_name(f"xorq-{method_name}")

--- a/python/xorq/common/utils/gcloud_utils.py
+++ b/python/xorq/common/utils/gcloud_utils.py
@@ -12,7 +12,7 @@ from google.cloud import storage
 from toolz import curry
 
 from xorq.caching.storage import CacheStorage
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.vendor.ibis.backends import BaseBackend
 
 
@@ -56,7 +56,7 @@ class GCStorage(CacheStorage):
     bucket_name: str = field(validator=instance_of(str))
     source = field(
         validator=instance_of(BaseBackend),
-        factory=_backend_init,
+        factory=default_backend,
     )
     fs: gcsfs.GCSFileSystem = field(init=False)
 

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -4,12 +4,12 @@ import ast
 import pathlib
 from typing import Any, Optional
 
-from xorq.backends.xorq_datafusion import connect
 from xorq.common.utils.env_utils import (
     EnvConfigable,
     env_templates_dir,
 )
 from xorq.vendor import ibis
+from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.config import Config
 from xorq.vendor.ibis.config import Options as IbisOptions
 
@@ -167,8 +167,10 @@ class Options(IbisOptions):
     ----------
     cache : Cache
         Options controlling caching.
-    default_backend : Optional[xorq.backends.xorq_datafusion.Backend]
-        The default backend to use for execution.
+    default_backend : Optional[xorq.vendor.ibis.backends.BaseBackend]
+        The default backend to use for execution. Defaults to a lazily
+        initialised xorq_datafusion backend; may be set to any BaseBackend
+        instance (e.g. via ``xorq.set_backend``).
     repr : Repr
         Options controlling expression printing.
     """
@@ -177,6 +179,7 @@ class Options(IbisOptions):
     repr: Repr = Repr()
     sql: SQL = SQL()
     pins: Pins = Pins()
+    default_backend: Optional[BaseBackend] = None
     debug: bool = bool(ast.literal_eval(env_config.XORQ_DEBUG or 0))
 
     @property
@@ -192,9 +195,12 @@ class Options(IbisOptions):
 options = Options()
 
 
-def _backend_init():
+def default_backend():
+    """Return the lazily initialised default backend (xorq_datafusion)."""
     if (backend := options.default_backend) is not None:
         return backend
+
+    from xorq.backends.xorq_datafusion import connect  # noqa: PLC0415
 
     options.default_backend = con = connect()
     return con

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import ast
 import pathlib
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from xorq.backends.xorq_datafusion import connect
 from xorq.common.utils.env_utils import (
@@ -27,7 +29,7 @@ class Cache(Config):
 
     """
 
-    default_relative_path: Union[str, pathlib.Path] = pathlib.Path(
+    default_relative_path: str | pathlib.Path = pathlib.Path(
         env_config.XORQ_DEFAULT_RELATIVE_PATH
     )
     key_prefix: str = env_config.XORQ_CACHE_KEY_PREFIX
@@ -165,14 +167,13 @@ class Options(IbisOptions):
     ----------
     cache : Cache
         Options controlling caching.
-    backend : Optional[xorq.backends.xorq_datafusion.Backend]
-        The backend to use for execution.
+    default_backend : Optional[xorq.backends.xorq_datafusion.Backend]
+        The default backend to use for execution.
     repr : Repr
         Options controlling expression printing.
     """
 
     cache: Cache = Cache()
-    backend: Optional[Any] = None
     repr: Repr = Repr()
     sql: SQL = SQL()
     pins: Pins = Pins()
@@ -192,8 +193,8 @@ options = Options()
 
 
 def _backend_init():
-    if (backend := options.backend) is not None:
+    if (backend := options.default_backend) is not None:
         return backend
 
-    options.backend = con = connect()
+    options.default_backend = con = connect()
     return con

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -202,5 +202,12 @@ def default_backend():
 
     from xorq.backends.xorq_datafusion import connect  # noqa: PLC0415
 
-    options.default_backend = con = connect()
+    con = connect()
+    # Pin idx to a stable sentinel so the default backend's profile name is
+    # identical across processes and test orderings. Otherwise it varies with
+    # whatever the global itertools.count() factory has consumed, and leaks
+    # into profiles.yaml, expr.yaml profile refs, and cache keys derived from
+    # the default backend.
+    con._profile = con._profile.clone(idx=-1)
+    options.default_backend = con
     return con

--- a/python/xorq/examples/__init__.py
+++ b/python/xorq/examples/__init__.py
@@ -1,4 +1,4 @@
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.examples.core import (
     get_name_to_suffix,
     get_table_from_name,
@@ -12,7 +12,7 @@ class Example:
 
     def fetch(self, backend=None, table_name=None, deferred=True, **kwargs):
         if backend is None:
-            backend = _backend_init()
+            backend = default_backend()
 
         return get_table_from_name(
             self.name,

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -51,8 +51,6 @@ if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
 
-EXCLUDE = ("read_csv", "read_parquet")
-
 __all__ = (
     "execute",
     "calc_split_column",
@@ -72,7 +70,7 @@ __all__ = (
     "deferred_read_parquet",
     "get_object_metadata",
     "bind_params",
-    *(member for member in api.__all__ if member not in EXCLUDE),
+    *api.__all__,
 )
 
 

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -39,9 +39,11 @@ from xorq.expr.relations import (
     Tag,
     register_and_transform_remote_tables,
 )
+from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import api
 from xorq.vendor.ibis.expr.api import *  # noqa: F403
 from xorq.vendor.ibis.expr.sql import SQLString
+from xorq.vendor.ibis.expr.types import Expr
 
 
 if TYPE_CHECKING:
@@ -54,9 +56,11 @@ if TYPE_CHECKING:
 __all__ = (
     "execute",
     "calc_split_column",
+    "get_backend",
     "read_postgres",
     "read_pyarrow_stream",
     "register",
+    "set_backend",
     "train_test_splits",
     "to_parquet",
     "to_csv",
@@ -74,15 +78,80 @@ __all__ = (
 )
 
 
+def set_backend(backend: str | BaseBackend) -> None:
+    """Set the default xorq backend.
+
+    Parameters
+    ----------
+    backend
+        May be a backend name or URL, or an existing backend instance.
+
+    Examples
+    --------
+    You can pass the backend as a name:
+
+    >>> import xorq
+    >>> xorq.set_backend("datafusion")  # doctest: +SKIP
+
+    Or as a URI:
+
+    >>> xorq.set_backend(
+    ...     "postgres://user:password@hostname:5432"
+    ... )  # quartodoc: +SKIP # doctest: +SKIP
+
+    Or as an existing backend instance:
+
+    >>> con = xorq.connect()  # doctest: +SKIP
+    >>> xorq.set_backend(con)  # doctest: +SKIP
+
+    """
+    from xorq.config import options  # noqa: PLC0415
+    from xorq.loader import load_backend  # noqa: PLC0415
+    from xorq.vendor.ibis.backends import connect as ibis_connect  # noqa: PLC0415
+
+    if isinstance(backend, str):
+        if backend.isidentifier():
+            backend = load_backend(backend).connect()
+        else:
+            # URL path also dispatches through the ``xorq.backends`` entry
+            # points (see ``xorq.loader.load_backend``), so the resulting
+            # backend is a xorq backend, not the vendored ibis one.
+            backend = ibis_connect(backend)
+
+    options.default_backend = backend
+
+
+def get_backend(expr: Expr | None = None) -> BaseBackend:
+    """Get the xorq backend to use for a given expression.
+
+    Parameters
+    ----------
+    expr
+        An expression to get the backend from. If not passed, the default
+        backend is returned.
+
+    Returns
+    -------
+    BaseBackend
+        The backend.
+
+    """
+    if expr is None:
+        from xorq.config import default_backend  # noqa: PLC0415
+
+        return default_backend()
+    return expr._find_backend(use_default=True)
+
+
 def read_pyarrow_stream(
     source,
     con=None,
     table_name=None,
     **kwargs,
 ) -> ir.Table:
-    from xorq.config import _backend_init  # noqa: PLC0415
+    from xorq.config import default_backend  # noqa: PLC0415
 
-    con = con or _backend_init()
+    con = con or default_backend()
     rbr = pa.ipc.open_stream(source, **kwargs)
     return con.read_record_batches(rbr, table_name=table_name)
 
@@ -92,9 +161,9 @@ def register(
     table_name: str | None = None,
     **kwargs: Any,
 ):
-    from xorq.config import _backend_init  # noqa: PLC0415
+    from xorq.config import default_backend  # noqa: PLC0415
 
-    con = _backend_init()
+    con = default_backend()
     return con.register(source, table_name=table_name, **kwargs)
 
 
@@ -103,9 +172,9 @@ def read_postgres(
     table_name: str | None = None,
     **kwargs: Any,
 ):
-    from xorq.config import _backend_init  # noqa: PLC0415
+    from xorq.config import default_backend  # noqa: PLC0415
 
-    con = _backend_init()
+    con = default_backend()
     return con.read_postgres(uri, table_name=table_name, **kwargs)
 
 
@@ -578,9 +647,9 @@ def get_plans(expr):
 
 
 def get_object_metadata(path: str, **kwargs: Any) -> dict:
-    from xorq.config import _backend_init  # noqa: PLC0415
+    from xorq.config import default_backend  # noqa: PLC0415
 
-    con = _backend_init()
+    con = default_backend()
 
     suffix = extract_suffix(path).lstrip(".")
 

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -55,7 +55,7 @@ from xorq.common.utils.node_utils import (
     update_read_kwargs,
 )
 from xorq.config import _backend_init
-from xorq.expr.api import deferred_read_parquet, read_parquet
+from xorq.expr.api import deferred_read_parquet
 from xorq.expr.operations import _MISSING
 from xorq.expr.relations import (
     CachedNode,
@@ -692,7 +692,7 @@ class ExprLoader:
                 df = (
                     pq.read_schema(path).empty_table().to_pandas()
                     if read_only_parquet_metadata
-                    else read_parquet(path).execute()
+                    else _backend_init().read_parquet(path).execute()
                 )
                 return ibis.memtable(df, schema=dr.schema, name=dr.name).op()
             resolved_kwargs = update_read_kwargs(dr.read_kwargs, (("hash_path", path),))

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -54,7 +54,7 @@ from xorq.common.utils.node_utils import (
     recreate,
     update_read_kwargs,
 )
-from xorq.config import _backend_init
+from xorq.config import default_backend
 from xorq.expr.api import deferred_read_parquet
 from xorq.expr.operations import _MISSING
 from xorq.expr.relations import (
@@ -341,7 +341,9 @@ def hydrate_cons(hash_to_profile_kwargs, lazy=False):
     return profiles
 
 
-def make_read_op(parquet_path, read_kwargs, con=_backend_init()):  # noqa: B008
+def make_read_op(parquet_path, read_kwargs, con=None):
+    if con is None:
+        con = default_backend()
     op = deferred_read_parquet(parquet_path, con, **read_kwargs).op()
     args = dict(zip(op.__argnames__, op.__args__))
     op = op.__recreate__(args)
@@ -692,7 +694,7 @@ class ExprLoader:
                 df = (
                     pq.read_schema(path).empty_table().to_pandas()
                     if read_only_parquet_metadata
-                    else _backend_init().read_parquet(path).execute()
+                    else default_backend().read_parquet(path).execute()
                 )
                 return ibis.memtable(df, schema=dr.schema, name=dr.name).op()
             resolved_kwargs = update_read_kwargs(dr.read_kwargs, (("hash_path", path),))

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "14f28a7fe020",
-  "expr.yaml": "6ca64bf0d7c8813e95d6e92e02cb18cc",
-  "expr_metadata.json": "1a2e30847b8cf23d21dbb50b3f586672",
-  "profiles.yaml": "8ce157f3b30e82f40d53d80397a2301c"
+  "expr.yaml": "0b57cd6f2a3f1140eaea0c8dda01dc7a",
+  "expr_metadata.json": "23b3c965bfa8c39429a6f6c63edb5321",
+  "profiles.yaml": "36cb6dafbc7613d5a3259a7cc51b893d"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "14f28a7fe020",
-  "expr.yaml": "0b57cd6f2a3f1140eaea0c8dda01dc7a",
+  "expr.yaml": "a2b9b016cc41ec5a33708025f104e2b1",
   "expr_metadata.json": "23b3c965bfa8c39429a6f6c63edb5321",
-  "profiles.yaml": "36cb6dafbc7613d5a3259a7cc51b893d"
+  "profiles.yaml": "0b42056eeda03dc3b550ccf51546c110"
 }

--- a/python/xorq/tests/test_api.py
+++ b/python/xorq/tests/test_api.py
@@ -10,7 +10,7 @@ from pytest import param
 import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
 from xorq.backends.xorq_datafusion import Backend
-from xorq.config import _backend_init, options
+from xorq.config import default_backend, options
 from xorq.tests.conftest import TEST_TABLES
 
 
@@ -134,24 +134,41 @@ def test_deferred_read(method):
     assert hasattr(xo, method)
 
 
-def test_default_backend_is_datafusion():
-    assert isinstance(_backend_init(), Backend)
+@pytest.fixture
+def reset_default_backend():
+    saved = options.default_backend
+    options.default_backend = None
+    try:
+        yield
+    finally:
+        options.default_backend = saved
 
 
-def test_default_backend_is_singleton():
-    first = _backend_init()
-    second = _backend_init()
+def test_default_backend_is_datafusion(reset_default_backend):
+    assert isinstance(default_backend(), Backend)
+
+
+def test_default_backend_is_singleton(reset_default_backend):
+    first = default_backend()
+    second = default_backend()
     assert first is second
 
 
-def test_get_backend_no_args_returns_default():
+def test_get_backend_no_args_returns_default(reset_default_backend):
     backend = xo.get_backend()
     assert backend is options.default_backend
 
 
-def test_get_backend_with_expr_returns_expr_backend(con):
-    t = con.table("functional_alltypes")
-    assert xo.get_backend(t) is con
+@pytest.fixture
+def non_default_con(con):
+    if con is options.default_backend:
+        pytest.skip("conftest `con` fixture is the default backend")
+    return con
+
+
+def test_get_backend_with_expr_returns_expr_backend(non_default_con):
+    t = non_default_con.table("functional_alltypes")
+    assert xo.get_backend(t) is non_default_con
 
 
 @pytest.mark.benchmark

--- a/python/xorq/tests/test_api.py
+++ b/python/xorq/tests/test_api.py
@@ -9,6 +9,8 @@ from pytest import param
 
 import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
+from xorq.backends.xorq_datafusion import Backend
+from xorq.config import _backend_init, options
 from xorq.tests.conftest import TEST_TABLES
 
 
@@ -130,6 +132,26 @@ def test_write(alltypes, df, tmp_path, extension, write, read):
 )
 def test_deferred_read(method):
     assert hasattr(xo, method)
+
+
+def test_default_backend_is_datafusion():
+    assert isinstance(_backend_init(), Backend)
+
+
+def test_default_backend_is_singleton():
+    first = _backend_init()
+    second = _backend_init()
+    assert first is second
+
+
+def test_get_backend_no_args_returns_default():
+    backend = xo.get_backend()
+    assert backend is options.default_backend
+
+
+def test_get_backend_with_expr_returns_expr_backend(con):
+    t = con.table("functional_alltypes")
+    assert xo.get_backend(t) is con
 
 
 @pytest.mark.benchmark

--- a/python/xorq/vendor/ibis/config.py
+++ b/python/xorq/vendor/ibis/config.py
@@ -7,12 +7,10 @@ from typing import Annotated, Any, Optional
 
 from public import public
 
-import xorq.common.exceptions as com
 from xorq.common.utils.env_utils import (
     EnvConfigable,
     env_templates_dir,
 )
-from xorq.loader import load_backend
 from xorq.vendor.ibis.common.grounds import Annotable
 from xorq.vendor.ibis.common.patterns import Between
 
@@ -188,38 +186,6 @@ class Options(Config):
     pandas: Optional[Config] = None
     pyspark: Optional[Config] = None
     profiles: Profiles = Profiles()
-
-
-def _default_backend() -> Any:
-    if (backend := options.default_backend) is not None:
-        return backend
-
-    try:
-        import duckdb as _  # noqa: F401
-    except ImportError:
-        raise com.XorqError(
-            """\
-You have used a function that relies on the default backend, but the default
-backend (DuckDB) is not installed.
-
-You may specify an alternate backend to use, e.g.
-
-ibis.set_backend("polars")
-
-or to install the DuckDB backend, run:
-
-    pip install 'ibis-framework[duckdb]'
-
-or
-
-    conda install -c conda-forge ibis-framework
-
-For more information on available backends, visit https://ibis-project.org/install
-"""
-        )
-
-    options.default_backend = con = load_backend("duckdb").connect(":memory:")
-    return con
 
 
 options = Options()

--- a/python/xorq/vendor/ibis/config.py
+++ b/python/xorq/vendor/ibis/config.py
@@ -156,8 +156,8 @@ class Options(Config):
     graphviz_repr : bool
         Render expressions as GraphViz PNGs when running in a Jupyter notebook.
     default_backend : Optional[ibis.backends.BaseBackend]
-        The default backend to use for execution, defaults to DuckDB if not
-        set.
+        The default backend to use for execution. xorq lazily initialises this
+        to an ``xorq_datafusion`` backend on first use if unset.
     sql: SQL
         SQL-related options.
     clickhouse : Config | None
@@ -189,6 +189,17 @@ class Options(Config):
 
 
 options = Options()
+
+
+def _default_backend() -> Any:
+    """Return the default backend, lazily initialising it via the outer xorq layer.
+
+    Single seam through which vendored code obtains the default backend so the
+    rest of the vendor tree does not import ``xorq.config`` directly.
+    """
+    from xorq.config import default_backend  # noqa: PLC0415
+
+    return default_backend()
 
 
 @public

--- a/python/xorq/vendor/ibis/examples/__init__.py
+++ b/python/xorq/vendor/ibis/examples/__init__.py
@@ -34,7 +34,9 @@ class Example(Concrete):
         backend: BaseBackend | None = None,
     ) -> ir.Table:
         if backend is None:
-            backend = ibis.get_backend()
+            from xorq.vendor.ibis.config import _default_backend  # noqa: PLC0415
+
+            backend = _default_backend()
 
         name = self.name
 
@@ -140,7 +142,9 @@ class Zones(Concrete):
         backend: BaseBackend | None = None,
     ) -> ir.Table:
         if backend is None:
-            backend = ibis.get_backend()
+            from xorq.vendor.ibis.config import _default_backend  # noqa: PLC0415
+
+            backend = _default_backend()
 
         name = self.name
 

--- a/python/xorq/vendor/ibis/expr/api.py
+++ b/python/xorq/vendor/ibis/expr/api.py
@@ -18,7 +18,7 @@ import xorq.vendor.ibis.expr.schema as sch
 import xorq.vendor.ibis.expr.types as ir
 from xorq.common.exceptions import XorqInputError
 from xorq.vendor.ibis import selectors, util
-from xorq.vendor.ibis.backends import BaseBackend, connect
+from xorq.vendor.ibis.backends import connect
 from xorq.vendor.ibis.common.deferred import Deferred, _, deferrable
 from xorq.vendor.ibis.common.dispatch import lazy_singledispatch
 from xorq.vendor.ibis.common.grounds import Concrete
@@ -134,7 +134,6 @@ __all__ = (
     "geo_y",
     "geo_y_max",
     "geo_y_min",
-    "get_backend",
     "greatest",
     "ifelse",
     "infer_dtype",
@@ -164,7 +163,6 @@ __all__ = (
     "rows_window",
     "schema",
     "selectors",
-    "set_backend",
     "struct",
     "table",
     "time",
@@ -1456,68 +1454,6 @@ def row_number() -> ir.IntegerColumn:
 
     """
     return ops.RowNumber().to_expr()
-
-
-def set_backend(backend: str | BaseBackend) -> None:
-    """Set the default xorq backend.
-
-    Parameters
-    ----------
-    backend
-        May be a backend name or URL, or an existing backend instance.
-
-    Examples
-    --------
-    You can pass the backend as a name:
-
-    >>> import xorq
-    >>> xorq.set_backend("datafusion")
-
-    Or as a URI
-
-    >>> xorq.set_backend(
-    ...     "postgres://user:password@hostname:5432"
-    ... )  # quartodoc: +SKIP # doctest: +SKIP
-
-    Or as an existing backend instance
-
-    >>> import xorq
-    >>> xorq.set_backend(xorq.connect())
-
-    """
-    from xorq.vendor import ibis
-
-    if isinstance(backend, str) and backend.isidentifier():
-        try:
-            backend_type = getattr(ibis, backend)
-        except AttributeError:
-            pass
-        else:
-            backend = backend_type.connect()
-    if isinstance(backend, str):
-        backend = ibis.connect(backend)
-
-    ibis.options.default_backend = backend
-
-
-def get_backend(expr: Expr | None = None) -> BaseBackend:
-    """Get the current Ibis backend to use for a given expression.
-
-    expr
-        An expression to get the backend from. If not passed, the default
-        backend is returned.
-
-    Returns
-    -------
-    BaseBackend
-        The Ibis backend.
-
-    """
-    if expr is None:
-        from xorq.config import _backend_init  # noqa: PLC0415
-
-        return _backend_init()
-    return expr._find_backend(use_default=True)
 
 
 def window(

--- a/python/xorq/vendor/ibis/expr/api.py
+++ b/python/xorq/vendor/ibis/expr/api.py
@@ -41,12 +41,11 @@ from xorq.vendor.ibis.expr.types import (
     null,
     struct,
 )
-from xorq.vendor.ibis.util import deprecated, experimental
+from xorq.vendor.ibis.util import deprecated
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
-    from pathlib import Path
+    from collections.abc import Iterable
 
     import pandas as pd
     import polars as pl
@@ -161,10 +160,6 @@ __all__ = (
     "range",
     "range_window",
     "rank",
-    "read_csv",
-    "read_delta",
-    "read_json",
-    "read_parquet",
     "row_number",
     "rows_window",
     "schema",
@@ -1463,230 +1458,8 @@ def row_number() -> ir.IntegerColumn:
     return ops.RowNumber().to_expr()
 
 
-def read_csv(
-    sources: str | Path | Sequence[str | Path],
-    table_name: str | None = None,
-    **kwargs: Any,
-) -> ir.Table:
-    """Lazily load a CSV or set of CSVs.
-
-    This function delegates to the `read_csv` method on the current default
-    backend (DuckDB or `ibis.config.default_backend`).
-
-    Parameters
-    ----------
-    sources
-        A filesystem path or URL or list of same.  Supports CSV and TSV files.
-    table_name
-        A name to refer to the table.  If not provided, a name will be generated.
-    kwargs
-        Backend-specific keyword arguments for the file type. For the DuckDB
-        backend used by default, please refer to:
-
-        * CSV/TSV: https://duckdb.org/docs/data/csv/overview.html#parameters.
-
-    Returns
-    -------
-    ir.Table
-        Table expression representing a file
-
-    Examples
-    --------
-    >>> import ibis
-    >>> ibis.options.interactive = True
-    >>> lines = '''a,b
-    ... 1,d
-    ... 2,
-    ... ,f
-    ... '''
-    >>> with open("/tmp/lines.csv", mode="w") as f:
-    ...     nbytes = f.write(lines)  # nbytes is unused
-    >>> t = ibis.read_csv("/tmp/lines.csv")
-    >>> t
-    ┏━━━━━━━┳━━━━━━━━┓
-    ┃ a     ┃ b      ┃
-    ┡━━━━━━━╇━━━━━━━━┩
-    │ int64 │ string │
-    ├───────┼────────┤
-    │     1 │ d      │
-    │     2 │ NULL   │
-    │  NULL │ f      │
-    └───────┴────────┘
-
-    """
-    from xorq.vendor.ibis.config import _default_backend
-
-    con = _default_backend()
-    return con.read_csv(sources, table_name=table_name, **kwargs)
-
-
-@experimental
-def read_json(
-    sources: str | Path | Sequence[str | Path],
-    table_name: str | None = None,
-    **kwargs: Any,
-) -> ir.Table:
-    """Lazily load newline-delimited JSON data.
-
-    This function delegates to the `read_json` method on the current default
-    backend (DuckDB or `ibis.config.default_backend`).
-
-    Parameters
-    ----------
-    sources
-        A filesystem path or URL or list of same.
-    table_name
-        A name to refer to the table.  If not provided, a name will be generated.
-    kwargs
-        Backend-specific keyword arguments for the file type. See
-        https://duckdb.org/docs/extensions/json.html for details.
-
-    Returns
-    -------
-    ir.Table
-        Table expression representing a file
-
-    Examples
-    --------
-    >>> import ibis
-    >>> ibis.options.interactive = True
-    >>> lines = '''
-    ... {"a": 1, "b": "d"}
-    ... {"a": 2, "b": null}
-    ... {"a": null, "b": "f"}
-    ... '''
-    >>> with open("/tmp/lines.json", mode="w") as f:
-    ...     nbytes = f.write(lines)  # nbytes is unused
-    >>> t = ibis.read_json("/tmp/lines.json")
-    >>> t
-    ┏━━━━━━━┳━━━━━━━━┓
-    ┃ a     ┃ b      ┃
-    ┡━━━━━━━╇━━━━━━━━┩
-    │ int64 │ string │
-    ├───────┼────────┤
-    │     1 │ d      │
-    │     2 │ NULL   │
-    │  NULL │ f      │
-    └───────┴────────┘
-
-    """
-    from xorq.vendor.ibis.config import _default_backend
-
-    con = _default_backend()
-    return con.read_json(sources, table_name=table_name, **kwargs)
-
-
-def read_parquet(
-    sources: str | Path | Sequence[str | Path],
-    table_name: str | None = None,
-    **kwargs: Any,
-) -> ir.Table:
-    """Lazily load a parquet file or set of parquet files.
-
-    This function delegates to the `read_parquet` method on the current default
-    backend (DuckDB or `ibis.config.default_backend`).
-
-    Parameters
-    ----------
-    sources
-        A filesystem path or URL or list of same.
-    table_name
-        A name to refer to the table.  If not provided, a name will be generated.
-    kwargs
-        Backend-specific keyword arguments for the file type. For the DuckDB
-        backend used by default, please refer to:
-
-        * Parquet: https://duckdb.org/docs/data/parquet
-
-    Returns
-    -------
-    ir.Table
-        Table expression representing a file
-
-    Examples
-    --------
-    >>> import ibis
-    >>> import pandas as pd
-    >>> ibis.options.interactive = True
-    >>> df = pd.DataFrame({"a": [1, 2, 3], "b": list("ghi")})
-    >>> df
-       a  b
-    0  1  g
-    1  2  h
-    2  3  i
-    >>> df.to_parquet("/tmp/data.parquet")
-    >>> t = ibis.read_parquet("/tmp/data.parquet")
-    >>> t
-    ┏━━━━━━━┳━━━━━━━━┓
-    ┃ a     ┃ b      ┃
-    ┡━━━━━━━╇━━━━━━━━┩
-    │ int64 │ string │
-    ├───────┼────────┤
-    │     1 │ g      │
-    │     2 │ h      │
-    │     3 │ i      │
-    └───────┴────────┘
-
-    """
-    from xorq.vendor.ibis.config import _default_backend
-
-    con = _default_backend()
-    return con.read_parquet(sources, table_name=table_name, **kwargs)
-
-
-def read_delta(
-    source: str | Path, table_name: str | None = None, **kwargs: Any
-) -> ir.Table:
-    """Lazily load a Delta Lake table.
-
-    Parameters
-    ----------
-    source
-        A filesystem path or URL.
-    table_name
-        A name to refer to the table.  If not provided, a name will be generated.
-    kwargs
-        Backend-specific keyword arguments for the file type.
-
-    Returns
-    -------
-    ir.Table
-        Table expression representing a file
-
-    Examples
-    --------
-    >>> import ibis
-    >>> import pandas as pd
-    >>> ibis.options.interactive = True
-    >>> df = pd.DataFrame({"a": [1, 2, 3], "b": list("ghi")})
-    >>> df
-       a  b
-    0  1  g
-    1  2  h
-    2  3  i
-    >>> import deltalake as dl
-    >>> dl.write_deltalake("/tmp/data.delta", df, mode="overwrite")
-    >>> t = ibis.read_delta("/tmp/data.delta")
-    >>> t
-    ┏━━━━━━━┳━━━━━━━━┓
-    ┃ a     ┃ b      ┃
-    ┡━━━━━━━╇━━━━━━━━┩
-    │ int64 │ string │
-    ├───────┼────────┤
-    │     1 │ g      │
-    │     2 │ h      │
-    │     3 │ i      │
-    └───────┴────────┘
-
-    """
-    from xorq.vendor.ibis.config import _default_backend
-
-    con = _default_backend()
-    return con.read_delta(source, table_name=table_name, **kwargs)
-
-
 def set_backend(backend: str | BaseBackend) -> None:
-    """Set the default Ibis backend.
+    """Set the default xorq backend.
 
     Parameters
     ----------
@@ -1697,18 +1470,19 @@ def set_backend(backend: str | BaseBackend) -> None:
     --------
     You can pass the backend as a name:
 
-    >>> import ibis
-    >>> ibis.set_backend("polars")
+    >>> import xorq
+    >>> xorq.set_backend("datafusion")
 
     Or as a URI
 
-    >>> ibis.set_backend(
+    >>> xorq.set_backend(
     ...     "postgres://user:password@hostname:5432"
     ... )  # quartodoc: +SKIP # doctest: +SKIP
 
     Or as an existing backend instance
 
-    >>> ibis.set_backend(ibis.duckdb.connect())
+    >>> import xorq
+    >>> xorq.set_backend(xorq.connect())
 
     """
     from xorq.vendor import ibis
@@ -1740,9 +1514,9 @@ def get_backend(expr: Expr | None = None) -> BaseBackend:
 
     """
     if expr is None:
-        from xorq.vendor.ibis.config import _default_backend
+        from xorq.config import _backend_init  # noqa: PLC0415
 
-        return _default_backend()
+        return _backend_init()
     return expr._find_backend(use_default=True)
 
 

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -379,7 +379,7 @@ class Expr(Immutable, Coercible):
         BaseBackend
             A backend that is attached to the expression
         """
-        from xorq.config import _backend_init
+        from xorq.vendor.ibis.config import _default_backend
 
         backends, has_unbound = self._find_backends()
 
@@ -393,7 +393,7 @@ class Expr(Immutable, Coercible):
                         "using bound tables instead."
                     )
                 elif use_default:
-                    backend = _backend_init()
+                    backend = _default_backend()
                     return backend
                 else:
                     raise XorqError(


### PR DESCRIPTION
## Summary

Consolidate the xorq default backend around `xorq_datafusion`, dropping the vendored ibis DuckDB fallback. Rename and relocate the default-backend plumbing so the public surface lives in the xorq layer, and pin the default backend's profile identity so snapshot tests are deterministic.

## Default backend

- Remove the vendored ibis `_default_backend()` function and the top-level `read_csv`, `read_parquet`, `read_json`, `read_delta` helpers that bootstrapped DuckDB as the fallback.
- Rename `xorq.config._backend_init` to `xorq.config.default_backend` and migrate every internal call site (caching/, common/utils/, examples/, expr/api.py, tests/, vendor/ibis/expr/types/core.py). No backward-compat alias is kept.
- Make the `xorq_datafusion.connect` import lazy inside `default_backend` so importing `xorq.config` no longer eagerly loads the datafusion backend.
- Override `Options.default_backend` in `xorq.config.Options` with a tighter `Optional[BaseBackend]` annotation (vendor inherits `Optional[Any]` from upstream ibis).
- Re-introduce a thin `_default_backend` delegator in `xorq.vendor.ibis.config` so the rest of the vendor tree only knows about a single named seam to obtain the default backend.

## Public API

- Promote `get_backend` and `set_backend` from `xorq.vendor.ibis.expr.api` to `xorq.expr.api` so the user-facing accessors live in the xorq layer.
- `xorq.expr.api.__all__` no longer excludes `read_csv`/`read_parquet`; those vendor-level helpers are gone (see breaking change below).

## Determinism fix

- Pin the default backend's `Profile.idx` to a stable sentinel (`-1`) on first creation. Otherwise lazy initialisation makes the idx depend on whatever the global `itertools.count()` factory has consumed by the time of first use, which leaks into `profiles.yaml`, `expr.yaml` profile refs, and cache keys derived from the default backend — causing snapshot drift across processes, environments, and test orderings.
- Refresh `test_build_file_stability_and_relocatability` snapshot to the now-deterministic output.

## Affected modules

- `vendor/ibis/config.py`: drop the DuckDB bootstrap; thin delegator only
- `vendor/ibis/expr/api.py`: drop file-reading top-level functions and their `__all__` entries; remove `get_backend`/`set_backend` (promoted)
- `config.py`: rename `Options.backend` → `Options.default_backend`; pin profile idx
- `expr/api.py`: hoist `get_backend`/`set_backend`; drop EXCLUDE filter
- `backends/{databricks,postgres,sqlite}`: replace `read_parquet`/`read_csv` imports with `default_backend()` calls
- `ibis_yaml/compiler.py`: same replacement in `ExprLoader`
- `tests/test_api.py`: add tests for datafusion singleton and `get_backend()` contract

## BREAKING CHANGE

`xorq.read_parquet`, `xorq.read_csv`, `xorq.read_json`, and `xorq.read_delta` no longer delegate to DuckDB. Use `xorq.config.default_backend().read_parquet(...)` or connect to an explicit backend.

## Test plan

- [x] Snapshot tests deterministic across isolated, full-file, and `pytest-xdist -n 4 --dist loadfile` runs locally
- [x] `test_api.py` (default backend singleton, `get_backend`/`set_backend` contract) passes
- [x] `caching/tests/` passes
- [ ] CI green on this branch