### PR TITLE
docs(tutorials): add Fannie Mae vintage curves and PD classifier tutorials

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -86,6 +86,8 @@ website:
             - href: tutorials/analytics_tutorials/create_your_first_udf.qmd
             # - href: tutorials/analytics_tutorials/use_window_functions.qmd
             - href: tutorials/analytics_tutorials/work_with_schemas.qmd
+            - href: tutorials/analytics_tutorials/fannie_mae_vintage_curves.qmd
+            - href: tutorials/analytics_tutorials/fannie_mae_pd_classifier.qmd
 
 
     - id: guides

--- a/docs/tutorials/analytics_tutorials/fannie_mae_pd_classifier.qmd
+++ b/docs/tutorials/analytics_tutorials/fannie_mae_pd_classifier.qmd
@@ -1,0 +1,175 @@
+---
+title: 'Build a PD classifier with macro joins'
+description: "Predict 90+ DPD within 12 months of origination, joining across Postgres and DuckDB"
+icon: "wand-magic-sparkles"
+headline: "Multi-engine ML on the Fannie Mae panel"
+---
+
+This tutorial extends the [vintage curves tutorial](fannie_mae_vintage_curves.qmd) into a probability-of-default (PD) model. Origination data lives in Postgres, a state-by-quarter macro panel (HPI, unemployment) lives in DuckDB, and you'll join them in a single Xorq expression — no manual data movement.
+
+You'll then train an XGBoost classifier as an aggregate UDF and score the held-out set as an expression scalar UDF, so the model is pickled through the plan and applied per batch inside the engine.
+
+## Prerequisites
+
+You need:
+
+- Xorq installed with the Postgres extra: `pip install "xorq[examples,postgres]"`
+- XGBoost: `pip install xgboost`
+- Fannie Mae acquisition + monthly performance tables loaded into Postgres as `fnma_acquisition` and `fnma_perf_monthly` (see the [vintage curves tutorial](fannie_mae_vintage_curves.qmd) for staging notes).
+- A macro panel parquet file with columns `state`, `quarter`, `hpi`, `unemp`. Public sources: FHFA HPI by state, BLS state unemployment.
+
+## Connect to both backends
+
+```python
+# pd_classifier.py
+import xorq.api as xo
+from xorq.expr.relations import into_backend
+
+pg = xo.postgres.connect_env()  # <1>
+db = xo.duckdb.connect()
+
+acq = pg.table("fnma_acquisition")
+perf = pg.table("fnma_perf_monthly")
+macro = xo.deferred_read_parquet(
+    "s3://your-bucket/macro/state_quarter.parquet",
+    con=db,
+    table_name="macro",
+)
+```
+1. `connect_env()` reads connection details from standard `PG*` environment variables. See the [profiles guide](../../api_reference/backends/profiles_api.qmd) for alternatives.
+
+## Build the label
+
+The target is "ever 90+ DPD in the first 12 months of life." That's a per-loan aggregation over the monthly panel.
+
+```python
+dlq_int = perf.DLQ_STATUS.try_cast("int")
+labels = (
+    perf.filter(perf.LOAN_AGE <= 12)
+    .group_by("LOAN_ID")
+    .agg(event_occurred=(dlq_int.fill_null(0) >= 3).max())
+)
+```
+
+## Join across engines
+
+Origination + label live in Postgres; macro lives in DuckDB. `into_backend(macro, pg)` registers the DuckDB table inside the Postgres connection so the join runs in one engine — Xorq handles the data movement via Arrow.
+
+```python
+origination = acq.mutate(orig_q=acq.ORIG_DATE.truncate("Q"))
+
+training = (
+    origination
+    .join(labels, "LOAN_ID")
+    .join(
+        into_backend(macro, pg),                       # <1>
+        [
+            origination.STATE == macro.state,
+            origination.orig_q == macro.quarter,
+        ],
+    )
+)
+```
+1. Move the macro table to Postgres for the join. You could equally pull origination to DuckDB by wrapping the other side — pick whichever engine is closer to where you want the result.
+
+:::{.callout-tip}
+### Why this matters
+Without `into_backend`, you'd extract both sides to pandas, merge in Python, and lose query pushdown. With it, you write one expression and Xorq decides where each operator runs.
+:::
+
+## Define the UDFs
+
+Training is an **aggregate UDF**: it consumes a DataFrame and returns a single artifact (the pickled model). Scoring is an **expression scalar UDF**: it consumes per-batch features and the trained model, and returns predictions.
+
+```python
+import pickle
+
+import toolz
+import xgboost as xgb
+
+import xorq.expr.datatypes as dt
+import xorq.expr.udf as udf
+from xorq.common.utils.toolz_utils import curry
+from xorq.expr.udf import make_pandas_expr_udf
+
+
+features = ("CSCORE_B", "OLTV", "DTI", "ORIG_RATE", "ORIG_UPB", "hpi", "unemp")
+target = "event_occurred"
+
+
+@curry
+def fit(df, features=features, target=target):
+    X, y = df[list(features)], df[target]
+    return xgb.train(
+        {"objective": "binary:logistic", "max_depth": 5, "eta": 0.1},
+        xgb.DMatrix(X, y),
+        num_boost_round=200,
+    )
+
+
+@curry
+def score(model, df, features=features):
+    return model.predict(xgb.DMatrix(df[list(features)]))
+```
+
+## Wire training and scoring into the plan
+
+```python
+train, test = xo.train_test_splits(  # <1>
+    training,
+    unique_key="LOAN_ID",
+    test_sizes=0.2,
+    random_seed=42,
+)
+
+model_udaf = udf.agg.pandas_df(  # <2>
+    fn=toolz.compose(pickle.dumps, fit),
+    schema=training[features + (target,)].schema(),
+    return_type=dt.binary,
+    name="model",
+)
+
+predict_udf = make_pandas_expr_udf(  # <3>
+    computed_kwargs_expr=model_udaf.on_expr(train),
+    fn=score,
+    schema=training[features].schema(),
+    return_type=dt.dtype("float32"),
+    name="pd_hat",
+)
+
+scored = test.mutate(predict_udf.on_expr(test).name("pd_hat"))
+
+result = scored.execute()
+print(result.head())
+```
+1. `train_test_splits` keyed on `LOAN_ID` ensures a loan never leaks across folds — every monthly observation for a given loan lands in the same split.
+2. `udf.agg.pandas_df` wraps the fit function and pickles the model. `on_expr(train)` binds it to the training expression.
+3. `make_pandas_expr_udf` takes the trained model (via `computed_kwargs_expr`) and a per-batch scoring function. The model is computed once and reused across batches.
+
+## Evaluate
+
+```python
+from sklearn.metrics import roc_auc_score
+
+auc = roc_auc_score(result["event_occurred"], result["pd_hat"])
+print(f"Test AUC: {auc:.3f}")
+```
+
+A reasonable target on this dataset with these features is AUC in the 0.78–0.82 range. Better calibration usually comes from richer features (e.g., DTI bucketing, geographic FE) rather than model tuning.
+
+:::{.callout-warning}
+### Out-of-time validation matters
+Random splits leak temporal information — your 2009 macro features are still in the training set. For a serious PD model, train on originations through year `Y` and score on year `Y+1`. The AUC will drop, sometimes dramatically.
+:::
+
+## What you learned
+
+- Joined data across Postgres and DuckDB with `into_backend`, no pandas merge in the middle
+- Built a label expression from a per-loan rollup of the monthly panel
+- Trained and scored a model entirely inside the expression graph using the aggregate-UDF + expression-scalar-UDF pattern
+- Used `train_test_splits` keyed on a loan ID to prevent leakage
+
+## Next steps
+
+- [Cache expression results](../../getting_started/cache_expression_results.qmd) — cache the joined training table so model iteration doesn't replay the cross-engine join.
+- [Deploy your first model](../ml_tutorials/deploy_your_first_model.qmd) — serve the trained UDF behind Arrow Flight.

