### PR TITLE
ci: add downstream BSL compatibility check

### DIFF
--- a/.github/workflows/ci-downstream-bsl.yml
+++ b/.github/workflows/ci-downstream-bsl.yml
@@ -1,0 +1,57 @@
+name: ci-downstream-bsl
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      bsl-ref:
+        description: "boring-semantic-layer branch/tag to test against"
+        required: false
+        default: "feat/catalog-rebuild-reemit"
+
+permissions:
+  contents: read
+
+jobs:
+  bsl:
+    name: BSL downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout xorq (PR branch)
+        uses: actions/checkout@v6
+        with:
+          path: _xorq
+
+      - name: Checkout boring-semantic-layer
+        uses: actions/checkout@v6
+        with:
+          repository: xorq-labs/boring-semantic-layer
+          ref: ${{ inputs.bsl-ref || 'feat/catalog-rebuild-reemit' }}
+          path: _bsl
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: _bsl/docs/web/package-lock.json
+
+      - name: Install BSL deps then override xorq with this PR
+        working-directory: _bsl
+        run: |
+          uv sync --all-extras
+          uv pip install -e "../_xorq[duckdb]"
+          cd docs/web && npm ci
+
+      - name: Run BSL checks
+        working-directory: _bsl
+        run: make check


### PR DESCRIPTION
## Summary
- Run the boring-semantic-layer test suite (`xorq-labs/boring-semantic-layer`, `feat/catalog-rebuild-reemit`
branch) against xorq from the PR branch.
- Gives a green/red signal before merging xorq changes that BSL depends on.

## Test plan
- [ ] CI workflow appears on this PR and on subsequent PRs.
- [ ] Workflow runs against the xorq-labs fork and reports pass/fail.