### PR TITLE
release: 0.3.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.23] - 2026-05-07
+### Details
+#### Added
+- Add `xorq catalog show <name|alias>` for entry metadata by @hussainsultan in [#1918](https://github.com/xorq-labs/xorq/pull/1918)
+- Add bsl and thrift overrides for darwin by @hussainsultan in [#1925](https://github.com/xorq-labs/xorq/pull/1925)
+
+#### Changed
+- Catalog visual polish + configurable panels by @hussainsultan in [#1896](https://github.com/xorq-labs/xorq/pull/1896)
+- BSL semantic catalog + working-with-catalog tutorials (redo of #1878) by @paddymul in [#1920](https://github.com/xorq-labs/xorq/pull/1920)
+- Update dependency gitpython to v3.1.49 [security] by @renovate[bot] in [#1930](https://github.com/xorq-labs/xorq/pull/1930)
+- Update dependency pip to v26.1 [security] by @renovate[bot] in [#1926](https://github.com/xorq-labs/xorq/pull/1926)
+
+#### Fixed
+- Preserve tag_metadata structure in lineage DAG by @hussainsultan in [#1931](https://github.com/xorq-labs/xorq/pull/1931)
+
 ## [0.3.22] - 2026-05-05
 ### Details
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ only-include = ["python"]
 
 [project]
 name = "xorq"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
     "dask==2025.1.0; python_version >= '3.10' and python_version < '4.0'",
     "attrs>=24.1.0; python_version >= '3.10' and python_version < '4.0'",

--- a/uv.lock
+++ b/uv.lock
@@ -5861,7 +5861,7 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.22"
+version = "0.3.23"
 source = { editable = "." }
 dependencies = [
     { name = "atpublic" },


### PR DESCRIPTION
## Summary
- Bump version to 0.3.23
- Update CHANGELOG with entries since v0.3.22

## Changes since v0.3.22
**Added**
- `xorq catalog show <name|alias>` for entry metadata (#1918)
- bsl and thrift overrides for darwin (#1925)

**Changed**
- Catalog visual polish + configurable panels (#1896)
- BSL semantic catalog + working-with-catalog tutorials (redo of #1878) (#1920)
- Update dependency gitpython to v3.1.49 [security] (#1930)
- Update dependency pip to v26.1 [security] (#1926)

**Fixed**
- Preserve tag_metadata structure in lineage DAG (#1931)

## Test plan
- [ ] Trigger ci-pre-release workflow from this branch
- [ ] Wait for all ci-pre-release tests to pass
- [ ] Squash-and-merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)