### PR TITLE
feat(catalog): tokenize-tolerant normalize_read via read_path

### DIFF
--- a/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
+++ b/python/xorq/common/utils/dask_normalize/dask_normalize_expr.py
@@ -408,33 +408,11 @@ def normalize_ibis_datatype(datatype):
 @dask.base.normalize_token.register(rel.Read)
 def normalize_read(read):
     read_kwargs = dict(read.read_kwargs)
-    path = read_kwargs["hash_path"]
-    if isinstance(path, (list, tuple)):
-        # normalize_filenames may have converted a single path to a list
-        path = path[0] if len(path) == 1 else path
-    if isinstance(path, (str, pathlib.Path)):
-        path = str(path)
-        if path.startswith(("http://", "https://")):
-            tpls = _normalize_path_stat(path)
-        elif path.startswith(("s3://", "gs://", "gcs://")):
-            tpls = _normalize_path_stat(
-                path, **{k: v for k, v in read_kwargs.items() if k != "hash_path"}
-            )
-        elif not pathlib.Path(path).is_absolute() and path == read_kwargs.get(
-            "read_path"
-        ):
-            # Build-bundled Read whose hash_path was rewritten to the relative
-            # read_path for deterministic YAML (see common.py register_node).
-            # The filename is already a content hash, so use it directly.
-            tpls = (("build-relative-path", path),)
-        elif (path := pathlib.Path(path)).exists():
-            tpls = read.normalize_method(path)
-        else:
-            raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    elif isinstance(path, (list, tuple)) and all(isinstance(el, str) for el in path):
-        raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+    # Catalog stamps read_path as a stable content-addressed key; hash_path is per-load.
+    if (read_path := read_kwargs.get("read_path")) is not None:
+        tpls = (("read_path", str(read_path)),)
     else:
-        raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+        tpls = _normalize_read_by_hash_path(read, read_kwargs)
     tpls += tuple(
         (k, v)
         for k, v in read.read_kwargs
@@ -450,6 +428,30 @@ def normalize_read(read):
         tpls,
         caller="normalize_read",
     )
+
+
+def _normalize_read_by_hash_path(read, read_kwargs):
+    path = read_kwargs["hash_path"]
+    if isinstance(path, (list, tuple)):
+        # normalize_filenames may have converted a single path to a list
+        path = path[0] if len(path) == 1 else path
+    if isinstance(path, (str, pathlib.Path)):
+        path = str(path)
+        if path.startswith(("http://", "https://")):
+            tpls = _normalize_path_stat(path)
+        elif path.startswith(("s3://", "gs://", "gcs://")):
+            tpls = _normalize_path_stat(
+                path, **{k: v for k, v in read_kwargs.items() if k != "hash_path"}
+            )
+        elif (path := pathlib.Path(path)).exists():
+            tpls = read.normalize_method(path)
+        else:
+            raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+    elif isinstance(path, (list, tuple)) and all(isinstance(el, str) for el in path):
+        raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+    else:
+        raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
+    return tpls
 
 
 @dask.base.normalize_token.register(ir.DatabaseTable)

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1033,3 +1033,97 @@ def test_join_order_permutations_catalog_roundtrip(tmp_path, three_tables_mixed,
         actual.sort_values(list(actual.columns), ignore_index=True),
         expected.sort_values(list(expected.columns), ignore_index=True),
     )
