### PR TITLE
feat(catalog): add `xorq catalog show <name|alias>` for entry metadata

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -954,7 +954,7 @@ class CatalogEntry:
 
     @cached_property
     def backends(self) -> tuple[str, ...]:
-        return tuple(self.sidecar_metadata["backends"])
+        return tuple(self.sidecar_metadata.get("backends", ()))
 
     @property
     def aliases(self):

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -494,6 +494,81 @@ def schema(ctx, name, as_json):
 
 
 @cli.command()
+@click.argument("name", shell_complete=_complete_entry_or_alias_names)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON.")
+@click.option(
+    "--raw",
+    "as_raw",
+    is_flag=True,
+    default=False,
+    help="Print the metadata sidecar file as-is (YAML).",
+)
+@click.pass_context
+def show(ctx, name, as_json, as_raw):
+    """Show full metadata for a catalog entry (name or alias)."""
+    import json as json_mod
+
+    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
+
+    if as_json and as_raw:
+        raise click.UsageError("--json and --raw are mutually exclusive.")
+
+    with click_context_catalog(ctx):
+        catalog = ctx.obj.make_catalog(init=False)
+        try:
+            entry = catalog.get_catalog_entry(name, maybe_alias=True)
+        except (ValueError, AssertionError) as err:
+            raise click.ClickException(
+                f"Entry {name!r} not found — run 'xorq catalog list' or 'xorq catalog list-aliases' to see available entries and aliases."
+            ) from err
+
+        if as_raw:
+            click.echo(entry.metadata_path.read_text(), nl=False)
+            return
+
+        if as_json:
+            click.echo(json_mod.dumps(entry.sidecar_metadata, indent=2, default=str))
+            return
+
+        meta = entry.metadata
+        type_label = (
+            "Partial (unbound)"
+            if entry.kind == ExprKind.UnboundExpr
+            else "Source (bound)"
+        )
+        click.echo(f"Name:    {entry.name}")
+        aliases = tuple(a.alias for a in entry.aliases)
+        if aliases:
+            click.echo(f"Aliases: {', '.join(aliases)}")
+        click.echo(f"Type:    {type_label}")
+        if meta.root_tag:
+            click.echo(f"Root tag:      {meta.root_tag}")
+        backends = entry.backends
+        if backends:
+            click.echo(f"Backends:      {', '.join(backends)}")
+        click.echo(f"Content local: {'yes' if entry.is_content_local else 'no'}")
+        if meta.composed_from:
+            click.echo(f"Composed from: {len(meta.composed_from)}")
+        if meta.projected_cache_key and meta.projected_cache_key.key:
+            click.echo(f"Cache key:     {meta.projected_cache_key.key}")
+        if meta.params:
+            click.echo()
+            click.echo("Params:")
+            for p in meta.params:
+                tail = f" = {p['default']!r}" if "default" in p else ""
+                click.echo(f"  {p['param_name']:<24} {p['type']}{tail}")
+        for label, schema in (
+            ("Schema In", meta.schema_in),
+            ("Schema Out", meta.schema_out),
+        ):
+            if schema is not None:
+                click.echo()
+                click.echo(f"{label}:")
+                for col, dtype in schema.items():
+                    click.echo(f"  {col:<24} {dtype}")
+
+
+@cli.command()
 @click.pass_context
 def check(ctx):
     """Validate catalog consistency."""

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 from contextlib import contextmanager
 from functools import cache, partial
@@ -457,8 +458,6 @@ def clone(ctx, url, dest_name, dest_path):
 @click.pass_context
 def schema(ctx, name, as_json):
     """Show schema of a catalog entry (name or alias)."""
-    import json as json_mod
-
     from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
 
     with click_context_catalog(ctx):
@@ -471,7 +470,7 @@ def schema(ctx, name, as_json):
             ) from err
 
         if as_json:
