### PR TITLE
ci(docs): cache test data, quarto, npm and start only postgres

### DIFF
--- a/.github/workflows/ci-docs-deploy.yml
+++ b/.github/workflows/ci-docs-deploy.yml
@@ -28,7 +28,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: cache ibis test data
+        id: cache-test-data
+        uses: actions/cache@v4
+        with:
+          path: ci/ibis-testing-data
+          key: ibis-testing-data-${{ hashFiles('justfile') }}
+
       - name: download test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
         run: just download-data
 
       - uses: actions/setup-python@v5
@@ -44,12 +52,18 @@ jobs:
         run: uv sync --all-extras --all-groups
         working-directory: ${{ github.workspace }}
 
+      - name: cache quarto
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/quarto
+          key: quarto-1.8.24
+
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: 1.8.24
 
       - name: start services
-        run: docker compose up --build --wait
+        run: docker compose up postgres --wait --remove-orphans
 
       - name: build api docs
         run: just docs-apigen --verbose

--- a/.github/workflows/ci-docs-preview.yml
+++ b/.github/workflows/ci-docs-preview.yml
@@ -35,7 +35,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: cache ibis test data
+        id: cache-test-data
+        uses: actions/cache@v4
+        with:
+          path: ci/ibis-testing-data
+          key: ibis-testing-data-${{ hashFiles('justfile') }}
+
       - name: download test data
+        if: steps.cache-test-data.outputs.cache-hit != 'true'
         run: just download-data
 
       - uses: actions/setup-python@v5
@@ -51,12 +59,18 @@ jobs:
         run: uv sync --all-extras --all-groups
         working-directory: ${{ github.workspace }}
 
+      - name: cache quarto
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/quarto
+          key: quarto-1.8.24
+
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: 1.8.24
 
       - name: start services
-        run: docker compose up --build --wait
+        run: docker compose up postgres --wait --remove-orphans
 
       - name: build docs
         run: just docs-build-all
@@ -66,6 +80,11 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
           POSTGRES_DATABASE: ibis_testing
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
 
       - name: install netlify cli
         run: npm install -g netlify-cli


### PR DESCRIPTION
- Cache ibis-testing-data keyed on justfile hash; skip download on hit
- Cache quarto installation at fixed version key (1.8.24)
- Start only the postgres service instead of full docker compose stack
- Add setup-node with npm cache before netlify-cli install (preview only)