+
+
+def _build_fitted_pipeline_entry(catalog):
+    """Build a FittedPipeline predict entry exercising the tokenize side-channel.
+    Returns the ``preds`` entry."""
+    from xorq.catalog.bind import bind  # noqa: PLC0415
+    from xorq.vendor.ibis.expr import operations as ops  # noqa: PLC0415
+
+    sk_pipeline = pytest.importorskip("sklearn.pipeline")
+    sk_preprocessing = pytest.importorskip("sklearn.preprocessing")
+    sk_linear_model = pytest.importorskip("sklearn.linear_model")
+
+    training = catalog.add(
+        xo.memtable({"f": [1.0, 2.0, 3.0, 4.0], "t": [0.0, 0.0, 1.0, 1.0]}),
+        aliases=("training",),
+    )
+    scoring = catalog.add(
+        xo.memtable({"f": [1.5, 2.5], "t": [0.0, 1.0]}),
+        aliases=("scoring",),
+    )
+    unbound = ops.UnboundTable(name="p", schema=training.expr.schema()).to_expr()
+    identity = catalog.add(unbound.select("f", "t"), aliases=("identity",))
+    sk = sk_pipeline.make_pipeline(
+        sk_preprocessing.StandardScaler(),
+        sk_linear_model.LinearRegression(),
+    )
+    pipeline = xo.Pipeline.from_instance(sk)
+    fitted = pipeline.fit(bind(training, identity), features=("f",), target="t")
+    predict_expr = fitted.predict(bind(scoring, identity))
+    _ = scoring  # referenced in predict_expr graph; silence unused-warnings
+    return catalog.add(predict_expr, aliases=("preds",))
+
+
+def test_tokenize_survives_side_channel_read(tmp_path):
+    """Canonical repro: the FittedPipeline UDF closure hosts a pre-d2m Expr
+    whose Read has a catalog-relative `hash_path`. Before Plan B,
+    ``normalize_read`` would raise NotImplementedError on that path. With
+    ``read_path`` preferred, tokenize goes through the stable content-addressed
+    key."""
+    repo = Catalog.init_repo_path(tmp_path / "repo")
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    preds = _build_fitted_pipeline_entry(catalog)
+
+    token = dask.base.tokenize(preds.lazy_expr)
+    assert isinstance(token, str) and token
+
+
+def test_tokenize_stable_across_reload(tmp_path):
+    """Loading the same catalog entry twice produces distinct extract tempdirs
+    (`xorq-catalog-*`), so `hash_path` differs between reloads. The stable,
+    catalog-relative `read_path` must make the tokens match anyway."""
+    repo = Catalog.init_repo_path(tmp_path / "repo")
+    catalog = Catalog(backend=GitBackend(repo=repo))
+    preds = _build_fitted_pipeline_entry(catalog)
+
+    load1 = preds.lazy_expr
+    load2 = preds.lazy_expr
+    assert load1 is not load2
+    assert dask.base.tokenize(load1) == dask.base.tokenize(load2)
+
+
+def test_tokenize_non_catalog_read_unchanged(parquet_dir):
+    """User-created `deferred_read_parquet` has no `read_path` kwarg and must
+    keep taking the existing `hash_path` branch (path-existence check +
+    content-md5sum). Non-catalog Reads are unaffected by Plan B."""
+    parquet_path = parquet_dir / "awards_players.parquet"
+    backend = xo.duckdb.connect()
+    t = deferred_read_parquet(parquet_path, backend, table_name="awards_players")
+
+    reads = tuple(walk_nodes((Read,), t))
+    assert reads, "deferred_read_parquet must produce a Read"
+    assert "read_path" not in dict(reads[0].read_kwargs)
+
+    assert dask.base.tokenize(t) == dask.base.tokenize(t)
+
+
+def test_tokenize_missing_path_still_raises(parquet_dir):
+    """A Read without `read_path` whose `hash_path` is a bogus relative path
+    must still raise NotImplementedError. The read_path-preferring branch only
+    kicks in when the catalog contract is in effect."""
+    parquet_path = parquet_dir / "awards_players.parquet"
+    backend = xo.duckdb.connect()
+    t = deferred_read_parquet(parquet_path, backend, table_name="awards_players")
+    op = t.op()
+    bogus = tuple(
+        (k, "memtables/does-not-exist.parquet" if k == "hash_path" else v)
+        for k, v in op.read_kwargs
+    )
+    bad = op.__recreate__(
+        dict(zip(op.__argnames__, op.__args__)) | {"read_kwargs": bogus}
+    )
+
+    with pytest.raises(NotImplementedError, match="memtables/does-not-exist"):
+        dask.base.tokenize(bad.to_expr())


### PR DESCRIPTION
## Summary

Catalog-stamped Reads carry a stable, content-addressed `read_path` alongside the per-load `hash_path`. Prefer `read_path` when present so `dask.base.tokenize` succeeds for Reads reached via side-channels (UDF closures, `toolz.curry` partials, attrs state on `FittedStep` / `FittedPipeline`) whose `hash_path` never gets resolved by `deferred_reads_to_memtables`.

Unblocks `get_expr_hash`, provenance, and `catalog replay --rebuild` for entries containing `FittedPipeline.predict(...)` expressions.

> Split out of #1847 so the tokenization change can land independently of the rebuild feature.

### Behavior change

This changes `dask.base.tokenize` output for catalog-stamped Reads. The `expr.yaml` hash in the build-stability snapshot drifts as a downstream effect (snapshot updated). Existing built artifacts will tokenize differently after upgrade — downstream caches keyed by `dask.base.tokenize(expr)` / `get_expr_hash` will see a one-time invalidation. User-supplied deferred reads (no `read_path` kwarg) continue through the existing `hash_path`-based path unchanged.

## Test plan

- [x] `test_compiler.py` — 4 new tokenize-tolerant `normalize_read` round-trip tests:
  - `test_tokenize_survives_side_channel_read` — FittedPipeline UDF closure carries a pre-d2m Read with a catalog-relative `hash_path`; previously raised `NotImplementedError`, now tokenizes via stable `read_path`.
  - `test_tokenize_stable_across_reload` — two loads of the same catalog entry produce distinct extract tempdirs but matching tokens.
  - `test_tokenize_non_catalog_read_unchanged` — user-created `deferred_read_parquet` (no `read_path`) keeps the existing path-existence + content-md5sum branch.
  - `test_tokenize_missing_path_still_raises` — Reads without `read_path` whose `hash_path` is bogus still raise `NotImplementedError`.
- [x] Build-stability snapshot updated (`expected.json`) to reflect the new `expr.yaml` hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)