### PR TITLE
fix(profiles): raise informative ValueError for unknown backend

### DIFF
--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -181,8 +181,9 @@ class Profile:
 
     @con_name.validator
     def validate_con_name(self, attr, value):
-        installed = sorted(ep.name for ep in _load_entry_points())
-        if value not in installed:
+        entry_points = _load_entry_points()
+        if not any(ep.name == value for ep in entry_points):
+            installed = sorted(ep.name for ep in entry_points)
             raise ValueError(
                 f"Unknown backend {value!r}; installed backends: {installed}"
             )


### PR DESCRIPTION
Replace the bare `assert` in Profile.validate_con_name with a ValueError that names the rejected backend and lists the installed ones. The assert failed silently under -O and gave no hint which backend was unavailable.