### PR TITLE
refactor(worktree): make new-worktree project-agnostic

### DIFF
--- a/dev/new-worktree
+++ b/dev/new-worktree
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+[ -f "$SCRIPT_DIR/project.env" ] && . "$SCRIPT_DIR/project.env"
+
 branch="${1:?usage: new-worktree <branch-name>}"
 root=$(git rev-parse --show-toplevel)
-dest="$(dirname "$root")/xorq-${branch//\//-}"
+: "${PROJECT_NAME:=$(basename "$root")}"
+dest="$(dirname "$root")/${PROJECT_NAME}-${branch//\//-}"
 
 git worktree add "$dest" "$branch" >&2
 cd "$dest"

--- a/dev/project.env
+++ b/dev/project.env
@@ -1,0 +1,2 @@
+# PROJECT_NAME=xorq
+# CONTAINER_WORKSPACE=/workspaces/xorq


### PR DESCRIPTION
## Summary

- Extract the hardcoded `xorq-` prefix in `dev/new-worktree` into a `PROJECT_NAME` variable, sourced from `dev/project.env` with a fallback to the repo directory basename
- Add `dev/project.env` with commented-out `PROJECT_NAME` and `CONTAINER_WORKSPACE` — works without edits, provides a config seam for the devcontainer workflow (`feat/devcontainer`)

## Motivation

The worktree scripts should be project-agnostic so they can be reused across repos. This is also a prerequisite for generalizing the devcontainer workflow, which needs `PROJECT_NAME` for container naming and `CONTAINER_WORKSPACE` for mount paths.

## Test plan

- [ ] `dev/new-worktree <branch>` creates sibling dir named `<reponame>-<branch>`
- [ ] Uncommenting `PROJECT_NAME=foo` in `project.env` changes the prefix to `foo-<branch>`
- [ ] Deleting `project.env` still works (guarded source falls through to basename default)
- [ ] `dev/setup-worktree` and `dev/cleanup-worktree` still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)