### PR TITLE
fix(catalog): guard annex branch push when branch is missing

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -56,7 +56,11 @@ from xorq.catalog.git_utils import (
     commit_context,
 )
 from xorq.catalog.zip_utils import BuildZip, make_zip_context, with_pure_suffix
+from xorq.common.utils.logging_utils import get_logger
 from xorq.ibis_yaml.enums import DumpFiles, ExprKind
+
+
+logger = get_logger(__name__)
 
 
 abspath = toolz.compose(Path.absolute, Path)
@@ -103,6 +107,11 @@ popen_shell = partial(Popen, shell=True)
 def _has_annex_branch(repo):
     """Check whether a Repo has a git-annex branch (local or remote-tracking)."""
     return any(ref.name.endswith(ANNEX_BRANCH) for ref in repo.refs)
+
+
+def _has_local_annex_branch(repo):
+    """Check whether a Repo has a local git-annex branch (i.e. a checked-out head)."""
+    return ANNEX_BRANCH in repo.heads
 
 
 def _try_resolve_annex_remote(repo_path, **remote_kwargs):
@@ -307,9 +316,18 @@ class Catalog:
         """Push to all git remotes after verifying consistency."""
         self.assert_consistency()
         results = tuple(map(Remote.push, self._git_remotes))
-        for remote in self._git_remotes:
-            remote.push(ANNEX_BRANCH)
-        return results
+        if _has_local_annex_branch(self.repo):
+            annex_results = tuple(
+                remote.push(ANNEX_BRANCH) for remote in self._git_remotes
+            )
+        else:
+            annex_results = ()
+            logger.debug(
+                "skipping annex branch push: no local branch",
+                annex_branch=ANNEX_BRANCH,
+                repo_path=str(self.repo_path),
+            )
+        return results + annex_results
 
     def pull(self):
         """Pull from all git remotes."""

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -205,6 +205,24 @@ def test_clone_from_no_annex_branch(tmpdir):
     assert cloned.list()
 
 
+def test_push_skips_missing_annex_branch(tmpdir):
+    """Catalog.push() succeeds when the local repo has no git-annex branch."""
+
+    bare_path = Path(tmpdir).joinpath("bare")
+    GitRepo.init(bare_path, bare=True, initial_branch=MAIN_BRANCH)
+
+    origin_path = Path(tmpdir).joinpath("origin")
+    catalog = Catalog.from_repo_path(origin_path, init=True)
+    remote = catalog.repo.create_remote("origin", str(bare_path))
+    remote.push(MAIN_BRANCH, set_upstream=True)
+
+    with build_expr_context_zip(xo.memtable({"plain": ["plain"]})) as zip_path:
+        catalog.add(zip_path, sync=False)
+
+    assert "git-annex" not in catalog.repo.heads
+    catalog.push()
+
+
 def test_clone_from_false_forces_plain_git(repo_cloned_bare, tmpdir):
     """annex=False forces GitBackend even when git-annex branch exists."""
 


### PR DESCRIPTION
## Summary
- Skip pushing the annex branch in `Catalog.push()` when it does not exist locally, avoiding a `GitCommandError` for repos where annex has not been initialized.
- Add a `_has_local_annex_branch(repo)` helper alongside the existing `_has_annex_branch`, so the local-vs-any-ref distinction is explicit and reusable.
- Log a debug line on skip so the silent absence of the annex branch is observable in logs.
- Fold the per-remote annex push results into `push()`'s return value (previously discarded), giving callers visibility into annex push status.

## Test plan
- [x] New regression test `test_push_skips_missing_annex_branch` — plain-git catalog with no annex branch, bare remote, `push()` succeeds.
- [x] Existing `test_catalog_clone_from_push` (annex backend) still passes — annex branch still pushed to all remotes when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)