### PR TITLE
refactor(backends): tighten type annotations across backends

### DIFF
--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -149,7 +149,9 @@ class BasePandasBackend(BaseBackend, NoUrl):
     def version(self) -> str:
         return pd.__version__
 
-    def list_tables(self, like=None, database=None):
+    def list_tables(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
         """Return the list of table names in the current database.
 
         Parameters
@@ -171,7 +173,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
         overridden_schema = {**inferred_schema, **(schema or {})}
         return ops.DatabaseTable(name, overridden_schema, self).to_expr()
 
-    def get_schema(self, table_name, *, database=None):
+    def get_schema(self, table_name: str, *, database: str | None = None) -> sch.Schema:
         try:
             schema = self.schemas[table_name]
         except KeyError:
@@ -180,7 +182,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
 
         return schema
 
-    def compile(self, expr, *args, **kwargs):
+    def compile(self, expr: ir.Expr, *args: Any, **kwargs: Any) -> ir.Expr:
         return expr
 
     def create_table(
@@ -305,7 +307,13 @@ class BasePandasBackend(BaseBackend, NoUrl):
 class Backend(BasePandasBackend):
     name = "pandas"
 
-    def execute(self, query, params=None, limit="default", **kwargs):
+    def execute(
+        self,
+        query: ir.Expr,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = "default",
+        **kwargs: Any,
+    ) -> Any:
         from xorq.backends.pandas.executor import PandasExecutor  # noqa: PLC0415
 
         if limit != "default" and limit is not None:
@@ -324,7 +332,7 @@ class Backend(BasePandasBackend):
 
         return PandasExecutor.execute(query.op(), backend=self, params=params)
 
-    def _create_cached_table(self, name, expr):
+    def _create_cached_table(self, name: str, expr: ir.Expr) -> ir.Table:
         return self.create_table(name, expr.execute())
 
     def _finalize_memtable(self, name: str) -> None:
@@ -344,7 +352,7 @@ class Backend(BasePandasBackend):
         | list[pa.RecordBatch]
         | tuple[pa.RecordBatch],
         table_name: str | None = None,
-    ):
+    ) -> ir.Table:
         if isinstance(record_batches, (list, tuple)):
             record_batches = pa.RecordBatchReader.from_batches(
                 record_batches[0].schema, record_batches

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Mapping
 
 import pandas as pd
 import pyarrow as pa
@@ -18,7 +20,7 @@ from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import gen_name
 
 
-def parse_url(url: str) -> Dict[str, Any]:
+def parse_url(url: str) -> dict[str, Any]:
     from urllib.parse import parse_qs, urlparse  # noqa: PLC0415
 
     parsed = urlparse(url)
@@ -56,7 +58,7 @@ class Backend(SQLBackend):
     compiler = postgres_compiler
 
     @property
-    def version(self):
+    def version(self) -> str:
         import importlib.metadata  # noqa: PLC0415
 
         return importlib.metadata.version("pyiceberg")
@@ -71,7 +73,7 @@ class Backend(SQLBackend):
         self.uri = None
 
     @staticmethod
-    def _from_url(url: str) -> Dict[str, Any]:
+    def _from_url(url: str) -> dict[str, Any]:
         return parse_url(url)
 
     @classmethod
@@ -124,10 +126,10 @@ class Backend(SQLBackend):
     def create_table(
         self,
         name: str,
-        obj: Optional[Union[pd.DataFrame, pa.Table, ir.Table]] = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
-        schema: Optional[ibis.Schema] = None,
-        database: Optional[str] = None,
+        schema: ibis.Schema | None = None,
+        database: str | None = None,
         temp: bool = False,
         overwrite: bool = False,
     ) -> ir.Table:
@@ -167,8 +169,8 @@ class Backend(SQLBackend):
     def insert(
         self,
         table_name: str,
-        data: Union[pd.DataFrame, pa.Table, ir.Table],
-        database: Optional[str] = None,
+        data: pd.DataFrame | pa.Table | ir.Table,
+        database: str | None = None,
         mode: str = "append",
     ) -> bool:
         database = database or self.namespace
@@ -196,13 +198,13 @@ class Backend(SQLBackend):
     def upsert(
         self,
         table_name: str,
-        data: Union[pd.DataFrame, pa.Table, ir.Table],
-        database: Optional[str] = None,
-        join_cols=None,
-        when_matched_update_all=True,
-        when_not_matched_insert_all=True,
-        case_sensitive=True,
-    ):
+        data: pd.DataFrame | pa.Table | ir.Table,
+        database: str | None = None,
+        join_cols: list[str] | None = None,
+        when_matched_update_all: bool = True,
+        when_not_matched_insert_all: bool = True,
+        case_sensitive: bool = True,
+    ) -> ir.Table:
         """Wrapper around upsert"""
         database = database or self.namespace
         full_table_name = f"{database}.{table_name}"
@@ -238,8 +240,8 @@ class Backend(SQLBackend):
         self,
         expr: ir.Expr,
         *,
-        params: Optional[Mapping[ir.Scalar, Any]] = None,
-        limit: Optional[Union[int, str]] = None,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
         chunk_size: int = 10_000,
         **_: Any,
     ) -> pa.ipc.RecordBatchReader:
@@ -248,9 +250,9 @@ class Backend(SQLBackend):
 
     def list_tables(
         self,
-        like: Optional[str] = None,
-        database: Optional[Union[Tuple[str, str], str]] = None,
-    ) -> List[str]:
+        like: str | None = None,
+        database: tuple[str, str] | str | None = None,
+    ) -> list[str]:
         database = database or self.namespace
         table_names = [t[1] for t in self.catalog.list_tables(database)]
 
@@ -264,7 +266,7 @@ class Backend(SQLBackend):
     def drop_table(
         self,
         name: str,
-        database: Optional[str] = None,
+        database: str | None = None,
         force: bool = False,
     ) -> None:
         database = database or self.namespace
@@ -277,8 +279,8 @@ class Backend(SQLBackend):
         self,
         table_name: str,
         *,
-        catalog: Optional[str] = None,
-        database: Optional[str] = None,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         database = database or self.namespace
         catalog = (
@@ -295,8 +297,8 @@ class Backend(SQLBackend):
 
     def read_record_batches(
         self,
-        reader: Union[pa.RecordBatchReader, pa.ChunkedArray],
-        table_name: Optional[str] = None,
+        reader: pa.RecordBatchReader | pa.ChunkedArray,
+        table_name: str | None = None,
     ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
         table = pa.Table.from_batches(reader, reader.schema)
@@ -304,7 +306,7 @@ class Backend(SQLBackend):
         self.create_table(name=table_name, obj=table, database=self.namespace)
         return self.table(table_name)
 
-    def list_snapshots(self, database=None) -> dict[str, int]:
+    def list_snapshots(self, database: str | None = None) -> dict[str, list[int]]:
         database = database or self.namespace
         table_names = [t[1] for t in self.catalog.list_tables(database)]
 

--- a/python/xorq/backends/pyiceberg/relations.py
+++ b/python/xorq/backends/pyiceberg/relations.py
@@ -1,9 +1,7 @@
-from typing import Optional
-
 import xorq.vendor.ibis.expr.operations as ops
 
 
 class PyIcebergTable(ops.DatabaseTable):
     """A table that is bound to a PyIceberg backend."""
 
-    snapshot_id: Optional[int] = None
+    snapshot_id: int | None = None

--- a/python/xorq/backends/xorq_datafusion/datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/datafusion/__init__.py
@@ -176,7 +176,7 @@ def _inspect_xgboost_model_from_json(json_file_path):
     return metadata
 
 
-def _fields_to_parameters(fields):
+def _fields_to_parameters(fields: Mapping[str, Any]) -> list[inspect.Parameter]:
     parameters = []
     for name, arg in fields.items():
         param = inspect.Parameter(
@@ -186,7 +186,7 @@ def _fields_to_parameters(fields):
     return parameters
 
 
-def translate_sort(exprs: list[ir.Expr]):
+def translate_sort(exprs: list[ir.Expr]) -> list[Expr]:
     result = []
     for expr in exprs:
         node = expr.op()
@@ -260,7 +260,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             }
         )
 
-    def _register_builtin_udfs(self):
+    def _register_builtin_udfs(self) -> None:
         from xorq.backends.xorq_datafusion.datafusion import udfs  # noqa: PLC0415
 
         for name, func in inspect.getmembers(
@@ -309,7 +309,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                     udaf = _compile_pyarrow_udaf(agg_node)
                     self.con.register_udaf(udaf)
 
-    def _compile_pyarrow_expr_udf(self, udf_node):
+    def _compile_pyarrow_expr_udf(self, udf_node: Any) -> Any:
         def extract_computed_arg(expr):
             # user can do Scalar.to_table() if they want to cache it
             import pandas as pd  # noqa: PLC0415
@@ -333,7 +333,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             name=udf_node.__func_name__,
         )
 
-    def _compile_pyarrow_udf(self, udf_node):
+    def _compile_pyarrow_udf(self, udf_node: Any) -> Any:
         return df.udf(
             udf_node.__func__,
             input_types=[PyArrowType.from_ibis(arg.dtype) for arg in udf_node.args],
@@ -344,7 +344,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             name=udf_node.__func_name__,
         )
 
-    def _compile_elementwise_udf(self, udf_node):
+    def _compile_elementwise_udf(self, udf_node: Any) -> Any:
         return df.udf(
             udf_node.func,
             input_types=list(map(PyArrowType.from_ibis, udf_node.input_type)),
@@ -560,13 +560,13 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         self,
         source: str | Path | pa.Table | pa.RecordBatch | pa.Dataset | pd.DataFrame,
         table_name: str | None = None,
-    ):
+    ) -> ir.Table:
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
         self.con.register_table_provider(table_ident, IbisTableProvider(source))
         return self.table(table_name)
 
-    def _register_failure(self):
+    def _register_failure(self) -> None:
         import inspect  # noqa: PLC0415
 
         msg = ", ".join(
@@ -707,7 +707,9 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
         return self.register(delta_table.to_pyarrow_dataset(), table_name=table_name)
 
-    def read_record_batches(self, source, table_name=None):
+    def read_record_batches(
+        self, source: pa.ipc.RecordBatchReader, table_name: str | None = None
+    ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
@@ -729,7 +731,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         *,
         chunk_size: int = 1_000_000,
         **kwargs: Any,
-    ):
+    ) -> pa.ipc.RecordBatchReader:
         pa = self._import_pyarrow()
         self._register_udfs(expr)
         self._register_in_memory_tables(expr)
@@ -766,7 +768,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         arrow_table = batch_reader.read_all()
         return expr.__pyarrow_result__(arrow_table)
 
-    def execute(self, expr: ir.Expr, **kwargs: Any):
+    def execute(self, expr: ir.Expr, **kwargs: Any) -> Any:
         batch_reader = self._to_pyarrow_batches(expr, **kwargs)
         return expr.__pandas_result__(
             batch_reader.read_pandas(timestamp_as_object=True)
@@ -781,7 +783,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         database: str | None = None,
         temp: bool = False,
         overwrite: bool = False,
-    ):
+    ) -> ir.Table:
         """Create a table in Datafusion.
 
         Parameters

--- a/python/xorq/backends/xorq_datafusion/datafusion/provider.py
+++ b/python/xorq/backends/xorq_datafusion/datafusion/provider.py
@@ -1,18 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+
 import xorq.vendor.ibis.expr.types as ir
 from xorq.internal import AbstractTableProvider
+
+
+if TYPE_CHECKING:
+    from xorq.expr import Expr
 
 
 class IbisTableProvider(AbstractTableProvider):
     # scan() calls back into the backend synchronously, so same-connection
     # DataFusion expressions will trigger a nested tokio runtime panic.
     # Callers must convert those to native DataFrames before registration.
-    def __init__(self, table: ir.Table):
+    def __init__(self, table: ir.Table) -> None:
         self.table = table
 
-    def schema(self):
+    def schema(self) -> pa.Schema:
         return self.table.schema().to_pyarrow()
 
-    def scan(self, filters=None):
+    def scan(self, filters: list[Expr] | None = None) -> pa.ipc.RecordBatchReader:
         table = self.table
         if filters:
             table = self.table.filter(filters)

--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from attr import (
     field,
@@ -29,6 +30,10 @@ from xorq.common.utils.otel_utils import tracer
 from xorq.vendor.ibis.expr import types as ir
 
 
+if TYPE_CHECKING:
+    import xorq.vendor.ibis.expr.operations as ops
+
+
 __all__ = [  # noqa: PLE0604
     "ParquetCache",
     "ParquetSnapshotCache",
@@ -44,10 +49,10 @@ class Cache:
     strategy = field(validator=instance_of(CacheStrategy))
     storage = field(validator=instance_of(CacheStorage))
 
-    strategy_typ = None
-    storage_typ = None
+    strategy_typ: ClassVar[type[CacheStrategy] | None] = None
+    storage_typ: ClassVar[type[CacheStorage] | None] = None
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if not isinstance(self.strategy, self.strategy_typ):
             raise TypeError(
                 f"expected strategy of type {self.strategy_typ.__name__}, "
@@ -59,28 +64,33 @@ class Cache:
                 f"got {type(self.storage).__name__}"
             )
 
-    def calc_key(self, expr):
+    def calc_key(self, expr: ir.Expr) -> str:
         # the order here matters: must check is_cached before calling maybe_prevent_cross_source_caching
         if expr.ls.is_cached and expr.ls.cache is self:
             expr = expr.ls.uncached_one
         expr = maybe_prevent_cross_source_caching(expr, self)
         return self.strategy.calc_key(expr)
 
-    def key_exists(self, key):
+    def key_exists(self, key: str) -> bool:
         return self.storage.exists(key)
 
-    def exists(self, expr):
+    def exists(self, expr: ir.Expr) -> bool:
         key = self.calc_key(expr)
         return self.storage.exists(key)
 
-    def get(self, expr: ir.Expr):
+    def get(self, expr: ir.Expr) -> ops.Node:
         key = self.calc_key(expr)
         if not self.key_exists(key):
             raise KeyError(key)
         else:
             return self.storage.get(key)
 
-    def put(self, expr: ir.Expr, value, parquet_metadata=None):
+    def put(
+        self,
+        expr: ir.Expr,
+        value: ops.Node,
+        parquet_metadata: dict[str, Any] | None = None,
+    ) -> ops.Node:
         key = self.calc_key(expr)
         if self.key_exists(key):
             raise ValueError(f"cache entry already exists for key {key!r}")
@@ -88,7 +98,12 @@ class Cache:
             return self.storage.put(key, value, parquet_metadata=parquet_metadata)
 
     @tracer.start_as_current_span("cache.set_default")
-    def set_default(self, expr: ir.Expr, default, parquet_metadata=None):
+    def set_default(
+        self,
+        expr: ir.Expr,
+        default: ops.Node,
+        parquet_metadata: dict[str, Any] | None = None,
+    ) -> ops.Node:
         span = trace.get_current_span()
         key = self.calc_key(expr)
         if not self.key_exists(key):
@@ -100,14 +115,14 @@ class Cache:
             span.add_event("cache.hit", {"key": key})
             return self.storage.get(key)
 
-    def drop(self, expr: ir.Expr):
+    def drop(self, expr: ir.Expr) -> None:
         key = self.calc_key(expr)
         if not self.key_exists(key):
             raise KeyError(key)
         else:
             self.storage.drop(key)
 
-    def __dask_tokenize__(self):
+    def __dask_tokenize__(self) -> Any:
         from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
             normalize_seq_with_caller,
         )
@@ -120,7 +135,7 @@ class Cache:
         )
 
     @classmethod
-    def from_kwargs(cls, **kwargs):
+    def from_kwargs(cls, **kwargs: Any) -> Cache:
         strategy = cls.strategy_typ()
         storage = cls.storage_typ(**kwargs)
         return cls(strategy=strategy, storage=storage)
@@ -219,7 +234,7 @@ class GCSCache(Cache):
             )
 
     @classmethod
-    def from_kwargs(cls, bucket_name, source):
+    def from_kwargs(cls, bucket_name: str, source: Any) -> GCSCache:
         from xorq.common.utils.gcloud_utils import GCStorage  # noqa: PLC0415
 
         strategy = cls.strategy_typ()
@@ -227,7 +242,7 @@ class GCSCache(Cache):
         return cls(strategy=strategy, storage=storage)
 
 
-def maybe_prevent_cross_source_caching(expr, storage):
+def maybe_prevent_cross_source_caching(expr: ir.Expr, storage: Cache) -> ir.Expr:
     with contextlib.suppress(XorqError):
         if storage.storage.source != expr._find_backend(use_default=False):
             return expr.into_backend(storage.storage.source)

