### PR TITLE
fix(direnv): replace deprecated nix_direnv_watch_file with watch_file

### DIFF
--- a/.envrcs/.envrc.nix-config
+++ b/.envrcs/.envrc.nix-config
@@ -3,7 +3,7 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.4.0; then
 fi
 
 # https://github.com/nix-community/nix-direnv/pull/148#issuecomment-1049287263
-nix_direnv_watch_file ../nix/{commands.nix,xorq.nix,nix.conf}
+watch_file ../nix/{commands.nix,xorq.nix,nix.conf}
 
 # within this repo, we want to control the nix.conf contents
 export NIX_CONF_DIR=$(realpath ../nix)


### PR DESCRIPTION
## Summary
- Replace deprecated `nix_direnv_watch_file` with the standard direnv built-in `watch_file` in `.envrcs/.envrc.nix-config`
- Eliminates the `` direnv: `nix_direnv_watch_file` is deprecated - use `watch_file` `` warning

## Test plan
- [ ] Run `direnv allow` and verify no deprecation warning is emitted
- [ ] Confirm nix files are still watched (edit a watched file and verify direnv reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)