### PR TITLE
feat(catalog/tui): log subprocess errors to xorq.log

### DIFF
--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1128,14 +1128,13 @@ class DataViewScreen(Screen):
 
     @work(thread=True, exit_on_error=False)
     def _load_data(self) -> None:
+        entry_hash = self._row_data.hash[:12]
         try:
             self._stack = ExprStack(base_expr=self._entry)
             df = self._run_catalog_subprocess()
             self.app.call_from_thread(self._on_data_loaded, df)
         except Exception as e:
-            logger.exception(
-                "data_view_load_failed", entry_hash=self._row_data.hash[:12]
-            )
+            logger.exception("data_view_load_failed", entry_hash=entry_hash)
             self.app.call_from_thread(self._render_error, str(e))
 
     def _on_data_loaded(self, df) -> None:
@@ -1219,7 +1218,7 @@ class DataViewScreen(Screen):
                 "stack_execute_failed",
                 cursor=stack.cursor,
                 steps=len(stack.steps),
-                code=code,
+                code=code[:500] + "..." if code and len(code) > 500 else code,
             )
             self.app.call_from_thread(self._on_stack_execute_failed, stack, str(e))
             return
@@ -1418,7 +1417,11 @@ class DataViewScreen(Screen):
             msg = f"Saved as '{alias}'" if alias else "Saved"
             self.app.call_from_thread(self._show_persist_success, msg)
         except Exception as e:
-            logger.exception("catalog_compose_failed", alias=alias, code=code)
+            logger.exception(
+                "catalog_compose_failed",
+                alias=alias,
+                code=code[:500] + "..." if code and len(code) > 500 else code,
+            )
             self.app.call_from_thread(self._show_command_error, f"Save failed: {e}")
 
     def _show_persist_success(self, message) -> None:

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -40,7 +40,10 @@ from textual.widgets import (
 from xorq.caching.storage import resolve_parquet_cache_path
 from xorq.catalog.catalog import CatalogEntry
 from xorq.common.utils.caching_utils import CacheKey
+from xorq.common.utils.logging_utils import get_logger
 
+
+logger = get_logger(__name__)
 
 DEFAULT_REFRESH_INTERVAL = 10
 
@@ -1130,6 +1133,9 @@ class DataViewScreen(Screen):
             df = self._run_catalog_subprocess()
             self.app.call_from_thread(self._on_data_loaded, df)
         except Exception as e:
+            logger.exception(
+                "data_view_load_failed", entry_hash=self._row_data.hash[:12]
+            )
             self.app.call_from_thread(self._render_error, str(e))
 
     def _on_data_loaded(self, df) -> None:
@@ -1205,10 +1211,16 @@ class DataViewScreen(Screen):
     def _execute_current(self) -> None:
         """Evaluate current stack expression via subprocess."""
         stack = self._stack
+        code = stack.current_code or None
         try:
-            code = stack.current_code or None
             df = self._run_catalog_subprocess(code)
         except Exception as e:
+            logger.exception(
+                "stack_execute_failed",
+                cursor=stack.cursor,
+                steps=len(stack.steps),
+                code=code,
+            )
             self.app.call_from_thread(self._on_stack_execute_failed, stack, str(e))
             return
         self.app.call_from_thread(self._on_stack_executed, stack, df)
@@ -1397,8 +1409,8 @@ class DataViewScreen(Screen):
 
     @work(thread=True, exit_on_error=False)
     def _persist_to_catalog(self, alias) -> None:
+        code = self._stack.current_code
         try:
-            code = self._stack.current_code
             cmd = self._catalog_compose_cmd(code, alias)
             proc = subprocess.run(cmd, capture_output=True)
             if proc.returncode != 0:
@@ -1406,6 +1418,7 @@ class DataViewScreen(Screen):
             msg = f"Saved as '{alias}'" if alias else "Saved"
             self.app.call_from_thread(self._show_persist_success, msg)
         except Exception as e:
+            logger.exception("catalog_compose_failed", alias=alias, code=code)
             self.app.call_from_thread(self._show_command_error, f"Save failed: {e}")
 
     def _show_persist_success(self, message) -> None:


### PR DESCRIPTION
## Summary

Routes DataViewScreen subprocess errors through the existing `xorq.common.utils.logging_utils.get_logger` so they land in `~/.config/xorq/xorq.log` (rotating, JSON, level via `XORQ_LOG_LEVEL`) in addition to the on-screen notification.

Logged sites in `python/xorq/catalog/tui.py`:
- `_load_data` — initial table load (`data_view_load_failed`, includes `entry_hash`)
- `_execute_current` — stack re-execute via `xorq catalog run -c` (`stack_execute_failed`, includes `cursor`, `steps`, `code`)
- `_persist_to_catalog` — save via `xorq catalog compose` (`catalog_compose_failed`, includes `alias`, `code`)

Each call uses `logger.exception(...)` with structured fields so the full traceback is captured. User-facing `notify` / status-bar behavior is unchanged.

`code` is assigned outside the `try` in `_execute_current` and `_persist_to_catalog` so the new `logger.exception(..., code=code)` call cannot raise `UnboundLocalError` if the source assignment itself fails.

## Test plan
- [ ] Trigger a compose failure (e.g. `:` an invalid expression, then `w`) and confirm a `catalog_compose_failed` event with traceback appears in `~/.config/xorq/xorq.log`
- [ ] Trigger a stack-execute failure and confirm `stack_execute_failed` is logged
- [ ] Confirm `XORQ_LOG_LEVEL=OFF` suppresses the new log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)