### PR TITLE
fix(catalog): conflict-matrix pull resolution for catalog.pull (#1886 Bug B)

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -153,6 +153,24 @@ def _try_resolve_annex_remote(repo_path, **remote_kwargs):
     return None
 
 
+class CatalogMergeConflict(Exception):
+    """Raised by ``Catalog.pull`` when a merge leaves files unresolved.
+
+    The ``conflicted`` attribute is a tuple of repo-relative paths still
+    in the unmerged state — typically alias symlinks under
+    ``.xorq/aliases/``. The merge is left in-progress in the working
+    tree so the user can resolve it (see xorq-labs/xorq#1886 for the
+    recovery recipe).
+    """
+
+    def __init__(self, conflicted):
+        self.conflicted = tuple(conflicted)
+        super().__init__(
+            f"catalog.pull() left {len(self.conflicted)} path(s) in conflict: "
+            f"{', '.join(self.conflicted)}"
+        )
+
+
 @frozen
 class Catalog:
     """A git-backed registry for versioned build artifacts.

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -531,6 +531,16 @@ class Catalog:
         - HEAD must be on a branch (the catalog API never detaches HEAD
           on its own — this only fails if the repo was put in detached
           state outside xorq).  Raises ``CatalogPullError``.
+        - ``catalog.yaml`` in both ours (HEAD) and the remote tip must
+          exist, parse, and have the expected dict-or-list shape.  The
+          resolver assumes well-formed input on both sides; without
+          this check, a ``catalog.yaml`` deleted on the remote tip
+          would be silently treated as "theirs removed every entry"
+          and the 3-way list merge would drop every prior entry, while
+          a malformed or scalar-shaped yaml would leak a bare
+          ``ValueError`` / ``AttributeError`` from inside the
+          resolver.  Raises ``CatalogPullError`` naming the corrupt
+          side.
         - A non-conflict ``git merge`` failure (e.g. the remote ref
           doesn't exist, the working tree is dirty, a hook rejected the
           merge commit) re-raises the original ``GitCommandError``
@@ -550,10 +560,26 @@ class Catalog:
         (remote,) = remotes
         branch = self.repo.active_branch.name
         fetch_result = remote.fetch()
+        self._validate_catalog_yaml_in_commit(self.repo.head.commit, "ours")
+        try:
+            remote_commit = self.repo.commit(f"{remote.name}/{branch}")
+        except Exception:
+            # Remote ref didn't resolve (e.g. remote has no branches
+            # yet).  Skip the theirs-side pre-flight and let `git
+            # merge` raise the actionable ref-missing error below.
+            remote_commit = None
+        if remote_commit is not None:
+            self._validate_catalog_yaml_in_commit(
+                remote_commit, f"remote {remote.name!r}"
+            )
         try:
             self.repo.git.merge(f"{remote.name}/{branch}", "--no-edit")
         except GitCommandError:
             if not (Path(self.repo.git_dir) / "MERGE_HEAD").exists():
+                # `git merge` failed for a non-conflict reason (missing
+                # remote ref, dirty tree, hook reject, ...).  No merge
+                # is in progress, so don't try to resolve or commit —
+                # surface the original error.
                 raise
             self._resolve_yaml_conflict_if_any()
             unmerged = tuple(self.repo.index.unmerged_blobs().keys())
@@ -585,6 +611,43 @@ class Catalog:
         }
         self.catalog_yaml.set_contents(merged)
         self.repo.git.add(yaml_relpath)
+
+    def _validate_catalog_yaml_in_commit(self, commit, side_label):
+        """Pre-flight check that ``catalog.yaml`` in *commit*'s tree
+        exists, parses, and has the expected dict-or-list shape.
+
+        Raises ``CatalogPullError`` (with *side_label* in the message)
+        if the file is missing, fails to parse, or parses to anything
+        other than a dict (current schema) or a list (legacy schema).
+        See the ``pull`` docstring for the failure modes this guards
+        against.
+        """
+        yaml_relpath = str(self.catalog_yaml.yaml_relpath)
+        blob = next(
+            (
+                b
+                for b in commit.tree.list_traverse()
+                if isinstance(b, Blob) and b.path == yaml_relpath
+            ),
+            None,
+        )
+        if blob is None:
+            raise CatalogPullError(
+                f"{side_label} commit {commit.hexsha[:8]} is missing {yaml_relpath}"
+            )
+        try:
+            raw = yaml12.parse_yaml(blob.data_stream.read().decode())
+        except Exception as e:
+            raise CatalogPullError(
+                f"{side_label} commit {commit.hexsha[:8]} has malformed "
+                f"{yaml_relpath}: {e}"
+            ) from e
+        if not isinstance(raw, (dict, list)):
+            raise CatalogPullError(
+                f"{side_label} commit {commit.hexsha[:8]} has unexpected "
+                f"{yaml_relpath} shape: {type(raw).__name__} "
+                f"(expected dict or list)"
+            )
 
     @contextmanager
     def synchronizing(self):

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -504,7 +504,7 @@ class Catalog:
         unmerged = self.repo.index.unmerged_blobs()
         if yaml_relpath not in unmerged:
             return
-        stages = {stage: blob for stage, blob in unmerged[yaml_relpath]}
+        stages = dict(unmerged[yaml_relpath])
         base = _parse_catalog_yaml_blob(stages.get(1))
         ours = _parse_catalog_yaml_blob(stages.get(2))
         theirs = _parse_catalog_yaml_blob(stages.get(3))

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -576,41 +576,38 @@ class Catalog:
             self.repo.git.merge(f"{remote.name}/{branch}", "--no-edit")
         except GitCommandError:
             if not (Path(self.repo.git_dir) / "MERGE_HEAD").exists():
-                # `git merge` failed for a non-conflict reason (missing
-                # remote ref, dirty tree, hook reject, ...).  No merge
-                # is in progress, so don't try to resolve or commit —
-                # surface the original error.
                 raise
-            self._resolve_yaml_conflict_if_any()
-            unmerged = tuple(self.repo.index.unmerged_blobs().keys())
+            unmerged = self._resolve_yaml_conflict_if_any()
             if unmerged:
                 raise CatalogMergeConflict(unmerged, remote_name=remote.name) from None
             self.repo.git.commit("--no-edit")
         return (fetch_result,)
 
     def _resolve_yaml_conflict_if_any(self):
+        """Resolve ``catalog.yaml`` in the unmerged index and return remaining unmerged paths."""
         yaml_relpath = str(self.catalog_yaml.yaml_relpath)
         unmerged = self.repo.index.unmerged_blobs()
-        if yaml_relpath not in unmerged:
-            return
-        stages = dict(unmerged[yaml_relpath])
-        base = _parse_catalog_yaml_blob(stages.get(1))
-        ours = _parse_catalog_yaml_blob(stages.get(2))
-        theirs = _parse_catalog_yaml_blob(stages.get(3))
-        merged = {
-            CatalogInfix.ENTRY: _three_way_list_merge(
-                base[CatalogInfix.ENTRY],
-                ours[CatalogInfix.ENTRY],
-                theirs[CatalogInfix.ENTRY],
-            ),
-            CatalogInfix.ALIAS: _three_way_list_merge(
-                base[CatalogInfix.ALIAS],
-                ours[CatalogInfix.ALIAS],
-                theirs[CatalogInfix.ALIAS],
-            ),
-        }
-        self.catalog_yaml.set_contents(merged)
-        self.repo.git.add(yaml_relpath)
+        if yaml_relpath in unmerged:
+            stages = dict(unmerged[yaml_relpath])
+            base = _parse_catalog_yaml_blob(stages.get(1))
+            ours = _parse_catalog_yaml_blob(stages.get(2))
+            theirs = _parse_catalog_yaml_blob(stages.get(3))
+            merged = {
+                CatalogInfix.ENTRY: _three_way_list_merge(
+                    base[CatalogInfix.ENTRY],
+                    ours[CatalogInfix.ENTRY],
+                    theirs[CatalogInfix.ENTRY],
+                ),
+                CatalogInfix.ALIAS: _three_way_list_merge(
+                    base[CatalogInfix.ALIAS],
+                    ours[CatalogInfix.ALIAS],
+                    theirs[CatalogInfix.ALIAS],
+                ),
+            }
+            self.catalog_yaml.set_contents(merged)
+            self.repo.git.add(yaml_relpath)
+        remaining = self.repo.index.unmerged_blobs()
+        return tuple(remaining.keys())
 
     def _validate_catalog_yaml_in_commit(self, commit, side_label):
         """Pre-flight check that ``catalog.yaml`` in *commit*'s tree
@@ -648,6 +645,15 @@ class Catalog:
                 f"{yaml_relpath} shape: {type(raw).__name__} "
                 f"(expected dict or list)"
             )
+        if isinstance(raw, dict):
+            for key in (CatalogInfix.ENTRY, CatalogInfix.ALIAS):
+                val = raw.get(key)
+                if val is not None and not isinstance(val, list):
+                    raise CatalogPullError(
+                        f"{side_label} commit {commit.hexsha[:8]} has "
+                        f"non-list {key!r} in {yaml_relpath}: "
+                        f"{type(val).__name__}"
+                    )
 
     @contextmanager
     def synchronizing(self):

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -31,6 +31,7 @@ from git import (
     Remote,
     Repo,
 )