-            click.echo(json_mod.dumps(entry.metadata.to_dict(), indent=2))
+            click.echo(json.dumps(entry.metadata.to_dict(), indent=2))
             return
 
         type_label = (
@@ -506,10 +505,6 @@ def schema(ctx, name, as_json):
 @click.pass_context
 def show(ctx, name, as_json, as_raw):
     """Show full metadata for a catalog entry (name or alias)."""
-    import json as json_mod
-
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
-
     if as_json and as_raw:
         raise click.UsageError("--json and --raw are mutually exclusive.")
 
@@ -527,8 +522,10 @@ def show(ctx, name, as_json, as_raw):
             return
 
         if as_json:
-            click.echo(json_mod.dumps(entry.sidecar_metadata, indent=2, default=str))
+            click.echo(json.dumps(entry.sidecar_metadata, indent=2, default=str))
             return
+
+        from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
 
         meta = entry.metadata
         type_label = {
@@ -538,21 +535,23 @@ def show(ctx, name, as_json, as_raw):
             ExprKind.Composed: "Composed",
             ExprKind.ExprBuilder: "Expression Builder",
         }.get(entry.kind, str(entry.kind))
-        click.echo(f"Name:    {entry.name}")
+        click.echo(f"{'Name:':<15} {entry.name}")
         aliases = tuple(a.alias for a in entry.aliases)
         if aliases:
-            click.echo(f"Aliases: {', '.join(aliases)}")
-        click.echo(f"Type:    {type_label}")
+            click.echo(f"{'Aliases:':<15} {', '.join(aliases)}")
+        click.echo(f"{'Type:':<15} {type_label}")
         if meta.root_tag:
-            click.echo(f"Root tag:      {meta.root_tag}")
+            click.echo(f"{'Root tag:':<15} {meta.root_tag}")
         backends = entry.backends
         if backends:
-            click.echo(f"Backends:      {', '.join(backends)}")
-        click.echo(f"Content local: {'yes' if entry.is_content_local else 'no'}")
+            click.echo(f"{'Backends:':<15} {', '.join(backends)}")
+        click.echo(
+            f"{'Content local:':<15} {'yes' if entry.is_content_local else 'no'}"
+        )
         if meta.composed_from:
-            click.echo(f"Composed from: {len(meta.composed_from)}")
+            click.echo(f"{'Composed from:':<15} {len(meta.composed_from)}")
         if meta.projected_cache_key and meta.projected_cache_key.key:
-            click.echo(f"Cache key:     {meta.projected_cache_key.key}")
+            click.echo(f"{'Cache key:':<15} {meta.projected_cache_key.key}")
         if meta.params:
             click.echo()
             click.echo("Params:")
@@ -598,8 +597,6 @@ def check(ctx):
 @click.pass_context
 def log(ctx, as_json):
     """Show catalog history as structured operations."""
-    import json as json_mod
-
     import attr
 
     from xorq.catalog.replay import Replayer
@@ -609,7 +606,7 @@ def log(ctx, as_json):
         replayer = Replayer(from_catalog=catalog)
         if as_json:
             click.echo(
-                json_mod.dumps(
+                json.dumps(
                     [
                         {"type": type(op).__name__, **attr.asdict(op)}
                         for op in replayer.ops

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -531,11 +531,13 @@ def show(ctx, name, as_json, as_raw):
             return
 
         meta = entry.metadata
-        type_label = (
-            "Partial (unbound)"
-            if entry.kind == ExprKind.UnboundExpr
-            else "Source (bound)"
-        )
+        type_label = {
+            ExprKind.UnboundExpr: "Partial (unbound)",
+            ExprKind.Source: "Source (bound)",
+            ExprKind.Expr: "Expression",
+            ExprKind.Composed: "Composed",
+            ExprKind.ExprBuilder: "Expression Builder",
+        }.get(entry.kind, str(entry.kind))
         click.echo(f"Name:    {entry.name}")
         aliases = tuple(a.alias for a in entry.aliases)
         if aliases:
@@ -557,6 +559,19 @@ def show(ctx, name, as_json, as_raw):
             for p in meta.params:
                 tail = f" = {p['default']!r}" if "default" in p else ""
                 click.echo(f"  {p['param_name']:<24} {p['type']}{tail}")
+        if meta.builders:
+            click.echo()
+            click.echo("Builders:")
+            for builder in meta.builders:
+                click.echo(f"  Type: {builder.get('type', 'unknown')}")
+                for key, value in builder.items():
+                    if key == "type":
+                        continue
+                    if isinstance(value, (list, tuple)):
+                        if value:
+                            click.echo(f"    {key}: {', '.join(str(v) for v in value)}")
+                    elif value is not None:
+                        click.echo(f"    {key}: {value}")
         for label, schema in (
             ("Schema In", meta.schema_in),
             ("Schema Out", meta.schema_out),

--- a/python/xorq/catalog/tests/test_cli_inspect_git.py
+++ b/python/xorq/catalog/tests/test_cli_inspect_git.py
@@ -484,3 +484,68 @@ def test_schema_nonexistent(runner, catalog_path):
     assert result.exit_code != 0
     assert "not found" in result.output
     assert "list-aliases" in result.output
+
+
+# --- show command ---
+
+
+def test_show_command(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-entry")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    result = runner.invoke(cli, ["--path", catalog_path, "show", archive.stem])
+    assert result.exit_code == 0, result.output
+    assert f"Name:    {archive.stem}" in result.output
+    assert "Type:" in result.output
+    assert "Source (bound)" in result.output
+    assert "Backends:" in result.output
+    assert "Content local:" in result.output
+    assert "Schema Out:" in result.output
+
+
+def test_show_by_alias(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-alias")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    runner.invoke(cli, ["--path", catalog_path, "add-alias", archive.stem, "my-alias"])
+    result = runner.invoke(cli, ["--path", catalog_path, "show", "my-alias"])
+    assert result.exit_code == 0, result.output
+    assert f"Name:    {archive.stem}" in result.output
+    assert "Aliases: my-alias" in result.output
+
+
+def test_show_json(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-json")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "show", archive.stem, "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "expr_metadata" in data
+    assert "backends" in data
+    assert data["expr_metadata"]["kind"] == "source"
+
+
+def test_show_raw(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-raw")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    result = runner.invoke(cli, ["--path", catalog_path, "show", archive.stem, "--raw"])
+    assert result.exit_code == 0, result.output
+    assert "expr_metadata:" in result.output
+    assert "backends:" in result.output
+
+
+def test_show_json_raw_mutually_exclusive(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-mx")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "show", archive.stem, "--json", "--raw"]
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_show_nonexistent(runner, catalog_path):
+    result = runner.invoke(cli, ["--path", catalog_path, "show", "no-such-entry"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "list-aliases" in result.output

--- a/python/xorq/catalog/tests/test_cli_inspect_git.py
+++ b/python/xorq/catalog/tests/test_cli_inspect_git.py
@@ -3,6 +3,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+import yaml12
 
 from xorq.catalog.catalog import (
     Catalog,
@@ -549,3 +550,26 @@ def test_show_nonexistent(runner, catalog_path):
     assert result.exit_code != 0
     assert "not found" in result.output
     assert "list-aliases" in result.output
+
+
+def test_show_renders_builders(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-builders")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = catalog.get_catalog_entry(archive.stem)
+    sidecar = yaml12.parse_yaml(entry.metadata_path.read_text())
+    sidecar["expr_metadata"]["builders"] = [
+        {
+            "type": "semantic_model",
+            "dimensions": ["origin", "destination"],
+            "measures": ["avg_delay"],
+        }
+    ]
+    entry.metadata_path.write_text(yaml12.format_yaml(sidecar))
+
+    result = runner.invoke(cli, ["--path", catalog_path, "show", archive.stem])
+    assert result.exit_code == 0, result.output
+    assert "Builders:" in result.output
+    assert "Type: semantic_model" in result.output
+    assert "dimensions: origin, destination" in result.output
+    assert "measures: avg_delay" in result.output

--- a/python/xorq/catalog/tests/test_cli_inspect_git.py
+++ b/python/xorq/catalog/tests/test_cli_inspect_git.py
@@ -495,7 +495,7 @@ def test_show_command(runner, catalog_path, tmpdir):
     runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
     result = runner.invoke(cli, ["--path", catalog_path, "show", archive.stem])
     assert result.exit_code == 0, result.output
-    assert f"Name:    {archive.stem}" in result.output
+    assert f"Name:           {archive.stem}" in result.output
     assert "Type:" in result.output
     assert "Source (bound)" in result.output
     assert "Backends:" in result.output
@@ -509,8 +509,9 @@ def test_show_by_alias(runner, catalog_path, tmpdir):
     runner.invoke(cli, ["--path", catalog_path, "add-alias", archive.stem, "my-alias"])
     result = runner.invoke(cli, ["--path", catalog_path, "show", "my-alias"])
     assert result.exit_code == 0, result.output
-    assert f"Name:    {archive.stem}" in result.output
-    assert "Aliases: my-alias" in result.output
+    assert f"Name:           {archive.stem}" in result.output
+    assert "Aliases:" in result.output
+    assert "my-alias" in result.output
 
 
 def test_show_json(runner, catalog_path, tmpdir):
@@ -550,6 +551,25 @@ def test_show_nonexistent(runner, catalog_path):
     assert result.exit_code != 0
     assert "not found" in result.output
     assert "list-aliases" in result.output
+
+
+def test_show_json_default_str(runner, catalog_path, tmpdir):
+    archive = make_build_zip(tmpdir, "show-json-str")
+    runner.invoke(cli, ["--path", catalog_path, "add", str(archive)])
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = catalog.get_catalog_entry(archive.stem)
+    sidecar = yaml12.parse_yaml(entry.metadata_path.read_text())
+    sidecar["custom_ts"] = "2026-01-01T00:00:00"
+    sidecar["custom_path"] = "/tmp/test"
+    entry.metadata_path.write_text(yaml12.format_yaml(sidecar))
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "show", archive.stem, "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["custom_ts"] == "2026-01-01T00:00:00"
+    assert data["custom_path"] == "/tmp/test"
 
 
 def test_show_renders_builders(runner, catalog_path, tmpdir):


### PR DESCRIPTION
## Summary
- Adds a per-entry metadata command alongside the existing catalog-level `info` and the schema-only `schema`.
- Default output is human-formatted: name, aliases, kind, root tag, backends, content-local, composed-from, cache key, params, and schemas.
- `--json` dumps the parsed sidecar dict (`expr_metadata`, `backends`, `md5sum`); `--raw` cats the YAML sidecar file as-is. The two flags are mutually exclusive.

## Test plan
- [x] `test_show_command` — default human output for a freshly-added entry
- [x] `test_show_by_alias` — entry resolution by alias
- [x] `test_show_json` — `--json` dumps the full sidecar with `expr_metadata`, `backends`
- [x] `test_show_raw` — `--raw` cats the YAML sidecar file
- [x] `test_show_json_raw_mutually_exclusive` — usage error when both flags passed
- [x] `test_show_nonexistent` — friendly error pointing at `list` / `list-aliases`
- [x] `test_show_json_default_str` — verifies `--json` round-trips non-standard sidecar keys via `default=str`
- [x] `test_show_renders_builders` — builder rendering (semantic_model dimensions/measures)
- [x] All tests pass under both `git` and `annex` backends (22/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)