### PR TITLE
fix(lineage): preserve tag_metadata structure in lineage DAG

### DIFF
--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import singledispatch
 from itertools import count
 from typing import Any, Callable, Tuple
@@ -196,6 +197,23 @@ class LineageDAG:
         )
 
 
+def _to_jsonable(v: Any) -> Any:
+    """Convert frozen tag metadata to JSON-friendly primitives.
+
+    Tag metadata may carry FrozenDict / FrozenOrderedDict / nested tuples
+    (e.g. BSL's serialized dimensions and measures). Stringifying them with
+    repr() loses structure for downstream consumers like `xorq catalog show
+    --json | jq`; recursing through Mapping/Sequence preserves it.
+    """
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return v
+    if isinstance(v, Mapping):
+        return {str(k): _to_jsonable(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_to_jsonable(x) for x in v]
+    return str(v)
+
+
 def _node_dict(node: Node, node_ids: dict[Node, str]) -> dict:
     d: dict[str, Any] = {
         "id": node_ids[node],
@@ -206,10 +224,7 @@ def _node_dict(node: Node, node_ids: dict[Node, str]) -> dict:
     if schema is not None:
         d["schema"] = {k: str(v) for k, v in schema.items()}
     if isinstance(node, rel.Tag):
-        d["tag_metadata"] = {
-            k: v if isinstance(v, (str, int, float, bool)) else str(v)
-            for k, v in node.metadata.items()
-        }
+        d["tag_metadata"] = {k: _to_jsonable(v) for k, v in node.metadata.items()}
     return d
 
 

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -211,6 +211,8 @@ def _to_jsonable(v: Any) -> Any:
         return {str(k): _to_jsonable(val) for k, val in v.items()}
     if isinstance(v, (list, tuple)):
         return [_to_jsonable(x) for x in v]
+    if isinstance(v, (set, frozenset)):
+        return [_to_jsonable(x) for x in sorted(v, key=str)]
     return str(v)
 
 
@@ -224,7 +226,7 @@ def _node_dict(node: Node, node_ids: dict[Node, str]) -> dict:
     if schema is not None:
         d["schema"] = {k: str(v) for k, v in schema.items()}
     if isinstance(node, rel.Tag):
-        d["tag_metadata"] = {k: _to_jsonable(v) for k, v in node.metadata.items()}
+        d["tag_metadata"] = _to_jsonable(node.metadata)
     return d
 
 

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -430,3 +430,35 @@ def test_lineage_dag_backward_compat_from_dict():
     assert isinstance(result.nodes, tuple)
     assert isinstance(result.edges, tuple)
     assert result.edges[0] == ("a", "b")
+
+
+def test_lineage_dag_tag_metadata_preserves_structure():
+    """Tag metadata with frozen mappings/sequences should round-trip as JSON,
+    not be flattened into Python repr strings."""
+    sales = xo.memtable({"x": [1]}, name="sales")
+    tagged = sales.tag(
+        tag="bsl",
+        name="flights",
+        dimensions=(
+            ("origin", (("description", None), ("is_entity", False))),
+            ("carrier", (("description", None), ("is_entity", False))),
+        ),
+        measures=(("flight_count", (("requires_unnest", ()),)),),
+    )
+
+    dag = extract_lineage_dag(tagged)
+    [tag_node] = [n for n in dag.nodes if n["type"] == "Tag"]
+    tm = tag_node["tag_metadata"]
+
+    assert tm["tag"] == "bsl"
+    assert tm["name"] == "flights"
+
+    # Top-level dimensions should be a list of [name, attrs] pairs, not a
+    # serialized "(('origin', (...)), ...)" string.
+    assert isinstance(tm["dimensions"], list)
+    assert [d[0] for d in tm["dimensions"]] == ["origin", "carrier"]
+    assert isinstance(tm["dimensions"][0][1], list)
+    assert tm["dimensions"][0][1][0] == ["description", None]
+
+    assert isinstance(tm["measures"], list)
+    assert [m[0] for m in tm["measures"]] == ["flight_count"]


### PR DESCRIPTION
## Summary

- `_node_dict` previously stringified non-primitive `tag_metadata` values via `str(v)`, flattening `FrozenDict` / `FrozenOrderedDict` / nested tuples into Python repr blobs.
- For BSL-tagged entries this meant `xorq catalog show --json` exposed dimensions/measures as serialized AST strings like `"(('origin', (('description', None), …)), ('carrier', …), ('dep_month', …))"`, forcing downstream consumers (e.g. `jq`) to regex-parse them.
- Recurse through `Mapping` / `list` / `tuple` in a small `_to_jsonable` helper, falling back to `str(v)` for unknown types. `tag_metadata` now round-trips as proper JSON in `expr_metadata.json`.

After:

```bash
xorq catalog show semantic-flights --json \
  | jq '.expr_metadata.lineage.nodes[] | select(.type=="Tag") | .tag_metadata
        | {name, dimensions: [.dimensions[][0]], measures: [.measures[][0]]}'
{ "name": "flights",
  "dimensions": ["origin", "carrier", "dep_month"],
  "measures":   ["flight_count", "avg_dep_delay", "late_pct"] }
```

## Test plan

- [x] `pytest python/xorq/common/utils/tests/test_lineage_utils.py` — new test `test_lineage_dag_tag_metadata_preserves_structure` plus all existing tests pass (15/15).
- [x] `pre-commit run --files python/xorq/common/utils/lineage_utils.py python/xorq/common/utils/tests/test_lineage_utils.py` — clean.
- [x] End-to-end check against a real BSL `to_tagged()` flights cube: `tag_metadata.dimensions[0]` comes out as `["origin", [["description", null], ["is_entity", false], …]]` instead of a repr string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)