+from git.exc import GitCommandError
 
 from xorq.catalog.annex import (
     LOCAL_ANNEX,
@@ -151,6 +152,44 @@ def _try_resolve_annex_remote(repo_path, **remote_kwargs):
         if remote_kwargs:
             raise
     return None
+
+
+def _parse_catalog_yaml_blob(blob):
+    """Parse a ``catalog.yaml`` blob from a merge stage; return defaults
+    when the blob is missing (the file did not exist in that stage)."""
+    if blob is None:
+        return {CatalogInfix.ENTRY: [], CatalogInfix.ALIAS: []}
+    raw = yaml12.parse_yaml(blob.data_stream.read().decode())
+    if isinstance(raw, list):
+        # Legacy on-disk format predates the entries/aliases dict schema.
+        return {CatalogInfix.ENTRY: raw, CatalogInfix.ALIAS: []}
+    return {
+        CatalogInfix.ENTRY: raw.get(str(CatalogInfix.ENTRY), []),
+        CatalogInfix.ALIAS: raw.get(str(CatalogInfix.ALIAS), []),
+    }
+
+
+def _three_way_list_merge(base, ours, theirs):
+    """3-way merge of ordered lists treated as sets with ours-first ordering.
+
+    An item in ``base`` that's been dropped by one side is treated as a
+    removal and excluded from the result.  Items added by either side
+    survive.  Duplicates collapse.
+    """
+    base_set = set(base)
+    ours_set = set(ours)
+    theirs_set = set(theirs)
+    result = []
+    seen = set()
+    for item in (*ours, *theirs):
+        if item in seen:
+            continue
+        if item in base_set and (item not in ours_set or item not in theirs_set):
+            # present in base and dropped by at least one side -> remove
+            continue
+        result.append(item)
+        seen.add(item)
+    return result
 
 
 class CatalogMergeConflict(Exception):
@@ -429,8 +468,60 @@ class Catalog:
         return results
 
     def pull(self):
-        """Pull from the configured git remote (no-op if no remote is configured)."""
-        return tuple(map(Remote.pull, self._validated_git_remotes()))
+        """Fetch and merge from the configured git remote; raise on unmerged paths.
+
+        Replaces ``git pull`` (which inherits the user's ``pull.rebase``
+        config and bails on divergent branches by default) with explicit
+        ``git fetch`` + ``git merge``.  When the merge leaves
+        ``catalog.yaml`` conflicted (typical when both sides appended
+        to the entries or aliases lists), a Python 3-way list-merge
+        resolves it: items present in the merge base and removed by
+        one side are propagated as removals; items added by either
+        side survive; duplicates are collapsed.  Anything still
+        unmerged after that — typically alias symlinks at the same
+        path with diverging targets — surfaces as
+        ``CatalogMergeConflict`` with the conflicted paths; the merge
+        is left in-progress so the user can resolve it.
+        """
+        branch = self.repo.active_branch.name
+        fetch_results = []
+        for remote in self._validated_git_remotes():
+            fetch_results.append(remote.fetch())
+            try:
+                self.repo.git.merge(f"{remote.name}/{branch}", "--no-edit")
+                continue
+            except GitCommandError:
+                pass
+            self._resolve_yaml_conflict_if_any()
+            unmerged = tuple(self.repo.index.unmerged_blobs().keys())
+            if unmerged:
+                raise CatalogMergeConflict(unmerged) from None
+            self.repo.git.commit("--no-edit")
+        return tuple(fetch_results)
+
+    def _resolve_yaml_conflict_if_any(self):
+        yaml_relpath = str(self.catalog_yaml.yaml_relpath)
+        unmerged = self.repo.index.unmerged_blobs()
+        if yaml_relpath not in unmerged:
+            return
+        stages = {stage: blob for stage, blob in unmerged[yaml_relpath]}
+        base = _parse_catalog_yaml_blob(stages.get(1))
+        ours = _parse_catalog_yaml_blob(stages.get(2))
+        theirs = _parse_catalog_yaml_blob(stages.get(3))
+        merged = {
+            str(CatalogInfix.ENTRY): _three_way_list_merge(
+                base[CatalogInfix.ENTRY],
+                ours[CatalogInfix.ENTRY],
+                theirs[CatalogInfix.ENTRY],
+            ),
+            str(CatalogInfix.ALIAS): _three_way_list_merge(
+                base[CatalogInfix.ALIAS],
+                ours[CatalogInfix.ALIAS],
+                theirs[CatalogInfix.ALIAS],
+            ),
+        }
+        self.catalog_yaml.set_contents(merged)
+        self.repo.git.add(yaml_relpath)
 
     @contextmanager
     def synchronizing(self):

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -164,8 +164,8 @@ def _parse_catalog_yaml_blob(blob):
         # Legacy on-disk format predates the entries/aliases dict schema.
         return {CatalogInfix.ENTRY: raw, CatalogInfix.ALIAS: []}
     return {
-        CatalogInfix.ENTRY: raw.get(str(CatalogInfix.ENTRY), []),
-        CatalogInfix.ALIAS: raw.get(str(CatalogInfix.ALIAS), []),
+        CatalogInfix.ENTRY: raw.get(CatalogInfix.ENTRY, []),
+        CatalogInfix.ALIAS: raw.get(CatalogInfix.ALIAS, []),
     }
 
 
@@ -192,20 +192,62 @@ def _three_way_list_merge(base, ours, theirs):
     return result
 
 
+class CatalogPullError(RuntimeError):
+    """Raised by ``Catalog.pull`` for failures other than an unresolved
+    merge — e.g. a detached HEAD pre-flight check, or a non-conflict
+    ``git merge`` failure where re-raising the underlying error gives
+    the user the actionable message.
+
+    Distinct from ``CatalogMergeConflict``, which is raised specifically
+    when a merge leaves files unresolved and the recovery recipe applies.
+    Symmetric with ``CatalogPushError`` from #1899.
+    """
+
+
 class CatalogMergeConflict(Exception):
     """Raised by ``Catalog.pull`` when a merge leaves files unresolved.
 
     The ``conflicted`` attribute is a tuple of repo-relative paths still
-    in the unmerged state — typically alias symlinks under
-    ``.xorq/aliases/``. The merge is left in-progress in the working
-    tree so the user can resolve it (see xorq-labs/xorq#1886 for the
-    recovery recipe).
+    in the unmerged state — typically alias symlinks under ``aliases/``
+    (add/add with diverging targets, or modify/delete).  The
+    ``remote_name`` attribute is the name of the remote whose merge
+    raised, when known.  The merge is left in-progress in the working
+    tree so the user can resolve it.
+
+    Recovery options:
+
+    1. Abort the pull and keep your local state::
+
+        catalog.repo.git.merge("--abort")
+
+    2. Resolve manually, then commit::
+
+        # for each path in exc.conflicted, pick a side or write the
+        # resolved content, then:
+        catalog.repo.git.add(*exc.conflicted)
+        catalog.repo.git.commit("--no-edit")
+
+    3. Take theirs wholesale for the conflicted alias::
+
+        catalog.repo.git.checkout("--theirs", *exc.conflicted)
+        catalog.repo.git.add(*exc.conflicted)
+        catalog.repo.git.commit("--no-edit")
+
+    The catalog's ``catalog.yaml`` has already been auto-resolved and
+    staged before this exception is raised, so manual resolution only
+    needs to address the paths in ``conflicted``.
     """
 
-    def __init__(self, conflicted):
+    def __init__(self, conflicted, remote_name=None):
         self.conflicted = tuple(conflicted)
+        self.remote_name = remote_name
+        prefix = (
+            f"pull from remote {remote_name!r} "
+            if remote_name is not None
+            else "catalog.pull() "
+        )
         super().__init__(
-            f"catalog.pull() left {len(self.conflicted)} path(s) in conflict: "
+            f"{prefix}left {len(self.conflicted)} path(s) in conflict: "
             f"{', '.join(self.conflicted)}"
         )
 
@@ -468,7 +510,7 @@ class Catalog:
         return results
 
     def pull(self):
-        """Fetch and merge from the configured git remote; raise on unmerged paths.
+        """Fetch and merge from the catalog's git remote; raise on unmerged paths.
 
         Replaces ``git pull`` (which inherits the user's ``pull.rebase``
         config and bails on divergent branches by default) with explicit
@@ -480,24 +522,45 @@ class Catalog:
         side survive; duplicates are collapsed.  Anything still
         unmerged after that — typically alias symlinks at the same
         path with diverging targets — surfaces as
-        ``CatalogMergeConflict`` with the conflicted paths; the merge
-        is left in-progress so the user can resolve it.
+        ``CatalogMergeConflict`` with the conflicted paths and the
+        remote name; the merge is left in-progress so the user can
+        resolve it (see ``CatalogMergeConflict`` for recovery recipes).
+
+        Pre-flights:
+
+        - HEAD must be on a branch (the catalog API never detaches HEAD
+          on its own — this only fails if the repo was put in detached
+          state outside xorq).  Raises ``CatalogPullError``.
+        - A non-conflict ``git merge`` failure (e.g. the remote ref
+          doesn't exist, the working tree is dirty, a hook rejected the
+          merge commit) re-raises the original ``GitCommandError``
+          rather than swallowing it and falling through to a misleading
+          ``git commit --no-edit``.
+
+        A catalog has at most one git remote (see ADR on single-remote
+        catalogs).  No remote → no-op.
         """
+        if self.repo.head.is_detached:
+            raise CatalogPullError(
+                "catalog.pull() requires a checked-out branch; HEAD is detached"
+            )
+        remotes = self._validated_git_remotes()
+        if not remotes:
+            return ()
+        (remote,) = remotes
         branch = self.repo.active_branch.name
-        fetch_results = []
-        for remote in self._validated_git_remotes():
-            fetch_results.append(remote.fetch())
-            try:
-                self.repo.git.merge(f"{remote.name}/{branch}", "--no-edit")
-                continue
-            except GitCommandError:
-                pass
+        fetch_result = remote.fetch()
+        try:
+            self.repo.git.merge(f"{remote.name}/{branch}", "--no-edit")
+        except GitCommandError:
+            if not (Path(self.repo.git_dir) / "MERGE_HEAD").exists():
+                raise
             self._resolve_yaml_conflict_if_any()
             unmerged = tuple(self.repo.index.unmerged_blobs().keys())
             if unmerged:
-                raise CatalogMergeConflict(unmerged) from None
+                raise CatalogMergeConflict(unmerged, remote_name=remote.name) from None
             self.repo.git.commit("--no-edit")
-        return tuple(fetch_results)
+        return (fetch_result,)
 
     def _resolve_yaml_conflict_if_any(self):
         yaml_relpath = str(self.catalog_yaml.yaml_relpath)
@@ -509,12 +572,12 @@ class Catalog:
         ours = _parse_catalog_yaml_blob(stages.get(2))
         theirs = _parse_catalog_yaml_blob(stages.get(3))
         merged = {
-            str(CatalogInfix.ENTRY): _three_way_list_merge(
+            CatalogInfix.ENTRY: _three_way_list_merge(
                 base[CatalogInfix.ENTRY],
                 ours[CatalogInfix.ENTRY],
                 theirs[CatalogInfix.ENTRY],
             ),
-            str(CatalogInfix.ALIAS): _three_way_list_merge(
+            CatalogInfix.ALIAS: _three_way_list_merge(
                 base[CatalogInfix.ALIAS],
                 ours[CatalogInfix.ALIAS],
                 theirs[CatalogInfix.ALIAS],

--- a/python/xorq/catalog/tests/conftest.py
+++ b/python/xorq/catalog/tests/conftest.py
@@ -18,6 +18,7 @@ from xorq.catalog.catalog import (
     METADATA_APPEND,
     PREFERRED_SUFFIX,
     Catalog,
+    CatalogAlias,
 )
 from xorq.catalog.constants import MAIN_BRANCH, CatalogInfix
 from xorq.catalog.expr_utils import build_expr_context_zip
@@ -247,3 +248,48 @@ def repo_cloned_bare(catalog_populated, backend_type, tmpdir):
     # sync content from origin (the populated catalog)
     _do_inside(bare_path, "sync", "--content")
     yield repo_cloned_bare
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for catalog pull tests
+# ---------------------------------------------------------------------------
+
+
+def add_expr_entry(catalog, table_name, value, aliases=()):
+    """Add a tiny memtable expression as a catalog entry; return its hash name."""
+    expr = xo.memtable({"x": [value]}, name=table_name)
+    with build_expr_context_zip(expr) as zip_path:
+        entry = catalog.add(zip_path, sync=False, aliases=aliases)
+    return entry.name
+
+
+def remove_alias(catalog, alias):
+    CatalogAlias.from_name(alias, catalog).remove()
+
+
+def alias_target_hash(catalog, alias):
+    return CatalogAlias.from_name(alias, catalog).catalog_entry.name
+
+
+@pytest.fixture
+def two_clones(tmpdir):
+    """Two plain-git catalogs sharing a bare origin, both at the boot commit.
+
+    Initial state on origin/main:
+        entries: ['boot']
+        aliases: ['boot-alias' -> boot]
+    """
+    workdir = Path(tmpdir)
+    origin_path = workdir / "origin.git"
+    user_a_path = workdir / "user-a"
+    user_b_path = workdir / "user-b"
+
+    Repo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
+
+    cat_a = Catalog.from_repo_path(user_a_path, init=True, annex=False)
+    add_expr_entry(cat_a, "boot", value=0, aliases=("boot-alias",))
+    cat_a.repo.create_remote(name="origin", url=str(origin_path))
+    cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
+
+    cat_b = Catalog.clone_from(url=str(origin_path), repo_path=user_b_path, annex=False)
+    return cat_a, cat_b

--- a/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
@@ -32,6 +32,7 @@ hygiene smell, not a merge conflict, and is filed as #1901.)
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -61,6 +62,16 @@ def _remove_alias(catalog, alias):
 
 def _alias_target_hash(catalog, alias):
     return CatalogAlias.from_name(alias, catalog).catalog_entry.name
+
+
+# Git commit SHAs include the author/commit timestamp at second
+# resolution.  When both clones perform the same operation against the
+# same content within the same wall-clock second, their commits hash to
+# the same SHA and `cat_b.pull()` becomes a trivial fast-forward no-op
+# instead of exercising the divergent-merge path the test is meant to
+# describe.  Sleep just over a second to guarantee divergent SHAs even
+# when the operations are otherwise identical.
+_FORCE_DIVERGENT_TIMESTAMP = 1.05
 
 
 @pytest.fixture
@@ -116,6 +127,7 @@ def test_case_02_add_same_entry(two_clones):
     auto-merge in stock git; resolver does not need to fire."""
     cat_a, cat_b = two_clones
     name_x_a = _add_expr_entry(cat_a, "x", value=1)
+    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
     name_x_b = _add_expr_entry(cat_b, "x", value=1)
     assert name_x_a == name_x_b, "test setup: same content must hash the same"
     cat_a.push()
@@ -154,6 +166,7 @@ def test_case_04_remove_same_entry(two_clones):
     cat_b.pull()
 
     cat_a.remove(name_x, sync=False)
+    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
     cat_b.remove(name_x, sync=False)
     cat_a.push()
 
@@ -206,6 +219,7 @@ def test_case_08_add_same_alias_same_target(two_clones):
     diverges."""
     cat_a, cat_b = two_clones
     name_x_a = _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
     name_x_b = _add_expr_entry(cat_b, "x", value=1, aliases=("shared",))
     assert name_x_a == name_x_b
     cat_a.push()
@@ -225,6 +239,7 @@ def test_case_10_remove_same_alias(two_clones):
     cat_b.pull()
 
     _remove_alias(cat_a, "shared")
+    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
     _remove_alias(cat_b, "shared")
     cat_a.push()
 

--- a/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
@@ -1,0 +1,316 @@
+"""Conflict-matrix tests for ``Catalog.pull()`` — xorq-labs/xorq#1886 (Bug B).
+
+Each test mirrors a row of the conflict matrix from the issue.  Tests
+describe the *desired* post-fix behavior; on current code (where
+``catalog.pull()`` bails on divergent branches before any merge attempt)
+every test fails.
+
+Two-clone setup throughout:  ``cat_a`` and ``cat_b`` share a bare
+origin and start from the same boot commit.  ``cat_a`` does its action
+and pushes; ``cat_b`` does its action locally; ``cat_b.pull()`` is the
+operation under test.
+
+Auto-resolve cases (pull succeeds silently after fix):
+    01  add entry X        | add entry Y                 -> both present
+    02  add entry X        | add entry X (same hash)     -> X present
+    03  remove entry X     | remove entry Y              -> neither present
+    04  remove entry X     | remove entry X              -> X gone
+    05  add entry X        | remove entry Y              -> X added, Y gone
+    06  add α->X           | add β->Y (different names)  -> both aliases present
+    08  add α->X           | add α->X (identical)        -> α->X
+    10  remove α           | remove α                    -> α gone
+    11  remove α           | remove β                    -> both gone
+    12  remove α           | add β->Y (different names)  -> α gone, β added
+
+Genuine conflict cases (pull raises CatalogMergeConflict):
+    09  add α->X           | add α->Y (same name, different target)
+    13  remove α (in base) | re-point α->Y
+
+(Case 07 — different alias names pointing at the same entry — is a
+hygiene smell, not a merge conflict, and is filed as #1901.)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from git import Repo as GitRepo
+
+import xorq.api as xo
+from xorq.catalog.catalog import (
+    Catalog,
+    CatalogAlias,
+    CatalogMergeConflict,
+)
+from xorq.catalog.constants import MAIN_BRANCH
+from xorq.catalog.expr_utils import build_expr_context_zip
+
+
+def _add_expr_entry(catalog, table_name, value, aliases=()):
+    """Add a tiny memtable expression as a catalog entry; return its hash name."""
+    expr = xo.memtable({"x": [value]}, name=table_name)
+    with build_expr_context_zip(expr) as zip_path:
+        entry = catalog.add(zip_path, sync=False, aliases=aliases)
+    return entry.name
+
+
+def _remove_alias(catalog, alias):
+    CatalogAlias.from_name(alias, catalog).remove()
+
+
+def _alias_target_hash(catalog, alias):
+    return CatalogAlias.from_name(alias, catalog).catalog_entry.name
+
+
+@pytest.fixture
+def two_clones(tmpdir):
+    """Two plain-git catalogs sharing a bare origin, both at the boot commit.
+
+    Initial state on origin/main:
+        entries: ['boot']
+        aliases: ['boot-alias' -> boot]
+    """
+    workdir = Path(tmpdir)
+    origin_path = workdir / "origin.git"
+    user_a_path = workdir / "userA"
+    user_b_path = workdir / "userB"
+
+    GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
+
+    cat_a = Catalog.from_repo_path(user_a_path, init=True, annex=False)
+    _add_expr_entry(cat_a, "boot", value=0, aliases=("boot-alias",))
+    cat_a.repo.create_remote(name="origin", url=str(origin_path))
+    cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
+
+    cat_b = Catalog.clone_from(
+        url=str(origin_path), repo_path=user_b_path, annex=False
+    )
+    return cat_a, cat_b
+
+
+# ---------------------------------------------------------------------------
+# Auto-resolve cases — catalog.pull() should succeed silently after fix
+# ---------------------------------------------------------------------------
+
+
+def test_case_01_add_different_entries(two_clones):
+    """Both sides add a different entry hash. The yaml entries: list
+    grows in both directions from the common ancestor — stock git's
+    line-based diff sees overlapping trailing-region edits and produces
+    conflict markers. The yaml-aware resolver must union both adds."""
+    cat_a, cat_b = two_clones
+    name_x = _add_expr_entry(cat_a, "x", value=1)
+    name_y = _add_expr_entry(cat_b, "y", value=2)
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert name_x in cat_b.list()
+    assert name_y in cat_b.list()
+    cat_b.assert_consistency()
+
+
+def test_case_02_add_same_entry(two_clones):
+    """Both sides add the identical entry hash. Identical line additions
+    auto-merge in stock git; resolver does not need to fire."""
+    cat_a, cat_b = two_clones
+    name_x_a = _add_expr_entry(cat_a, "x", value=1)
+    name_x_b = _add_expr_entry(cat_b, "x", value=1)
+    assert name_x_a == name_x_b, "test setup: same content must hash the same"
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert name_x_a in cat_b.list()
+    cat_b.assert_consistency()
+
+
+def test_case_03_remove_different_entries(two_clones):
+    """Both sides remove a different entry that was in the base.
+    Resolver propagates both removals via 3-way merge."""
+    cat_a, cat_b = two_clones
+    name_x = _add_expr_entry(cat_a, "x", value=1)
+    name_y = _add_expr_entry(cat_a, "y", value=2)
+    cat_a.push()
+    cat_b.pull()
+
+    cat_a.remove(name_x, sync=False)
+    cat_b.remove(name_y, sync=False)
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert name_x not in cat_b.list()
+    assert name_y not in cat_b.list()
+    cat_b.assert_consistency()
+
+
+def test_case_04_remove_same_entry(two_clones):
+    """Both sides remove the same entry. Idempotent."""
+    cat_a, cat_b = two_clones
+    name_x = _add_expr_entry(cat_a, "x", value=1)
+    cat_a.push()
+    cat_b.pull()
+
+    cat_a.remove(name_x, sync=False)
+    cat_b.remove(name_x, sync=False)
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert name_x not in cat_b.list()
+    cat_b.assert_consistency()
+
+
+def test_case_05_add_and_remove_unrelated(two_clones):
+    """Ours adds X; theirs removes Y (Y was in base; X is fresh).
+    Independent edits in different yaml regions."""
+    cat_a, cat_b = two_clones
+    name_y = _add_expr_entry(cat_a, "y", value=2)
+    cat_a.push()
+    cat_b.pull()
+
+    name_x = _add_expr_entry(cat_a, "x", value=1)
+    cat_b.remove(name_y, sync=False)
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert name_x in cat_b.list()
+    assert name_y not in cat_b.list()
+    cat_b.assert_consistency()
+
+
+def test_case_06_add_aliases_different_names(two_clones):
+    """Ours adds α->X; theirs adds β->Y. Different alias names land at
+    distinct symlink paths (no filesystem conflict); only the yaml
+    aliases: list overlaps and needs the resolver."""
+    cat_a, cat_b = two_clones
+    name_x = _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    name_y = _add_expr_entry(cat_b, "y", value=2, aliases=("beta",))
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert "alpha" in cat_b.list_aliases()
+    assert "beta" in cat_b.list_aliases()
+    assert _alias_target_hash(cat_b, "alpha") == name_x
+    assert _alias_target_hash(cat_b, "beta") == name_y
+    cat_b.assert_consistency()
+
+
+def test_case_08_add_same_alias_same_target(two_clones):
+    """Both sides add the identical alias name pointing at the identical
+    entry. Identical adds in both yaml and the symlink path; nothing
+    diverges."""
+    cat_a, cat_b = two_clones
+    name_x_a = _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    name_x_b = _add_expr_entry(cat_b, "x", value=1, aliases=("shared",))
+    assert name_x_a == name_x_b
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert "shared" in cat_b.list_aliases()
+    assert _alias_target_hash(cat_b, "shared") == name_x_a
+    cat_b.assert_consistency()
+
+
+def test_case_10_remove_same_alias(two_clones):
+    """Both sides remove the same alias. Idempotent."""
+    cat_a, cat_b = two_clones
+    _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    cat_a.push()
+    cat_b.pull()
+
+    _remove_alias(cat_a, "shared")
+    _remove_alias(cat_b, "shared")
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert "shared" not in cat_b.list_aliases()
+    cat_b.assert_consistency()
+
+
+def test_case_11_remove_different_aliases(two_clones):
+    """Ours removes α; theirs removes β. Both were in the base."""
+    cat_a, cat_b = two_clones
+    _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    _add_expr_entry(cat_a, "y", value=2, aliases=("beta",))
+    cat_a.push()
+    cat_b.pull()
+
+    _remove_alias(cat_a, "alpha")
+    _remove_alias(cat_b, "beta")
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert "alpha" not in cat_b.list_aliases()
+    assert "beta" not in cat_b.list_aliases()
+    cat_b.assert_consistency()
+
+
+def test_case_12_remove_alias_and_add_unrelated(two_clones):
+    """Ours removes α (in base); theirs adds β->Y (fresh)."""
+    cat_a, cat_b = two_clones
+    _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    cat_a.push()
+    cat_b.pull()
+
+    _remove_alias(cat_a, "alpha")
+    name_y = _add_expr_entry(cat_b, "y", value=2, aliases=("beta",))
+    cat_a.push()
+
+    cat_b.pull()
+
+    assert "alpha" not in cat_b.list_aliases()
+    assert "beta" in cat_b.list_aliases()
+    assert _alias_target_hash(cat_b, "beta") == name_y
+    cat_b.assert_consistency()
+
+
+# ---------------------------------------------------------------------------
+# Genuine conflict cases — catalog.pull() should raise CatalogMergeConflict
+# ---------------------------------------------------------------------------
+
+
+def test_case_09_add_same_alias_different_targets(two_clones):
+    """Both sides add the same alias name pointing at different entries.
+    The yaml aliases: list dedupes trivially, but the symlink at
+    .xorq/aliases/<name>.zip is an add/add conflict on the same path
+    with diverging targets — the only genuine merge conflict we can't
+    auto-resolve."""
+    cat_a, cat_b = two_clones
+    _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    _add_expr_entry(cat_b, "y", value=2, aliases=("shared",))
+    cat_a.push()
+
+    with pytest.raises(CatalogMergeConflict) as excinfo:
+        cat_b.pull()
+
+    conflicted = excinfo.value.conflicted
+    assert any("aliases" in p and "shared" in p for p in conflicted), conflicted
+
+
+def test_case_13_remove_alias_vs_repoint(two_clones):
+    """Alias α exists in base. Ours removes α; theirs re-points α to a
+    different entry. The symlink at .xorq/aliases/α.zip is a
+    modify/delete conflict that survives any auto-resolve."""
+    cat_a, cat_b = two_clones
+    _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    name_y = _add_expr_entry(cat_a, "y", value=2)
+    cat_a.push()
+    cat_b.pull()
+
+    _remove_alias(cat_b, "alpha")
+    cat_a.add_alias(name_y, "alpha", sync=False)
+    cat_a.push()
+
+    with pytest.raises(CatalogMergeConflict) as excinfo:
+        cat_b.pull()
+
+    conflicted = excinfo.value.conflicted
+    assert any("aliases" in p and "alpha" in p for p in conflicted), conflicted

--- a/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
@@ -32,7 +32,8 @@ hygiene smell, not a merge conflict, and is filed as #1901.)
 
 from __future__ import annotations
 
-import time
+import os
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -66,12 +67,31 @@ def _alias_target_hash(catalog, alias):
 
 # Git commit SHAs include the author/commit timestamp at second
 # resolution.  When both clones perform the same operation against the
-# same content within the same wall-clock second, their commits hash to
-# the same SHA and `cat_b.pull()` becomes a trivial fast-forward no-op
-# instead of exercising the divergent-merge path the test is meant to
-# describe.  Sleep just over a second to guarantee divergent SHAs even
-# when the operations are otherwise identical.
-_FORCE_DIVERGENT_TIMESTAMP = 1.05
+# same content, their commits would hash to the same SHA and
+# `cat_b.pull()` would become a trivial fast-forward no-op instead of
+# exercising the divergent-merge path the test is meant to describe.
+# Pin cat_b's commit dates with `_commit_dates(_DIVERGENT_DATE)` to
+# guarantee divergent SHAs deterministically, without relying on
+# wall-clock drift.
+_DIVERGENT_DATE = "2030-01-01T00:00:00"
+
+
+@contextmanager
+def _commit_dates(date_str):
+    """Force git to use ``date_str`` for both author and committer dates
+    on commits made inside the context.  Restores prior env on exit."""
+    keys = ("GIT_AUTHOR_DATE", "GIT_COMMITTER_DATE")
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ[k] = date_str
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 @pytest.fixture
@@ -125,8 +145,8 @@ def test_case_02_add_same_entry(two_clones):
     auto-merge in stock git; resolver does not need to fire."""
     cat_a, cat_b = two_clones
     name_x_a = _add_expr_entry(cat_a, "x", value=1)
-    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
-    name_x_b = _add_expr_entry(cat_b, "x", value=1)
+    with _commit_dates(_DIVERGENT_DATE):
+        name_x_b = _add_expr_entry(cat_b, "x", value=1)
     assert name_x_a == name_x_b, "test setup: same content must hash the same"
     cat_a.push()
 
@@ -164,8 +184,8 @@ def test_case_04_remove_same_entry(two_clones):
     cat_b.pull()
 
     cat_a.remove(name_x, sync=False)
-    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
-    cat_b.remove(name_x, sync=False)
+    with _commit_dates(_DIVERGENT_DATE):
+        cat_b.remove(name_x, sync=False)
     cat_a.push()
 
     cat_b.pull()
@@ -217,8 +237,8 @@ def test_case_08_add_same_alias_same_target(two_clones):
     diverges."""
     cat_a, cat_b = two_clones
     name_x_a = _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
-    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
-    name_x_b = _add_expr_entry(cat_b, "x", value=1, aliases=("shared",))
+    with _commit_dates(_DIVERGENT_DATE):
+        name_x_b = _add_expr_entry(cat_b, "x", value=1, aliases=("shared",))
     assert name_x_a == name_x_b
     cat_a.push()
 
@@ -237,8 +257,8 @@ def test_case_10_remove_same_alias(two_clones):
     cat_b.pull()
 
     _remove_alias(cat_a, "shared")
-    time.sleep(_FORCE_DIVERGENT_TIMESTAMP)
-    _remove_alias(cat_b, "shared")
+    with _commit_dates(_DIVERGENT_DATE):
+        _remove_alias(cat_b, "shared")
     cat_a.push()
 
     cat_b.pull()
@@ -293,8 +313,8 @@ def test_case_12_remove_alias_and_add_unrelated(two_clones):
 def test_case_09_add_same_alias_different_targets(two_clones):
     """Both sides add the same alias name pointing at different entries.
     The yaml aliases: list dedupes trivially, but the symlink at
-    .xorq/aliases/<name>.zip is an add/add conflict on the same path
-    with diverging targets — the only genuine merge conflict we can't
+    aliases/<name>.zip is an add/add conflict on the same path with
+    diverging targets — the only genuine merge conflict we can't
     auto-resolve."""
     cat_a, cat_b = two_clones
     _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
@@ -304,14 +324,13 @@ def test_case_09_add_same_alias_different_targets(two_clones):
     with pytest.raises(CatalogMergeConflict) as excinfo:
         cat_b.pull()
 
-    conflicted = excinfo.value.conflicted
-    assert any("aliases" in p and "shared" in p for p in conflicted), conflicted
+    assert "aliases/shared.zip" in excinfo.value.conflicted, excinfo.value.conflicted
 
 
 def test_case_13_remove_alias_vs_repoint(two_clones):
     """Alias α exists in base. Ours removes α; theirs re-points α to a
-    different entry. The symlink at .xorq/aliases/α.zip is a
-    modify/delete conflict that survives any auto-resolve."""
+    different entry. The symlink at aliases/α.zip is a modify/delete
+    conflict that survives any auto-resolve."""
     cat_a, cat_b = two_clones
     _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
     name_y = _add_expr_entry(cat_a, "y", value=2)
@@ -325,5 +344,4 @@ def test_case_13_remove_alias_vs_repoint(two_clones):
     with pytest.raises(CatalogMergeConflict) as excinfo:
         cat_b.pull()
 
-    conflicted = excinfo.value.conflicted
-    assert any("aliases" in p and "alpha" in p for p in conflicted), conflicted
+    assert "aliases/alpha.zip" in excinfo.value.conflicted, excinfo.value.conflicted

--- a/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
@@ -94,9 +94,7 @@ def two_clones(tmpdir):
     cat_a.repo.create_remote(name="origin", url=str(origin_path))
     cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
 
-    cat_b = Catalog.clone_from(
-        url=str(origin_path), repo_path=user_b_path, annex=False
-    )
+    cat_b = Catalog.clone_from(url=str(origin_path), repo_path=user_b_path, annex=False)
     return cat_a, cat_b
 
 

--- a/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
@@ -73,8 +73,8 @@ def two_clones(tmpdir):
     """
     workdir = Path(tmpdir)
     origin_path = workdir / "origin.git"
-    user_a_path = workdir / "userA"
-    user_b_path = workdir / "userB"
+    user_a_path = workdir / "user-a"
+    user_b_path = workdir / "user-b"
 
     GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
 

--- a/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_conflicts.py
@@ -37,32 +37,10 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from git import Repo as GitRepo
 
-import xorq.api as xo
-from xorq.catalog.catalog import (
-    Catalog,
-    CatalogAlias,
-    CatalogMergeConflict,
-)
-from xorq.catalog.constants import MAIN_BRANCH
-from xorq.catalog.expr_utils import build_expr_context_zip
+from xorq.catalog.catalog import CatalogMergeConflict
 
-
-def _add_expr_entry(catalog, table_name, value, aliases=()):
-    """Add a tiny memtable expression as a catalog entry; return its hash name."""
-    expr = xo.memtable({"x": [value]}, name=table_name)
-    with build_expr_context_zip(expr) as zip_path:
-        entry = catalog.add(zip_path, sync=False, aliases=aliases)
-    return entry.name
-
-
-def _remove_alias(catalog, alias):
-    CatalogAlias.from_name(alias, catalog).remove()
-
-
-def _alias_target_hash(catalog, alias):
-    return CatalogAlias.from_name(alias, catalog).catalog_entry.name
+from .conftest import add_expr_entry, alias_target_hash, remove_alias
 
 
 # Git commit SHAs include the author/commit timestamp at second
@@ -94,28 +72,8 @@ def _commit_dates(date_str):
                 os.environ[k] = v
 
 
-@pytest.fixture
-def two_clones(tmpdir):
-    """Two plain-git catalogs sharing a bare origin, both at the boot commit.
-
-    Initial state on origin/main:
-        entries: ['boot']
-        aliases: ['boot-alias' -> boot]
-    """
-    workdir = Path(tmpdir)
-    origin_path = workdir / "origin.git"
-    user_a_path = workdir / "user-a"
-    user_b_path = workdir / "user-b"
-
-    GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
-
-    cat_a = Catalog.from_repo_path(user_a_path, init=True, annex=False)
-    _add_expr_entry(cat_a, "boot", value=0, aliases=("boot-alias",))
-    cat_a.repo.create_remote(name="origin", url=str(origin_path))
-    cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
-
-    cat_b = Catalog.clone_from(url=str(origin_path), repo_path=user_b_path, annex=False)
-    return cat_a, cat_b
+def _assert_no_merge_in_progress(catalog):
+    assert not (Path(catalog.repo.git_dir) / "MERGE_HEAD").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -129,8 +87,8 @@ def test_case_01_add_different_entries(two_clones):
     line-based diff sees overlapping trailing-region edits and produces
     conflict markers. The yaml-aware resolver must union both adds."""
     cat_a, cat_b = two_clones
-    name_x = _add_expr_entry(cat_a, "x", value=1)
-    name_y = _add_expr_entry(cat_b, "y", value=2)
+    name_x = add_expr_entry(cat_a, "x", value=1)
+    name_y = add_expr_entry(cat_b, "y", value=2)
     cat_a.push()
 
     cat_b.pull()
@@ -138,15 +96,16 @@ def test_case_01_add_different_entries(two_clones):
     assert name_x in cat_b.list()
     assert name_y in cat_b.list()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_02_add_same_entry(two_clones):
     """Both sides add the identical entry hash. Identical line additions
     auto-merge in stock git; resolver does not need to fire."""
     cat_a, cat_b = two_clones
-    name_x_a = _add_expr_entry(cat_a, "x", value=1)
+    name_x_a = add_expr_entry(cat_a, "x", value=1)
     with _commit_dates(_DIVERGENT_DATE):
-        name_x_b = _add_expr_entry(cat_b, "x", value=1)
+        name_x_b = add_expr_entry(cat_b, "x", value=1)
     assert name_x_a == name_x_b, "test setup: same content must hash the same"
     cat_a.push()
 
@@ -154,14 +113,15 @@ def test_case_02_add_same_entry(two_clones):
 
     assert name_x_a in cat_b.list()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_03_remove_different_entries(two_clones):
     """Both sides remove a different entry that was in the base.
     Resolver propagates both removals via 3-way merge."""
     cat_a, cat_b = two_clones
-    name_x = _add_expr_entry(cat_a, "x", value=1)
-    name_y = _add_expr_entry(cat_a, "y", value=2)
+    name_x = add_expr_entry(cat_a, "x", value=1)
+    name_y = add_expr_entry(cat_a, "y", value=2)
     cat_a.push()
     cat_b.pull()
 
@@ -174,12 +134,13 @@ def test_case_03_remove_different_entries(two_clones):
     assert name_x not in cat_b.list()
     assert name_y not in cat_b.list()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_04_remove_same_entry(two_clones):
     """Both sides remove the same entry. Idempotent."""
     cat_a, cat_b = two_clones
-    name_x = _add_expr_entry(cat_a, "x", value=1)
+    name_x = add_expr_entry(cat_a, "x", value=1)
     cat_a.push()
     cat_b.pull()
 
@@ -192,17 +153,18 @@ def test_case_04_remove_same_entry(two_clones):
 
     assert name_x not in cat_b.list()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_05_add_and_remove_unrelated(two_clones):
     """Ours adds X; theirs removes Y (Y was in base; X is fresh).
     Independent edits in different yaml regions."""
     cat_a, cat_b = two_clones
-    name_y = _add_expr_entry(cat_a, "y", value=2)
+    name_y = add_expr_entry(cat_a, "y", value=2)
     cat_a.push()
     cat_b.pull()
 
-    name_x = _add_expr_entry(cat_a, "x", value=1)
+    name_x = add_expr_entry(cat_a, "x", value=1)
     cat_b.remove(name_y, sync=False)
     cat_a.push()
 
@@ -211,6 +173,7 @@ def test_case_05_add_and_remove_unrelated(two_clones):
     assert name_x in cat_b.list()
     assert name_y not in cat_b.list()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_06_add_aliases_different_names(two_clones):
@@ -218,17 +181,18 @@ def test_case_06_add_aliases_different_names(two_clones):
     distinct symlink paths (no filesystem conflict); only the yaml
     aliases: list overlaps and needs the resolver."""
     cat_a, cat_b = two_clones
-    name_x = _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
-    name_y = _add_expr_entry(cat_b, "y", value=2, aliases=("beta",))
+    name_x = add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    name_y = add_expr_entry(cat_b, "y", value=2, aliases=("beta",))
     cat_a.push()
 
     cat_b.pull()
 
     assert "alpha" in cat_b.list_aliases()
     assert "beta" in cat_b.list_aliases()
-    assert _alias_target_hash(cat_b, "alpha") == name_x
-    assert _alias_target_hash(cat_b, "beta") == name_y
+    assert alias_target_hash(cat_b, "alpha") == name_x
+    assert alias_target_hash(cat_b, "beta") == name_y
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_08_add_same_alias_same_target(two_clones):
@@ -236,47 +200,49 @@ def test_case_08_add_same_alias_same_target(two_clones):
     entry. Identical adds in both yaml and the symlink path; nothing
     diverges."""
     cat_a, cat_b = two_clones
-    name_x_a = _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    name_x_a = add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
     with _commit_dates(_DIVERGENT_DATE):
-        name_x_b = _add_expr_entry(cat_b, "x", value=1, aliases=("shared",))
+        name_x_b = add_expr_entry(cat_b, "x", value=1, aliases=("shared",))
     assert name_x_a == name_x_b
     cat_a.push()
 
     cat_b.pull()
 
     assert "shared" in cat_b.list_aliases()
-    assert _alias_target_hash(cat_b, "shared") == name_x_a
+    assert alias_target_hash(cat_b, "shared") == name_x_a
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_10_remove_same_alias(two_clones):
     """Both sides remove the same alias. Idempotent."""
     cat_a, cat_b = two_clones
-    _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
     cat_a.push()
     cat_b.pull()
 
-    _remove_alias(cat_a, "shared")
+    remove_alias(cat_a, "shared")
     with _commit_dates(_DIVERGENT_DATE):
-        _remove_alias(cat_b, "shared")
+        remove_alias(cat_b, "shared")
     cat_a.push()
 
     cat_b.pull()
 
     assert "shared" not in cat_b.list_aliases()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_11_remove_different_aliases(two_clones):
     """Ours removes α; theirs removes β. Both were in the base."""
     cat_a, cat_b = two_clones
-    _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
-    _add_expr_entry(cat_a, "y", value=2, aliases=("beta",))
+    add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    add_expr_entry(cat_a, "y", value=2, aliases=("beta",))
     cat_a.push()
     cat_b.pull()
 
-    _remove_alias(cat_a, "alpha")
-    _remove_alias(cat_b, "beta")
+    remove_alias(cat_a, "alpha")
+    remove_alias(cat_b, "beta")
     cat_a.push()
 
     cat_b.pull()
@@ -284,25 +250,27 @@ def test_case_11_remove_different_aliases(two_clones):
     assert "alpha" not in cat_b.list_aliases()
     assert "beta" not in cat_b.list_aliases()
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 def test_case_12_remove_alias_and_add_unrelated(two_clones):
     """Ours removes α (in base); theirs adds β->Y (fresh)."""
     cat_a, cat_b = two_clones
-    _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
     cat_a.push()
     cat_b.pull()
 
-    _remove_alias(cat_a, "alpha")
-    name_y = _add_expr_entry(cat_b, "y", value=2, aliases=("beta",))
+    remove_alias(cat_a, "alpha")
+    name_y = add_expr_entry(cat_b, "y", value=2, aliases=("beta",))
     cat_a.push()
 
     cat_b.pull()
 
     assert "alpha" not in cat_b.list_aliases()
     assert "beta" in cat_b.list_aliases()
-    assert _alias_target_hash(cat_b, "beta") == name_y
+    assert alias_target_hash(cat_b, "beta") == name_y
     cat_b.assert_consistency()
+    _assert_no_merge_in_progress(cat_b)
 
 
 # ---------------------------------------------------------------------------
@@ -317,8 +285,8 @@ def test_case_09_add_same_alias_different_targets(two_clones):
     diverging targets — the only genuine merge conflict we can't
     auto-resolve."""
     cat_a, cat_b = two_clones
-    _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
-    _add_expr_entry(cat_b, "y", value=2, aliases=("shared",))
+    add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    add_expr_entry(cat_b, "y", value=2, aliases=("shared",))
     cat_a.push()
 
     with pytest.raises(CatalogMergeConflict) as excinfo:
@@ -332,12 +300,12 @@ def test_case_13_remove_alias_vs_repoint(two_clones):
     different entry. The symlink at aliases/α.zip is a modify/delete
     conflict that survives any auto-resolve."""
     cat_a, cat_b = two_clones
-    _add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
-    name_y = _add_expr_entry(cat_a, "y", value=2)
+    add_expr_entry(cat_a, "x", value=1, aliases=("alpha",))
+    name_y = add_expr_entry(cat_a, "y", value=2)
     cat_a.push()
     cat_b.pull()
 
-    _remove_alias(cat_b, "alpha")
+    remove_alias(cat_b, "alpha")
     cat_a.add_alias(name_y, "alpha", sync=False)
     cat_a.push()
 

--- a/python/xorq/catalog/tests/test_catalog_pull_errors.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_errors.py
@@ -139,6 +139,10 @@ def test_pull_remote_deleted_catalog_yaml_does_not_silently_drop_entries(two_clo
     destroys every entry the deleter side never explicitly removed."""
     cat_a, cat_b = two_clones
 
+    # Capture cat_b's pre-pull state so we can verify the failed pull
+    # didn't silently rewrite the local catalog.yaml.
+    pre_pull_entries = cat_b.list()
+
     # cat_a manually deletes catalog.yaml — bypasses the catalog API
     # entirely (Catalog.push asserts consistency, so we can't use it
     # to push a corrupt state).  Push the broken commit to origin.
@@ -155,11 +159,13 @@ def test_pull_remote_deleted_catalog_yaml_does_not_silently_drop_entries(two_clo
         cat_b.pull()
 
     # Pre-fix: pull silently "succeeds" but cat_b's catalog.yaml is
-    # rewritten with the empty-defaults theirs side, which drops the
-    # boot entry from the entries list.  Post-fix: pre-flight refuses
-    # the merge, cat_b's tree is untouched, and boot survives.
-    assert "boot" in cat_b.list(), (
-        f"pull silently dropped entries: cat_b.list() == {cat_b.list()}"
+    # rewritten with the empty-defaults theirs side, which drops every
+    # pre-existing entry from the entries list.  Post-fix: pre-flight
+    # refuses the merge, cat_b's tree is untouched, and the original
+    # entries survive.
+    assert all(e in cat_b.list() for e in pre_pull_entries), (
+        f"pull silently dropped entries: cat_b.list() == {cat_b.list()}, "
+        f"expected to contain {pre_pull_entries}"
     )
 
 

--- a/python/xorq/catalog/tests/test_catalog_pull_errors.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_errors.py
@@ -19,6 +19,7 @@ import xorq.api as xo
 from xorq.catalog.catalog import (
     Catalog,
     CatalogMergeConflict,
+    CatalogPullError,
 )
 from xorq.catalog.constants import MAIN_BRANCH
 from xorq.catalog.expr_utils import build_expr_context_zip
@@ -112,3 +113,89 @@ def test_pull_conflict_names_remote_in_error(two_clones):
         cat_b.pull()
 
     assert "origin" in str(excinfo.value), str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight consistency checks (review feedback #3 — open-items #4).
+#
+# When the remote tip is in a state that would trip ``assert_consistency``
+# (catalog.yaml deleted by hand, malformed, or has an unexpected shape),
+# the resolver currently treats the missing/garbage data as legitimate
+# input and either silently destroys data (modify/delete revives empty
+# defaults → 3-way merge drops every prior entry) or lets a raw parser
+# exception leak with no catalog context.
+#
+# Desired post-fix: pre-flight ``assert_consistency`` against ours and
+# against the remote tip before any merge attempt; surface as
+# ``CatalogPullError`` naming the corrupt side.
+# ---------------------------------------------------------------------------
+
+
+def test_pull_remote_deleted_catalog_yaml_does_not_silently_drop_entries(two_clones):
+    """If the remote tip has deleted ``catalog.yaml`` (manual rm
+    bypassing the catalog API), ``pull()`` must refuse rather than
+    treating the deletion as 'theirs removed every entry' and 3-way-
+    merging the entries list against empty defaults — which silently
+    destroys every entry the deleter side never explicitly removed."""
+    cat_a, cat_b = two_clones
+
+    # cat_a manually deletes catalog.yaml — bypasses the catalog API
+    # entirely (Catalog.push asserts consistency, so we can't use it
+    # to push a corrupt state).  Push the broken commit to origin.
+    (Path(cat_a.repo.working_dir) / "catalog.yaml").unlink()
+    cat_a.repo.git.add("--all")
+    cat_a.repo.git.commit("-m", "external: rm catalog.yaml")
+    cat_a.repo.git.push("origin", MAIN_BRANCH)
+
+    # cat_b makes a normal commit so the histories diverge and
+    # cat_b.pull() exercises the merge path (rather than fast-forward).
+    _add_expr_entry(cat_b, "y", value=2)
+
+    with pytest.raises(CatalogPullError):
+        cat_b.pull()
+
+    # Pre-fix: pull silently "succeeds" but cat_b's catalog.yaml is
+    # rewritten with the empty-defaults theirs side, which drops the
+    # boot entry from the entries list.  Post-fix: pre-flight refuses
+    # the merge, cat_b's tree is untouched, and boot survives.
+    assert "boot" in cat_b.list(), (
+        f"pull silently dropped entries: cat_b.list() == {cat_b.list()}"
+    )
+
+
+def test_pull_remote_malformed_yaml_raises_catalog_error(two_clones):
+    """If the remote tip has a malformed ``catalog.yaml`` (manual edit
+    bypassing the catalog API), ``pull()`` must surface that as a
+    catalog-level error rather than letting ``yaml12.parse_yaml``'s raw
+    exception leak out of the resolver with no catalog context."""
+    cat_a, cat_b = two_clones
+
+    yaml_path = Path(cat_a.repo.working_dir) / "catalog.yaml"
+    yaml_path.write_text("[1, 2,\n")  # unclosed flow sequence — fails to parse
+    cat_a.repo.git.add("catalog.yaml")
+    cat_a.repo.git.commit("-m", "external: corrupt catalog.yaml")
+    cat_a.repo.git.push("origin", MAIN_BRANCH)
+
+    _add_expr_entry(cat_b, "y", value=2)
+
+    with pytest.raises(CatalogPullError):
+        cat_b.pull()
+
+
+def test_pull_remote_unexpected_yaml_shape_raises_catalog_error(two_clones):
+    """If the remote tip has a ``catalog.yaml`` that parses but isn't a
+    dict-or-list (e.g. a scalar — manual edit / corruption), ``pull()``
+    must surface that as a catalog-level error rather than letting the
+    ``AttributeError`` from ``raw.get(...)`` leak out of the resolver."""
+    cat_a, cat_b = two_clones
+
+    yaml_path = Path(cat_a.repo.working_dir) / "catalog.yaml"
+    yaml_path.write_text("42\n")  # parses to an int, not a dict
+    cat_a.repo.git.add("catalog.yaml")
+    cat_a.repo.git.commit("-m", "external: scalar catalog.yaml")
+    cat_a.repo.git.push("origin", MAIN_BRANCH)
+
+    _add_expr_entry(cat_b, "y", value=2)
+
+    with pytest.raises(CatalogPullError):
+        cat_b.pull()

--- a/python/xorq/catalog/tests/test_catalog_pull_errors.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_errors.py
@@ -13,42 +13,16 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from git import Repo as GitRepo
+from git import Repo
 
-import xorq.api as xo
 from xorq.catalog.catalog import (
     Catalog,
     CatalogMergeConflict,
     CatalogPullError,
 )
 from xorq.catalog.constants import MAIN_BRANCH
-from xorq.catalog.expr_utils import build_expr_context_zip
 
-
-def _add_expr_entry(catalog, table_name, value, aliases=()):
-    expr = xo.memtable({"x": [value]}, name=table_name)
-    with build_expr_context_zip(expr) as zip_path:
-        entry = catalog.add(zip_path, sync=False, aliases=aliases)
-    return entry.name
-
-
-@pytest.fixture
-def two_clones(tmpdir):
-    """Two plain-git catalogs sharing a bare origin, both at a boot commit."""
-    workdir = Path(tmpdir)
-    origin_path = workdir / "origin.git"
-    user_a_path = workdir / "user-a"
-    user_b_path = workdir / "user-b"
-
-    GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
-
-    cat_a = Catalog.from_repo_path(user_a_path, init=True, annex=False)
-    _add_expr_entry(cat_a, "boot", value=0, aliases=("boot-alias",))
-    cat_a.repo.create_remote(name="origin", url=str(origin_path))
-    cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
-
-    cat_b = Catalog.clone_from(url=str(origin_path), repo_path=user_b_path, annex=False)
-    return cat_a, cat_b
+from .conftest import add_expr_entry
 
 
 def test_pull_in_detached_head_raises_clear_error(two_clones):
@@ -63,9 +37,6 @@ def test_pull_in_detached_head_raises_clear_error(two_clones):
     with pytest.raises(Exception) as excinfo:
         cat_b.pull()
 
-    # Pre-fix: gitpython's internal TypeError("HEAD is a detached
-    # symbolic reference ...") leaks out. Post-fix: a catalog-level
-    # error explaining the user needs a checked-out branch.
     assert not isinstance(excinfo.value, TypeError), (
         f"detached HEAD surfaced as bare TypeError instead of a "
         f"catalog-level error: {excinfo.value!r}"
@@ -82,18 +53,15 @@ def test_pull_remote_without_branch_surfaces_cause(tmpdir):
     origin_path = workdir / "origin.git"
     user_path = workdir / "user"
 
-    GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
+    Repo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
     cat = Catalog.from_repo_path(user_path, init=True, annex=False)
-    _add_expr_entry(cat, "boot", value=0)
+    add_expr_entry(cat, "boot", value=0)
     cat.repo.create_remote(name="origin", url=str(origin_path))
-    # NOTE: deliberately not pushing — origin has no branches.
 
     with pytest.raises(Exception) as excinfo:
         cat.pull()
 
     msg = str(excinfo.value).lower()
-    # The downstream "nothing to commit" from the swallowed-GCE
-    # fall-through is the bug we're fixing — it masks the real cause.
     assert "nothing to commit" not in msg, (
         f"pull() masked the real failure with a downstream "
         f"'nothing to commit' from git commit --no-edit: {excinfo.value}"
@@ -105,8 +73,8 @@ def test_pull_conflict_names_remote_in_error(two_clones):
     remote name must appear in the error — symmetric with #1899's
     ``CatalogPushError(f\"push to remote {remote_name!r} ...\")``."""
     cat_a, cat_b = two_clones
-    _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
-    _add_expr_entry(cat_b, "y", value=2, aliases=("shared",))
+    add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    add_expr_entry(cat_b, "y", value=2, aliases=("shared",))
     cat_a.push()
 
     with pytest.raises(CatalogMergeConflict) as excinfo:
@@ -139,30 +107,18 @@ def test_pull_remote_deleted_catalog_yaml_does_not_silently_drop_entries(two_clo
     destroys every entry the deleter side never explicitly removed."""
     cat_a, cat_b = two_clones
 
-    # Capture cat_b's pre-pull state so we can verify the failed pull
-    # didn't silently rewrite the local catalog.yaml.
     pre_pull_entries = cat_b.list()
 
-    # cat_a manually deletes catalog.yaml — bypasses the catalog API
-    # entirely (Catalog.push asserts consistency, so we can't use it
-    # to push a corrupt state).  Push the broken commit to origin.
     (Path(cat_a.repo.working_dir) / "catalog.yaml").unlink()
     cat_a.repo.git.add("--all")
     cat_a.repo.git.commit("-m", "external: rm catalog.yaml")
     cat_a.repo.git.push("origin", MAIN_BRANCH)
 
-    # cat_b makes a normal commit so the histories diverge and
-    # cat_b.pull() exercises the merge path (rather than fast-forward).
-    _add_expr_entry(cat_b, "y", value=2)
+    add_expr_entry(cat_b, "y", value=2)
 
     with pytest.raises(CatalogPullError):
         cat_b.pull()
 
-    # Pre-fix: pull silently "succeeds" but cat_b's catalog.yaml is
-    # rewritten with the empty-defaults theirs side, which drops every
-    # pre-existing entry from the entries list.  Post-fix: pre-flight
-    # refuses the merge, cat_b's tree is untouched, and the original
-    # entries survive.
     assert all(e in cat_b.list() for e in pre_pull_entries), (
         f"pull silently dropped entries: cat_b.list() == {cat_b.list()}, "
         f"expected to contain {pre_pull_entries}"
@@ -177,12 +133,12 @@ def test_pull_remote_malformed_yaml_raises_catalog_error(two_clones):
     cat_a, cat_b = two_clones
 
     yaml_path = Path(cat_a.repo.working_dir) / "catalog.yaml"
-    yaml_path.write_text("[1, 2,\n")  # unclosed flow sequence — fails to parse
+    yaml_path.write_text("[1, 2,\n")
     cat_a.repo.git.add("catalog.yaml")
     cat_a.repo.git.commit("-m", "external: corrupt catalog.yaml")
     cat_a.repo.git.push("origin", MAIN_BRANCH)
 
-    _add_expr_entry(cat_b, "y", value=2)
+    add_expr_entry(cat_b, "y", value=2)
 
     with pytest.raises(CatalogPullError):
         cat_b.pull()
@@ -196,12 +152,12 @@ def test_pull_remote_unexpected_yaml_shape_raises_catalog_error(two_clones):
     cat_a, cat_b = two_clones
 
     yaml_path = Path(cat_a.repo.working_dir) / "catalog.yaml"
-    yaml_path.write_text("42\n")  # parses to an int, not a dict
+    yaml_path.write_text("42\n")
     cat_a.repo.git.add("catalog.yaml")
     cat_a.repo.git.commit("-m", "external: scalar catalog.yaml")
     cat_a.repo.git.push("origin", MAIN_BRANCH)
 
-    _add_expr_entry(cat_b, "y", value=2)
+    add_expr_entry(cat_b, "y", value=2)
 
     with pytest.raises(CatalogPullError):
         cat_b.pull()

--- a/python/xorq/catalog/tests/test_catalog_pull_errors.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_errors.py
@@ -1,0 +1,116 @@
+"""Error-handling tests for ``Catalog.pull()`` — review feedback for
+xorq#1902.
+
+These describe the *desired* post-fix behavior; on current code (where
+non-conflict ``GitCommandError`` is swallowed and falls through to
+``git commit --no-edit``, ``active_branch`` raises ``TypeError`` on a
+detached HEAD, and ``CatalogMergeConflict`` doesn't name the failing
+remote) every test fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from git import Repo as GitRepo
+
+import xorq.api as xo
+from xorq.catalog.catalog import (
+    Catalog,
+    CatalogMergeConflict,
+)
+from xorq.catalog.constants import MAIN_BRANCH
+from xorq.catalog.expr_utils import build_expr_context_zip
+
+
+def _add_expr_entry(catalog, table_name, value, aliases=()):
+    expr = xo.memtable({"x": [value]}, name=table_name)
+    with build_expr_context_zip(expr) as zip_path:
+        entry = catalog.add(zip_path, sync=False, aliases=aliases)
+    return entry.name
+
+
+@pytest.fixture
+def two_clones(tmpdir):
+    """Two plain-git catalogs sharing a bare origin, both at a boot commit."""
+    workdir = Path(tmpdir)
+    origin_path = workdir / "origin.git"
+    user_a_path = workdir / "user-a"
+    user_b_path = workdir / "user-b"
+
+    GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
+
+    cat_a = Catalog.from_repo_path(user_a_path, init=True, annex=False)
+    _add_expr_entry(cat_a, "boot", value=0, aliases=("boot-alias",))
+    cat_a.repo.create_remote(name="origin", url=str(origin_path))
+    cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
+
+    cat_b = Catalog.clone_from(
+        url=str(origin_path), repo_path=user_b_path, annex=False
+    )
+    return cat_a, cat_b
+
+
+def test_pull_in_detached_head_raises_clear_error(two_clones):
+    """When HEAD is detached, ``pull()`` must raise a clear catalog-level
+    error rather than a bare ``TypeError`` from gitpython's
+    ``active_branch.name`` (the only path to detached HEAD on a catalog
+    is external git mucking around; the catalog API itself never
+    detaches)."""
+    _, cat_b = two_clones
+    cat_b.repo.git.checkout("--detach", "HEAD")
+
+    with pytest.raises(Exception) as excinfo:
+        cat_b.pull()
+
+    # Pre-fix: gitpython's internal TypeError("HEAD is a detached
+    # symbolic reference ...") leaks out. Post-fix: a catalog-level
+    # error explaining the user needs a checked-out branch.
+    assert not isinstance(excinfo.value, TypeError), (
+        f"detached HEAD surfaced as bare TypeError instead of a "
+        f"catalog-level error: {excinfo.value!r}"
+    )
+
+
+def test_pull_remote_without_branch_surfaces_cause(tmpdir):
+    """Pulling from a remote whose branch doesn't exist must surface
+    that as the failure cause (e.g. mention the missing ref or that
+    nothing was merged) rather than swallowing the ``git merge`` error
+    and falling through to a misleading ``git commit --no-edit``
+    follow-up."""
+    workdir = Path(tmpdir)
+    origin_path = workdir / "origin.git"
+    user_path = workdir / "user"
+
+    GitRepo.init(origin_path, bare=True, initial_branch=MAIN_BRANCH)
+    cat = Catalog.from_repo_path(user_path, init=True, annex=False)
+    _add_expr_entry(cat, "boot", value=0)
+    cat.repo.create_remote(name="origin", url=str(origin_path))
+    # NOTE: deliberately not pushing — origin has no branches.
+
+    with pytest.raises(Exception) as excinfo:
+        cat.pull()
+
+    msg = str(excinfo.value).lower()
+    # The downstream "nothing to commit" from the swallowed-GCE
+    # fall-through is the bug we're fixing — it masks the real cause.
+    assert "nothing to commit" not in msg, (
+        f"pull() masked the real failure with a downstream "
+        f"'nothing to commit' from git commit --no-edit: {excinfo.value}"
+    )
+
+
+def test_pull_conflict_names_remote_in_error(two_clones):
+    """When ``pull()`` raises ``CatalogMergeConflict``, the failing
+    remote name must appear in the error — symmetric with #1899's
+    ``CatalogPushError(f\"push to remote {remote_name!r} ...\")``."""
+    cat_a, cat_b = two_clones
+    _add_expr_entry(cat_a, "x", value=1, aliases=("shared",))
+    _add_expr_entry(cat_b, "y", value=2, aliases=("shared",))
+    cat_a.push()
+
+    with pytest.raises(CatalogMergeConflict) as excinfo:
+        cat_b.pull()
+
+    assert "origin" in str(excinfo.value), str(excinfo.value)

--- a/python/xorq/catalog/tests/test_catalog_pull_errors.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_errors.py
@@ -46,9 +46,7 @@ def two_clones(tmpdir):
     cat_a.repo.create_remote(name="origin", url=str(origin_path))
     cat_a.repo.git.push("-u", "origin", MAIN_BRANCH)
 
-    cat_b = Catalog.clone_from(
-        url=str(origin_path), repo_path=user_b_path, annex=False
-    )
+    cat_b = Catalog.clone_from(url=str(origin_path), repo_path=user_b_path, annex=False)
     return cat_a, cat_b
 
 

--- a/python/xorq/catalog/tests/test_catalog_pull_errors.py
+++ b/python/xorq/catalog/tests/test_catalog_pull_errors.py
@@ -21,6 +21,7 @@ from xorq.catalog.catalog import (
     CatalogPullError,
 )
 from xorq.catalog.constants import MAIN_BRANCH
+from xorq.catalog.exceptions import CatalogConfigurationError
 
 from .conftest import add_expr_entry
 
@@ -125,6 +126,42 @@ def test_pull_remote_deleted_catalog_yaml_does_not_silently_drop_entries(two_clo
     )
 
 
+def test_pull_local_deleted_catalog_yaml_raises_preflight(two_clones):
+    """If the local (ours) commit has a deleted ``catalog.yaml`` (manual
+    rm bypassing the catalog API), ``pull()`` must raise
+    ``CatalogPullError`` on the ours-side pre-flight before any merge
+    attempt — symmetric with the remote-side check."""
+    cat_a, cat_b = two_clones
+
+    add_expr_entry(cat_a, "x", value=1)
+    cat_a.push()
+
+    (Path(cat_b.repo.working_dir) / "catalog.yaml").unlink()
+    cat_b.repo.git.add("--all")
+    cat_b.repo.git.commit("-m", "external: rm catalog.yaml locally")
+
+    with pytest.raises(CatalogPullError, match="ours"):
+        cat_b.pull()
+
+
+def test_pull_local_malformed_yaml_raises_preflight(two_clones):
+    """If the local (ours) commit has a malformed ``catalog.yaml``,
+    ``pull()`` must raise ``CatalogPullError`` mentioning 'ours'
+    before attempting the merge."""
+    cat_a, cat_b = two_clones
+
+    add_expr_entry(cat_a, "x", value=1)
+    cat_a.push()
+
+    yaml_path = Path(cat_b.repo.working_dir) / "catalog.yaml"
+    yaml_path.write_text("[broken\n")
+    cat_b.repo.git.add("catalog.yaml")
+    cat_b.repo.git.commit("-m", "external: corrupt local catalog.yaml")
+
+    with pytest.raises(CatalogPullError, match="ours"):
+        cat_b.pull()
+
+
 def test_pull_remote_malformed_yaml_raises_catalog_error(two_clones):
     """If the remote tip has a malformed ``catalog.yaml`` (manual edit
     bypassing the catalog API), ``pull()`` must surface that as a
@@ -161,3 +198,33 @@ def test_pull_remote_unexpected_yaml_shape_raises_catalog_error(two_clones):
 
     with pytest.raises(CatalogPullError):
         cat_b.pull()
+
+
+# ---------------------------------------------------------------------------
+# Multi-remote and no-remote edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_pull_multiple_remotes_raises_configuration_error(two_clones):
+    """A catalog with two git remotes must raise
+    ``CatalogConfigurationError`` (ADR-0011 single-remote contract)
+    rather than silently picking one or crashing with a destructuring
+    error."""
+    _, cat_b = two_clones
+    second_origin = Path(cat_b.repo.working_dir).parent / "second-origin.git"
+    Repo.init(second_origin, bare=True, initial_branch=MAIN_BRANCH)
+    cat_b.repo.create_remote(name="backup", url=str(second_origin))
+
+    with pytest.raises(CatalogConfigurationError):
+        cat_b.pull()
+
+
+def test_pull_no_remote_is_noop(tmpdir):
+    """A catalog with no git remote should return an empty tuple (no-op)
+    rather than raising."""
+    cat = Catalog.from_repo_path(Path(tmpdir) / "local-only", init=True, annex=False)
+    add_expr_entry(cat, "boot", value=0)
+
+    result = cat.pull()
+
+    assert result == ()

--- a/python/xorq/catalog/tests/test_three_way_list_merge.py
+++ b/python/xorq/catalog/tests/test_three_way_list_merge.py
@@ -13,9 +13,12 @@ a focused unit failure rather than a confusing pull-integration one.
 
 from __future__ import annotations
 
+import io
+
 import pytest
 
-from xorq.catalog.catalog import _three_way_list_merge
+from xorq.catalog.catalog import _parse_catalog_yaml_blob, _three_way_list_merge
+from xorq.catalog.constants import CatalogInfix
 
 
 def test_empty_inputs():
@@ -86,6 +89,63 @@ def test_input_lists_not_mutated():
     assert base == ["a"]
     assert ours == ["a", "b"]
     assert theirs == ["a", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _parse_catalog_yaml_blob
+# ---------------------------------------------------------------------------
+
+
+class _FakeBlob:
+    """Minimal stand-in for a gitpython Blob with a data_stream."""
+
+    def __init__(self, text: str):
+        self._stream = io.BytesIO(text.encode())
+
+    def data_stream_read(self):
+        return self._stream.read()
+
+    @property
+    def data_stream(self):
+        class _DS:
+            def __init__(self, stream):
+                self._s = stream
+
+            def read(self):
+                return self._s.read()
+
+        return _DS(self._stream)
+
+
+def test_parse_blob_none_returns_empty_defaults():
+    result = _parse_catalog_yaml_blob(None)
+    assert result == {CatalogInfix.ENTRY: [], CatalogInfix.ALIAS: []}
+
+
+def test_parse_blob_legacy_list_format():
+    blob = _FakeBlob("[a, b, c]\n")
+    result = _parse_catalog_yaml_blob(blob)
+    assert result[CatalogInfix.ENTRY] == ["a", "b", "c"]
+    assert result[CatalogInfix.ALIAS] == []
+
+
+def test_parse_blob_dict_format():
+    blob = _FakeBlob("entries:\n  - x\n  - y\naliases:\n  - alpha\n")
+    result = _parse_catalog_yaml_blob(blob)
+    assert result[CatalogInfix.ENTRY] == ["x", "y"]
+    assert result[CatalogInfix.ALIAS] == ["alpha"]
+
+
+def test_parse_blob_dict_missing_keys_default_to_empty():
+    blob = _FakeBlob("{}\n")
+    result = _parse_catalog_yaml_blob(blob)
+    assert result[CatalogInfix.ENTRY] == []
+    assert result[CatalogInfix.ALIAS] == []
+
+
+# ---------------------------------------------------------------------------
+# _three_way_list_merge edge-case
+# ---------------------------------------------------------------------------
 
 
 def test_unhashable_items_raise_type_error():

--- a/python/xorq/catalog/tests/test_three_way_list_merge.py
+++ b/python/xorq/catalog/tests/test_three_way_list_merge.py
@@ -1,0 +1,97 @@
+"""Unit tests for ``_three_way_list_merge`` — the set-with-removal
+semantics used by ``Catalog.pull()``'s ``catalog.yaml`` resolver.
+
+The function treats lists as ordered sets and drops any item that was
+in the merge base but missing from at least one side ("removed by one
+side").  Items added by either side survive; duplicates collapse.
+
+The full pull stack exercises these branches via the conflict matrix
+in ``test_catalog_pull_conflicts.py``; pinning them at the function
+level here means a regression in ``_three_way_list_merge`` surfaces as
+a focused unit failure rather than a confusing pull-integration one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from xorq.catalog.catalog import _three_way_list_merge
+
+
+def test_empty_inputs():
+    assert _three_way_list_merge([], [], []) == []
+
+
+def test_no_changes_passes_through():
+    assert _three_way_list_merge(["a", "b"], ["a", "b"], ["a", "b"]) == ["a", "b"]
+
+
+def test_both_sides_add_same_new_item_collapses():
+    # mirrors matrix case 02 / 08
+    assert _three_way_list_merge([], ["x"], ["x"]) == ["x"]
+
+
+def test_both_sides_add_different_items_unions():
+    # mirrors matrix case 01
+    result = _three_way_list_merge([], ["x"], ["y"])
+    assert sorted(result) == ["x", "y"]
+
+
+def test_ours_removes_theirs_keeps_drops_item():
+    # base had x, ours dropped it, theirs still has it → removed
+    assert _three_way_list_merge(["x"], [], ["x"]) == []
+
+
+def test_theirs_removes_ours_keeps_drops_item():
+    assert _three_way_list_merge(["x"], ["x"], []) == []
+
+
+def test_both_remove_same_item():
+    # mirrors matrix case 04
+    assert _three_way_list_merge(["x"], [], []) == []
+
+
+def test_each_side_removes_the_other_sides_item():
+    # mirrors matrix case 03: base = [x, y]; ours kept y, theirs kept x
+    assert _three_way_list_merge(["x", "y"], ["y"], ["x"]) == []
+
+
+def test_add_and_remove_independent():
+    # mirrors matrix case 05: base = [x]; ours kept x and added z;
+    # theirs removed x and added w
+    result = _three_way_list_merge(["x"], ["x", "z"], ["w"])
+    assert sorted(result) == ["w", "z"]
+
+
+def test_ours_first_ordering_then_theirs_only():
+    # ordering contract: ours items appear in their order, then
+    # theirs-only additions in their order
+    result = _three_way_list_merge([], ["a", "b"], ["c", "a"])
+    assert result == ["a", "b", "c"]
+
+
+def test_duplicates_within_one_side_collapse():
+    assert _three_way_list_merge([], ["x", "x"], []) == ["x"]
+
+
+def test_duplicates_across_sides_collapse():
+    assert _three_way_list_merge([], ["x"], ["x", "x"]) == ["x"]
+
+
+def test_input_lists_not_mutated():
+    base = ["a"]
+    ours = ["a", "b"]
+    theirs = ["a", "c"]
+    _three_way_list_merge(base, ours, theirs)
+    assert base == ["a"]
+    assert ours == ["a", "b"]
+    assert theirs == ["a", "c"]
+
+
+def test_unhashable_items_raise_type_error():
+    # documents the schema constraint: list items must be hashable.
+    # If a future schema makes entries dicts instead of strings, this
+    # helper has to change shape — see RESOLVE_LIST_ITEM_NOT_HASHABLE
+    # in the failure-mode catalog (PR-1902 open-items).
+    with pytest.raises(TypeError):
+        _three_way_list_merge([], [{"a": 1}], [])


### PR DESCRIPTION
Tests + fix for #1886 Bug B (`Catalog.pull()` bails on divergent branches before any merge attempt). Structured as separate commits: failing tests first, then the fix, then review-driven additions (error-handling tests, pre-flight validation, unit tests for the merge helper).

## Why

The discussion on #1886 settled on a **conflict matrix**: for every combination of (ours did X, theirs did Y), describe whether `catalog.pull()` should auto-resolve and succeed, or surface a `CatalogMergeConflict` for the user to resolve. This PR encodes that matrix as one test per case and ships the fix that makes them all pass.

Pre-fix, `catalog.pull()` is `tuple(map(Remote.pull, ...))` — it inherits the user's git config and bails with `fatal: Need to specify how to reconcile divergent branches` before any merge attempt. The fix replaces that with explicit `git fetch + git merge`; when the merge leaves `catalog.yaml` conflicted (typical when both sides appended to the entries or aliases lists), a Python 3-way list-merge resolves it (items dropped by either side propagate as removals; items added by either side survive; duplicates collapse). Anything still unmerged (typically alias symlinks at the same path with diverging targets) raises `CatalogMergeConflict` with the conflicted paths and leaves the merge in-progress for the user.

## New exception classes

- **`CatalogMergeConflict`** — raised when a merge leaves files unresolved (alias symlinks with diverging targets, modify/delete). Carries `.conflicted` (tuple of paths) and `.remote_name`. The merge is left in-progress so the user can resolve, abort, or take-theirs.
- **`CatalogPullError`** — raised for non-conflict failures: detached HEAD, missing/malformed `catalog.yaml` on either side, non-conflict `git merge` errors. Distinct from `CatalogMergeConflict` so callers can handle them differently. Symmetric with `CatalogPushError` from #1899.

## Pre-flight validation

Before any merge attempt, `pull()` now checks:

1. **HEAD must be on a branch** — the catalog API never detaches HEAD on its own; this only fails if the repo was put in detached state outside xorq. Raises `CatalogPullError`.
2. **`catalog.yaml` on ours (HEAD) must exist, parse, and have dict-or-list shape** — without this, a deleted or corrupted local `catalog.yaml` would leak raw parser exceptions or silently destroy data in the 3-way merge.
3. **`catalog.yaml` on theirs (remote tip) must pass the same check** — without this, a remote-side deletion would be treated as "theirs removed every entry" and the 3-way merge would drop all entries.
4. **Single-remote enforcement** — `(remote,) = remotes` destructures exactly one remote per the ADR-0011 contract; >1 remote raises `CatalogConfigurationError`.

## The matrix

`α`, `β` are alias names; `X`, `Y` are entry hashes. The `#` cell links to the test pinned to commit `10523d74`; `bail` = `git.exc.GitCommandError: fatal: Need to specify how to reconcile divergent branches`.

For the same-action cases (#02, #04, #08, #10): even though both sides perform the same operation against the same content, the resulting commits differ — git commit SHAs include the author/commit timestamp, and the two clones run their commits at different wall-clock times, so the resulting SHAs diverge and `cat_b.pull()` hits the same divergent-branches bail as the rest. The tests force `cat_b`'s commit dates to a fixed future value via the `_commit_dates("2030-01-01T00:00:00")` context manager (sets `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` env vars) to guarantee divergent SHAs deterministically, without relying on wall-clock drift.

### Auto-resolve cases — pull succeeds silently after fix

| # | Ours did | Theirs did | What stock git sees | Behavior pre-fix | Expected result (post-fix) |
|---|----------|------------|---------------------|------------------|----------------------------|
| [01](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L84) | add entry X | add entry Y | `catalog.yaml` trailing-region overlap | fails: `bail` | pull succeeds; both X and Y in `cat_b.list()` |
| [02](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L102) | add entry X | add entry X | identical add → auto-merges | fails: `bail` | pull succeeds; X in `cat_b.list()` |
| [03](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L119) | remove entry X | remove entry Y | possibly adjacent-line yaml conflict | fails: `bail` | pull succeeds; neither X nor Y in `cat_b.list()` |
| [04](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L140) | remove entry X | remove entry X | identical delete → auto-merges | fails: `bail` | pull succeeds; X gone |
| [05](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L159) | add entry X | remove entry Y | non-overlapping yaml regions | fails: `bail` | pull succeeds; X present, Y gone |
| [06](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L179) | add α→X | add β→Y (different names) | yaml list overlap; symlinks at distinct paths | fails: `bail` | pull succeeds; both α→X and β→Y in `cat_b.list_aliases()`, each resolving to the right hash |
| [08](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L198) | add α→X | add α→X (identical) | identical line + identical symlink | fails: `bail` | pull succeeds; α→X |
| [10](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L217) | remove α | remove α | identical removal | fails: `bail` | pull succeeds; α gone |
| [11](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L236) | remove α | remove β | independent | fails: `bail` | pull succeeds; both α and β gone |
| [12](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L256) | remove α | add β→Y (β ≠ α) | independent | fails: `bail` | pull succeeds; α gone, β→Y present |

### Genuine conflict cases — pull raises `CatalogMergeConflict`

| # | Ours did | Theirs did | What stock git sees | Behavior pre-fix | Expected result (post-fix) |
|---|----------|------------|---------------------|------------------|----------------------------|
| [09](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L281) | add α → X | add α → Y | `.xorq/aliases/α.zip` add/add with diverging targets | fails: `bail` (never reaches the genuine-conflict state) | raises `CatalogMergeConflict`; `excinfo.value.conflicted` contains the `.xorq/aliases/α.zip` symlink path |
| [13](https://github.com/xorq-labs/xorq/blob/10523d74/python/xorq/catalog/tests/test_catalog_pull_conflicts.py#L298) | remove α (in base) | re-point α → Y | `.xorq/aliases/α.zip` modify/delete | fails: `bail` (never reaches the modify/delete state) | raises `CatalogMergeConflict`; `excinfo.value.conflicted` contains the `.xorq/aliases/α.zip` symlink path |

### Filed separately

| # | Ours did | Theirs did | Why not here |
|---|----------|------------|--------------|
| 07 | add α → X | add β → X (different names, same target) | hygiene smell, not a merge conflict — #1901 |

## Test files

| File | Tests | Scope |
|------|-------|-------|
| `test_catalog_pull_conflicts.py` | 12 | Conflict matrix (the table above) |
| `test_catalog_pull_errors.py` | 10 | Error handling: detached HEAD, missing remote branch, conflict names remote, pre-flight validation (deleted/malformed/scalar yaml on both sides), multi-remote rejection, no-remote no-op |
| `test_three_way_list_merge.py` | 18 | Unit tests for `_three_way_list_merge` and `_parse_catalog_yaml_blob` |
| **Total** | **40** | |

## Production changes

`catalog.py` (+245 lines):
- `_parse_catalog_yaml_blob()` — parse a `catalog.yaml` blob from a merge stage
- `_three_way_list_merge()` — 3-way set merge with ours-first ordering
- `CatalogPullError` — non-conflict pull failures
- `CatalogMergeConflict` — unresolved merge paths (with `.conflicted` and `.remote_name`)
- `Catalog.pull()` — rewritten: fetch + merge + yaml resolver + pre-flights
- `Catalog._resolve_yaml_conflict_if_any()` — resolve `catalog.yaml` in the unmerged index
- `Catalog._validate_catalog_yaml_in_commit()` — pre-flight blob validation

## Test plan

- [x] CI runs the new test files in the `core` job
- [x] Local: all 40 tests pass at `10523d74`
- [x] No regression in existing catalog tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)