### PR TITLE
fix(devcontainer): release flock before spawning helper subprocesses

### DIFF
--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -289,13 +289,13 @@ ensure_up() {
         tag_image
         setup
     fi
+    exec 9>&-
+
     setup_git
     setup_gh
     setup_ssh_forward
     setup_claude
     sync_if_needed
-
-    exec 9>&-
 }
 
 case "${1:-up}" in


### PR DESCRIPTION
## Summary
- Moves `exec 9>&-` (lock release) to immediately after the container-up/build block in `ensure_up()`, before any helper functions run
- Previously, `setup_ssh_forward` spawned a background socat that inherited fd 9, keeping the flock held indefinitely and blocking all subsequent `devcontainer` invocations with "Another devcontainer operation is in progress, waiting..."

## Test plan
- [ ] Run `devcontainer claude` twice in a row — second invocation should not block
- [ ] Verify `ls -la /proc/$(pgrep -f 'socat TCP-LISTEN')/fd/` does not show the lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)