--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -8,7 +8,9 @@ from abc import (
 from pathlib import (
     Path,
 )
+from typing import TYPE_CHECKING, Any
 
+import pyarrow as pa
 from attr import (
     field,
     frozen,
@@ -17,6 +19,10 @@ from attr.validators import (
     instance_of,
     optional,
 )
+
+
+if TYPE_CHECKING:
+    import xorq.vendor.ibis.expr.operations as ops
 
 from xorq.common.utils.caching_utils import (
     get_xorq_cache_dir,
@@ -51,23 +57,29 @@ def resolve_parquet_cache_path(
 @frozen
 class CacheStorage:
     @abstractmethod
-    def exists(self, key):
+    def exists(self, key: str) -> bool:
         pass
 
     @abstractmethod
-    def get(self, key):
+    def get(self, key: str) -> ops.Node:
         pass
 
     @abstractmethod
-    def put(self, key, value, parquet_metadata=None):
+    def put(
+        self, key: str, value: ops.Node, parquet_metadata: dict[str, Any] | None = None
+    ) -> ops.Node:
         pass
 
     @abstractmethod
-    def drop(self, key):
+    def drop(self, key: str) -> None:
         pass
 
 
-def _write_parquet(path, batch_reader, parquet_metadata=None):
+def _write_parquet(
+    path: Path,
+    batch_reader: pa.ipc.RecordBatchReader,
+    parquet_metadata: dict[str, Any] | None = None,
+) -> None:
     import pyarrow.parquet as pq  # noqa: PLC0415
 
     schema = batch_reader.schema
@@ -115,16 +127,16 @@ class ParquetStorage(CacheStorage):
         self.path.mkdir(exist_ok=True, parents=True)
 
     @property
-    def path(self):
+    def path(self) -> Path:
         return resolve_parquet_cache_dir(self.relative_path, self.base_path)
 
-    def get_path(self, key):
+    def get_path(self, key: str) -> Path:
         return resolve_parquet_cache_path(self.relative_path, key, self.base_path)
 
-    def exists(self, key):
+    def exists(self, key: str) -> bool:
         return self.get_path(key).exists()
 
-    def get(self, key):
+    def get(self, key: str) -> ops.Node:
         op = deferred_read_parquet(
             path=self.get_path(key),
             con=self.source,
@@ -132,7 +144,9 @@ class ParquetStorage(CacheStorage):
         ).op()
         return op
 
-    def put(self, key, value, parquet_metadata=None):
+    def put(
+        self, key: str, value: ops.Node, parquet_metadata: dict[str, Any] | None = None
+    ) -> ops.Node:
         path = self.get_path(key)
         # move from temp location upon success to prevent empty files on failure
         tmp_path = path.with_name(path.name + ".tmp")
@@ -141,7 +155,7 @@ class ParquetStorage(CacheStorage):
         tmp_path.rename(path)
         return self.get(key)
 
-    def drop(self, key):
+    def drop(self, key: str) -> None:
         path = self.get_path(key)
         path.unlink()
 
@@ -165,11 +179,11 @@ class ParquetTTLStorage(ParquetStorage):
             caller="normalize_parquet_ttl_storage",
         )
 
-    def exists(self, key):
+    def exists(self, key: str) -> bool:
         path = self.get_path(key)
         return path.exists() and self.satisfies_ttl(path)
 
-    def satisfies_ttl(self, path):
+    def satisfies_ttl(self, path: Path) -> bool:
         delta = datetime.datetime.now() - datetime.datetime.fromtimestamp(
             path.stat().st_mtime
         )
@@ -196,13 +210,15 @@ class SourceStorage(CacheStorage):
 
         return normalize_seq_with_caller(self.source, caller="normalize_source_storage")
 
-    def exists(self, key):
+    def exists(self, key: str) -> bool:
         return key in self.source.tables
 
-    def get(self, key):
+    def get(self, key: str) -> ops.Node:
         return self.source.table(key).op()
 
-    def put(self, key, value, parquet_metadata=None):
+    def put(
+        self, key: str, value: ops.Node, parquet_metadata: dict[str, Any] | None = None
+    ) -> ops.Node:
         def is_remote(value):
             name = value.to_expr()._find_backend().name
             # FIXME: add pyiceberg, trino
@@ -232,5 +248,5 @@ class SourceStorage(CacheStorage):
             self.source.create_table(key, value.to_expr().to_pyarrow())
         return self.get(key)
 
-    def drop(self, key):
+    def drop(self, key: str) -> None:
         self.source.drop_table(key)

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -7,6 +7,8 @@ import pathlib
 from abc import (
     abstractmethod,
 )
+from collections.abc import Iterator
+from typing import Any
 
 import dask
 from attr import (
@@ -33,10 +35,11 @@ from xorq.expr.relations import (
     Read,
     RemoteTable,
 )
+from xorq.vendor import ibis
 from xorq.vendor.ibis.expr import types as ir
 
 
-def snapshot_normalize_read(read):
+def snapshot_normalize_read(read: Read) -> Any:
     """Normalize Read for snapshot caching using path identity only, not file modification stats."""
     read_kwargs = dict(read.read_kwargs)
     # Materialized build-bundle reads carry a content-hash-named read_path that is
@@ -71,7 +74,7 @@ _in_normalization_context: contextvars.ContextVar[bool] = contextvars.ContextVar
 )
 
 
-def _rename_remote_table(node, kwargs):
+def _rename_remote_table(node: ops.Node, kwargs: dict[str, Any] | None) -> ops.Node:
     if isinstance(node, RemoteTable):
         if not _in_normalization_context.get():
             raise RuntimeError(
@@ -97,29 +100,29 @@ class CacheStrategy:
     )
 
     @abstractmethod
-    def calc_key(self, expr):
+    def calc_key(self, expr: ir.Expr) -> str:
         pass
 
-    def __dask_tokenize__(self):
+    def __dask_tokenize__(self) -> tuple[str, str]:
         return (type(self).__name__, self.key_prefix)
 
 
 @frozen
 class ModificationTimeStrategy(CacheStrategy):
-    def calc_key(self, expr: ir.Expr):
+    def calc_key(self, expr: ir.Expr) -> str:
         return self.key_prefix + expr.ls.tokenized
 
 
 @frozen
 class SnapshotStrategy(CacheStrategy):
-    def calc_key(self, expr: ir.Expr):
+    def calc_key(self, expr: ir.Expr) -> str:
         with self.normalization_context(expr):
             replaced = self.replace_remote_table(expr)
             tokenized = replaced.ls.tokenized
             return self.key_prefix + "-".join(("snapshot", tokenized))
 
     @contextlib.contextmanager
-    def normalization_context(self, expr):
+    def normalization_context(self, expr: ir.Expr) -> Iterator[None]:
         # patch_normalize_op_caching memoizes normalize_op by (op, compiler).
         # Without it, tokenizing depth-n pipeline expressions is O(2^n) because
         # normalize_remote_table recursively tokenizes remote_expr and
@@ -142,7 +145,7 @@ class SnapshotStrategy(CacheStrategy):
         finally:
             _in_normalization_context.reset(token)
 
-    def replace_remote_table(self, expr):
+    def replace_remote_table(self, expr: ir.Expr) -> ir.Expr:
         """replace remote table with deterministic name ***strictly for key calculation***"""
         if expr.op().find(RemoteTable):
             expr = self.cached_replace_remote_table(expr.op()).to_expr()
@@ -150,18 +153,18 @@ class SnapshotStrategy(CacheStrategy):
 
     @staticmethod
     @functools.cache
-    def cached_normalize_read(op):
+    def cached_normalize_read(op: Read) -> Any:
         # Wrapped function must be pure over `op` (no file I/O, no clock): the
         # process-global cache assumes equal ops always produce equal results.
         return snapshot_normalize_read(op)
 
     @staticmethod
     @functools.cache
-    def cached_replace_remote_table(op):
+    def cached_replace_remote_table(op: ops.Node) -> ops.Node:
         return op.replace(_rename_remote_table)
 
     @staticmethod
-    def normalize_backend(con):
+    def normalize_backend(con: ibis.backends.BaseBackend) -> Any:
         name = con.name
         if name in ("pandas", "duckdb", "datafusion", "xorq_datafusion"):
             return (name, None)
@@ -169,7 +172,7 @@ class SnapshotStrategy(CacheStrategy):
             return normalize_backend(con)
 
     @staticmethod
-    def normalize_databasetable(dt):
+    def normalize_databasetable(dt: ops.DatabaseTable) -> Any:
         if isinstance(dt, RemoteTable):
             # one alternative is to explicitly iterate over the fields name, schema, source, namespace
             # but explicit is better than implicit, additionally the name is not a safe bet for caching

--- a/python/xorq/catalog/annex.py
+++ b/python/xorq/catalog/annex.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import base64
 import json
@@ -7,6 +9,7 @@ import subprocess
 import time
 import uuid
 from pathlib import Path
+from typing import Any
 
 import attr
 import toolz
@@ -37,7 +40,7 @@ class AnnexError(RuntimeError):
     """Raised when a git-annex command fails."""
 
 
-def require_git_annex():
+def require_git_annex() -> None:
     """Raise a clear error if the git-annex binary is not on $PATH."""
     if shutil.which(GIT_ANNEX_COMMAND) is None:
         raise AnnexError(
@@ -46,7 +49,9 @@ def require_git_annex():
         )
 
 
-def _do_inside(repo_path, *args, env=None):
+def _do_inside(
+    repo_path: Path | str, *args: Any, env: dict | None = None
+) -> tuple[int, str, str]:
     cmd = [GIT_ANNEX_COMMAND, *args]
     run_env = None
     if env:
@@ -61,7 +66,12 @@ def _do_inside(repo_path, *args, env=None):
     return result.returncode, result.stdout, result.stderr
 
 
-def _check_output_do_inside(repo_path, *args, check_stderr=True, env=None):
+def _check_output_do_inside(
+    repo_path: Path | str,
+    *args: Any,
+    check_stderr: bool = True,
+    env: dict | None = None,
+) -> str:
     returncode, stdout, stderr = _do_inside(repo_path, *args, env=env)
     if returncode != 0:
         raise AnnexError(f"git-annex {args} failed: {stderr}")
@@ -83,30 +93,30 @@ class Annex:
     # Mutated via object.__setattr__ to bypass frozen.
     _remote_log_cache = field(init=False, default=None, eq=False, repr=False)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         require_git_annex()
         if not self.annex_path.exists():
             raise ValueError(f"git-annex not initialized at {self.repo_path}")
 
     @property
-    def annex_path(self):
+    def annex_path(self) -> Path:
         return self.repo_path.joinpath(".git", "annex")
 
     @property
-    def annex_objects_path(self):
+    def annex_objects_path(self) -> Path:
         return self.annex_path.joinpath("objects")
 
-    def _do(self, *args):
+    def _do(self, *args: Any) -> tuple[str, str]:
         returncode, stdout, stderr = _do_inside(self.repo_path, *args, env=self.env)
         if returncode != 0:
             raise AnnexError(f"git-annex {args} failed (rc={returncode}): {stderr}")
         return stdout, stderr
 
-    def _check_output_do(self, *args, **kwargs):
+    def _check_output_do(self, *args: Any, **kwargs: Any) -> str:
         return _check_output_do_inside(self.repo_path, *args, env=self.env, **kwargs)
 
     @property
-    def remote_name(self):
+    def remote_name(self) -> str | None:
         """Return the name of the single configured special remote, or None."""
         remote_log = self.remote_log
         if not remote_log:
@@ -118,7 +128,7 @@ class Annex:
         else:
             return name
 
-    def add(self, relpath, copy_to_remote=True):
+    def add(self, relpath: Path | str, copy_to_remote: bool = True) -> None:
         path = self.repo_path.joinpath(relpath)
         if not path.exists():
             raise FileNotFoundError(f"{path} does not exist")
@@ -128,41 +138,43 @@ class Annex:
         if copy_to_remote and (name := self.remote_name) is not None:
             self.copy(to=name, path=str(relpath))
 
-    def init(self):
+    def init(self) -> None:
         self._do("init")
 
-    def get(self, *paths):
+    def get(self, *paths: Path | str) -> None:
         self._do("get", *(str(p) for p in paths) or (".",))
 
-    def copy(self, to=None, from_=None, path="."):
+    def copy(
+        self, to: str | None = None, from_: str | None = None, path: str = "."
+    ) -> None:
         if (to is None) == (from_ is None):
             raise ValueError("specify exactly one of to/from_")
         direction = f"--to={to}" if to else f"--from={from_}"
         self._do("copy", direction, str(path))
 
-    def drop(self, path="."):
+    def drop(self, path: str = ".") -> None:
         self._do("drop", "--force", str(path))
 
-    def sync(self, **kwargs):
+    def sync(self, **kwargs: Any) -> None:
         self._do("sync")
 
-    def push(self):
+    def push(self) -> None:
         self._do("push")
 
-    def pull(self):
+    def pull(self) -> None:
         self._do("pull")
 
-    def info(self, name=None):
+    def info(self, name: str | None = None) -> dict:
         args = ("info", "--json") if name is None else ("info", name, "--json")
         out = self._check_output_do(*args, check_stderr=False)
         return json.loads(out)
 
-    def _merge_annex_branch(self):
+    def _merge_annex_branch(self) -> None:
         """Flush the git-annex journal to the git-annex branch."""
         _do_inside(self.repo_path, "merge", env=self.env)
 
     @property
-    def remote_log(self):
+    def remote_log(self) -> dict[str, dict[str, str]]:
         """Parse the git-annex branch's remote.log into {uuid: {key: value}}.
 
         Cached for the lifetime of the instance; ``initremote``/``enableremote``
@@ -187,7 +199,7 @@ class Annex:
         object.__setattr__(self, "_remote_log_cache", result)
         return result
 
-    def _invalidate_remote_log(self):
+    def _invalidate_remote_log(self) -> None:
         object.__setattr__(self, "_remote_log_cache", None)
 
     # Maps AWS env-var names (as stored in Annex.env) back to attrs field names
@@ -197,7 +209,7 @@ class Annex:
         "AWS_SECRET_ACCESS_KEY": "aws_secret_access_key",
     }
 
-    def resolve_remote_config(self, **kwargs):
+    def resolve_remote_config(self, **kwargs: Any) -> RemoteConfig | None:
         """Recover the RemoteConfig from the git-annex branch, env vars, and kwargs.
 
         Precedence (highest to lowest):
@@ -257,22 +269,22 @@ class Annex:
         return cls.from_dict(merged)
 
     @property
-    def remote_config(self):
+    def remote_config(self) -> RemoteConfig | None:
         """Convenience property — calls ``resolve_remote_config()`` with no overrides."""
         return self.resolve_remote_config()
 
-    def findkeys(self):
+    def findkeys(self) -> list[str]:
         out = self._check_output_do("findkeys", check_stderr=False)
         return out.split()
 
-    def dropkey(self, key):
+    def dropkey(self, key: str) -> None:
         self._do("dropkey", key, "--force")
 
-    def uninit(self):
+    def uninit(self) -> None:
         self._do("uninit")
 
     @classmethod
-    def from_repo_path(cls, repo_path, **kwargs):
+    def from_repo_path(cls, repo_path: Path | str, **kwargs: Any) -> Annex:
         """Construct an ``Annex`` from a repo path (``str`` or ``Path``)."""
         return cls(repo_path=Path(repo_path), **kwargs)
 
@@ -338,7 +350,7 @@ class Annex:
             Annex.from_repo_path(repo_path).initremote(remote_config)
 
 
-def teardown_local(git_annex):
+def teardown_local(git_annex: Any) -> None:
     annex = git_annex.annex
     keys = annex.findkeys()
     for key in keys:
@@ -356,7 +368,7 @@ def teardown_local(git_annex):
     shutil.rmtree(git_annex.repo_path)
 
 
-def teardown_remote(git_annex, remote_config=None):
+def teardown_remote(git_annex: Any, remote_config: RemoteConfig | None = None) -> None:
     """Remove all content from a remote and purge it from the git-annex branch."""
     if remote_config is None:
         remote_config = git_annex.annex.remote_config
@@ -374,7 +386,7 @@ def teardown_remote(git_annex, remote_config=None):
     )
 
 
-def teardown(git_annex, remote_config=None):
+def teardown(git_annex: Any, remote_config: RemoteConfig | None = None) -> None:
     teardown_remote(git_annex, remote_config=remote_config)
     teardown_local(git_annex)
 
@@ -397,11 +409,11 @@ LOCAL_ANNEX = LocalAnnexConfig()
 
 class RemoteConfig(AnnexConfig, abc.ABC):
     @abc.abstractmethod
-    def initremote(self, repo_path, *, remote_uuid): ...
+    def initremote(self, repo_path: Path | str, *, remote_uuid: str) -> None: ...
 
-    def enableremote(self, repo_path): ...  # noqa: B027
+    def enableremote(self, repo_path: Path | str) -> None: ...  # noqa: B027
 
-    def augment_fileprefix(self, remote_uuid):
+    def augment_fileprefix(self, remote_uuid: str) -> RemoteConfig:
         """Return self with ``{name}/{remote_uuid}/`` namespacing applied.
 
         Default is a no-op — only remotes that store content under a
@@ -411,27 +423,27 @@ class RemoteConfig(AnnexConfig, abc.ABC):
         """
         return self
 
-    def verify_fileprefix(self, remote_uuid, existing_fileprefix):
+    def verify_fileprefix(self, remote_uuid: str, existing_fileprefix: str) -> None:
         """Raise ``AnnexError`` if *existing_fileprefix* is not properly namespaced.
 
         Default is a no-op for the same reason ``augment_fileprefix`` is.
         """
 
     @abc.abstractmethod
-    def validate_config(self, repo_path): ...
+    def validate_config(self, repo_path: Path | str) -> None: ...
 
     @abc.abstractmethod
-    def to_dict(self): ...
+    def to_dict(self) -> dict[str, Any]: ...
 
     @classmethod
-    def from_dict(cls, d, **kwargs):
+    def from_dict(cls, d: dict[str, Any], **kwargs: Any) -> RemoteConfig:
         valid_keys = {a.name for a in attr.fields(cls)}
         d = {k: v for k, v in d.items() if k in valid_keys}
         kwargs = {k: v for k, v in kwargs.items() if k in valid_keys}
         return cls(**{**d, **kwargs})
 
     @classmethod
-    def from_env(cls, **kwargs):
+    def from_env(cls, **kwargs: Any) -> RemoteConfig:
         env_config = cls.EnvConfig.from_env()
         env = {
             a.name: getattr(env_config, a.name)

--- a/python/xorq/catalog/backend.py
+++ b/python/xorq/catalog/backend.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import abc
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 from attr import (
     field,
@@ -16,22 +20,22 @@ class CatalogBackend(abc.ABC):
     """ABC for the storage layer that Catalog delegates to."""
 
     @abc.abstractmethod
-    def stage(self, path): ...
+    def stage(self, path: Path | str) -> None: ...
 
     @abc.abstractmethod
-    def stage_content(self, path): ...
+    def stage_content(self, path: Path | str) -> None: ...
 
     @abc.abstractmethod
-    def stage_unlink(self, path): ...
+    def stage_unlink(self, path: Path | str) -> None: ...
 
     @abc.abstractmethod
-    def commit_context(self, message): ...
+    def commit_context(self, message: str) -> Iterator[Any]: ...
 
     @abc.abstractmethod
-    def is_content_local(self, path) -> bool: ...
+    def is_content_local(self, path: Path | str) -> bool: ...
 
     @abc.abstractmethod
-    def fetch_content(self, *paths): ...
+    def fetch_content(self, *paths: Path | str) -> None: ...
 
 
 @frozen
@@ -41,28 +45,28 @@ class GitBackend(CatalogBackend):
     repo = field(validator=instance_of(Repo))
 
     @property
-    def repo_path(self):
+    def repo_path(self) -> Path:
         return Path(self.repo.working_dir)
 
-    def stage(self, path):
+    def stage(self, path: Path | str) -> None:
         self.repo.index.add([str(path)])
 
-    def stage_content(self, path):
+    def stage_content(self, path: Path | str) -> None:
         self.stage(path)
 
-    def stage_unlink(self, path):
+    def stage_unlink(self, path: Path | str) -> None:
         self.repo.index.remove([str(path)])
         Path(path).unlink()
 
     @contextmanager
-    def commit_context(self, message):
+    def commit_context(self, message: str) -> Iterator[Any]:
         yield self.repo.index
         self.repo.index.commit(message)
 
-    def is_content_local(self, path):
+    def is_content_local(self, path: Path | str) -> bool:
         return Path(path).exists()
 
-    def fetch_content(self, *paths):
+    def fetch_content(self, *paths: Path | str) -> None:
         pass
 
 
@@ -71,7 +75,7 @@ class GitAnnexBackend(CatalogBackend):
     repo = field(validator=instance_of(Repo))
     annex = field(validator=instance_of(Annex))
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if Path(self.repo.working_dir).absolute() != self.annex.repo_path:
             raise ValueError(
                 f"repo working_dir {self.repo.working_dir} does not match "
@@ -79,40 +83,40 @@ class GitAnnexBackend(CatalogBackend):
             )
 
     @property
-    def repo_path(self):
+    def repo_path(self) -> Path:
         return Path(self.repo.working_dir)
 
-    def get_relpath(self, path):
+    def get_relpath(self, path: Path | str) -> Path:
         return Path(path).relative_to(self.repo_path)
 
-    def stage(self, path):
+    def stage(self, path: Path | str) -> None:
         self.repo.index.add([str(path)])
 
-    def stage_content(self, path):
+    def stage_content(self, path: Path | str) -> None:
         relpath = self.get_relpath(path)
         self.annex.add(relpath)
         self.repo.index.add([str(path)])
 
-    def stage_unlink(self, path):
+    def stage_unlink(self, path: Path | str) -> None:
         self.repo.index.remove([str(path)])
         Path(path).unlink()
 
     @contextmanager
-    def commit_context(self, message):
+    def commit_context(self, message: str) -> Iterator[Any]:
         yield self.repo.index
         self.repo.index.commit(message)
 
-    def is_content_local(self, path):
+    def is_content_local(self, path: Path | str) -> bool:
         p = Path(path)
         return p.exists() and not (p.is_symlink() and not p.resolve().exists())
 
-    def _has_any_remote(self):
+    def _has_any_remote(self) -> bool:
         """True if the repo has any git remote or annex special remote."""
         if self.annex.remote_name is not None:
             return True
         return bool(self.repo.remotes)
 
-    def fetch_content(self, *paths):
+    def fetch_content(self, *paths: Path | str) -> None:
         if not self._has_any_remote():
             missing = [p for p in paths if not self.is_content_local(p)]
             if missing:

--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -1,9 +1,17 @@
+from __future__ import annotations
+
 from enum import StrEnum
 from functools import reduce
+from typing import TYPE_CHECKING, Any
 
 from xorq.common.utils.graph_utils import replace_unbound
 from xorq.expr.relations import RemoteTable, gen_name
 from xorq.ibis_yaml.enums import ExprKind
+
+
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr import schema as sch
+    from xorq.vendor.ibis.expr import types as ir
 
 
 class CatalogTag(StrEnum):
@@ -12,7 +20,9 @@ class CatalogTag(StrEnum):
     CODE = "catalog-code"
 
 
-def _get_transform_schema_issues(source_schema, transform_schema):
+def _get_transform_schema_issues(
+    source_schema: sch.Schema, transform_schema: sch.Schema
+) -> tuple[dict[str, Any], dict[str, tuple[Any, Any]]]:
     bads = {
         col: (source_typ, transform_typ)
         for col, transform_typ in transform_schema.items()
@@ -31,7 +41,12 @@ def _get_transform_schema_issues(source_schema, transform_schema):
     return missing, mismatch
 
 
-def _validate_schema(source_schema, transform_schema, source_name, transform_name):
+def _validate_schema(
+    source_schema: sch.Schema,
+    transform_schema: sch.Schema,
+    source_name: str,
+    transform_name: str,
+) -> None:
     """Validate that source schema is a superset of transform's input schema."""
     missing, mismatch = _get_transform_schema_issues(source_schema, transform_schema)
     if missing or mismatch:
@@ -52,7 +67,7 @@ def _validate_schema(source_schema, transform_schema, source_name, transform_nam
         )
 
 
-def _validate_chain(source_schema, transforms):
+def _validate_chain(source_schema: sch.Schema, transforms: tuple) -> tuple:
     """Pre-validate the full transform chain before building expressions.
 
     Checks that every transform has an UnboundTable and that schemas are
@@ -83,12 +98,12 @@ def _validate_chain(source_schema, transforms):
     return tuple(metas)
 
 
-def _ensure_remote(node, con, expr):
+def _ensure_remote(node: Any, con: Any, expr: ir.Expr) -> RemoteTable:
     """Return *node* as-is if already a RemoteTable, otherwise wrap *expr*."""
     return node if isinstance(node, RemoteTable) else RemoteTable.from_expr(con, expr)
 
 
-def _make_source_tag(expr, entry, alias):
+def _make_source_tag(expr: ir.Expr, entry: Any, alias: str | None) -> ir.Expr:
     """Wrap *expr* in a HashingTag recording the catalog source provenance."""
     resolved_alias = (
         alias
@@ -103,7 +118,7 @@ def _make_source_tag(expr, entry, alias):
     )
 
 
-def _resolve_source(source, con, alias):
+def _resolve_source(source: Any, con: Any, alias: str | None) -> tuple[ir.Expr, Any]:
     """Resolve *source* to a ``(tagged_expr, backend)`` pair."""
     from xorq.catalog.catalog import CatalogEntry  # noqa: PLC0415
     from xorq.vendor.ibis.expr.types.core import Expr  # noqa: PLC0415
@@ -126,7 +141,7 @@ def _resolve_source(source, con, alias):
             )
 
 
-def _bind_one(current_expr, transform_entry, con):
+def _bind_one(current_expr: ir.Expr, transform_entry: Any, con: Any) -> ir.Expr:
     """Bind a single transform entry onto *current_expr*, tagging the result."""
     if not transform_entry.is_content_local:
         transform_entry.fetch()
@@ -148,7 +163,7 @@ def _bind_one(current_expr, transform_entry, con):
     )
 
 
-def _validate_one_catalog(source, transforms):
+def _validate_one_catalog(source: Any, transforms: Any) -> None:
     """Assert all CatalogEntry arguments belong to the same catalog."""
     from xorq.catalog.catalog import CatalogEntry  # noqa: PLC0415
 
@@ -164,7 +179,9 @@ def _validate_one_catalog(source, transforms):
         raise ValueError(f"Got multiple catalogs: {', '.join(map(str, repo_paths))}")
 
 
-def bind(source, *transforms, con=None, alias=None):
+def bind(
+    source: Any, *transforms: Any, con: Any = None, alias: str | None = None
+) -> ir.Expr:
     """Bind a source through one or more unbound transform entries.
 
     Parameters
@@ -195,7 +212,7 @@ def bind(source, *transforms, con=None, alias=None):
     )
 
 
-def _eval_code(code, source):
+def _eval_code(code: str, source: ir.Expr) -> ir.Expr:
     """Evaluate inline Ibis code with a restricted namespace.
 
     Only xorq, vendored ibis, and the bound ``source`` expression are
@@ -210,13 +227,15 @@ def _eval_code(code, source):
     return safe_eval(code, namespace)
 
 
-def _make_source_expr(source, con=None, alias=None):
+def _make_source_expr(
+    source: Any, con: Any = None, alias: str | None = None
+) -> ir.Expr:
     """Wrap a CatalogEntry as a RemoteTable + HashingTag without transforms."""
     source_expr, _ = _resolve_source(source, con, alias)
     return source_expr
 
 
-def fuse_catalog_source(expr):
+def fuse_catalog_source(expr: ir.Expr) -> ir.Expr:
     """Strip catalog-created RemoteTable + HashingTag layers for catalog sources.
 
     When ``bind()`` composes catalog entries it wraps everything in

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Iterator
 from contextlib import (
     contextmanager,
     nullcontext,
@@ -10,7 +13,12 @@ from contextlib import (
 from functools import cached_property, partial
 from pathlib import Path
 from subprocess import Popen
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+
+
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr import types as ir
 
 import attr
 import toolz
@@ -66,7 +74,9 @@ logger = get_logger(__name__)
 abspath = toolz.compose(Path.absolute, Path)
 
 
-def _ensure_wheel_artifacts(build_dir, project_path=None):
+def _ensure_wheel_artifacts(
+    build_dir: Path | str, project_path: Path | str | None = None
+) -> None:
     """Ensure a build directory contains a wheel and requirements.txt.
 
     If either is missing, builds them from the given project_path
@@ -104,17 +114,19 @@ def _ensure_wheel_artifacts(build_dir, project_path=None):
 popen_shell = partial(Popen, shell=True)
 
 
-def _has_annex_branch(repo):
+def _has_annex_branch(repo: Any) -> bool:
     """Check whether a Repo has a git-annex branch (local or remote-tracking)."""
     return any(ref.name.endswith(ANNEX_BRANCH) for ref in repo.refs)
 
 
-def _has_local_annex_branch(repo):
+def _has_local_annex_branch(repo: Any) -> bool:
     """Check whether a Repo has a local git-annex branch (i.e. a checked-out head)."""
     return ANNEX_BRANCH in repo.heads
 
 
-def _try_resolve_annex_remote(repo_path, **remote_kwargs):
+def _try_resolve_annex_remote(
+    repo_path: Path | str, **remote_kwargs: Any
+) -> RemoteConfig | None:
     """Try to resolve and enable an annex remote, with graceful degradation.
 
     Reads remote.log from the git-annex branch and resolves credentials
@@ -153,13 +165,13 @@ class Catalog:
     submodule_rel_path = Path(".xorq/catalogs")
 
     @property
-    def repo(self):
+    def repo(self) -> Any:
         return self.backend.repo
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         self._ensure_catalog_yaml()
 
-    def _ensure_catalog_yaml(self):
+    def _ensure_catalog_yaml(self) -> None:
         assert not self.repo.bare
         if not any(
             self.catalog_yaml.yaml_relpath.name == blob.name
@@ -169,15 +181,15 @@ class Catalog:
                 self.backend.stage(self.catalog_yaml.yaml_path)
 
     @property
-    def repo_path(self):
+    def repo_path(self) -> Path:
         return Path(self.repo.working_dir)
 
     @property
-    def catalog_yaml(self):
+    def catalog_yaml(self) -> CatalogYAML:
         return CatalogYAML(self.repo_path)
 
     @property
-    def remote_config(self):
+    def remote_config(self) -> RemoteConfig | None:
         """The resolved remote config, or None.
 
         On GitAnnexBackend catalogs, resolves from remote.log using the
@@ -189,7 +201,7 @@ class Catalog:
             return None
         return annex.resolve_remote_config()
 
-    def set_remote_config(self, remote_config):
+    def set_remote_config(self, remote_config: RemoteConfig) -> None:
         """Update the git-annex special remote configuration.
 
         Calls ``enableremote`` to write the config to remote.log on the
@@ -197,7 +209,7 @@ class Catalog:
         """
         Annex.from_repo_path(self.repo_path).enableremote(remote_config)
 
-    def embed_readonly(self, readonly_config):
+    def embed_readonly(self, readonly_config: RemoteConfig) -> None:
         """Embed read-only credentials into the git-annex branch.
 
         Verifies that *readonly_config* cannot write to the bucket, then
@@ -236,7 +248,14 @@ class Catalog:
                 project_path=project_path,
             )
 
-    def add(self, obj, sync=True, aliases=(), exist_ok=False, project_path=None):
+    def add(
+        self,
+        obj: Any,
+        sync: bool = True,
+        aliases: tuple[str, ...] = (),
+        exist_ok: bool = False,
+        project_path: Path | str | None = None,
+    ) -> CatalogEntry:
         """Add a build to the catalog.
 
         *obj* may be a ``Path`` to a zip archive, a ``Path`` to a build
@@ -268,7 +287,7 @@ class Catalog:
             project_path=project_path,
         )
 
-    def remove(self, name, sync=True):
+    def remove(self, name: str, sync: bool = True) -> CatalogEntry:
         """Remove an entry (and its aliases) from the catalog by name."""
         with self.maybe_synchronizing(sync):
             catalog_removal = CatalogRemoval.from_name_catalog(name, self)
@@ -276,12 +295,12 @@ class Catalog:
             self.assert_consistency()
             return catalog_entry
 
-    def list(self):
+    def list(self) -> list[str]:
         """Return the list of entry names in the catalog."""
         return self.catalog_yaml.contents[CatalogInfix.ENTRY]
 
     @property
-    def _git_remotes(self):
+    def _git_remotes(self) -> tuple[Any, ...]:
         """Remotes that are real git remotes (have a fetch refspec), excluding annex special remotes."""
 
         def _has_fetch_refspec(remote):
@@ -345,17 +364,17 @@ class Catalog:
         with ctx():
             yield
 
-    def sync(self):
+    def sync(self) -> None:
         """Pull then push — shorthand for a full round-trip synchronization."""
         with self.synchronizing():
             pass
 
-    def contains(self, name):
+    def contains(self, name: str) -> bool:
         """Return True if an entry with *name* exists in the catalog."""
         catalog_entry = CatalogEntry(name, self, require_exists=False)
         return catalog_entry.exists()
 
-    def get_catalog_entry(self, name, maybe_alias: bool = False):
+    def get_catalog_entry(self, name: str, maybe_alias: bool = False) -> CatalogEntry:
         """Look up a ``CatalogEntry`` by name.  Raises if not found."""
         if maybe_alias:
             if name in self.list_aliases():
@@ -366,7 +385,7 @@ class Catalog:
         catalog_entry = CatalogEntry(name, self)
         return catalog_entry
 
-    def load(self, name_or_alias, con=None):
+    def load(self, name_or_alias: str, con: Any = None) -> ir.Expr:
         """Return a tagged RemoteTable expression for a catalog entry (by hash or alias)."""
         from xorq.catalog.bind import _make_source_expr  # noqa: PLC0415
 
@@ -374,27 +393,27 @@ class Catalog:
         alias = name_or_alias if name_or_alias in self.list_aliases() else None
         return _make_source_expr(entry, con=con, alias=alias)
 
-    def bind(self, source_entry, *transforms, con=None):
+    def bind(self, source_entry: Any, *transforms: Any, con: Any = None) -> ir.Expr:
         """Bind a source entry through one or more transform entries."""
         from xorq.catalog.bind import bind  # noqa: PLC0415
 
         return bind(source_entry, *transforms, con=con)
 
-    def get_zip(self, name, dir_path=None):
+    def get_zip(self, name: str, dir_path: Path | str | None = None) -> Path:
         """Export an entry's archive to *dir_path* (default: cwd).  Returns the output path."""
         catalog_entry = self.get_catalog_entry(name)
         return catalog_entry.get(dir_path)
 
     @property
-    def catalog_entries(self):
+    def catalog_entries(self) -> tuple[CatalogEntry, ...]:
         return tuple(CatalogEntry(name, self) for name in self.list())
 
     @contextmanager
-    def commit_context(self, message):
+    def commit_context(self, message: str) -> Iterator[Any]:
         with self.backend.commit_context(message) as index:
             yield index
 
-    def add_alias(self, name, alias, sync=True):
+    def add_alias(self, name: str, alias: str, sync: bool = True) -> CatalogAlias:
         """Create an alias pointing at entry *name*.  Overwrites if the alias already exists."""
         with self.maybe_synchronizing(sync):
             catalog_entry = CatalogEntry(name, self)
@@ -402,12 +421,12 @@ class Catalog:
             catalog_alias.add()
             return catalog_alias
 
-    def list_aliases(self):
+    def list_aliases(self) -> list[str]:
         """Return the list of alias names in the catalog."""
         return self.catalog_yaml.contents[CatalogInfix.ALIAS]
 
     @property
-    def catalog_aliases(self):
+    def catalog_aliases(self) -> tuple[CatalogAlias, ...]:
         return tuple(
             CatalogAlias(
                 alias=alias,
@@ -424,7 +443,7 @@ class Catalog:
             for alias in self.list_aliases()
         )
 
-    def assert_consistency(self):
+    def assert_consistency(self) -> None:
         """Verify that catalog.yaml, entries, metadata, and aliases are all in agreement."""
         # catalog_yaml is in repo
         catalog_yaml_relpath_string = str(self.catalog_yaml.yaml_relpath)
@@ -460,7 +479,7 @@ class Catalog:
         )
         assert actual == expected
 
-    def add_as_submodule(self, root_repo):
+    def add_as_submodule(self, root_repo: Any) -> None:
         message = f"add submodule: {self.repo_path.name}"
         with commit_context(root_repo, message):
             add_as_submodule(root_repo, self.repo)
@@ -559,12 +578,12 @@ class Catalog:
     @classmethod
     def from_repo_path(
         cls,
-        repo_path,
-        init=None,
-        check_consistency=True,
-        annex=None,
-        **remote_kwargs,
-    ):
+        repo_path: Path | str,
+        init: bool | None = None,
+        check_consistency: bool = True,
+        annex: Any = None,
+        **remote_kwargs: Any,
+    ) -> Catalog:
         remote_config = annex if isinstance(annex, RemoteConfig) else None
         init = not Path(repo_path).exists() if init is None else init
         if init:
@@ -620,8 +639,13 @@ class Catalog:
 
     @classmethod
     def from_name(
-        cls, name, init=None, check_consistency=True, annex=None, **remote_kwargs
-    ):
+        cls,
+        name: str,
+        init: bool | None = None,
+        check_consistency: bool = True,
+        annex: Any = None,
+        **remote_kwargs: Any,
+    ) -> Catalog:
         repo_path = cls.name_to_repo_path(name)
         return cls.from_repo_path(
             repo_path,
@@ -632,7 +656,7 @@ class Catalog:
         )
 
     @classmethod
-    def _resolve_default_name(cls):
+    def _resolve_default_name(cls) -> str:
         from xorq.catalog.constants import (  # noqa: PLC0415
             DEFAULT_CATALOG_CONFIG,
             DEFAULT_CATALOG_NAME,
@@ -649,8 +673,12 @@ class Catalog:
 
     @classmethod
     def from_default(
-        cls, init=None, check_consistency=True, annex=None, **remote_kwargs
-    ):
+        cls,
+        init: bool | None = None,
+        check_consistency: bool = True,
+        annex: Any = None,
+        **remote_kwargs: Any,
+    ) -> Catalog:
         name = cls._resolve_default_name()
         return cls.from_name(
             name=name,
@@ -686,14 +714,14 @@ class Catalog:
     @classmethod
     def from_kwargs(
         cls,
-        name=None,
-        path=None,
-        url=None,
-        root_repo=None,
-        init=None,
-        check_consistency=True,
-        annex=None,
-    ):
+        name: str | None = None,
+        path: Path | str | None = None,
+        url: str | None = None,
+        root_repo: Any = None,
+        init: bool | None = None,
+        check_consistency: bool = True,
+        annex: Any = None,
+    ) -> Catalog:
         if isinstance(root_repo, (str, Path)):
             root_repo = Repo(root_repo)
         if root_repo:
@@ -757,12 +785,14 @@ class Catalog:
             return catalog
 
     @classmethod
-    def name_to_repo_path(cls, name):
+    def name_to_repo_path(cls, name: str) -> Path:
         repo_path = cls.by_name_base_path.joinpath(name)
         return repo_path
 
     @staticmethod
-    def init_repo_path(repo_path, bare=False, annex=None):
+    def init_repo_path(
+        repo_path: Path | str, bare: bool = False, annex: Any = None
+    ) -> Any:
         assert not (repo_path := Path(repo_path)).exists(), (
             f"Catalog repo already exists at {repo_path}"
         )
@@ -791,11 +821,11 @@ class CatalogAddition:
     )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.build_zip.name
 
     @cached_property
-    def metadata(self):
+    def metadata(self) -> dict:
         prefix = self.build_zip.internal_prefix
         expr_data = self.build_zip.read_member(
             f"{prefix}/{DumpFiles.expr_metadata}", json.loads
@@ -817,24 +847,24 @@ class CatalogAddition:
         }
 
     @property
-    def catalog_entry(self):
+    def catalog_entry(self) -> CatalogEntry:
         return CatalogEntry(self.name, self.catalog, require_exists=False)
 
-    def ensure_dirs(self):
+    def ensure_dirs(self) -> None:
         for p in (self.catalog_entry.metadata_path, self.catalog_entry.catalog_path):
             p.parent.mkdir(exist_ok=True, parents=True)
 
     @property
-    def catalog_aliases(self):
+    def catalog_aliases(self) -> tuple[CatalogAlias, ...]:
         return tuple(CatalogAlias(alias, self.catalog_entry) for alias in self.aliases)
 
     @property
-    def message(self):
+    def message(self) -> str:
         alias_message = f" (aliases {', '.join(self.aliases)})" if self.aliases else ""
         message = f"add: {self.name}{alias_message}"
         return message
 
-    def _add(self, exist_ok=False):
+    def _add(self, exist_ok: bool = False) -> CatalogEntry | None:
         if self.catalog.contains(self.name):
             if not exist_ok:
                 raise ValueError(f"Entry '{self.name}' already exists in catalog")
@@ -855,12 +885,12 @@ class CatalogAddition:
             catalog_alias._add()
         return CatalogEntry(self.name, self.catalog, require_exists=True)
 
-    def add(self, exist_ok=False):
+    def add(self, exist_ok: bool = False) -> CatalogEntry | None:
         with self.catalog.commit_context(self.message):
             return self._add(exist_ok=exist_ok)
 
     @classmethod
-    def from_expr(cls, expr, catalog):
+    def from_expr(cls, expr: ir.Expr, catalog: Catalog) -> CatalogAddition:
         ntfh = tempfile.NamedTemporaryFile(suffix=PREFERRED_SUFFIX)
         with build_expr_context_zip(expr) as zip_path:
             shutil.copy(zip_path, ntfh.name)
@@ -885,37 +915,37 @@ class CatalogEntry:
     catalog = field(validator=instance_of(Catalog))
     require_exists = field(validator=instance_of(bool), default=True)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         self.assert_consistency()
         if self.require_exists:
             assert self.exists(), f"Catalog entry '{self.name}' does not exist"
 
     @property
-    def repo_path(self):
+    def repo_path(self) -> Path:
         return self.catalog.repo_path
 
     @property
-    def metadata_path(self):
+    def metadata_path(self) -> Path:
         metadata_path = self.repo_path.joinpath(
             CatalogInfix.METADATA, self.name + PREFERRED_SUFFIX + METADATA_APPEND
         )
         return metadata_path
 
     @property
-    def catalog_path(self):
+    def catalog_path(self) -> Path:
         catalog_path = self.repo_path.joinpath(
             CatalogInfix.ENTRY, self.name
         ).with_suffix(PREFERRED_SUFFIX)
         return catalog_path
 
     @property
-    def expr(self):
+    def expr(self) -> ir.Expr:
         if not self.is_content_local:
             self.fetch()
         return load_expr_from_zip(self.catalog_path)
 
     @property
-    def lazy_expr(self):
+    def lazy_expr(self) -> ir.Expr:
         if not self.is_content_local:
             self.fetch()
         return load_expr_from_zip(self.catalog_path, lazy=True)
@@ -957,7 +987,7 @@ class CatalogEntry:
         return tuple(self.sidecar_metadata.get("backends", ()))
 
     @property
-    def aliases(self):
+    def aliases(self) -> tuple[CatalogAlias, ...]:
         return tuple(
             catalog_alias
             for catalog_alias in self.catalog.catalog_aliases
@@ -965,16 +995,16 @@ class CatalogEntry:
         )
 
     @property
-    def is_content_local(self):
+    def is_content_local(self) -> bool:
         """True when the entry's archive can be read right now."""
         return self.catalog.backend.is_content_local(self.catalog_path)
 
     @property
-    def is_available(self):
+    def is_available(self) -> bool:
         """True when the entry is registered *and* its content is local."""
         return self.exists() and self.is_content_local
 
-    def fetch(self):
+    def fetch(self) -> None:
         """Fetch this entry's annex content from the remote.
 
         No-op for plain-git backends.
@@ -982,7 +1012,7 @@ class CatalogEntry:
         self.catalog.backend.fetch_content(self.catalog_path)
 
     @property
-    def _exists_components(self):
+    def _exists_components(self) -> dict[str, bool]:
         # catalog_path may be an annex symlink pointing to content not yet
         # available locally; lexists / is_symlink handles that case.
         catalog_path = self.catalog_path
@@ -992,7 +1022,7 @@ class CatalogEntry:
             "catalog_yaml_contents": self.catalog.catalog_yaml.contains(self.name),
         }
 
-    def get(self, dir_path=None):
+    def get(self, dir_path: Path | str | None = None) -> Path:
         if not self.is_content_local:
             self.fetch()
         target = (
@@ -1003,11 +1033,11 @@ class CatalogEntry:
         shutil.copy(self.catalog_path, target)
         return target
 
-    def assert_consistency(self):
+    def assert_consistency(self) -> None:
         values = self._exists_components.values()
         assert all(values) or not any(values)
 
-    def exists(self):
+    def exists(self) -> bool:
         """True when the entry is registered in the catalog (content may not be local)."""
         return all(self._exists_components.values())
 
@@ -1024,21 +1054,21 @@ class CatalogAlias:
     catalog_entry = field(validator=instance_of(CatalogEntry))
 
     @property
-    def alias_path(self):
+    def alias_path(self) -> Path:
         return self.catalog_entry.repo_path.joinpath(
             CatalogInfix.ALIAS, self.alias
         ).with_suffix(PREFERRED_SUFFIX)
 
     @property
-    def target(self):
+    def target(self) -> Path:
         return Path("..").joinpath(
             CatalogInfix.ENTRY, self.catalog_entry.name + PREFERRED_SUFFIX
         )
 
-    def ensure_dirs(self):
+    def ensure_dirs(self) -> None:
         self.alias_path.parent.mkdir(exist_ok=True, parents=True)
 
-    def _add(self):
+    def _add(self) -> CatalogAlias | None:
         alias_path = self.alias_path
         if alias_path.exists():
             if not alias_path.is_symlink():
@@ -1061,12 +1091,12 @@ class CatalogAlias:
         backend.stage(catalog_yaml.yaml_path)
         return self
 
-    def add(self):
+    def add(self) -> None:
         message = f"add alias: {self.alias} -> {self.catalog_entry.name}"
         with self.catalog_entry.catalog.commit_context(message):
             self._add()
 
-    def list_revisions(self):
+    def list_revisions(self) -> tuple[tuple[CatalogEntry, Any], ...]:
         repo = self.catalog_entry.catalog.repo
         catalog = self.catalog_entry.catalog
         alias_relpath = str(self.alias_path.relative_to(self.catalog_entry.repo_path))
@@ -1094,7 +1124,7 @@ class CatalogAlias:
         )
         return result
 
-    def _remove(self):
+    def _remove(self) -> CatalogAlias:
         alias_path = self.alias_path
         assert alias_path.is_symlink(), f"no alias symlink at {alias_path}"
         catalog = self.catalog_entry.catalog
@@ -1106,14 +1136,14 @@ class CatalogAlias:
         backend.stage_unlink(alias_path)
         return self
 
-    def remove(self):
+    def remove(self) -> CatalogAlias:
         message = f"rm alias: {self.alias}"
         with self.catalog_entry.catalog.commit_context(message):
             self._remove()
         return self
 
     @classmethod
-    def from_name(cls, name, catalog):
+    def from_name(cls, name: str, catalog: Catalog) -> CatalogAlias:
         alias_path = catalog.repo_path.joinpath(
             CatalogInfix.ALIAS,
             name,
@@ -1135,7 +1165,7 @@ class CatalogRemoval:
     catalog_entry = field(validator=instance_of(CatalogEntry))
 
     @property
-    def message(self):
+    def message(self) -> str:
         name = with_pure_suffix(self.catalog_entry.catalog_path, "").name
         catalog_aliases = self.catalog_entry.aliases
         aliases_message = (
@@ -1146,7 +1176,7 @@ class CatalogRemoval:
         message = f"rm: {name}{aliases_message}"
         return message
 
-    def _remove(self):
+    def _remove(self) -> CatalogEntry:
         catalog_entry = self.catalog_entry
         catalog = catalog_entry.catalog
         assert catalog_entry.exists(), (
@@ -1162,12 +1192,12 @@ class CatalogRemoval:
             backend.stage_unlink(path)
         return catalog_entry
 
-    def remove(self):
+    def remove(self) -> CatalogEntry:
         with self.catalog_entry.catalog.commit_context(self.message):
             return self._remove()
 
     @classmethod
-    def from_name_catalog(cls, name, catalog):
+    def from_name_catalog(cls, name: str, catalog: Catalog) -> CatalogRemoval:
         return cls(CatalogEntry(name=name, catalog=catalog))
 
 
@@ -1175,7 +1205,7 @@ class CatalogRemoval:
 class CatalogYAML:
     repo_path = field(validator=instance_of(Path), converter=abspath)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if not self.yaml_path.exists():
             self.yaml_path.write_text(
                 yaml12.format_yaml(
@@ -1184,52 +1214,52 @@ class CatalogYAML:
             )
 
     @property
-    def yaml_path(self):
+    def yaml_path(self) -> Path:
         return self.repo_path.joinpath(CATALOG_YAML_NAME)
 
     @property
-    def yaml_relpath(self):
+    def yaml_relpath(self) -> Path:
         return self.yaml_path.relative_to(self.repo_path)
 
     @property
-    def contents(self):
+    def contents(self) -> dict[str, list[str]]:
         raw = yaml12.read_yaml(self.yaml_path)
         if isinstance(raw, list):
             # legacy format: plain list of entry names, no aliases section
             return {str(CatalogInfix.ENTRY): raw, str(CatalogInfix.ALIAS): []}
         return raw
 
-    def set_contents(self, contents):
+    def set_contents(self, contents: dict[str, list[str]]) -> Path:
         self.yaml_path.write_text(yaml12.format_yaml(contents))
         return self.yaml_path
 
-    def contains(self, entry):
+    def contains(self, entry: str) -> bool:
         return entry in self.contents[CatalogInfix.ENTRY]
 
-    def add(self, entry):
+    def add(self, entry: str) -> Path:
         assert not self.contains(entry)
         contents = self.contents
         contents[CatalogInfix.ENTRY] = contents[CatalogInfix.ENTRY] + [entry]
         return self.set_contents(contents)
 
-    def remove(self, entry):
+    def remove(self, entry: str) -> Path:
         contents = self.contents
         contents[CatalogInfix.ENTRY] = [
             el for el in contents[CatalogInfix.ENTRY] if el != entry
         ]
         return self.set_contents(contents)
 
-    def contains_alias(self, alias):
+    def contains_alias(self, alias: str) -> bool:
         return alias in self.contents[CatalogInfix.ALIAS]
 
-    def add_alias(self, alias):
+    def add_alias(self, alias: str) -> Path:
         if not self.contains_alias(alias):
             contents = self.contents
             contents[CatalogInfix.ALIAS] = contents[CatalogInfix.ALIAS] + [alias]
             self.set_contents(contents)
         return self.yaml_path
 
-    def remove_alias(self, alias):
+    def remove_alias(self, alias: str) -> Path:
         contents = self.contents
         contents[CatalogInfix.ALIAS] = [
             el for el in contents[CatalogInfix.ALIAS] if el != alias

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1,20 +1,24 @@
+from __future__ import annotations
+
 import json
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cache, partial
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import click
 
 from xorq.cli import OutputFormats
 
 
-def click_handler(e):
+def click_handler(e: Exception) -> None:
     raise click.ClickException(str(e)) from e
 
 
-def _init_hint(ctx):
+def _init_hint(ctx: click.Context) -> str:
     """Return the `xorq catalog ... init` command the user should run."""
     group_ctx = ctx.parent or ctx
     match (group_ctx.params.get("name"), group_ctx.params.get("path")):
@@ -26,13 +30,13 @@ def _init_hint(ctx):
             return "xorq catalog init"
 
 
-def _pdb_active(ctx):
+def _pdb_active(ctx: click.Context) -> bool:
     """Return True when --pdb was passed to the top-level CLI group."""
     return ctx.find_root().params.get("use_pdb", False)
 
 
 @contextmanager
-def click_context(ctx, *typs):
+def click_context(ctx: click.Context, *typs: type) -> Iterator[None]:
     try:
         yield
     except click.ClickException:
@@ -44,7 +48,7 @@ def click_context(ctx, *typs):
 
 
 @contextmanager
-def click_context_catalog(ctx):
+def click_context_catalog(ctx: click.Context) -> Iterator[None]:
     from git import NoSuchPathError
 
     try:
@@ -62,7 +66,7 @@ def click_context_catalog(ctx):
         click_handler(e)
 
 
-def click_context_default(ctx):
+def click_context_default(ctx: click.Context) -> Any:
     return click_context(ctx, AssertionError, Exception)
 
 
@@ -177,7 +181,9 @@ def tui(ctx, refresh):
     app.run()
 
 
-def _resolve_annex_option(env_file, env_prefix, gcs):
+def _resolve_annex_option(
+    env_file: str | None, env_prefix: str | None, gcs: bool
+) -> Any:
     """Return a RemoteConfig from CLI options, or None for plain git."""
     if env_file and env_prefix:
         raise click.UsageError("--env-file and --env-prefix are mutually exclusive.")

--- a/python/xorq/catalog/composer.py
+++ b/python/xorq/catalog/composer.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from functools import cached_property
+from typing import TYPE_CHECKING, Any
 
 from attr import Attribute, field, frozen
 from attr.validators import deep_iterable, instance_of, optional
@@ -13,7 +16,11 @@ from xorq.catalog.bind import (
 from xorq.catalog.catalog import CatalogEntry
 
 
-def _same_catalog(instance, attribute: Attribute, value):
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr import types as ir
+
+
+def _same_catalog(instance: Any, attribute: Attribute, value: Any) -> None:
     if value:
         _validate_one_catalog(instance.source, value)
 
@@ -39,7 +46,7 @@ class ExprComposer:
     alias = field(default=None, validator=optional(instance_of(str)))
 
     @cached_property
-    def expr(self):
+    def expr(self) -> ir.Expr:
         if self.transforms:
             current = bind(self.source, *self.transforms, alias=self.alias)
         else:
@@ -52,7 +59,7 @@ class ExprComposer:
         return current
 
     @classmethod
-    def from_expr(cls, expr, catalog):
+    def from_expr(cls, expr: ir.Expr, catalog: Any) -> ExprComposer:
         """Recover an ExprComposer from a tagged expression.
 
         Walks the HashingTag nodes embedded by a prior ``ExprComposer.expr``

--- a/python/xorq/catalog/expr_utils.py
+++ b/python/xorq/catalog/expr_utils.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import atexit
 import shutil
 import tempfile
 import weakref
+from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from xorq.catalog.zip_utils import (
     extract_build_zip_to,
@@ -10,17 +15,21 @@ from xorq.catalog.zip_utils import (
 )
 
 
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr import types as ir
+
+
 # Tracks temp dirs that haven't been cleaned up yet.
 # weakref.finalize handles per-expression cleanup; atexit sweeps stragglers.
 _live_extract_dirs: set[str] = set()
 
 
-def _cleanup_one(path: str):
+def _cleanup_one(path: str) -> None:
     shutil.rmtree(path, ignore_errors=True)
     _live_extract_dirs.discard(path)
 
 
-def _cleanup_all():
+def _cleanup_all() -> None:
     for p in tuple(_live_extract_dirs):
         _cleanup_one(p)
 
@@ -29,7 +38,7 @@ atexit.register(_cleanup_all)
 
 
 @contextmanager
-def build_expr_context(expr):
+def build_expr_context(expr: ir.Expr) -> Iterator[Any]:
     from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
 
     with tempfile.TemporaryDirectory() as td:
@@ -38,7 +47,9 @@ def build_expr_context(expr):
 
 
 @contextmanager
-def build_expr_context_zip(expr, project_path=None):
+def build_expr_context_zip(
+    expr: ir.Expr, project_path: Path | str | None = None
+) -> Iterator[Path]:
     from xorq.catalog.catalog import _ensure_wheel_artifacts  # noqa: PLC0415
 
     with build_expr_context(expr) as build_dir:
@@ -47,7 +58,9 @@ def build_expr_context_zip(expr, project_path=None):
             yield zip_path
 
 
-def load_expr_from_zip(zip_path, lazy=False, read_only_parquet_metadata=False):
+def load_expr_from_zip(
+    zip_path: Path | str, lazy: bool = False, read_only_parquet_metadata: bool = False
+) -> ir.Expr:
     from xorq.ibis_yaml.compiler import load_expr  # noqa: PLC0415
 
     td = tempfile.mkdtemp(prefix="xorq-catalog-")

--- a/python/xorq/catalog/git_utils.py
+++ b/python/xorq/catalog/git_utils.py
@@ -1,19 +1,26 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from toolz import curry
 
 from xorq.catalog.constants import DEFAULT_REMOTE
 
 
+if TYPE_CHECKING:
+    from git import Repo
+
+
 @contextmanager
 @curry
-def commit_context(repo, message):
+def commit_context(repo: Repo, message: str):
     yield repo.index
     repo.index.commit(message)
 
 
-def add_as_submodule(repo, subrepo, remote=DEFAULT_REMOTE):
+def add_as_submodule(repo: Repo, subrepo: Repo, remote: str = DEFAULT_REMOTE) -> None:
     strpath = "./" + str(Path(subrepo.working_dir).relative_to(repo.working_dir))
     match subrepo.remotes:
         case ():

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cached_property
+from typing import Any
 
 from attr import field, frozen, validators
 
@@ -34,7 +36,7 @@ class CommitMetadata:
     committed_date: str = field(validator=validators.instance_of(str))
 
     @contextmanager
-    def git_env(self):
+    def git_env(self) -> Iterator[None]:
         """Temporarily override git author/committer env vars."""
         env_vars = {
             "GIT_AUTHOR_NAME": self.author_name,
@@ -56,7 +58,7 @@ class CommitMetadata:
                     os.environ[k] = v
 
     @staticmethod
-    def _git_date(unix_ts, tz_offset_seconds):
+    def _git_date(unix_ts: int, tz_offset_seconds: int) -> str:
         """Format as git-internal date: '<unix_ts> <+/-HHMM>'.
 
         GitPython's tz_offset is seconds west of UTC (positive = behind UTC),
@@ -68,7 +70,7 @@ class CommitMetadata:
         return f"{unix_ts} {sign}{hours:02d}{minutes:02d}"
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> CommitMetadata:
         return cls(
             sha=str(commit.hexsha),
             author_name=str(commit.author),
@@ -88,20 +90,20 @@ _RM_RE = re.compile(r"^rm: (?P<hash>[a-f0-9]+)(?:\s+\(aliases\s+(?P<aliases>.+)\
 _RM_ALIAS_RE = re.compile(r"^rm alias: (?P<alias>.+)$")
 
 
-def _make_commit_metadata_field():
+def _make_commit_metadata_field() -> Any:
     return field(
         default=None,
         validator=validators.optional(validators.instance_of(CommitMetadata)),
     )
 
 
-def _parse_aliases(raw):
+def _parse_aliases(raw: str | None) -> tuple[str, ...]:
     if raw:
         return tuple(a.strip() for a in raw.split(","))
     return ()
 
 
-def _changed_paths(commit):
+def _changed_paths(commit: Any) -> set[str]:
     """Return the set of file paths changed by a commit."""
     if not commit.parents:
         # initial commit — all files are new
@@ -117,19 +119,19 @@ class InitCatalog:
     message: str = field(validator=validators.instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         pass
 
     @staticmethod
-    def verify_commit(commit):
+    def verify_commit(commit: Any) -> None:
         assert not commit.parents, f"InitCatalog commit {commit.hexsha[:8]} has parents"
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> InitCatalog | None:
         msg = commit.message.strip()
         if msg == "initial commit":
             return cls(message=msg, commit_metadata=CommitMetadata.from_commit(commit))
@@ -143,15 +145,15 @@ class AddCatalogYAML:
     message: str = field(validator=validators.instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[init]  {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         pass
 
     @staticmethod
-    def verify_commit(commit):
+    def verify_commit(commit: Any) -> None:
         paths = _changed_paths(commit)
         assert any(
             p == CATALOG_YAML_NAME or p.endswith(CATALOG_YAML_NAME) for p in paths
@@ -160,7 +162,7 @@ class AddCatalogYAML:
         )
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> AddCatalogYAML | None:
         msg = commit.message.strip()
         if msg.startswith("add catalog"):
             return cls(message=msg, commit_metadata=CommitMetadata.from_commit(commit))
@@ -180,12 +182,12 @@ class AddEntry:
     )
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[add]   {sha}  entry={self.entry_hash}  aliases=[{alias_str}]"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         catalog_entry = from_catalog.get_catalog_entry(self.entry_hash)
         to_catalog.add(
             catalog_entry.catalog_path,
@@ -194,7 +196,7 @@ class AddEntry:
             exist_ok=True,
         )
 
-    def verify_commit(self, commit):
+    def verify_commit(self, commit: Any) -> None:
         paths = _changed_paths(commit)
         entry_prefix = f"{CatalogInfix.ENTRY}/{self.entry_hash}"
         assert any(p.startswith(entry_prefix) for p in paths), (
@@ -207,7 +209,7 @@ class AddEntry:
             )
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> AddEntry | None:
         msg = commit.message.strip()
         if m := _ADD_RE.match(msg):
             return cls(
@@ -226,14 +228,14 @@ class AddAlias:
     entry_name: str = field(validator=validators.instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[alias] {sha}  {self.alias} -> {self.entry_name}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         to_catalog.add_alias(self.entry_name, self.alias, sync=False)
 
-    def verify_commit(self, commit):
+    def verify_commit(self, commit: Any) -> None:
         paths = _changed_paths(commit)
         alias_prefix = f"{CatalogInfix.ALIAS}/{self.alias}"
         assert any(p.startswith(alias_prefix) for p in paths), (
@@ -241,7 +243,7 @@ class AddAlias:
         )
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> AddAlias | None:
         msg = commit.message.strip()
         if m := _ADD_ALIAS_RE.match(msg):
             return cls(
@@ -265,15 +267,15 @@ class RemoveEntry:
     )
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         alias_str = ", ".join(self.aliases) if self.aliases else "(none)"
         return f"[rm]    {sha}  entry={self.entry_name}  aliases=[{alias_str}]"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         to_catalog.remove(self.entry_name, sync=False)
 
-    def verify_commit(self, commit):
+    def verify_commit(self, commit: Any) -> None:
         paths = _changed_paths(commit)
         entry_prefix = f"{CatalogInfix.ENTRY}/{self.entry_name}"
         assert any(p.startswith(entry_prefix) for p in paths), (
@@ -281,7 +283,7 @@ class RemoveEntry:
         )
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> RemoveEntry | None:
         msg = commit.message.strip()
         if m := _RM_RE.match(msg):
             return cls(
@@ -299,16 +301,16 @@ class RemoveAlias:
     alias: str = field(validator=validators.instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[rm-a]  {sha}  alias={self.alias}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         from xorq.catalog.catalog import CatalogAlias  # noqa: PLC0415
 
         CatalogAlias.from_name(self.alias, to_catalog).remove()
 
-    def verify_commit(self, commit):
+    def verify_commit(self, commit: Any) -> None:
         paths = _changed_paths(commit)
         alias_prefix = f"{CatalogInfix.ALIAS}/{self.alias}"
         assert any(p.startswith(alias_prefix) for p in paths), (
@@ -316,7 +318,7 @@ class RemoveAlias:
         )
 
     @classmethod
-    def from_commit(cls, commit):
+    def from_commit(cls, commit: Any) -> RemoveAlias | None:
         msg = commit.message.strip()
         if m := _RM_ALIAS_RE.match(msg):
             return cls(
@@ -334,15 +336,15 @@ class UnknownOp:
     hexsha: str = field(validator=validators.instance_of(str))
     commit_metadata: CommitMetadata | None = _make_commit_metadata_field()
 
-    def __str__(self):
+    def __str__(self) -> str:
         sha = self.commit_metadata.sha[:8] if self.commit_metadata else "--------"
         return f"[???]   {sha}  {self.message}"
 
-    def do(self, from_catalog, to_catalog):
+    def do(self, from_catalog: Any, to_catalog: Any) -> None:
         patch = from_catalog.repo.git.format_patch("-1", self.hexsha, stdout=True)
         to_catalog.repo.git.am(input=patch)
 
-    def verify_commit(self, commit):
+    def verify_commit(self, commit: Any) -> None:
         pass
 
 

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import re
 import subprocess
@@ -6,7 +8,7 @@ from collections import Counter
 from datetime import datetime
 from functools import cache, cached_property
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from attr import evolve, field, frozen
 from attr.validators import instance_of, optional
@@ -298,7 +300,7 @@ class ExprStack:
     steps: tuple[ExprStep, ...] = field(factory=tuple)
     cursor: int = field(default=0, validator=instance_of(int))
 
-    def push(self, step: ExprStep) -> "ExprStack":
+    def push(self, step: ExprStep) -> ExprStack:
         """Apply new step, discard any steps after cursor (fork)."""
         return evolve(
             self,
@@ -306,10 +308,10 @@ class ExprStack:
             cursor=self.cursor + 1,
         )
 
-    def undo(self) -> "ExprStack":
+    def undo(self) -> ExprStack:
         return evolve(self, cursor=max(0, self.cursor - 1))
 
-    def redo(self) -> "ExprStack":
+    def redo(self) -> ExprStack:
         return evolve(self, cursor=min(len(self.steps), self.cursor + 1))
 
     @property
@@ -343,29 +345,29 @@ def _entry_info(entry: CatalogEntry) -> tuple[int | None, bool | None]:
     return len(entry.columns), cached
 
 
-def _load_catalog_row(entry, aliases=()) -> CatalogRowData:
+def _load_catalog_row(entry: CatalogEntry, aliases: tuple = ()) -> CatalogRowData:
     return CatalogRowData(entry=entry, aliases=aliases)
 
 
 @cache
-def _catalog_list_cached(catalog, yaml_mtime: float) -> tuple:
+def _catalog_list_cached(catalog: Any, yaml_mtime: float) -> tuple:
     """Compute catalog entry list; auto-invalidates when yaml mtime changes."""
     return tuple(catalog.list())
 
 
-def _get_catalog_list(catalog) -> tuple:
+def _get_catalog_list(catalog: Any) -> tuple:
     """Return catalog entry list, recomputing only when the YAML file has changed."""
     yaml_mtime = catalog.catalog_yaml.yaml_path.stat().st_mtime
     return _catalog_list_cached(catalog, yaml_mtime)
 
 
 @cache
-def _catalog_aliases_cached(catalog, yaml_mtime: float) -> tuple:
+def _catalog_aliases_cached(catalog: Any, yaml_mtime: float) -> tuple:
     """Compute catalog aliases; auto-invalidates when yaml mtime changes."""
     return tuple(catalog.catalog_aliases)
 
 
-def _get_catalog_aliases(catalog) -> tuple:
+def _get_catalog_aliases(catalog: Any) -> tuple:
     """Return catalog aliases, recomputing only when the YAML file has changed."""
     yaml_mtime = catalog.catalog_yaml.yaml_path.stat().st_mtime
     return _catalog_aliases_cached(catalog, yaml_mtime)
@@ -373,7 +375,7 @@ def _get_catalog_aliases(catalog) -> tuple:
 
 @cache
 def _build_alias_multimap(
-    catalog_aliases,
+    catalog_aliases: Any,
 ) -> dict[str, tuple[str, ...]]:
     from itertools import groupby  # noqa: PLC0415
     from operator import attrgetter  # noqa: PLC0415
@@ -386,7 +388,7 @@ def _build_alias_multimap(
     }
 
 
-def _build_git_log_rows(repo, max_count=100) -> tuple[GitLogRowData, ...]:
+def _build_git_log_rows(repo: Any, max_count: int = 100) -> tuple[GitLogRowData, ...]:
     return tuple(
         GitLogRowData(
             hash=commit.hexsha[:12],
@@ -440,7 +442,9 @@ def _render_sql_dag(sqls: tuple[tuple[str, str, str], ...]) -> str:
     return "\n\n".join(parts)
 
 
-def _revision_pair(i, rev_entry, commit):
+def _revision_pair(
+    i: int, rev_entry: Any, commit: Any
+) -> tuple[RevisionRowData, tuple[Any, Any, bool]]:
     exists = rev_entry.exists()
     col_count, cached = _entry_info(rev_entry) if exists else (None, None)
     row = RevisionRowData(

--- a/python/xorq/catalog/zip_utils.py
+++ b/python/xorq/catalog/zip_utils.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import hashlib
 import tempfile
 import zipfile
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
+from typing import Any
 
 from attr import field, frozen
 from attr.validators import instance_of
@@ -15,13 +19,13 @@ from xorq.catalog.constants import (
 from xorq.ibis_yaml.enums import REQUIRED_ARCHIVE_NAMES
 
 
-def with_pure_suffix(path, suffix=""):
+def with_pure_suffix(path: Path, suffix: str = "") -> Path:
     return path.with_name(path.name.removesuffix("".join(path.suffixes))).with_suffix(
         suffix
     )
 
 
-def test_zip(zip_path):
+def test_zip(zip_path: Path | str) -> None:
     with zipfile.ZipFile(zip_path, "r") as zf:
         names = {
             Path(info.filename).name for info in zf.infolist() if not info.is_dir()
@@ -39,7 +43,7 @@ def test_zip(zip_path):
 
 
 @contextmanager
-def make_zip_context(build_dir):
+def make_zip_context(build_dir: Path | str) -> Iterator[Path]:
     # Determinism: fixed mtime, sorted iteration, fixed permissions. Two
     # builds of the same expression with identical member bytes must produce
     # byte-identical zip archives, so downstream content-addressed storage
@@ -62,7 +66,7 @@ def make_zip_context(build_dir):
         yield zip_path
 
 
-def extract_build_zip_to(zip_path, td):
+def extract_build_zip_to(zip_path: Path | str, td: str) -> Path:
     """Extract a build zip into `td` and return the single top-level build dir."""
     with zipfile.ZipFile(zip_path, "r") as zf:
         zf.extractall(td)
@@ -72,12 +76,12 @@ def extract_build_zip_to(zip_path, td):
 
 
 @contextmanager
-def extract_build_zip_context(zip_path):
+def extract_build_zip_context(zip_path: Path | str) -> Iterator[Path]:
     with tempfile.TemporaryDirectory() as td:
         yield extract_build_zip_to(zip_path, td)
 
 
-def write_zip(path, relpath_to_bytes):
+def write_zip(path: Path | str, relpath_to_bytes: Mapping[str | Path, bytes]) -> Path:
     path = Path(path)
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for relpath, byts in dict(relpath_to_bytes).items():
@@ -99,25 +103,25 @@ class BuildZip:
         test_zip(self.path)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return with_pure_suffix(self.path, "").name
 
     @cached_property
-    def internal_prefix(self):
+    def internal_prefix(self) -> str:
         """The top-level directory inside the zip archive."""
         with zipfile.ZipFile(self.path, "r") as zf:
             first = zf.namelist()[0]
             return first.split("/", 1)[0]
 
     @property
-    def md5sum(self):
+    def md5sum(self) -> str:
         from xorq.common.utils.dask_normalize.dask_normalize_utils import (  # noqa: PLC0415
             file_digest,
         )
 
         return file_digest(self.path, hashlib.md5)
 
-    def read_member(self, member_path, read_f):
+    def read_member(self, member_path: str, read_f: Callable[[str], Any]) -> Any:
         """Read and parse a single member from the zip archive."""
         with zipfile.ZipFile(self.path, "r") as zf:
             return read_f(zf.read(member_path).decode())

--- a/python/xorq/common/utils/adbc_utils.py
+++ b/python/xorq/common/utils/adbc_utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class ADBCBase(ABC):
@@ -12,17 +15,17 @@ class ADBCBase(ABC):
     __slots__ = ()
 
     @abstractmethod
-    def get_conn(self, **kwargs): ...
+    def get_conn(self, **kwargs: Any) -> Any: ...
 
     def adbc_ingest(
         self,
-        table_name,
-        record_batch_reader,
-        mode="create",
-        temporary=False,
-        conn_kwargs=None,
-        **kwargs,
-    ):
+        table_name: str,
+        record_batch_reader: Any,
+        mode: str = "create",
+        temporary: bool = False,
+        conn_kwargs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
         with self.get_conn(**(conn_kwargs or {})) as conn:
             with conn.cursor() as cur:
                 cur.adbc_ingest(

--- a/python/xorq/common/utils/attr_utils.py
+++ b/python/xorq/common/utils/attr_utils.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
 from toolz import compose
 
 
 convert_sorted_kwargs_tuple = compose(tuple, sorted, dict.items, dict)
 
 
-def validate_kwargs_tuple(instance, attribute, value):
+def validate_kwargs_tuple(instance: Any, attribute: Any, value: Any) -> None:
     assert isinstance(value, tuple) and all(
         isinstance(el, tuple) and len(el) == 2 for el in value
     )

--- a/python/xorq/common/utils/aws_utils.py
+++ b/python/xorq/common/utils/aws_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from xorq.common.utils.env_utils import (
     EnvConfigable,
     env_templates_dir,
@@ -10,14 +12,16 @@ AWSConfig = EnvConfigable.subclass_from_env_file(
 aws_config = AWSConfig.from_env()
 
 
-def make_s3_credentials_defaults():
+def make_s3_credentials_defaults() -> dict[str, str]:
     return {
         "aws.access_key_id": aws_config["AWS_ACCESS_KEY_ID"],
         "aws.secret_access_key": aws_config["AWS_SECRET_ACCESS_KEY"],
     }
 
 
-def make_s3_connection(AWS_REGION=None, **kwargs):
+def make_s3_connection(
+    AWS_REGION: str | None = None, **kwargs: str
+) -> tuple[dict[str, str], bool]:
     connection = {
         **make_s3_credentials_defaults(),
         "aws.session_token": aws_config["AWS_SESSION_TOKEN"],
@@ -31,6 +35,6 @@ def make_s3_connection(AWS_REGION=None, **kwargs):
     return connection, connection_is_set(connection)
 
 
-def connection_is_set(connection: dict[str, str]):
+def connection_is_set(connection: dict[str, str]) -> bool:
     keys = ("aws.access_key_id", "aws.secret_access_key")
     return all(connection[value] for value in keys)

--- a/python/xorq/common/utils/databricks_utils.py
+++ b/python/xorq/common/utils/databricks_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from adbc_driver_manager import dbapi
 from attr import field, frozen
 from attr.validators import instance_of
@@ -14,7 +16,7 @@ DatabricksConfig = EnvConfigable.subclass_from_env_file(
 databricks_config = DatabricksConfig.from_env()
 
 
-def make_connection_params():
+def make_connection_params() -> dict[str, str]:
     """Create connection parameters from environment variables."""
     return {
         "server_hostname": databricks_config["DATABRICKS_SERVER_HOSTNAME"],
@@ -23,7 +25,7 @@ def make_connection_params():
     }
 
 
-def make_connection(**kwargs):
+def make_connection(**kwargs: Any) -> Any:
     """Create a Databricks connection using environment variables."""
     con = DatabricksBackend()
     con = con.connect(
@@ -49,14 +51,14 @@ class DatabricksADBC:
         }
 
     @property
-    def uri(self):
+    def uri(self) -> str:
         return self.get_uri()
 
-    def get_uri(self, **kwargs):
+    def get_uri(self, **kwargs: Any) -> str:
         params = {**self.default_kwargs, **kwargs}
         return f"databricks://token:{params['token']}@{params['hostname']}:{params['port']}/{params['http_path']}"
 
-    def get_conn(self, **kwargs):
+    def get_conn(self, **kwargs: Any) -> Any:
         return dbapi.connect(
             driver="databricks",
             uri=self.get_uri(**kwargs),

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import pyarrow as pa
 import toolz
@@ -38,7 +38,9 @@ _ADBC_BACKENDS = frozenset(("sqlite", "postgres", "snowflake", "databricks"))
 _PATH_PARAM_NAMES = frozenset(("path", "paths", "source", "source_list"))
 
 
-def make_read_kwargs(f, *args, **kwargs):
+def make_read_kwargs(
+    f: Callable, *args: Any, **kwargs: Any
+) -> tuple[tuple[str, Any], ...]:
     # FIXME: if any kwarg is a dictionary, we'll fail Concrete's hashable requirement, so just pickle
     read_kwargs = get_arguments(f, *args, **kwargs)
     kwargs = read_kwargs.pop("kwargs", {})
@@ -52,7 +54,7 @@ def make_read_kwargs(f, *args, **kwargs):
     return tpl
 
 
-def normalize_read_path_stat(path):
+def normalize_read_path_stat(path: Path) -> tuple[tuple[str, Any], ...]:
     stat = path.stat()
     tpls = tuple(
         (attrname, getattr(stat, attrname))
@@ -260,7 +262,9 @@ def deferred_read_parquet(
     ).to_expr()
 
 
-def rbr_wrapper(reader, clean_up):
+def rbr_wrapper(
+    reader: pa.RecordBatchReader, clean_up: Callable[[], None]
+) -> pa.RecordBatchReader:
     def gen():
         yield from reader
         clean_up()

--- a/python/xorq/common/utils/download_utils.py
+++ b/python/xorq/common/utils/download_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zipfile
 from pathlib import Path
 from shutil import move
@@ -7,7 +9,13 @@ from urllib.request import urlretrieve
 from xorq.init_templates import InitTemplates
 
 
-def download_github_archive(org, repo, branch, suffix=".zip", target=None):
+def download_github_archive(
+    org: str,
+    repo: str,
+    branch: str,
+    suffix: str = ".zip",
+    target: str | Path | None = None,
+) -> Path:
     target = Path(target or f"{branch}{suffix}")
     assert not target.exists()
     archive_url = f"https://github.com/{org}/{repo}/archive/{branch}.zip"
@@ -15,7 +23,7 @@ def download_github_archive(org, repo, branch, suffix=".zip", target=None):
     return target
 
 
-def extract_zip(source, target):
+def extract_zip(source: str | Path, target: str | Path) -> Path:
     (source, target) = map(Path, (source, target))
     assert not target.exists()
     with zipfile.ZipFile(source, "r") as zf:
@@ -31,7 +39,9 @@ def extract_zip(source, target):
     return target
 
 
-def download_xorq_template(template, branch=None, target=None):
+def download_xorq_template(
+    template: str, branch: str | None = None, target: str | Path | None = None
+) -> Path:
     branch = branch or InitTemplates.get_default_branch(template)
     return download_github_archive(
         org="xorq-labs",
@@ -41,7 +51,9 @@ def download_xorq_template(template, branch=None, target=None):
     )
 
 
-def download_unpacked_xorq_template(target, template, branch=None):
+def download_unpacked_xorq_template(
+    target: str | Path, template: str, branch: str | None = None
+) -> Path:
     target = Path(target)
     if target.exists():
         raise ValueError(

--- a/python/xorq/common/utils/eval_utils.py
+++ b/python/xorq/common/utils/eval_utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import ast
+from typing import Any
 
 
 _ALLOWED_NODES = frozenset(
@@ -56,7 +59,7 @@ _ALLOWED_NODES = frozenset(
 )
 
 
-def safe_eval(code, namespace):
+def safe_eval(code: str, namespace: dict[str, Any]) -> Any:
     """Evaluate *code* as a Python expression within *namespace*.
 
     The AST is walked before execution and only a whitelist of node types is

--- a/python/xorq/common/utils/func_utils.py
+++ b/python/xorq/common/utils/func_utils.py
@@ -1,21 +1,29 @@
+from __future__ import annotations
+
 import functools
 import itertools
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import toolz
 
 
+_T = TypeVar("_T")
+
 count = itertools.count()
 
 
-def return_constant(value):
-    def wrapped(*args, **kwargs):
+def return_constant(value: _T) -> Callable[..., _T]:
+    def wrapped(*args: Any, **kwargs: Any) -> _T:
         return value
 
     return wrapped
 
 
 @toolz.curry
-def log_excepts(f, exception=Exception):
+def log_excepts(
+    f: Callable[..., Any], exception: type[Exception] = Exception
+) -> Callable[..., Any]:
     # file logger
     # from xorq.common.utils.logging_utils import get_logger
 
@@ -25,7 +33,7 @@ def log_excepts(f, exception=Exception):
     logger = get_logger(__name__)
 
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         i = next(count)
         try:
             logger.info(f"{f.__name__} :: entering :: {i}")
@@ -39,7 +47,11 @@ def log_excepts(f, exception=Exception):
 
 
 @toolz.curry
-def maybe_log_excepts(f, exception=Exception, debug=None):
+def maybe_log_excepts(
+    f: Callable[..., Any],
+    exception: type[Exception] = Exception,
+    debug: bool | None = None,
+) -> Callable[..., Any]:
     from xorq.config import options  # noqa: PLC0415
 
     if options.debug or debug:
@@ -49,9 +61,9 @@ def maybe_log_excepts(f, exception=Exception, debug=None):
 
 
 @toolz.curry
-def with_lock(lock, f):
+def with_lock(lock: Any, f: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         with lock:
             return f(*args, **kwargs)
 
@@ -59,5 +71,5 @@ def with_lock(lock, f):
 
 
 @toolz.curry
-def if_not_none(f, value):
+def if_not_none(f: Callable[[_T], Any], value: _T | None) -> Any:
     return value if value is None else f(value)

--- a/python/xorq/common/utils/gcloud_utils.py
+++ b/python/xorq/common/utils/gcloud_utils.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import gcsfs
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -17,14 +21,14 @@ from xorq.vendor.ibis.backends import BaseBackend
 
 
 @curry
-def rbr_from_fs(fs, path):
-    def get_schema(fs, path):
+def rbr_from_fs(fs: Any, path: str) -> pa.RecordBatchReader:
+    def get_schema(fs: Any, path: str) -> pa.Schema:
         with fs.open(path, "rb") as fh:
             pf = pq.ParquetFile(fh)
             schema = pf.schema.to_arrow_schema()
             return schema
 
-    def gen_batches(fs, path):
+    def gen_batches(fs: Any, path: str) -> Any:
         with fs.open(path, "rb") as fh:
             pf = pq.ParquetFile(fh)
             yield from pf.iter_batches()
@@ -37,7 +41,13 @@ def rbr_from_fs(fs, path):
 
 
 @curry
-def rbr_to_fs(fs, path, rbr, parquet_metadata=None, **kwargs):
+def rbr_to_fs(
+    fs: Any,
+    path: str,
+    rbr: pa.RecordBatchReader,
+    parquet_metadata: dict | None = None,
+    **kwargs: Any,
+) -> None:
     schema = rbr.schema
     if parquet_metadata is not None:
         from xorq.common.utils.provenance_utils import (  # noqa: PLC0415
@@ -73,32 +83,32 @@ class GCStorage(CacheStorage):
             self.source, self.bucket_name, caller="normalize_gc_storage"
         )
 
-    def get_path(self, key):
+    def get_path(self, key: str) -> str:
         path = f"{self.bucket_name}/{key}.parquet"
         return path
 
-    def exists(self, key):
+    def exists(self, key: str) -> bool:
         path = self.get_path(key)
         return self.fs.exists(path)
 
-    def get(self, key):
+    def get(self, key: str) -> Any:
         path = self.get_path(key)
         rbr = rbr_from_fs(self.fs, path)
         op = self.source.read_record_batches(rbr).op()
         return op
 
-    def put(self, key, value, parquet_metadata=None):
+    def put(self, key: str, value: Any, parquet_metadata: dict | None = None) -> Any:
         path = self.get_path(key)
         rbr = value.to_expr().to_pyarrow_batches()
         rbr_to_fs(self.fs, path, rbr, parquet_metadata=parquet_metadata)
         return self.get(key)
 
-    def drop(self, key):
+    def drop(self, key: str) -> None:
         path = self.get_path(key)
         self.fs.delete(path)
 
 
-def get_file_metadata(uri, client=None):
+def get_file_metadata(uri: str, client: Any = None) -> tuple[tuple[str, Any], ...]:
     blob = storage.Blob.from_string(uri)
     # Refresh metadata (required for accurate timestamps)
     blob.reload(client or storage.Client.create_anonymous_client())

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -1,5 +1,8 @@
-from collections import defaultdict
-from typing import Any, OrderedDict, Tuple
+from __future__ import annotations
+
+from collections import OrderedDict, defaultdict
+from collections.abc import Callable, Generator
+from typing import Any
 
 import xorq.expr.relations as rel
 import xorq.expr.udf as udf
@@ -29,7 +32,7 @@ def to_node(maybe_expr: Any) -> Node:
             raise ValueError(f"Don't know how to handle type {type(maybe_expr)}")
 
 
-def gen_children_of(node: Node) -> Tuple[Node, ...]:
+def gen_children_of(node: Node) -> Generator[Node, None, None]:
     match node:
         case ops.Field():
             rel_node = node.rel
@@ -55,7 +58,7 @@ def gen_children_of(node: Node) -> Tuple[Node, ...]:
     yield from filter(None, gen)
 
 
-def bfs(node):
+def bfs(node: Any) -> Any:
     from collections import deque  # noqa: PLC0415
 
     from xorq.vendor.ibis.common.graph import Graph  # noqa: PLC0415
@@ -70,7 +73,7 @@ def bfs(node):
     return Graph(dct)
 
 
-def walk_nodes(node_types, expr):
+def walk_nodes(node_types: Any, expr: Any) -> tuple[Any, ...]:
     # TODO should this function use an ordered set
     visited = set()
     to_visit = [to_node(expr)]
@@ -93,7 +96,7 @@ def walk_nodes(node_types, expr):
     return result
 
 
-def replace_nodes(replacer, expr):
+def replace_nodes(replacer: Callable[..., Any], expr: Any) -> Node:
     # Cache results of opaque sub-expression traversals by their root node.
     # Sub-expression roots are often shared across multiple opaque nodes (e.g.
     # each pipeline step's ExprScalarUDF references accumulated sub-expressions
@@ -138,7 +141,9 @@ def replace_nodes(replacer, expr):
     return op
 
 
-def replace_sources(source_mapping, expr, *, transfer_tables=False):
+def replace_sources(
+    source_mapping: dict[int, Any], expr: Any, *, transfer_tables: bool = False
+) -> Expr:
     """Rewrite an expression graph, replacing backend sources.
 
     Every node that carries a ``source`` attribute (DatabaseTable, Read,
@@ -241,7 +246,7 @@ def replace_sources(source_mapping, expr, *, transfer_tables=False):
     return result
 
 
-def _namespace_to_database(namespace):
+def _namespace_to_database(namespace: Any) -> str | tuple[str, str] | None:
     """Convert a Namespace to the ``database`` kwarg accepted by backend methods."""
     if namespace.catalog and namespace.database:
         return (namespace.catalog, namespace.database)
@@ -250,7 +255,7 @@ def _namespace_to_database(namespace):
     return None
 
 
-def _find_missing_tables(tables_to_transfer):
+def _find_missing_tables(tables_to_transfer: list[Any]) -> list[tuple[Any, Any, str]]:
     """Return the subset of tables that don't exist on the target backend."""
     missing = []
     seen = set()
@@ -269,14 +274,14 @@ def _find_missing_tables(tables_to_transfer):
     return missing
 
 
-def _transfer_tables(tables_to_transfer):
+def _transfer_tables(tables_to_transfer: list[tuple[Any, Any, str]]) -> None:
     """Materialize and register table data on new backends."""
     for old_backend, new_backend, table_name in tables_to_transfer:
         table = old_backend.table(table_name).to_pyarrow()
         new_backend.create_table(table_name, table)
 
 
-def replace_unbound(expr, replacement, *, target=None):
+def replace_unbound(expr: Any, replacement: Any, *, target: Node | None = None) -> Expr:
     """Replace a single UnboundTable in *expr* with *replacement*.
 
     When *target* is ``None`` the expression is searched for UnboundTable
@@ -356,7 +361,7 @@ def validate_params(expr):
         raise TypeError("\n".join(messages))
 
 
-def get_ordered_unique_sources(nodes):
+def get_ordered_unique_sources(nodes: Any) -> tuple[Any, ...]:
     # Use id() for deduplication because backend __hash__ collides for
     # same-class instances and __eq__ only differs by session-local idx.
     sources, seen = (), set()
@@ -367,7 +372,7 @@ def get_ordered_unique_sources(nodes):
     return sources
 
 
-def find_all_sources(expr):
+def find_all_sources(expr: Any) -> tuple[Any, ...]:
     import xorq.vendor.ibis.expr.operations as ops  # noqa: PLC0415
 
     node_types = (

--- a/python/xorq/common/utils/hotfix_utils.py
+++ b/python/xorq/common/utils/hotfix_utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import warnings
+from typing import Any
 
 import dask
 import toolz
@@ -23,12 +26,18 @@ none_tokenized = dask.base.tokenize(None)
 
 
 @toolz.curry
-def hotfix(obj, attrname, target_tokenized, hotfix):
+def hotfix(obj: Any, attrname: str, target_tokenized: str, hotfix: Any) -> Any:
     return maybe_hotfix(obj, attrname, target_tokenized, hotfix, definitely=True)
 
 
 @toolz.curry
-def maybe_hotfix(obj, attrname, target_tokenized, hotfix, definitely=False):
+def maybe_hotfix(
+    obj: Any,
+    attrname: str,
+    target_tokenized: str,
+    hotfix: Any,
+    definitely: bool = False,
+) -> Any:
     to_hotfix = getattr(obj, attrname, None)
     tokenized = dask.base.tokenize(to_hotfix)
     dct = {

--- a/python/xorq/common/utils/import_utils.py
+++ b/python/xorq/common/utils/import_utils.py
@@ -1,19 +1,22 @@
+from __future__ import annotations
+
 import importlib
 import json
 import sys
 import tempfile
+import types
 import urllib
 from pathlib import Path
 
 
-def import_python(path, module_name=None):
+def import_python(path: Path | str, module_name: str | None = None) -> types.ModuleType:
     path = Path(path)
     return importlib.machinery.SourceFileLoader(
         module_name or path.stem, str(path)
     ).load_module()
 
 
-def import_ipynb(path, module_name):
+def import_ipynb(path: Path, module_name: str) -> types.ModuleType:
     """Import a Jupyter notebook as a module."""
 
     # Create a new module
@@ -51,7 +54,9 @@ def import_ipynb(path, module_name):
     return module
 
 
-def import_from_path(path, module_name="__main__"):
+def import_from_path(
+    path: Path | str, module_name: str = "__main__"
+) -> types.ModuleType:
     """
     Import a Python script or Jupyter notebook as a module.
 
@@ -83,7 +88,7 @@ def import_from_path(path, module_name="__main__"):
         )
 
 
-def import_from_gist(user, gist):
+def import_from_gist(user: str, gist: str) -> types.ModuleType:
     path = f"https://gist.githubusercontent.com/{user}/{gist}/raw/"
     req = urllib.request.Request(path, method="GET")
     resp = urllib.request.urlopen(req)

--- a/python/xorq/common/utils/inspect_utils.py
+++ b/python/xorq/common/utils/inspect_utils.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import inspect
 from sysconfig import get_python_version
+from typing import Any
 
 
-def get_enclosing_function(level=2):
+def get_enclosing_function(level: int = 2) -> str:
     # let caller inspect it's caller's name with level=2
     return inspect.stack()[level].function
 
 
-def maybe_unwrap_curry(func, *args, **kwargs):
+def maybe_unwrap_curry(
+    func: Any, *args: Any, **kwargs: Any
+) -> tuple[Any, tuple[Any, ...], dict[str, Any]]:
     # from toolz.curry.__init__
     if (
         hasattr(func, "func")
@@ -15,7 +20,7 @@ def maybe_unwrap_curry(func, *args, **kwargs):
         and hasattr(func, "keywords")
         and isinstance(func.args, tuple)
     ):
-        _kwargs = {}
+        _kwargs: dict[str, Any] = {}
         if func.keywords:
             _kwargs.update(func.keywords)
         _kwargs.update(kwargs)
@@ -27,7 +32,7 @@ def maybe_unwrap_curry(func, *args, **kwargs):
     return (func, args, kwargs)
 
 
-def get_arguments(f, *args, **kwargs):
+def get_arguments(f: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
     (f, args, kwargs) = maybe_unwrap_curry(f, *args, **kwargs)
     signature = inspect.signature(f)
     bound = signature.bind(*args, **kwargs)
@@ -36,7 +41,7 @@ def get_arguments(f, *args, **kwargs):
     return arguments
 
 
-def get_partial_arguments(f, *args, **kwargs):
+def get_partial_arguments(f: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
     (f, args, kwargs) = maybe_unwrap_curry(f, *args, **kwargs)
     signature = inspect.signature(f)
     bound = signature.bind_partial(*args, **kwargs)
@@ -45,5 +50,5 @@ def get_partial_arguments(f, *args, **kwargs):
     return arguments
 
 
-def get_python_version_no_dot():
+def get_python_version_no_dot() -> str:
     return get_python_version().replace(".", "")

--- a/python/xorq/common/utils/io_utils.py
+++ b/python/xorq/common/utils/io_utils.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import io
 import itertools
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from attr import (
@@ -19,7 +23,7 @@ from xorq.common.utils.func_utils import (
 
 
 @contextmanager
-def maybe_open(obj, *args, **kwargs):
+def maybe_open(obj: Any, *args: Any, **kwargs: Any) -> Iterator[Any]:
     if isinstance(obj, io.TextIOWrapper) | hasattr(obj, "write"):
         yield obj
     else:
@@ -57,19 +61,19 @@ class Peeker:
     fileobj = field(validator=instance_of(io.IOBase))
     buf = field(validator=instance_of(io.BytesIO), init=False, factory=io.BytesIO)
 
-    def _append_to_buf(self, contents):
+    def _append_to_buf(self, contents: bytes) -> None:
         oldpos = self.buf.tell()
         self.buf.seek(0, io.SEEK_END)
         self.buf.write(contents)
         self.buf.seek(oldpos)
 
-    def _buffered(self):
+    def _buffered(self) -> bytes:
         oldpos = self.buf.tell()
         data = self.buf.read()
         self.buf.seek(oldpos)
         return data
 
-    def peek(self, size):
+    def peek(self, size: int) -> bytes:
         buf = self._buffered()[:size]
         if len(buf) < size:
             contents = self.fileobj.read(size - len(buf))
@@ -78,7 +82,7 @@ class Peeker:
         return buf
 
     @staticmethod
-    def make_timed_out(timeout):
+    def make_timed_out(timeout: float | None) -> Callable[[], bool]:
         if timeout is None:
             return return_constant(False)
         else:
@@ -88,14 +92,20 @@ class Peeker:
 
             return timed_out
 
-    def peek_line(self, n=1, timed_out=return_constant(False)):  # noqa: B008
+    def peek_line(
+        self,
+        n: int = 1,
+        timed_out: Callable[[], bool] = return_constant(False),  # noqa: B008
+    ) -> bytes:
         buf = b""
         for n_chars in itertools.count(1):
             if (buf := self.peek(n_chars)).count(b"\n") >= n or timed_out():
                 break
         return buf
 
-    def peek_line_until(self, condition, timeout=None):
+    def peek_line_until(
+        self, condition: Callable[[bytes], bool], timeout: float | None = None
+    ) -> bytes:
         timed_out = self.make_timed_out(timeout)
         for n_lines in itertools.count(1):
             if (
@@ -107,7 +117,7 @@ class Peeker:
             raise TimeoutError
         return buf
 
-    def read(self, size=None):
+    def read(self, size: int | None = None) -> bytes:
         if size is None:
             contents = self.buf.read() + ValueError, self.fileobj.read()
             self.buf = io.BytesIO()
@@ -118,14 +128,14 @@ class Peeker:
             self.buf = io.BytesIO()
         return contents
 
-    def readline(self):
+    def readline(self) -> bytes:
         line = self.buf.readline()
         if not line.endswith(b"\n"):
             line += self.fileobj.readline()
             self.buf = io.BytesIO()
         return line
 
-    def close(self):
+    def close(self) -> bytes:
         contents = self.read()
         (self.buf, self.fileobj) = (None, None)
         return contents

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import singledispatch
 from itertools import count
-from typing import Any, Callable, Tuple
+from typing import Any
 
 import dask.base
 from attrs import evolve, field, frozen
@@ -32,7 +33,7 @@ class TextTree:
     """Plain-text tree for displaying lineage."""
 
     label: str = field(validator=instance_of(str))
-    children: Tuple["TextTree", ...] = field(
+    children: tuple["TextTree", ...] = field(
         factory=tuple, validator=instance_of(tuple)
     )
 
@@ -61,7 +62,7 @@ class TextTree:
 @frozen
 class GenericNode:
     op: Node = field(validator=instance_of(Node))
-    children: Tuple["GenericNode", ...] = field(
+    children: tuple["GenericNode", ...] = field(
         factory=tuple, validator=instance_of(tuple)
     )
 

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import hashlib
 import json
@@ -6,8 +8,10 @@ import pathlib
 import subprocess
 import tempfile
 import uuid
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 from opentelemetry.trace import SpanContext, StatusCode
 
@@ -32,14 +36,14 @@ _log_env_config = EnvConfigable.subclass_from_env_file(
 ).from_env()
 
 
-def _git_is_present(cwd=None):
+def _git_is_present(cwd: pathlib.Path | None = None) -> bool:
     if cwd is None:
         cwd = pathlib.Path().absolute()
 
     return any(p for p in (cwd, *cwd.parents) if p.joinpath(".git").exists())
 
 
-def get_git_state(hash_diffs):
+def get_git_state(hash_diffs: bool) -> dict[str, str]:
     (commit, diff, diff_cached) = (
         subprocess.check_output(lst).decode().strip()
         for lst in (
@@ -61,7 +65,9 @@ def get_git_state(hash_diffs):
     return git_state
 
 
-def log_initial_state(hash_diffs=False, cwd=None):
+def log_initial_state(
+    hash_diffs: bool = False, cwd: pathlib.Path | None = None
+) -> None:
     logger = structlog.get_logger(__name__)
     logger.info("initial log level", log_level=log_level)
     try:
@@ -79,7 +85,7 @@ def log_initial_state(hash_diffs=False, cwd=None):
         logger.exception("failed to log git repo info")
 
 
-def get_log_path(log_path=default_log_path):
+def get_log_path(log_path: pathlib.Path = default_log_path) -> pathlib.Path:
     try:
         log_path.parent.mkdir(exist_ok=True, parents=True)
     except Exception:
@@ -202,7 +208,7 @@ class RunLogger:
     def _finalized(self) -> bool:
         return self._meta_path.exists()
 
-    def log_event(self, event: str, fields: dict = None):
+    def log_event(self, event: str, fields: dict[str, Any] | None = None) -> None:
         record = {
             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "event": event,
@@ -211,7 +217,9 @@ class RunLogger:
         self._fh.write(json.dumps(record) + "\n")
         self._fh.flush()
 
-    def log_span_event(self, span, event: str, fields: dict = None):
+    def log_span_event(
+        self, span: Any, event: str, fields: dict[str, Any] | None = None
+    ) -> None:
         """Log to both the run log and an OTel span."""
         self.log_event(event, fields)
         if span is not None:
@@ -220,9 +228,9 @@ class RunLogger:
     def finalize(
         self,
         status: str,
-        span_context: SpanContext = None,
-        error: str = None,
-    ):
+        span_context: SpanContext | None = None,
+        error: str | None = None,
+    ) -> None:
         """Write meta.json and close the log file. Idempotent."""
         if self._finalized:
             return
@@ -279,8 +287,13 @@ class RunLogger:
     @classmethod
     @contextmanager
     def from_expr_hash(
-        cls, expr_hash: str, *, params_tuple: tuple = None, runs_dir=None, span=None
-    ):
+        cls,
+        expr_hash: str,
+        *,
+        params_tuple: tuple[Any, ...] | None = None,
+        runs_dir: str | Path | None = None,
+        span: Any = None,
+    ) -> Iterator[RunLogger | _NullRunLogger]:
         """Context manager that creates a :class:`RunLogger` and finalizes it on exit.
 
         If the run store directory cannot be created (e.g. permission error), a
@@ -327,16 +340,18 @@ class RunLogger:
 class _NullRunLogger:
     """No-op RunLogger used when the run store cannot be initialized."""
 
-    run_id = None
-    run_dir = None
+    run_id: str | None = None
+    run_dir: Path | None = None
 
-    def log_event(self, event: str, fields: dict = None):
+    def log_event(self, event: str, fields: dict[str, Any] | None = None) -> None:
         pass
 
-    def log_span_event(self, span, event: str, fields: dict = None):
+    def log_span_event(
+        self, span: Any, event: str, fields: dict[str, Any] | None = None
+    ) -> None:
         pass
 
-    def finalize(self, **kwargs):
+    def finalize(self, **kwargs: Any) -> None:
         pass
 
 

--- a/python/xorq/common/utils/name_utils.py
+++ b/python/xorq/common/utils/name_utils.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
+
 import re
+from typing import Any
 
 
-def tokenize_to_int(*args) -> int:
+def tokenize_to_int(*args: Any) -> int:
     """Derive a deterministic integer from arbitrary args via dask tokenize."""
     import dask  # noqa: PLC0415
 
     return int(dask.base.tokenize(args), 16) % (2**31)
 
 
-def make_name(prefix, to_tokenize):
+def make_name(prefix: str, to_tokenize: Any) -> str:
     import dask  # noqa: PLC0415
 
     from xorq.ibis_yaml.config import config  # noqa: PLC0415
@@ -18,14 +21,14 @@ def make_name(prefix, to_tokenize):
     return name
 
 
-def _clean_udf_name(udf_name):
+def _clean_udf_name(udf_name: str) -> str:
     if udf_name.isidentifier():
         return udf_name
     else:
         return f"fun_{re.sub(r'[^0-9a-zA-Z_]', '_', udf_name)}".lower()
 
 
-def get_uid_prefix(name, pattern="^(ibis_[\\w-]+_)\\w{26}$"):
+def get_uid_prefix(name: str, pattern: str = "^(ibis_[\\w-]+_)\\w{26}$") -> str | None:
     # xorq.vendor.ibis.util.gen_name
     if match := re.match(pattern, name):
         return match.group(1)

--- a/python/xorq/common/utils/otel_utils.py
+++ b/python/xorq/common/utils/otel_utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import socket
 import sys
 import urllib.parse
+from typing import Any
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -17,7 +20,7 @@ from xorq.common.utils.env_utils import (
 )
 
 
-def is_localhost_collector_listening(uri):
+def is_localhost_collector_listening(uri: str) -> bool:
     parsed = urllib.parse.urlparse(uri)
     if parsed.hostname != "localhost":
         return False
@@ -30,7 +33,7 @@ def is_localhost_collector_listening(uri):
         return False
 
 
-def _should_use_otlp_exporter(endpoint):
+def _should_use_otlp_exporter(endpoint: str | None) -> bool:
     if not endpoint:
         return False
     parsed = urllib.parse.urlparse(endpoint)
@@ -67,7 +70,7 @@ else:
 otel_config = OTELConfig.from_env()
 
 
-def get_otlp_exporter():
+def get_otlp_exporter() -> Any:
     """Create OTLP exporter based on protocol configuration.
 
     SDK auto-configures from standard OTEL environment variables:

--- a/python/xorq/common/utils/postgres_utils.py
+++ b/python/xorq/common/utils/postgres_utils.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import adbc_driver_postgresql.dbapi
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -26,11 +30,11 @@ class PgADBC(ADBCBase):
     con = field(validator=instance_of(PGBackend))
 
     @property
-    def password(self):
+    def password(self) -> str:
         return self.con._con_kwargs["password"]
 
     @property
-    def params(self):
+    def params(self) -> dict[str, Any]:
         con_info = self.con.con.info
         dct = {key: getattr(con_info, key) for key in ("user", "host", "port")} | {
             "database": con_info.dbname,
@@ -39,19 +43,19 @@ class PgADBC(ADBCBase):
         return dct
 
     @property
-    def uri(self):
+    def uri(self) -> str:
         return self.get_uri()
 
     @property
-    def conn(self):
+    def conn(self) -> Any:
         return self.get_conn()
 
-    def get_uri(self, **kwargs):
+    def get_uri(self, **kwargs: Any) -> str:
         params = {**self.params, **kwargs}
         uri = f"postgresql://{params['user']}:{params['password']}@{params['host']}:{params['port']}/{params['database']}"
         return uri
 
-    def get_conn(self, **kwargs):
+    def get_conn(self, **kwargs: Any) -> Any:
         return adbc_driver_postgresql.dbapi.connect(self.get_uri(**kwargs))
 
 
@@ -61,14 +65,14 @@ PostgresConfig = EnvConfigable.subclass_from_env_file(
 postgres_config = PostgresConfig.from_env()
 
 
-def make_credential_defaults():
+def make_credential_defaults() -> dict[str, str]:
     return {
         "user": "$POSTGRES_USER",
         "password": "$POSTGRES_PASSWORD",
     }
 
 
-def make_connection_defaults():
+def make_connection_defaults() -> dict[str, str]:
     return {
         "host": postgres_config["POSTGRES_HOST"],
         "port": postgres_config["POSTGRES_PORT"],
@@ -76,7 +80,7 @@ def make_connection_defaults():
     }
 
 
-def make_connection(**kwargs):
+def make_connection(**kwargs: Any) -> Any:
     con = PGBackend()
     con = con.connect(
         **{
@@ -88,15 +92,15 @@ def make_connection(**kwargs):
     return con
 
 
-def do_checkpoint(con):
+def do_checkpoint(con: Any) -> None:
     con.raw_sql("CHECKPOINT")
 
 
-def do_analyze(con, name):
+def do_analyze(con: Any, name: str) -> None:
     con.raw_sql(f'ANALYZE "{name}"')
 
 
-def get_postgres_n_changes(dt):
+def get_postgres_n_changes(dt: Any) -> int:
     (con, name, schemaname) = (dt.source, dt.name, dt.namespace.catalog or "public")
     sql = f"""
         SELECT n_tup_upd + n_tup_ins + n_tup_del AS n_changes FROM pg_stat_user_tables
@@ -108,7 +112,7 @@ def get_postgres_n_changes(dt):
     return n_changes
 
 
-def get_postgres_n_reltuples(dt):
+def get_postgres_n_reltuples(dt: Any) -> float:
     # FIXME: determine how to track "temporary" tables
     (con, name) = (dt.source, dt.name)
     which = "reltuples"
@@ -126,7 +130,7 @@ def get_postgres_n_reltuples(dt):
     return n_reltuples
 
 
-def get_postgres_n_scans(dt):
+def get_postgres_n_scans(dt: Any) -> int:
     (con, name, schemaname) = (dt.source, dt.name, dt.namespace.catalog or "public")
     sql = f"""
         SELECT seq_scan FROM pg_stat_user_tables
@@ -136,7 +140,7 @@ def get_postgres_n_scans(dt):
     return n_scans
 
 
-def make_table_temporary(con, name):
+def make_table_temporary(con: Any, name: str) -> None:
     def rename_table_pg(con, old_name, new_name):
         # rename_stmt = f"ALTER TABLE {old_name} RENAME TO {new_name}"
         # sg.parse_one(rename_stmt)

--- a/python/xorq/common/utils/process_utils.py
+++ b/python/xorq/common/utils/process_utils.py
@@ -1,20 +1,25 @@
+from __future__ import annotations
+
 import functools
 import os
 import re
 import subprocess
+from typing import Any
 
 
 @functools.cache
-def in_nix_shell():
+def in_nix_shell() -> bool:
     return bool(os.environ.get("IN_NIX_SHELL"))
 
 
-def assert_not_in_nix_shell():
+def assert_not_in_nix_shell() -> None:
     if in_nix_shell():
         raise ValueError("in nix shell")
 
 
-def subprocess_run(args, text=False, **kwargs):
+def subprocess_run(
+    args: list[str], text: bool = False, **kwargs: Any
+) -> tuple[int, Any, Any]:
     result = subprocess.run(
         args,
         capture_output=True,

--- a/python/xorq/common/utils/profile_utils.py
+++ b/python/xorq/common/utils/profile_utils.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import cProfile
 import inspect
 import pstats
 import tempfile
 import time
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pstats import SortKey
 
 
-def profile(stmt, field=SortKey.CUMULATIVE):
+def profile(stmt: str, field: SortKey | None = SortKey.CUMULATIVE) -> pstats.Stats:
     f_back = inspect.currentframe().f_back
     with tempfile.NamedTemporaryFile() as ntf:
         cProfile.runctx(
@@ -23,6 +26,6 @@ def profile(stmt, field=SortKey.CUMULATIVE):
 
 
 @contextmanager
-def timed():
+def timed() -> Iterator[Callable[[], float]]:
     t = time.monotonic()
     yield lambda: time.monotonic() - t

--- a/python/xorq/common/utils/provenance_utils.py
+++ b/python/xorq/common/utils/provenance_utils.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import enum
+from typing import TYPE_CHECKING, Any
 
 import pyarrow.parquet as pq
 
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 XORQ_METADATA_PREFIX = "xorq:"
 
@@ -15,7 +19,7 @@ class ProvenanceField(enum.StrEnum):
     cache_ttl_seconds = f"{XORQ_METADATA_PREFIX}cache_ttl_seconds"
 
 
-def get_expr_hash(expr):
+def get_expr_hash(expr: Any) -> str:
     import dask.base  # noqa: PLC0415
 
     from xorq.caching.strategy import SnapshotStrategy  # noqa: PLC0415
@@ -27,7 +31,9 @@ def get_expr_hash(expr):
         return dask.base.tokenize(expr)[: config.hash_length]
 
 
-def build_provenance_metadata(expr, strategy, storage):
+def build_provenance_metadata(
+    expr: Any, strategy: Any, storage: Any
+) -> dict[bytes, bytes]:
     F = ProvenanceField
     expr_hash = get_expr_hash(expr)
     metadata = {
@@ -42,11 +48,11 @@ def build_provenance_metadata(expr, strategy, storage):
     return metadata
 
 
-def inject_metadata_into_schema(schema, metadata_dict):
+def inject_metadata_into_schema(schema: pa.Schema, metadata_dict: dict) -> pa.Schema:
     return schema.with_metadata((schema.metadata or {}) | metadata_dict)
 
 
-def read_parquet_provenance(path, fs=None):
+def read_parquet_provenance(path: str | Any, fs: Any = None) -> dict[str, str] | None:
     if fs is not None:
         with fs.open(path, "rb") as fh:
             schema = pq.ParquetFile(fh).schema_arrow

--- a/python/xorq/common/utils/pyiceberg_utils.py
+++ b/python/xorq/common/utils/pyiceberg_utils.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from xorq.backends.pyiceberg import (
     Backend as PyIcebergBackend,
 )
@@ -10,7 +14,7 @@ PyIcebergConfig = EnvConfigable.subclass_from_env_file(
 pyiceberg_config = PyIcebergConfig.from_env()
 
 
-def make_connection_defaults():
+def make_connection_defaults() -> dict[str, str]:
     return {
         "uri": pyiceberg_config["ICEBERG_URI"],
         "warehouse_path": pyiceberg_config["ICEBERG_WAREHOUSE_PATH"],
@@ -20,7 +24,7 @@ def make_connection_defaults():
     }
 
 
-def make_connection(**kwargs):
+def make_connection(**kwargs: Any) -> Any:
     con = PyIcebergBackend()
     con = con.connect(
         **{
@@ -31,7 +35,7 @@ def make_connection(**kwargs):
     return con
 
 
-def get_iceberg_snapshots_ids(dt):
+def get_iceberg_snapshots_ids(dt: Any) -> tuple[int, ...]:
     database = dt.source.namespace
     catalog = dt.source.catalog
     table_name = dt.name

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import itertools
 import traceback
+from collections.abc import Callable
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -12,13 +16,17 @@ from xorq.common.utils.otel_utils import (
 
 
 @toolz.curry
-def excepts_print_exc(func, exc=Exception, handler=toolz.functoolz.return_none):
+def excepts_print_exc(
+    func: Callable[..., Any],
+    exc: type[Exception] = Exception,
+    handler: Callable[..., Any] = toolz.functoolz.return_none,
+) -> Callable[..., Any]:
     _handler = toolz.compose(handler, toolz.curried.do(traceback.print_exception))
     return toolz.excepts(exc, func, _handler)
 
 
 @tracer.start_as_current_span("otel_instrument_reader")
-def otel_instrument_reader(reader):
+def otel_instrument_reader(reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
     span = trace.get_current_span()
     ctx = span.get_span_context()
     span_link = trace.Link(ctx)
@@ -51,18 +59,20 @@ def otel_instrument_reader(reader):
     return pa.RecordBatchReader.from_batches(reader.schema, instrument_reader(reader))
 
 
-def copy_rbr_batches(reader):
+def copy_rbr_batches(reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
     manager = pa.default_cpu_memory_manager()
     gen = (batch.copy_to(manager) for batch in reader)
     return pa.RecordBatchReader.from_batches(reader.schema, gen)
 
 
-def make_filtered_reader(reader):
+def make_filtered_reader(reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
     gen = (chunk.data for chunk in reader if chunk.data)
     return pa.RecordBatchReader.from_batches(reader.schema, gen)
 
 
-def instrument_reader(reader, prefix=""):
+def instrument_reader(
+    reader: pa.RecordBatchReader, prefix: str = ""
+) -> pa.RecordBatchReader:
     from xorq.common.utils.logging_utils import get_print_logger  # noqa: PLC0415
 
     logger = get_print_logger()
@@ -78,8 +88,14 @@ def instrument_reader(reader, prefix=""):
 
 @excepts_print_exc
 def streaming_split_exchange(
-    split_key, f, context, reader, writer, options=None, **kwargs
-):
+    split_key: str,
+    f: Callable[..., Any],
+    context: Any,
+    reader: pa.RecordBatchReader,
+    writer: Any,
+    options: Any = None,
+    **kwargs: Any,
+) -> None:
     started = False
     g = excepts_print_exc(f)
     for split_reader in ReaderSplitter(
@@ -96,7 +112,7 @@ def streaming_split_exchange(
 class ReaderSplitter:
     """Yield multiple record batch readers from a single record batch reader by `split_key`"""
 
-    def __init__(self, rbr, split_key):
+    def __init__(self, rbr: pa.RecordBatchReader, split_key: str) -> None:
         self.rbr = rbr
         self.split_key = split_key
         self._curr_batch = toolz.excepts(StopIteration, next)(self.rbr)

--- a/python/xorq/common/utils/sqlite_utils.py
+++ b/python/xorq/common/utils/sqlite_utils.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import adbc_driver_sqlite.dbapi
 from attr import (
     field,
@@ -13,7 +17,7 @@ from xorq.backends.sqlite import (
 from xorq.common.utils.adbc_utils import ADBCBase
 
 
-def get_sqlite_stats(dt):
+def get_sqlite_stats(dt: Any) -> tuple[int, int | None]:
     (con, name) = (dt.source, dt.name)
     sql = f"SELECT COUNT(*), MAX(id) FROM '{name}'"
     (count, max_id) = con.sql(sql).execute()
@@ -25,12 +29,12 @@ class SQLiteADBC(ADBCBase):
     con = field(validator=instance_of(SQLiteBackend))
 
     @property
-    def uri(self):
+    def uri(self) -> str:
         return self.con.uri
 
     @property
-    def conn(self):
+    def conn(self) -> Any:
         return self.get_conn()
 
-    def get_conn(self, **kwargs):
+    def get_conn(self, **kwargs: Any) -> Any:
         return adbc_driver_sqlite.dbapi.connect(self.uri)

--- a/python/xorq/common/utils/zip_utils.py
+++ b/python/xorq/common/utils/zip_utils.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import shutil
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import toolz
 from attr import (
@@ -20,7 +24,7 @@ __all__ = [
 ]
 
 
-def get_root_dir(zip_path):
+def get_root_dir(zip_path: Path | str) -> Path:
     with zipfile.ZipFile(zip_path, "r") as zf:
         (name, *rest) = zf.namelist()
         (root_dir, *_) = Path(name).parts
@@ -47,7 +51,7 @@ class ZipProxy:
     def root_dir(self):
         return get_root_dir(self.zip_path)
 
-    def toplevel_name_exists(self, name):
+    def toplevel_name_exists(self, name: str) -> bool:
         with self.open() as zf:
             return any(
                 relpath and str(relpath) == name
@@ -58,21 +62,21 @@ class ZipProxy:
             )
 
     @contextlib.contextmanager
-    def open(self):
+    def open(self) -> Iterator[zipfile.ZipFile]:
         with zipfile.ZipFile(self.zip_path, "r") as zf:
             yield zf
 
     @contextlib.contextmanager
-    def open_member(self, member_path):
+    def open_member(self, member_path: str | Path) -> Iterator[Any]:
         with self.open() as zf:
             yield zf.open(str(member_path))
 
     @contextlib.contextmanager
-    def open_toplevel_member(self, member_path):
+    def open_toplevel_member(self, member_path: str | Path) -> Iterator[Any]:
         with self.open_member(self.root_dir.joinpath(member_path)) as fh:
             yield fh
 
-    def extract_toplevel_name(self, name, dest):
+    def extract_toplevel_name(self, name: str, dest: str | Path) -> Path:
         dest = Path(dest)
         with dest.open("wb") as ofh:
             with self.open_toplevel_member(name) as ifh:
@@ -80,11 +84,11 @@ class ZipProxy:
         return dest
 
     @property
-    def members(self):
+    def members(self) -> list[str]:
         with self.open() as zf:
             return zf.namelist()
 
-    def extract_toplevel(self, dest):
+    def extract_toplevel(self, dest: str | Path) -> Path:
         dest = Path(dest).absolute()
         with self.open() as zf:
             for name in zf.namelist():
@@ -98,7 +102,7 @@ class ZipProxy:
         return dest
 
 
-def append_toplevel(zip_path, append_path):
+def append_toplevel(zip_path: Path | str, append_path: Path | str) -> Path | str:
     append_path = Path(append_path)
     arcname = str(ZipProxy(zip_path).root_dir.joinpath(append_path.name))
     with zipfile.ZipFile(zip_path, "a") as zf:

--- a/python/xorq/examples/__init__.py
+++ b/python/xorq/examples/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from xorq.config import default_backend
 from xorq.examples.core import (
     get_name_to_suffix,
@@ -6,11 +10,24 @@ from xorq.examples.core import (
 )
 
 
+if TYPE_CHECKING:
+    import xorq.vendor.ibis.expr.types as ir
+    from xorq.vendor.ibis.backends import BaseBackend
+
+
 class Example:
-    def __init__(self, name):
+    name: str
+
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def fetch(self, backend=None, table_name=None, deferred=True, **kwargs):
+    def fetch(
+        self,
+        backend: BaseBackend | None = None,
+        table_name: str | None = None,
+        deferred: bool = True,
+        **kwargs: Any,
+    ) -> ir.Table:
         if backend is None:
             backend = default_backend()
 
@@ -23,14 +40,14 @@ class Example:
         )
 
 
-def __dir__():
+def __dir__() -> tuple[str, ...]:
     return (
         "get_table_from_name",
         *whitelist,
     )
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     from xorq.vendor.ibis import examples as ibex  # noqa: PLC0415
 
     lookup = get_name_to_suffix()

--- a/python/xorq/examples/core.py
+++ b/python/xorq/examples/core.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
 import functools
 import pathlib
+from typing import TYPE_CHECKING, Any
 
 from xorq.common.utils.defer_utils import (
     deferred_read_csv,
     deferred_read_parquet,
 )
 from xorq.config import options
+
+
+if TYPE_CHECKING:
+    import xorq.vendor.ibis.expr.types as ir
+    from xorq.vendor.ibis.backends import BaseBackend
 
 
 whitelist = [
@@ -32,7 +40,13 @@ def get_name_to_suffix() -> dict[str, str]:
     return dct
 
 
-def get_table_from_name(name, backend, table_name=None, deferred=True, **kwargs):
+def get_table_from_name(
+    name: str,
+    backend: BaseBackend,
+    table_name: str | None = None,
+    deferred: bool = True,
+    **kwargs: Any,
+) -> ir.Table:
     suffix = get_name_to_suffix().get(name)
     match suffix:
         case ".parquet":

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -143,10 +143,10 @@ def get_backend(expr: Expr | None = None) -> BaseBackend:
 
 
 def read_pyarrow_stream(
-    source,
-    con=None,
-    table_name=None,
-    **kwargs,
+    source: Any,
+    con: Any | None = None,
+    table_name: str | None = None,
+    **kwargs: Any,
 ) -> ir.Table:
     from xorq.config import default_backend  # noqa: PLC0415
 
@@ -159,7 +159,7 @@ def register(
     source: str | Path | pa.Table | pa.RecordBatch | pa.Dataset | pd.DataFrame,
     table_name: str | None = None,
     **kwargs: Any,
-):
+) -> ir.Table:
     from xorq.config import default_backend  # noqa: PLC0415
 
     con = default_backend()

--- a/python/xorq/expr/operations.py
+++ b/python/xorq/expr/operations.py
@@ -14,18 +14,18 @@ class _MissingSentinel:
 
     _instance = None
 
-    def __new__(cls):
+    def __new__(cls) -> _MissingSentinel:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "_MISSING"
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
-    def __dask_tokenize__(self):
+    def __dask_tokenize__(self) -> tuple[str]:
         return (type(self).__qualname__,)
 
 
@@ -51,7 +51,13 @@ class NamedScalarParameter(ScalarParameter):
     label: str
     default: Any = _MISSING
 
-    def __init__(self, dtype, label, default=_MISSING, counter=None):
+    def __init__(
+        self,
+        dtype: Any,
+        label: str,
+        default: Any = _MISSING,
+        counter: int | None = None,
+    ) -> None:
         if counter is None:
             counter = tokenize_to_int(label, dtype)
         if default is not _MISSING:
@@ -69,5 +75,5 @@ class NamedScalarParameter(ScalarParameter):
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.label

--- a/python/xorq/expr/pyaggregator.py
+++ b/python/xorq/expr/pyaggregator.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import pickle
 from abc import (
     ABC,
     abstractmethod,
 )
+from collections.abc import Iterable
+from typing import Any
 
 import pyarrow as pa
 
@@ -10,7 +14,9 @@ from xorq.common.utils import classproperty
 from xorq.internal import Accumulator
 
 
-def make_struct_type(names, arrow_types):
+def make_struct_type(
+    names: Iterable[str], arrow_types: Iterable[pa.DataType]
+) -> pa.StructType:
     return pa.struct(
         (
             pa.field(
@@ -25,13 +31,13 @@ def make_struct_type(names, arrow_types):
 class PyAggregator(Accumulator, ABC):
     """Variadic aggregator for UDAFs"""
 
-    def __init__(self):
-        self._states = []
+    def __init__(self) -> None:
+        self._states: list[bytes] = []
 
-    def pystate(self):
+    def pystate(self) -> pa.Array:
         return pa.concat_arrays(map(pickle.loads, self._states))
 
-    def state(self):
+    def state(self) -> pa.Array:
         value = pa.array(
             [self._states],
             type=self.state_type,
@@ -39,10 +45,10 @@ class PyAggregator(Accumulator, ABC):
         return value
 
     @abstractmethod
-    def py_evaluate(self):
+    def py_evaluate(self) -> Any:
         pass
 
-    def evaluate(self):
+    def evaluate(self) -> pa.Scalar:
         return pa.scalar(
             self.py_evaluate(),
             type=self.return_type,
@@ -60,18 +66,18 @@ class PyAggregator(Accumulator, ABC):
             self._states.extend(state)
 
     @classproperty
-    def state_type(cls):
+    def state_type(cls) -> pa.DataType:
         return pa.list_(pa.large_binary())
 
     @classproperty
-    def names(cls):
+    def names(cls) -> tuple[str, ...]:
         return tuple(field.name for field in cls.struct_type)
 
     @classproperty
     @abstractmethod
-    def struct_type(cls):
+    def struct_type(cls) -> pa.StructType:
         pass
 
     @classproperty
-    def volatility(cls):
+    def volatility(cls) -> str:
         return "stable"

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import functools
 import itertools
 import operator
 from collections import defaultdict
-from typing import Any, Callable
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import pyarrow as pa
 import toolz
@@ -26,7 +29,7 @@ from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node, Relation
 
 
-def replace_cache_table(node, kwargs):
+def replace_cache_table(node: Node, kwargs: dict[str, Any]) -> Node:
     if kwargs:
         node = node.__recreate__(kwargs)
 
@@ -43,22 +46,22 @@ def replace_cache_table(node, kwargs):
 class SafeTee(object):
     """tee object wrapped to make it thread-safe"""
 
-    def __init__(self, teeobj, lock):
+    def __init__(self, teeobj: Any, lock: Any) -> None:
         self.teeobj = teeobj
         self.lock = lock
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SafeTee]:
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         with self.lock:
             return next(self.teeobj)
 
-    def __copy__(self):
+    def __copy__(self) -> SafeTee:
         return SafeTee(self.teeobj.__copy__(), self.lock)
 
     @classmethod
-    def tee(cls, iterable, n=2):
+    def tee(cls, iterable: Any, n: int = 2) -> tuple[SafeTee, ...]:
         """tuple of n independent thread-safe iterators"""
         from itertools import tee  # noqa: PLC0415
         from threading import Lock  # noqa: PLC0415
@@ -67,7 +70,7 @@ class SafeTee(object):
         return tuple(cls(teeobj, lock) for teeobj in tee(iterable, n))
 
 
-def recursive_update(obj, replacements):
+def recursive_update(obj: Any, replacements: dict[Any, Any]) -> Any:
     if isinstance(obj, Node):
         if obj in replacements:
             return replacements[obj]
@@ -89,8 +92,8 @@ def recursive_update(obj, replacements):
         return obj
 
 
-def replace_source_factory(source: Any):
-    def replace_source(node, _, **kwargs):
+def replace_source_factory(source: Any) -> Callable[..., Any]:
+    def replace_source(node: Any, _: Any, **kwargs: Any) -> Any:
         if "source" in kwargs:
             kwargs["source"] = source
         return node.__recreate__(kwargs)
@@ -105,10 +108,10 @@ class Tag(ops.Relation):
     values = FrozenDict()
 
     @property
-    def tag(self):
+    def tag(self) -> Any:
         return self.metadata.get("tag")
 
-    def __dask_tokenize__(self):
+    def __dask_tokenize__(self) -> Any:
         from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
             normalize_seq_with_caller,
         )
@@ -129,7 +132,7 @@ class HashingTag(Tag):
     produce distinct hashes.
     """
 
-    def __dask_tokenize__(self):
+    def __dask_tokenize__(self) -> Any:
         from xorq.common.utils.dask_normalize.dask_normalize_expr import (  # noqa: PLC0415
             normalize_seq_with_caller,
         )
@@ -163,7 +166,7 @@ class RemoteTable(DatabaseTableView):
     remote_expr: Expr
 
     @classmethod
-    def from_expr(cls, con, expr, name=None):
+    def from_expr(cls, con: Any, expr: Expr, name: str | None = None) -> RemoteTable:
         name = name or gen_name()
         return cls(
             name=name,
@@ -199,13 +202,13 @@ class FlightExpr(DatabaseTableView):
     @classmethod
     def from_exprs(
         cls,
-        input_expr,
-        unbound_expr,
-        make_server=None,
-        make_connection=None,
-        name=None,
-        **kwargs,
-    ):
+        input_expr: Expr,
+        unbound_expr: Expr,
+        make_server: Callable | None = None,
+        make_connection: Callable | None = None,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> FlightExpr:
         from xorq.flight import FlightServer  # noqa: PLC0415
 
         def roundtrip_cloudpickle(obj):
@@ -225,7 +228,7 @@ class FlightExpr(DatabaseTableView):
             **kwargs,
         )
 
-    def to_rbr(self, do_instrument_reader=None):
+    def to_rbr(self, do_instrument_reader: bool | None = None) -> pa.RecordBatchReader:
         from xorq.flight.action import AddExchangeAction  # noqa: PLC0415
         from xorq.flight.exchanger import (  # noqa: PLC0415
             UnboundExprExchanger,
@@ -262,25 +265,25 @@ class FlightExpr(DatabaseTableView):
         schema = self.schema.to_pyarrow()
         return pa.RecordBatchReader.from_batches(schema, gen)
 
-    def serve(self, make_server=None, **kwargs):
+    def serve(self, make_server: Callable | None = None, **kwargs: Any) -> Any:
         return flight_serve_unbound(
             self.unbound_expr, make_server=make_server, **kwargs
         )
 
 
 def flight_serve(
-    expr,
-    make_server=None,
-    **kwargs,
-):
+    expr: Expr,
+    make_server: Callable | None = None,
+    **kwargs: Any,
+) -> Any:
     return flight_serve_unbound(expr.unbind(), make_server=make_server, **kwargs)
 
 
 def flight_serve_unbound(
-    unbound_expr,
-    make_server=None,
-    **kwargs,
-):
+    unbound_expr: Expr,
+    make_server: Callable | None = None,
+    **kwargs: Any,
+) -> Any:
     from xorq.flight import FlightServer  # noqa: PLC0415
     from xorq.flight.exchanger import (  # noqa: PLC0415
         UnboundExprExchanger,
@@ -346,13 +349,13 @@ class FlightUDXF(DatabaseTableView):
     @classmethod
     def from_expr(
         cls,
-        input_expr,
-        udxf,
-        make_server=None,
-        make_connection=None,
-        name=None,
-        **kwargs,
-    ):
+        input_expr: Expr,
+        udxf: type,
+        make_server: Callable | None = None,
+        make_connection: Callable | None = None,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> FlightUDXF:
         from xorq.common.utils.tls_utils import TLSKwargs  # noqa: PLC0415
         from xorq.flight import FlightServer  # noqa: PLC0415
 
@@ -374,7 +377,7 @@ class FlightUDXF(DatabaseTableView):
             **kwargs,
         )
 
-    def to_rbr(self, do_instrument_reader=None):
+    def to_rbr(self, do_instrument_reader: bool | None = None) -> pa.RecordBatchReader:
         from xorq.flight.action import AddExchangeAction  # noqa: PLC0415
 
         if do_instrument_reader is None:
@@ -574,7 +577,7 @@ class Read(ops.DatabaseTable):
     read_kwargs: Any = ()
     normalize_method: Callable = None
 
-    def make_dt(self):
+    def make_dt(self) -> Node:
         method = getattr(self.source, self.method_name)
         _exclude = ("hash_path", "read_path")
         args = tuple(v for k, v in self.read_kwargs if k == "hash_path")
@@ -582,7 +585,7 @@ class Read(ops.DatabaseTable):
         dt = method(*args, **kwargs).op()
         return dt
 
-    def make_unbound_dt(self):
+    def make_unbound_dt(self) -> ops.UnboundTable:
         return ops.UnboundTable(
             name=self.name,
             schema=self.schema,
@@ -593,7 +596,9 @@ _count = itertools.count()
 
 
 @tracer.start_as_current_span("register_and_transform_remote_tables")
-def register_and_transform_remote_tables(expr, **kwargs):
+def register_and_transform_remote_tables(
+    expr: Expr, **kwargs: Any
+) -> tuple[Expr, dict[str, Any]]:
     created = {}
 
     op = expr.op()
@@ -663,11 +668,11 @@ def register_and_transform_remote_tables(expr, **kwargs):
     return expr, created
 
 
-def render_backend(con):
+def render_backend(con: Any) -> str:
     return f"{con.name}-{id(con)}"
 
 
-def get_cache_params(cache):
+def get_cache_params(cache: Any) -> tuple[str | None, bool | None, str]:
     from xorq.caching import (  # noqa: PLC0415
         ParquetCache,
         ParquetSnapshotCache,
@@ -708,7 +713,7 @@ def _fmt_read(op, name, method_name, source, **kwargs):
     return name + render_schema(op.schema, 1)
 
 
-def prepare_create_table_from_expr(con, expr, **kwargs):
+def prepare_create_table_from_expr(con: Any, expr: Expr, **kwargs: Any) -> Any:
     from xorq.expr.api import _transform_expr  # noqa: PLC0415
 
     if (expr_backend := expr._find_backend()) != con:

--- a/python/xorq/expr/translate.py
+++ b/python/xorq/expr/translate.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import hashlib
 import operator
 from functools import singledispatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 
 import xorq.vendor.ibis.expr.operations as ops
+
+
+if TYPE_CHECKING:
+    import xorq.vendor.ibis.expr.types as ir
+
 from xorq.expr import (
     Aggregate,
     AggregateFunction,
@@ -44,7 +49,7 @@ class Catalog(dict[str, Any]):
 
 
 @singledispatch
-def convert(step, catalog, *args):
+def convert(step: Any, catalog: Catalog, *args: Any) -> Any:
     raise TypeError(type(step))
 
 
@@ -417,7 +422,7 @@ def convert_not(is_not, catalog):
     return expr.negate()
 
 
-def plan_to_ibis(plan, catalog):
+def plan_to_ibis(plan: Any, catalog: dict[str, Any]) -> Any:
     """Parse a DataFusion logical plan into an Ibis expression.
 
     Parameters
@@ -441,8 +446,8 @@ def plan_to_ibis(plan, catalog):
 
 
 def sql_to_ibis(
-    sql: str, catalog: dict[str, ibis.ir.Table], dialect: str = None
-) -> ibis.Expr:
+    sql: str, catalog: dict[str, ir.Table], dialect: str | None = None
+) -> ir.Expr:
     plan = parser.parse_sql(
         sql,
         ContextProvider({k: v.schema().to_pyarrow() for k, v in catalog.items()}),

--- a/python/xorq/expr/udf.py
+++ b/python/xorq/expr/udf.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import functools
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import cloudpickle
@@ -25,11 +28,11 @@ from xorq.vendor.ibis.expr.operations.udf import (
 )
 
 
-def property_wrap_fn(fn):
+def property_wrap_fn(fn: Callable) -> property:
     return property(fget=lambda _, fn=fn: fn)
 
 
-def arrays_to_df(names, *arrays):
+def arrays_to_df(names: Iterable[str], *arrays: pa.Array) -> Any:
     import pandas as pd  # noqa: PLC0415
 
     return pd.DataFrame(
@@ -37,11 +40,11 @@ def arrays_to_df(names, *arrays):
     )
 
 
-def make_pyarrow_array(return_type, series):
+def make_pyarrow_array(return_type: Any, series: Any) -> pa.Array:
     return pa.Array.from_pandas(series, type=return_type.to_pyarrow())
 
 
-def make_dunder_func(fn, schema, return_type=None):
+def make_dunder_func(fn: Callable, schema: Any, return_type: Any = None) -> property:
     def fn_from_arrays(*arrays):
         df = arrays_to_df(schema, *arrays)
         value = fn(df)
@@ -52,7 +55,9 @@ def make_dunder_func(fn, schema, return_type=None):
     return property_wrap_fn(fn_from_arrays)
 
 
-def make_expr_scalar_udf_dunder_func(fn, schema, return_type):
+def make_expr_scalar_udf_dunder_func(
+    fn: Callable, schema: Any, return_type: Any
+) -> property:
     def fn_from_arrays(*arrays, computed_arg=None, **kwargs):
         if computed_arg is None:
             raise ValueError(
@@ -69,7 +74,7 @@ def make_expr_scalar_udf_dunder_func(fn, schema, return_type):
 
 
 @toolz.curry
-def wrap_model(value, model_key="model"):
+def wrap_model(value: Any, model_key: str = "model") -> bytes:
     return cloudpickle.dumps({model_key: value})
 
 
@@ -532,11 +537,11 @@ class agg(_agg):
     @classmethod
     def pyarrow(
         cls,
-        fn=None,
-        name=None,
-        signature=None,
-        **kwargs,
-    ):
+        fn: Callable | None = None,
+        name: str | None = None,
+        signature: Any = None,
+        **kwargs: Any,
+    ) -> Any:
         """
         Decorator for creating PyArrow-based aggregation functions.
 
@@ -818,11 +823,11 @@ class agg(_agg):
 
 
 def arbitrate_evaluate(
-    uses_window_frame=False,
-    supports_bounded_execution=False,
-    include_rank=False,
-    **config_kwargs,
-):
+    uses_window_frame: bool = False,
+    supports_bounded_execution: bool = False,
+    include_rank: bool = False,
+    **config_kwargs: Any,
+) -> str:
     match (uses_window_frame, supports_bounded_execution, include_rank):
         case (False, False, False):
             return "evaluate_all"

--- a/python/xorq/ibis_yaml/common.py
+++ b/python/xorq/ibis_yaml/common.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import base64
 import functools
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
@@ -45,24 +48,28 @@ class RegistryEnum(StrEnum):
 FROM_YAML_HANDLERS: dict[str, Any] = {}
 
 
-def serialize_callable(fn: callable) -> str:
+def serialize_callable(fn: Callable) -> str:
     pickled = cloudpickle.dumps(fn)
     encoded = base64.b64encode(pickled).decode("ascii")
     return encoded
 
 
-def deserialize_callable(encoded_fn: str) -> callable:
+def deserialize_callable(encoded_fn: str) -> Callable:
     pickled = base64.b64decode(encoded_fn)
     return cloudpickle.loads(pickled)
 
 
 class Registry:
-    def __init__(self, dtypes=(), nodes=(), schemas=()):
+    dtypes: dict[str, Any]
+    nodes: dict[str, Any]
+    schemas: dict[str, Any]
+
+    def __init__(self, dtypes: Any = (), nodes: Any = (), schemas: Any = ()) -> None:
         self.dtypes = dict(dtypes)
         self.nodes = dict(nodes)
         self.schemas = dict(schemas)
 
-    def getstate(self):
+    def getstate(self) -> Any:
         return freeze(
             {
                 RegistryEnum.dtypes: self.dtypes,
@@ -71,13 +78,13 @@ class Registry:
             }
         )
 
-    def register_dtype(self, dtype, dtype_dict):
+    def register_dtype(self, dtype: Any, dtype_dict: Any) -> Any:
         dtype_ref = f"dtype_{tokenize(dtype_dict)[: config.hash_length]}"
         self.dtypes.setdefault(dtype_ref, dtype_dict)
         frozen = freeze({RefEnum.dtype_ref: dtype_ref})
         return frozen
 
-    def register_node(self, node, node_dict):
+    def register_node(self, node: Any, node_dict: Any) -> Any:
         """Register a node and return its name.
 
         Returns a name like '@read_{hash}', '@filter_{hash}', etc.
@@ -136,7 +143,7 @@ class Registry:
         frozen = freeze({RefEnum.node_ref: node_ref})
         return frozen
 
-    def register_schema(self, schema):
+    def register_schema(self, schema: Any) -> Any:
         frozen_schema = freeze(
             toolz.valmap(
                 functools.partial(translate_to_yaml, context=None),
@@ -148,7 +155,7 @@ class Registry:
         frozen = freeze({RefEnum.schema_ref: schema_ref})
         return frozen
 
-    def get(self, which, ref):
+    def get(self, which: RegistryEnum, ref: str) -> Any:
         match which:
             case RegistryEnum.dtypes:
                 dct = self.dtypes
@@ -185,11 +192,11 @@ class TranslationContext:
     )
 
     @property
-    def definitions(self):
+    def definitions(self) -> Any:
         return self.registry.getstate()
 
     @contextmanager
-    def remote_table_scope(self, ident: str):
+    def remote_table_scope(self, ident: str) -> Iterator[None]:
         self.remote_table_stack.append(ident)
         try:
             yield
@@ -206,7 +213,7 @@ class TranslationContext:
     def translate_to_yaml(self, op: Any) -> dict:
         return safe_translate_to_yaml(op, self)
 
-    def register(self, which, op, frozen=None):
+    def register(self, which: RegistryEnum, op: Any, frozen: Any = None) -> Any:
         match which:
             case RegistryEnum.dtypes:
                 return self.registry.register_dtype(op, frozen)
@@ -217,25 +224,25 @@ class TranslationContext:
             case _:
                 raise ValueError(f"don't know how to register {which}")
 
-    def get_definition(self, which, ref):
+    def get_definition(self, which: RegistryEnum, ref: str) -> Any:
         return self.registry.get(which, ref)
 
-    def get_dtype(self, dtype_ref):
+    def get_dtype(self, dtype_ref: str) -> Any:
         dtype_def = self.get_definition(RegistryEnum.dtypes, dtype_ref)
         return self.translate_from_yaml(dtype_def)
 
-    def get_node(self, node_ref):
+    def get_node(self, node_ref: str) -> Any:
         node_def = self.get_definition(RegistryEnum.nodes, node_ref)
         return self.translate_from_yaml(node_def)
 
-    def get_schema(self, schema_ref):
+    def get_schema(self, schema_ref: str) -> Schema:
         schema_def = self.get_definition(RegistryEnum.schemas, schema_ref)
         schema = Schema(toolz.valmap(self.translate_from_yaml, schema_def))
         return schema
 
 
-def register_from_yaml_handler(*op_names: str):
-    def decorator(func):
+def register_from_yaml_handler(*op_names: str) -> Callable[[Callable], Callable]:
+    def decorator(func: Callable) -> Callable:
         for name in op_names:
             FROM_YAML_HANDLERS[name] = func
         return func
@@ -243,7 +250,7 @@ def register_from_yaml_handler(*op_names: str):
     return decorator
 
 
-def default_handler(yaml_dict: dict, context: TranslationContext):
+def default_handler(yaml_dict: dict, context: TranslationContext) -> Any:
     spec = dict(yaml_dict)
     cls = getattr(ops, spec["op"])
     return cls(

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import dask
 import pyarrow.parquet as pq
@@ -88,7 +88,7 @@ memory_backends = ("pandas", "duckdb", "datafusion", "xorq_datafusion")
 table_like_ops = tuple(o for o in opaque_ops if issubclass(o, DatabaseTable))
 
 
-def _to_yaml_safe(data):
+def _to_yaml_safe(data: Any) -> Any:
     if isinstance(data, (RefEnum, RegistryEnum)):
         return data.name
     elif isinstance(data, FrozenOrderedDict):
@@ -119,10 +119,10 @@ class ArtifactStore:
         with path.open("r") as f:
             return read_f(f)
 
-    def read_yaml(self, *path_parts) -> Dict[str, Any]:
+    def read_yaml(self, *path_parts: str) -> dict[str, Any]:
         return yaml12.read_yaml(self.get_path(*path_parts))
 
-    def read_json(self, *path_parts) -> Dict[str, Any]:
+    def read_json(self, *path_parts: str) -> dict[str, Any]:
         return self._read(json.load, *path_parts)
 
     def read_text(self, *path_parts) -> str:
@@ -135,7 +135,7 @@ class ArtifactStore:
         with path.open("w") as f:
             yield (path, f)
 
-    def write_yaml(self, data: Dict[str, Any], *path_parts) -> pathlib.Path:
+    def write_yaml(self, data: dict[str, Any], *path_parts: str) -> pathlib.Path:
         with self._write(*path_parts) as (path, _):
             yaml12.write_yaml(_to_yaml_safe(data), path)
         return path
@@ -145,7 +145,7 @@ class ArtifactStore:
             f.write(content)
         return path
 
-    def write_parquet(self, table, *path_parts) -> pathlib.Path:
+    def write_parquet(self, table: Any, *path_parts: str) -> pathlib.Path:
         with self._write(*path_parts) as (path, f):
             pq.write_table(table, path)
         return path
@@ -153,13 +153,13 @@ class ArtifactStore:
     def exists(self, *path_parts) -> bool:
         return self.get_path(*path_parts).exists()
 
-    def write_json(self, data: Dict[str, Any], *path_parts) -> pathlib.Path:
+    def write_json(self, data: dict[str, Any], *path_parts: str) -> pathlib.Path:
         return self.write_text(json.dumps(data, indent=2), *path_parts)
 
-    def save_yaml(self, yaml_dict: Dict[str, Any], filename) -> pathlib.Path:
+    def save_yaml(self, yaml_dict: dict[str, Any], filename: str) -> pathlib.Path:
         return self.write_yaml(yaml_dict, filename)
 
-    def load_yaml(self, filename) -> Dict[str, Any]:
+    def load_yaml(self, filename: str) -> dict[str, Any]:
         return self.read_yaml(filename)
 
     @staticmethod
@@ -177,7 +177,9 @@ class ArtifactStore:
 
 class YamlExpressionTranslator:
     @staticmethod
-    def to_yaml(expr: ir.Expr, profiles=(), cache_dir=None) -> Dict[str, Any]:
+    def to_yaml(
+        expr: ir.Expr, profiles: Any = (), cache_dir: Any = None
+    ) -> dict[str, Any]:
         _ensure_translate_registered()
         context = TranslationContext(
             profiles=freeze(dict(profiles)),
@@ -202,8 +204,8 @@ class YamlExpressionTranslator:
 
     @staticmethod
     def from_yaml(
-        yaml_dict: Dict[str, Any],
-        profiles=(),
+        yaml_dict: dict[str, Any],
+        profiles: Any = (),
     ) -> ir.Expr:
         _ensure_translate_registered()
         context = TranslationContext(
@@ -461,8 +463,8 @@ class ExprDumper:
 
     def _prepare_sql_plans(
         self,
-        sql_plans: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        sql_plans: dict[str, Any],
+    ) -> dict[str, Any]:
         queries = {}
         path_to_writer = {}
         for query_name, query_info in sql_plans["queries"].items():
@@ -481,8 +483,8 @@ class ExprDumper:
 
     def _prepare_deferred_reads(
         self,
-        deferred_reads: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        deferred_reads: dict[str, Any],
+    ) -> dict[str, Any]:
         reads = {}
         path_to_writer = {}
         for read_name, read_info in deferred_reads["reads"].items():
@@ -521,7 +523,7 @@ class ExprDumper:
         )
         return path, writer
 
-    def _make_expr_metadata(self, expr) -> Dict[str, Any]:
+    def _make_expr_metadata(self, expr: Any) -> dict[str, Any]:
         from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
             extract_lineage_dag,
         )

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -13,13 +13,17 @@ PackagedRunner   build directory → execution output (via `uv tool run xorq run
                  in the wheel's isolated environment.
 """
 
+from __future__ import annotations
+
 import functools
 import os
 import shutil
 import subprocess
 import zipfile
+from collections.abc import Iterable
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import tomlkit
 import toolz
@@ -56,14 +60,14 @@ def _validate_python_version(instance, attribute, value):
             raise ValueError(f"invalid python version specifier: {value!r}") from e
 
 
-def _requires_python_from_pyproject(pyproject_path):
+def _requires_python_from_pyproject(pyproject_path: Path | str) -> str:
     """Read requires-python from a pyproject.toml, intersected with PYTHON_VERSION_CAP."""
     data = tomlkit.loads(Path(pyproject_path).read_text())
     raw = toolz.get_in(("project", "requires-python"), data)
     return str(SpecifierSet(raw or DEFAULT_REQUIRES_PYTHON) & PYTHON_VERSION_CAP)
 
 
-def _read_requires_python(path):
+def _read_requires_python(path: Path | str) -> str:
     """Read requires-python from a project source, intersected with PYTHON_VERSION_CAP.
 
     Accepts a pyproject.toml path, a directory containing one, or a .whl file.
@@ -93,7 +97,7 @@ def _read_requires_python(path):
         )
 
 
-def _find_single_glob(directory, pattern):
+def _find_single_glob(directory: Path | str, pattern: str) -> Path:
     """Find exactly one file matching pattern in directory."""
     matches = list(Path(directory).glob(pattern))
     if len(matches) != 1:
@@ -122,7 +126,7 @@ class WheelBundle:
         default=None,
     )
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if not self.wheel_path.exists():
             raise FileNotFoundError(f"wheel not found: {self.wheel_path}")
         if not self.requirements_path.exists():
@@ -135,7 +139,7 @@ class WheelBundle:
             )
 
     @classmethod
-    def from_build_path(cls, build_path):
+    def from_build_path(cls, build_path: Path | str) -> WheelBundle:
         """Discover artifacts from an existing build directory."""
         build_path = Path(build_path)
         return cls(
@@ -178,18 +182,18 @@ class WheelPackager:
             )
 
     @property
-    def built(self):
+    def built(self) -> bool:
         return bool(
             any(self.tmpdir.glob("*.whl"))
             and (self.tmpdir / DumpFiles.requirements).exists()
         )
 
     @property
-    def pyproject_path(self):
+    def pyproject_path(self) -> Path:
         return self.project_path.joinpath(PYPROJECT_NAME)
 
     @property
-    def tmpdir(self):
+    def tmpdir(self) -> Path:
         return Path(self._tmpdir.name)
 
     def _build_wheel(self):
@@ -239,7 +243,7 @@ class WheelPackager:
         else:
             shutil.copy2(existing, self.tmpdir / DumpFiles.requirements)
 
-    def build(self):
+    def build(self) -> WheelBundle:
         """Build the wheel and export requirements. Returns a WheelBundle."""
         if not self.built:
             self._build_wheel()
@@ -252,7 +256,7 @@ class WheelPackager:
         )
 
     @classmethod
-    def from_script_path(cls, script_path, **kwargs):
+    def from_script_path(cls, script_path: Path | str, **kwargs: Any) -> WheelPackager:
         pyproject_path = find_file_upwards(script_path, PYPROJECT_NAME)
         return cls(pyproject_path.parent, **kwargs)
 
@@ -328,8 +332,13 @@ class PackagedBuilder:
 
     @classmethod
     def from_script_path(
-        cls, script_path, project_path=None, extras=(), all_extras=True, **kwargs
-    ):
+        cls,
+        script_path: Path | str,
+        project_path: Path | str | None = None,
+        extras: Iterable[str] = (),
+        all_extras: bool = True,
+        **kwargs: Any,
+    ) -> PackagedBuilder:
         packager_kwargs = {"extras": extras, "all_extras": all_extras}
         packager = (
             WheelPackager(project_path, **packager_kwargs)
@@ -402,7 +411,7 @@ class PackagedRunner:
         return self._run
 
 
-def find_file_upwards(start, name):
+def find_file_upwards(start: Path | str, name: str) -> Path:
     path = Path(start).absolute()
     if path.is_file():
         path = path.parent
@@ -424,7 +433,7 @@ def _xorq_exe_resolved():
     return Path(found).resolve()
 
 
-def _normalize_xorq_cmd(args):
+def _normalize_xorq_cmd(args: tuple[str, ...]) -> tuple[str, ...]:
     """If args[0] resolves to the current xorq exe, replace it with bare 'xorq'."""
     resolved = _xorq_exe_resolved()
     if resolved is None:
@@ -434,7 +443,7 @@ def _normalize_xorq_cmd(args):
     return args
 
 
-def _nix_env():
+def _nix_env() -> dict[str, str] | None:
     """Return an env dict with LD_LIBRARY_PATH fixed for nix, or None outside nix."""
     if not in_nix_shell():
         return None
@@ -448,14 +457,14 @@ def _nix_env():
 
 
 def uv_tool_run(
-    *args,
-    isolated=True,
-    python_version=None,
-    with_=None,
-    with_requirements=None,
-    check=True,
-    capture_output=True,
-):
+    *args: str,
+    isolated: bool = True,
+    python_version: str | None = None,
+    with_: Path | str | None = None,
+    with_requirements: Path | str | None = None,
+    check: bool = True,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
     from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
 
     with tracer.start_as_current_span("packager.uv_tool_run") as span:
@@ -484,7 +493,12 @@ def uv_tool_run(
         return subprocess.run(run_args, check=check, **kwargs)
 
 
-def uv_export_requirements(project_dir, python_version, extras=(), all_extras=True):
+def uv_export_requirements(
+    project_dir: Path | str,
+    python_version: str,
+    extras: Iterable[str] = (),
+    all_extras: bool = True,
+) -> str:
     """Run uv export in a directory with pyproject.toml + uv.lock."""
     args = (
         "uv",

--- a/python/xorq/ibis_yaml/sql.py
+++ b/python/xorq/ibis_yaml/sql.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import warnings
-from typing import Any, Dict, List, Tuple, TypedDict
+from typing import Any, TypedDict
 
 import toolz
 
@@ -18,11 +20,11 @@ class QueryInfo(TypedDict):
 
 
 class SQLPlans(TypedDict):
-    queries: Dict[str, QueryInfo]
+    queries: dict[str, QueryInfo]
 
 
 class DeferredReadsPlan(TypedDict):
-    reads: Dict[str, QueryInfo]
+    reads: dict[str, QueryInfo]
 
 
 def to_sql(expr: ir.Expr) -> str:
@@ -40,7 +42,7 @@ def to_sql(expr: ir.Expr) -> str:
     return ibis.to_sql(expr.ls.uncached)
 
 
-def find_relations(expr: ir.Expr) -> List[str]:
+def find_relations(expr: ir.Expr) -> list[str]:
     def get_name(node):
         name = None
         if isinstance(node, RemoteTable):
@@ -57,12 +59,12 @@ def find_relations(expr: ir.Expr) -> List[str]:
     return relations
 
 
-def find_tables(expr: ir.Expr) -> Tuple[Dict[str, QueryInfo], Dict[str, QueryInfo]]:
+def find_tables(expr: ir.Expr) -> tuple[dict[str, QueryInfo], dict[str, QueryInfo]]:
     def get_remote_table_backend(node):
         return node.remote_expr._find_backend()
 
     grouped = toolz.groupby(type, walk_nodes((RemoteTable, Read), expr))
-    remote_tables: Dict[str, QueryInfo] = {
+    remote_tables: dict[str, QueryInfo] = {
         node.name: {
             "engine": backend.name,
             "profile_name": backend._profile.hash_name,
@@ -73,7 +75,7 @@ def find_tables(expr: ir.Expr) -> Tuple[Dict[str, QueryInfo], Dict[str, QueryInf
         for node in grouped.get(RemoteTable, ())
         if (backend := get_remote_table_backend(node))
     }
-    deferred_reads: Dict[str, QueryInfo] = {
+    deferred_reads: dict[str, QueryInfo] = {
         dt.name: {
             "engine": backend.name,
             "profile_name": backend._profile.hash_name,
@@ -89,7 +91,7 @@ def find_tables(expr: ir.Expr) -> Tuple[Dict[str, QueryInfo], Dict[str, QueryInf
     return remote_tables, deferred_reads
 
 
-def get_read_options(read_instance) -> Dict[str, Any]:
+def get_read_options(read_instance: Any) -> dict[str, Any]:
     read_kwargs_list = [{k: v} for k, v in read_instance.read_kwargs]
     return {
         "method_name": read_instance.method_name,
@@ -98,11 +100,11 @@ def get_read_options(read_instance) -> Dict[str, Any]:
     }
 
 
-def generate_sql_plans(expr: ir.Expr) -> Tuple[SQLPlans, DeferredReadsPlan]:
+def generate_sql_plans(expr: ir.Expr) -> tuple[SQLPlans, DeferredReadsPlan]:
     remote_tables, deferred_reads = find_tables(expr)
     backend = expr._find_backend()
 
-    queries: Dict[str, QueryInfo] = {
+    queries: dict[str, QueryInfo] = {
         "main": {
             "engine": backend.name,
             "profile_name": backend._profile.hash_name,

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -165,7 +165,7 @@ def _timestamp_unit_to_yaml(
 
 
 @register_from_yaml_handler("IntervalUnit")
-def _interval_unit_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
+def _interval_unit_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     unit_classes = {
         "DateUnit": tm.DateUnit,
         "TimeUnit": tm.TimeUnit,
@@ -193,7 +193,7 @@ def _int_to_yaml(val: int, context: TranslationContext) -> int:
 
 
 @register_from_yaml_handler("int")
-def _int_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
+def _int_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     return int(yaml_dict["value"])
 
 
@@ -203,7 +203,7 @@ def _float_to_yaml(dct: float, context: TranslationContext) -> dict:
 
 
 @register_from_yaml_handler("float")
-def _float_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
+def _float_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     return float(yaml_dict["value"])
 
 
@@ -326,7 +326,7 @@ def _datatype_to_yaml(dtype: dt.DataType, context: TranslationContext) -> dict:
 
 
 @register_from_yaml_handler("DataType")
-def _datatype_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
+def _datatype_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     typ = getattr(dt, yaml_dict["type"])
     dct = toolz.dissoc(yaml_dict, "op", "type")
     return typ(
@@ -338,7 +338,7 @@ def _datatype_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
 
 
 @translate_to_yaml.register(ir.Expr)
-def _expr_to_yaml(expr: ir.Expr, context: any) -> dict:
+def _expr_to_yaml(expr: ir.Expr, context: Any) -> dict:
     return context.translate_to_yaml(expr.op())
 
 
@@ -487,7 +487,7 @@ def database_table_from_yaml(yaml_dict: dict, context: TranslationContext) -> ib
 
 @translate_to_yaml.register(CachedNode)
 @convert_to_node_ref
-def _cached_node_to_yaml(op: CachedNode, context: any) -> dict:
+def _cached_node_to_yaml(op: CachedNode, context: Any) -> dict:
     # source should be called profile_name
     return freeze(
         {
@@ -502,7 +502,7 @@ def _cached_node_to_yaml(op: CachedNode, context: any) -> dict:
 
 
 @register_from_yaml_handler("CachedNode")
-def _cached_node_from_yaml(yaml_dict: dict, context: any) -> ibis.Expr:
+def _cached_node_from_yaml(yaml_dict: dict, context: Any) -> ibis.Expr:
     schema = context.get_schema(yaml_dict[RefEnum.schema_ref])
     name = yaml_dict["name"]
 

--- a/python/xorq/ibis_yaml/udf.py
+++ b/python/xorq/ibis_yaml/udf.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 import toolz
 
@@ -52,7 +54,7 @@ def _scalar_udf_to_yaml(op: ops.ScalarUDF, compiler: Any) -> dict:
 
 
 @register_from_yaml_handler("ScalarUDF")
-def _scalar_udf_from_yaml(yaml_dict: dict, compiler: any) -> any:
+def _scalar_udf_from_yaml(yaml_dict: dict, compiler: Any) -> Any:
     encoded_fn = yaml_dict.get("pickle")
     if not encoded_fn:
         raise ValueError("Missing pickle data for ScalarUDF")
@@ -124,7 +126,7 @@ def _dict_to_yaml(dct: dict, context: TranslationContext) -> dict:
 
 
 @register_from_yaml_handler("dict")
-def _dict_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
+def _dict_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     dct = {
         key: context.translate_from_yaml(value)
         for key, value in toolz.dissoc(yaml_dict, "op").items()
@@ -143,7 +145,7 @@ def _namespace_to_yaml(ns: ops.Namespace, context: TranslationContext) -> dict:
 
 
 @register_from_yaml_handler("Namespace")
-def _namespace_from_yaml(yaml_dict: dict, compiler: any) -> any:
+def _namespace_from_yaml(yaml_dict: dict, compiler: Any) -> Any:
     return ops.Namespace(**yaml_dict["dict"])
 
 
@@ -158,11 +160,11 @@ def _inputtype_to_yaml(it: ops.udf.InputType, context: TranslationContext) -> di
 
 
 @register_from_yaml_handler("InputType")
-def _inputtype_from_yaml(yaml_dict: dict, context: TranslationContext) -> any:
+def _inputtype_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     return getattr(ops.udf.InputType, yaml_dict["name"])
 
 
-def require_input_types(input_types, op):
+def require_input_types(input_types: Any, op: Any) -> None:
     if (input_type := getattr(op.__class__, "__input_type__", None)) not in input_types:
         raise NotImplementedError(
             f"Translation of UDFs with input type {input_type} is not supported"
@@ -170,7 +172,7 @@ def require_input_types(input_types, op):
         )
 
 
-def make_op_kwargs(op):
+def make_op_kwargs(op: Any) -> dict[str, Any]:
     argnames = op.argnames
     if argnames and argnames[-1] == "where":
         (*argnames, _) = argnames
@@ -178,7 +180,7 @@ def make_op_kwargs(op):
     return kwargs
 
 
-def kwargs_to_schema(kwargs):
+def kwargs_to_schema(kwargs: dict[str, Any]) -> Any:
     schema = ibis.schema({argname: arg.type() for argname, arg in kwargs.items()})
     return schema
 
@@ -209,7 +211,7 @@ def _aggudf_to_yaml(op: ops.udf.AggUDF, compiler: Any) -> dict:
 
 
 @register_from_yaml_handler("AggUDF")
-def _aggudf_from_yaml(yaml_dict: dict, compiler: any) -> any:
+def _aggudf_from_yaml(yaml_dict: dict, compiler: Any) -> Any:
     (kwargs, meta) = (
         translate_from_yaml(yaml_dict[name], compiler) for name in ("kwargs", "meta")
     )
@@ -266,7 +268,7 @@ def _exprscalarudf_to_yaml(op: udf.ExprScalarUDF, compiler: Any) -> dict:
 
 
 @register_from_yaml_handler(udf.ExprScalarUDF.__name__)
-def _aggudf_from_yaml(yaml_dict: dict, compiler: any) -> any:
+def _aggudf_from_yaml(yaml_dict: dict, compiler: Any) -> Any:
     (kwargs, meta) = (
         translate_from_yaml(yaml_dict[name], compiler) for name in ("kwargs", "meta")
     )
@@ -295,7 +297,7 @@ def _aggudf_from_yaml(yaml_dict: dict, compiler: any) -> any:
 
 
 @translate_to_yaml.register(FlightExpr)
-def flight_expr_to_yaml(op: FlightExpr, context: any) -> dict:
+def flight_expr_to_yaml(op: FlightExpr, context: Any) -> dict:
     input_expr_yaml = context.translate_to_yaml(op.input_expr)
     unbound_expr_yaml = context.translate_to_yaml(op.unbound_expr)
     make_server_pickle = serialize_callable(op.make_server)
@@ -315,7 +317,7 @@ def flight_expr_to_yaml(op: FlightExpr, context: any) -> dict:
 
 
 @register_from_yaml_handler("FlightExpr")
-def flight_expr_from_yaml(yaml_dict: Dict, context: Any) -> Any:
+def flight_expr_from_yaml(yaml_dict: dict, context: Any) -> Any:
     name = yaml_dict.get("name")
     input_expr_yaml = yaml_dict.get("input_expr")
     unbound_expr_yaml = yaml_dict.get("unbound_expr")
@@ -344,7 +346,7 @@ def flight_expr_from_yaml(yaml_dict: Dict, context: Any) -> Any:
 
 
 @translate_to_yaml.register(FlightUDXF)
-def flight_udxf_to_yaml(op: FlightUDXF, context: any) -> dict:
+def flight_udxf_to_yaml(op: FlightUDXF, context: Any) -> dict:
     input_expr_yaml = context.translate_to_yaml(op.input_expr)
     udxf_pickle = serialize_callable(op.udxf)
     make_server_pickle = serialize_callable(op.make_server)
@@ -365,7 +367,7 @@ def flight_udxf_to_yaml(op: FlightUDXF, context: any) -> dict:
 
 
 @register_from_yaml_handler("FlightUDXF")
-def flight_udxf_from_yaml(yaml_dict: Dict, context: Any) -> Any:
+def flight_udxf_from_yaml(yaml_dict: dict, context: Any) -> Any:
     name = yaml_dict.get("name")
     input_expr_yaml = yaml_dict.get("input_expr")
     udxf_pickle = yaml_dict.get("udxf")

--- a/python/xorq/ibis_yaml/utils.py
+++ b/python/xorq/ibis_yaml/utils.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import pathlib
 from collections.abc import Mapping, Sequence
-from typing import Any, Dict
+from typing import Any
 
 from xorq.caching import (
     ParquetCache,
@@ -13,7 +15,7 @@ from xorq.caching import (
 from xorq.vendor.ibis.common.collections import FrozenOrderedDict
 
 
-def freeze(obj):
+def freeze(obj: Any) -> Any:
     if isinstance(obj, dict):
         return FrozenOrderedDict({k: freeze(v) for k, v in obj.items()})
     elif isinstance(obj, list):
@@ -24,14 +26,16 @@ def freeze(obj):
 
 
 class MissingValue:
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<MISSING>"
 
 
 MISSING = MissingValue()
 
 
-def deep_diff_objects(obj1, obj2, path="root"):
+def deep_diff_objects(
+    obj1: Any, obj2: Any, path: str = "root"
+) -> list[tuple[str, Any, Any]]:
     differences = []
 
     if obj1 is not obj2:
@@ -66,7 +70,7 @@ def deep_diff_objects(obj1, obj2, path="root"):
         return differences
 
 
-def serialize_ibis_expr(expr):
+def serialize_ibis_expr(expr: Any) -> Any:
     try:
         op = expr.op()
     except Exception:
@@ -104,7 +108,7 @@ def serialize_ibis_expr(expr):
     return serialized
 
 
-def diff_ibis_exprs(expr1, expr2):
+def diff_ibis_exprs(expr1: Any, expr2: Any) -> list[tuple[str, Any, Any]] | None:
     if expr1.equals(expr2):
         print("Expressions are equal")
         return
@@ -126,7 +130,7 @@ def diff_ibis_exprs(expr1, expr2):
     return diffs
 
 
-def translate_cache(cache, translation_context: Any) -> Dict:
+def translate_cache(cache: Any, translation_context: Any) -> dict[str, Any]:
     if isinstance(cache, SourceCache):
         return {
             "type": "SourceCache",
@@ -160,7 +164,7 @@ def translate_cache(cache, translation_context: Any) -> Dict:
         raise NotImplementedError(f"Unknown cache type: {type(cache)}")
 
 
-def load_cache_from_yaml(cache_yaml: Dict, compiler: Any):
+def load_cache_from_yaml(cache_yaml: dict[str, Any], compiler: Any) -> Any:
     if cache_yaml["type"] == "SourceCache":
         source_profile_name = cache_yaml["source"]
         source = compiler.profiles[source_profile_name]

--- a/python/xorq/sql/parser.py
+++ b/python/xorq/sql/parser.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
+from typing import Any
+
 from xorq_datafusion._internal import parser
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     return getattr(parser, name)


### PR DESCRIPTION
Replace legacy typing imports (Dict/List/Optional/Union/Tuple) with built-in generics and X | None syntax. Add missing return types and parameter annotations to Backend methods in pandas, pyiceberg, datafusion, and IbisTableProvider.