### PR TITLE
ci: move catalog tests to dedicated parallel workflow

### DIFF
--- a/.github/workflows/ci-test-catalog.yml
+++ b/.github/workflows/ci-test-catalog.yml
@@ -1,0 +1,85 @@
+name: ci-test-catalog
+
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.qmd"
+      - "*.md"
+      - "codecov.yml"
+      - ".envrc"
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        backend:
+          - name: git
+            k_filter: "not [annex] and not script_execution and not slow"
+          - name: annex
+            k_filter: "[annex] and not script_execution and not slow"
+            sys-deps:
+              - git-annex
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: configure git identity
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@xorq.dev"
+
+      - uses: extractions/setup-just@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: download test data
+        run: just download-data
+
+      - name: install system dependencies
+        if: matrix.backend.sys-deps != null
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq -y
+          sudo apt-get install -qq -y ${{ join(matrix.backend.sys-deps, ' ') }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install the project
+        run: uv sync --locked --group dev --group test
+        working-directory: ${{ github.workspace }}
+
+      - name: pytest
+        timeout-minutes: 20
+        run: >
+          uv run --no-sync pytest
+          --import-mode=importlib
+          --cov --cov-report=xml
+          python/xorq/catalog/tests
+          -k '${{ matrix.backend.k_filter }}'
+          -v --durations=20 -n auto --dist=loadfile
+        working-directory: ${{ github.workspace }}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5.5.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-test-catalog.yml
+++ b/.github/workflows/ci-test-catalog.yml
@@ -24,8 +24,17 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     strategy:
+      # Run both partitions to completion even if one fails — they're
+      # independent backends and a failure in one shouldn't mask the other.
+      fail-fast: false
       matrix:
         python-version: ["3.12"]
+        # Partition relies on the session fixture in
+        # python/xorq/catalog/tests/conftest.py (params=["git", "annex"]):
+        # tests that consume `backend_type` get [git]/[annex] in their
+        # nodeids; tests without it fall into the `git` job. New tests that
+        # need the git-annex binary must consume `backend_type` (or otherwise
+        # tag themselves with [annex]) to be routed to the annex job.
         backend:
           - name: git
             k_filter: "not [annex] and not script_execution and not slow"
@@ -70,12 +79,14 @@ jobs:
 
       - name: pytest
         timeout-minutes: 20
+        env:
+          K_FILTER: ${{ matrix.backend.k_filter }}
         run: >
           uv run --no-sync pytest
           --import-mode=importlib
           --cov --cov-report=xml
           python/xorq/catalog/tests
-          -k '${{ matrix.backend.k_filter }}'
+          -k "$K_FILTER"
           -v --durations=20 -n auto --dist=loadfile
         working-directory: ${{ github.workspace }}
 
@@ -83,3 +94,4 @@ jobs:
         uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: catalog-${{ matrix.backend.name }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,7 +12,6 @@ on:
       - ".envrc"
     branches:
       - main
-      - master
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -140,7 +140,15 @@ jobs:
 
       - name: pytest
         timeout-minutes: 20
-        run: uv run --no-sync pytest --import-mode=importlib --cov --cov-report=xml -m ${{ matrix.backend.name }} -k 'not script_execution and not slow' -v --durations=20${{ matrix.backend.parallel && ' -n auto --dist=loadfile' || '' }}
+        run: >
+          uv run --no-sync pytest
+          --import-mode=importlib
+          --cov --cov-report=xml
+          -m ${{ matrix.backend.name }}
+          --ignore=python/xorq/catalog
+          -k 'not script_execution and not slow'
+          -v --durations=20
+          ${{ matrix.backend.parallel && '-n auto --dist=loadfile' || '' }}
         working-directory: ${{ github.workspace }}
         env:
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Catalog tests (git-backend and git-annex) were running inside the core
backend job, blocking it and making parallelism harder. This PR offloads
them to a new workflow and speeds up CI.

Changes:
- Add `.github/workflows/ci-test-catalog.yml`: dedicated workflow for
  `python/xorq/catalog/tests`, split into git and annex matrix jobs,
  both run with `-n auto --dist=loadfile`; annex job installs git-annex
  as a sys-dep; runs `just download-data` before tests (needed by
  `test_tui.py` for `astronauts.parquet` via the `parquet_dir` fixture)
- Exclude `python/xorq/catalog` from `ci-test.yml` via
  `--ignore=python/xorq/catalog` on every backend (hard-coded, no
  per-matrix key)
- Reformat long pytest `run:` line in `ci-test.yml` with YAML block
  scalar (`>`) for readability
- `fail-fast: false` on the catalog matrix so the git and annex
  partitions don't cancel each other on failure
- Pass the `-k` filter via env var (`K_FILTER`) instead of GHA
  expression interpolation, to avoid quoting hazards if the filter ever
  contains a single quote
- Tag codecov uploads with `flags: catalog-git` / `catalog-annex` for
  partition-level coverage attribution
- Comment the implicit partition assumption on the matrix: split relies
  on the `backend_type` session fixture in
  `python/xorq/catalog/tests/conftest.py` (`params=["git", "annex"]`).
  Tests that don't consume that fixture fall into the `git` job — new
  tests that need the `git-annex` binary must consume `backend_type` or
  otherwise carry `[annex]` in their nodeid
- Drop `master` from `ci-test.yml` push trigger (remote only has `main`)