### PR TITLE
ci: add downstream BSL compatibility check

### DIFF
--- a/.github/workflows/ci-downstream-bsl.yml
+++ b/.github/workflows/ci-downstream-bsl.yml
@@ -1,0 +1,60 @@
+name: ci-downstream-bsl
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      bsl-ref:
+        description: "boring-semantic-layer branch/tag to test against (overrides BSL_REF env)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  BSL_REF: main
+
+jobs:
+  bsl:
+    name: BSL downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout xorq (PR branch)
+        uses: actions/checkout@v6
+        with:
+          path: _xorq
+
+      - name: Checkout boring-semantic-layer
+        uses: actions/checkout@v6
+        with:
+          repository: boringdata/boring-semantic-layer
+          ref: ${{ inputs.bsl-ref || env.BSL_REF }}
+          path: _bsl
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: _bsl/docs/web/package-lock.json
+
+      - name: Install BSL deps then override xorq with this PR
+        working-directory: _bsl
+        run: |
+          uv sync --all-extras
+          uv pip install -e "../_xorq[duckdb]"
+          cd docs/web && npm ci
+
+      - name: Run BSL checks
+        working-directory: _bsl
+        run: make check


### PR DESCRIPTION
## Summary
- New `ci-downstream-bsl` workflow runs the boring-semantic-layer test suite against xorq from the PR branch, catching regressions in the BSL contract during catalog/replay/rebuild refactors.
- Targets `boringdata/boring-semantic-layer:main` now that [PR 244](https://github.com/boringdata/boring-semantic-layer/pull/244) (`feat: add reemit to BSL TagHandler for catalog rebuild`) has landed upstream.
- BSL ref is overridable via the `bsl-ref` workflow_dispatch input or the `BSL_REF` env var, so a contributor can point CI at their branch when prepping a coordinated xorq+BSL change.

## Test plan
- [ ] Workflow appears under Actions on this PR and runs to completion
- [ ] BSL `make check` passes with xorq installed from this branch
- [ ] `workflow_dispatch` with a `bsl-ref` override checks out the requested ref