--- a/docs/tutorials/analytics_tutorials/fannie_mae_vintage_curves.qmd
+++ b/docs/tutorials/analytics_tutorials/fannie_mae_vintage_curves.qmd
@@ -1,0 +1,176 @@
+---
+title: 'Compute Fannie Mae vintage default curves'
+description: "Group loans by origination cohort and loan age to plot cumulative 90+ DPD rates"
+icon: "chart-line"
+headline: "Cohort analysis on a multi-GB mortgage panel"
+---
+
+This tutorial shows how to compute cumulative 90+ days-past-due (DPD) rates by origination cohort and loan age across the Fannie Mae Single-Family Loan Performance dataset. The full panel is too large to fit in pandas memory, so you'll stream it through DuckDB, aggregate in-engine, and only materialize the small `(vintage, age)` summary at the end.
+
+After completing this tutorial, you'll know how to express cohort-style analyses in Xorq, and how `.cache()` keeps iteration fast when you're tweaking plots.
+
+## Prerequisites
+
+You need:
+
+- Xorq installed: `pip install "xorq[examples]"`
+- Fannie Mae Single-Family Loan Performance Data, registered as parquet. Fannie Mae publishes the data as quarterly text files at [capitalmarkets.fanniemae.com](https://capitalmarkets.fanniemae.com/credit-risk-transfer/single-family-credit-risk-transfer/fannie-mae-single-family-loan-performance-data) (free account required).
+- Basic familiarity with groupby aggregations.
+
+:::{.callout-note}
+### Staging the data
+Fannie Mae ships pipe-delimited `.txt` files with no header row. The full schema is published alongside the data. Convert each quarterly file to parquet once (using `pandas.read_csv` with the published column list, or your warehouse's bulk loader) and partition by origination year. The rest of this tutorial assumes a parquet glob like `s3://your-bucket/fnma/perf/*.parquet` or a local path.
+:::
+
+## Read the panel
+
+Here's what you need to know: `deferred_read_parquet` registers the file with a backend without scanning it. Nothing executes until you call `.execute()`.
+
+```python
+# vintage_curves.py
+import xorq.api as xo
+
+con = xo.connect()
+
+perf = xo.deferred_read_parquet(
+    "s3://your-bucket/fnma/perf/*.parquet",  # <1>
+    con=con,
+    table_name="perf",
+)
+```
+1. Replace with your local path or warehouse table. The expression below works the same either way.
+
+The `perf` expression carries the schema but no data. You can inspect columns with `perf.schema()` to confirm the load worked.
+
+## Define the default flag
+
+`DLQ_STATUS` is a string column with values `"0"`, `"1"`, `"2"`, `"3"`, ..., plus `"X"` for unknown. A loan is 90+ DPD when the numeric value is at least 3.
+
+```python
+dlq_int = perf.DLQ_STATUS.try_cast("int")  # <1>
+is_90 = dlq_int.fill_null(0) >= 3           # <2>
+
+flagged = perf.mutate(
+    vintage=perf.ORIG_DATE.truncate("Q"),
+    is_90=is_90,
+)
+```
+1. `try_cast` returns NULL for non-numeric codes like `"X"` instead of raising.
+2. Treating `"X"` as `0` is one defensible choice. Another is `dlq_int.notnull() & (dlq_int >= 3)`, which excludes unknown-status months from the numerator and denominator. Pick the one that matches your reporting convention.
+
+## Roll up to loan-age curves
+
+Cohort curves answer "what fraction of loans originated in quarter `Q` had ever been 90+ DPD by month `M` of their life?" That's a two-stage aggregation: first per loan, then per cohort.
+
+```python
+ever_90 = (
+    flagged
+    .group_by(["LOAN_ID", "vintage", "LOAN_AGE"])  # <1>
+    .agg(is_90=xo._.is_90.max())                    # <2>
+)
+
+curve = (
+    ever_90
+    .group_by(["vintage", "LOAN_AGE"])
+    .agg(
+        default_rate=xo._.is_90.mean(),             # <3>
+        n_loans=xo._.LOAN_ID.nunique(),
+    )
+    .order_by(["vintage", "LOAN_AGE"])
+)
+```
+1. The first stage flattens the monthly panel: one row per `(loan, age)`.
+2. `.max()` of a boolean is "ever true" — captures whether the loan was 90+ DPD as of that age.
+3. `.mean()` of a boolean over loans in the cohort is the cohort default rate.
+
+:::{.callout-tip}
+### Why two stages
+Computing `default_rate` directly from the monthly panel would over-weight loans that linger in delinquency. Collapsing to `(loan, age)` first ensures every loan contributes one observation per age bucket.
+:::
+
+## Cache the summary
+
+The `(vintage, age)` table is small — typically a few thousand rows. Cache it so the next iteration of your plotting code doesn't re-scan the multi-GB panel.
+
+```python
+from xorq.caching import ParquetCache
+
+cache = ParquetCache.from_kwargs(source=con, relative_path="./fnma-cache")
+cached_curve = curve.cache(cache=cache)
+
+result = cached_curve.execute()
+print(result.head())
+```
+
+The cache key is derived from the expression hash. Change any upstream filter or aggregation and the next `.execute()` recomputes; leave it untouched and subsequent calls hit the cache.
+
+## Plot the curves
+
+```python
+import matplotlib.pyplot as plt
+
+for vintage, group in result.groupby("vintage"):
+    plt.plot(group["LOAN_AGE"], group["default_rate"], label=str(vintage)[:7])
+
+plt.xlabel("Loan age (months)")
+plt.ylabel("Cumulative 90+ DPD rate")
+plt.legend(title="Origination quarter")
+plt.show()
+```
+
+You should see the 2006–2008 vintages spike sharply between months 12 and 36, while 2010+ vintages stay near the floor — the textbook GFC fingerprint.
+
+## Complete example
+
+```python
+# vintage_curves.py
+import xorq.api as xo
+from xorq.caching import ParquetCache
+
+con = xo.connect()
+cache = ParquetCache.from_kwargs(source=con, relative_path="./fnma-cache")
+
+perf = xo.deferred_read_parquet(
+    "s3://your-bucket/fnma/perf/*.parquet",
+    con=con,
+    table_name="perf",
+)
+
+dlq_int = perf.DLQ_STATUS.try_cast("int")
+flagged = perf.mutate(
+    vintage=perf.ORIG_DATE.truncate("Q"),
+    is_90=dlq_int.fill_null(0) >= 3,
+)
+
+ever_90 = (
+    flagged
+    .group_by(["LOAN_ID", "vintage", "LOAN_AGE"])
+    .agg(is_90=xo._.is_90.max())
+)
+
+curve = (
+    ever_90
+    .group_by(["vintage", "LOAN_AGE"])
+    .agg(
+        default_rate=xo._.is_90.mean(),
+        n_loans=xo._.LOAN_ID.nunique(),
+    )
+    .order_by(["vintage", "LOAN_AGE"])
+    .cache(cache=cache)
+)
+
+result = curve.execute()
+print(result.head())
+```
+
+## What you learned
+
+- Loaded a multi-GB parquet panel as a deferred expression
+- Used `try_cast` to handle non-numeric domain codes safely
+- Wrote a two-stage aggregation (per-loan, then per-cohort) so each loan contributes one observation per age
+- Cached the small summary so plot iteration doesn't re-scan the panel
+
+## Next steps
+
+- [Build a PD classifier with macro joins](fannie_mae_pd_classifier.qmd) extends this dataset with cross-engine joins and trains a default model.
+- [Cache expression results](../../getting_started/cache_expression_results.qmd) covers cache invalidation and storage backends in more depth.


### PR DESCRIPTION
## Summary

Two analytics tutorials built around the public Fannie Mae Single-Family Loan Performance dataset, intended as a flagship pair that shows off cohort analysis and multi-engine ML workflows.

- **`fannie_mae_vintage_curves.qmd`** — cumulative 90+ DPD by origination quarter and loan age. Shows `deferred_read_parquet`, `try_cast` for non-numeric domain codes, two-stage groupby (per-loan → per-cohort), and `ParquetCache` for plot-iteration speed.
- **`fannie_mae_pd_classifier.qmd`** — predicts 90+ DPD within 12 months of origination. Shows `into_backend` to join Postgres acquisition data with a DuckDB macro panel, plus the aggregate-UDF + expression-scalar-UDF pattern from `examples/expr_scalar_udf.py` for in-engine train/score.

Both are wired into `docs/_quarto.yml` under the analytics tutorials sidebar.

## Reviewer notes / caveats

- **Data is BYO.** Fannie Mae publishes pipe-delimited `.txt` files; both tutorials describe the one-time text→parquet conversion in their Prerequisites section but don't ship a loader. If you'd prefer a runnable example with a small fixture, happy to add one.
- **Macro panel paths are placeholders.** `s3://your-bucket/...` is illustrative. Pointing at a real public macro source (FHFA HPI, BLS unemployment) would be a nice follow-up.
- **`DLQ_STATUS` handling.** `try_cast("int").fill_null(0) >= 3` treats `"X"` (unknown) as not-90+. The tutorial calls out the alternative (exclude unknown rows entirely) without picking a side.
- **No CI execution.** `.qmd` tutorials don't run end-to-end in CI, so placeholder paths won't cause failures. Worth a manual `quarto render` pass before merging if you want to spot-check formatting.
- **Out-of-time validation caveat** is called out in a callout-warning in the PD tutorial — the random `train_test_splits` leaks temporal info. Realistic backtest could be a follow-up tutorial.

Tangentially: while writing this I noticed `docs/api_reference/backends/supported_backends.qmd` is out of sync with `python/xorq/backends/` (missing SQLite/Postgres/Databricks/PyIceberg, lists BigQuery which isn't there). Not fixed in this PR — separate concern.

## Test plan

- [ ] `quarto render docs/tutorials/analytics_tutorials/fannie_mae_vintage_curves.qmd` renders cleanly
- [ ] `quarto render docs/tutorials/analytics_tutorials/fannie_mae_pd_classifier.qmd` renders cleanly
- [ ] Sidebar shows both new entries under Analytics tutorials
- [ ] Internal cross-links resolve (`fannie_mae_vintage_curves.qmd`, cache tutorial, deploy tutorial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)