### PR TITLE
fix(profiles): raise informative ValueError for unknown backend

### DIFF
--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -130,6 +130,11 @@ def test_profile_hash_order_independence():
     assert cloned.hash_name.split("_")[0] == profile1.hash_name.split("_")[0]
 
 
+def test_profile_unknown_backend_raises():
+    with pytest.raises(ValueError, match="Unknown backend 'nonexistent'"):
+        Profile(con_name="nonexistent", kwargs_tuple=())
+
+
 def test_parse_env_vars_empty_dict():
     """Test with empty dictionary."""
     assert maybe_substitute_env_vars({}) == {}

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -181,10 +181,12 @@ class Profile:
 
     @con_name.validator
     def validate_con_name(self, attr, value):
-        assert next(
-            (ep for ep in _load_entry_points() if ep.name == value),
-            None,
-        )
+        entry_points = _load_entry_points()
+        if not any(ep.name == value for ep in entry_points):
+            installed = sorted(ep.name for ep in entry_points)
+            raise ValueError(
+                f"Unknown backend {value!r}; installed backends: {installed}"
+            )
 
     def __attrs_post_init__(self):
         # Sort kwargs_tuple after initialization

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -181,9 +181,8 @@ class Profile:
 
     @con_name.validator
     def validate_con_name(self, attr, value):
-        entry_points = _load_entry_points()
-        if not any(ep.name == value for ep in entry_points):
-            installed = sorted(ep.name for ep in entry_points)
+        installed = sorted(ep.name for ep in _load_entry_points())
+        if value not in installed:
             raise ValueError(
                 f"Unknown backend {value!r}; installed backends: {installed}"
             )


### PR DESCRIPTION
## Summary
- Replace the bare `assert` in `Profile.validate_con_name` with a `ValueError` that names the rejected
backend and lists the installed ones.
- The assert failed silently under `-O` and gave no hint which backend was unavailable.

## Test plan
- [ ] Construct a `Profile` with an unknown `con_name` and confirm the error message lists installed
backends.
- [ ] Existing profile tests still pass.