### PR TITLE
fix(devcontainer): close flock fd before spawning socat SSH forwarder

### DIFF
--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -185,7 +185,7 @@ setup_ssh_forward() {
     fi
 
     socat "TCP-LISTEN:${port},bind=${bridge_ip},reuseaddr,fork" \
-          "UNIX-CONNECT:${SSH_AUTH_SOCK}" &
+          "UNIX-CONNECT:${SSH_AUTH_SOCK}" 9>&- &
     local host_pid=$!
     echo "$host_pid" > "$SSH_FORWARD_PIDFILE"
 


### PR DESCRIPTION
## Summary
- The background `socat` process launched by `setup_ssh_forward` inherits file descriptor 9 (the `flock` lockfile fd from `ensure_up`), preventing any concurrent `devcontainer` invocation for the same workspace from acquiring the lock until the first session exits.
- Fix: add `9>&-` to the socat launch to close the inherited fd before the child process starts.

## Test plan
- [ ] Run `devcontainer claude-dangerously-skip-permissions` — verify it starts normally
- [ ] While the first session is running, run `devcontainer claude-dangerously-skip-permissions` again in a second terminal for the same workspace — verify it proceeds without "Another devcontainer operation is in progress, waiting..."
- [ ] Verify SSH agent forwarding still works inside the container (`ssh-add -l`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)