### PR TITLE
fix(devcontainer): eliminate shared volume ownership warning

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -47,10 +47,12 @@ volumes:
   # per-project: shared across worktrees (content-addressed)
   uv-cache:
     name: ${DEV_PROJECT_NAME:?DEV_PROJECT_NAME is required}-uv-cache
+    external: true
   # per-worktree: virtualenv paths are workspace-specific
   venv:
   # per-project: shared across worktrees (read-mostly test fixtures)
   ibis-testing-data:
     name: ${DEV_PROJECT_NAME:?DEV_PROJECT_NAME is required}-ibis-testing-data
+    external: true
   # per-worktree: session symlinks and project keys are workspace-specific
   claude-home:

--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -261,12 +261,19 @@ sync_if_needed() {
     fi
 }
 
+ensure_shared_volumes() {
+    docker volume create "${PROJECT_NAME}-uv-cache" >/dev/null 2>&1 || true
+    docker volume create "${PROJECT_NAME}-ibis-testing-data" >/dev/null 2>&1 || true
+}
+
 ensure_up() {
     exec 9>"$LOCKFILE"
     if ! flock -n 9; then
         echo "Another devcontainer operation is in progress, waiting..."
         flock 9
     fi
+
+    ensure_shared_volumes
 
     if ! is_running; then
         dc up --build -d


### PR DESCRIPTION
## Summary
- Mark `uv-cache` and `ibis-testing-data` volumes as `external: true` in `docker-compose.yml` so Docker Compose doesn't track per-project ownership
- Add `ensure_shared_volumes()` in `dev/devcontainer` to pre-create these volumes before `dc up`, so the external declaration never fails on a fresh machine
- Eliminates the `volume "xorq-ibis-testing-data" already exists but was created for project ...` warning when running devcontainers from different worktrees

## Test plan
- [ ] `devcontainer up` from a worktree that previously triggered the warning — no warning
- [ ] `devcontainer reset` + `devcontainer up` on a fresh setup — volumes are pre-created, container starts cleanly
- [ ] Second worktree `devcontainer up` — no ownership warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)