### PR TITLE
feat(devcontainer): add unlock subcommand

### DIFF
--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -280,10 +280,12 @@ ensure_external_volumes() {
 ensure_up() {
     # Subshell scopes fd 9 so no child process can inherit the flock.
     (
-        flock -n 9 || {
+        if ! flock -n 9; then
             echo "Another devcontainer operation is in progress, waiting..."
-            flock 9
-        }
+            while ! flock -n 9; do
+                sleep 1
+            done
+        fi
 
         setup_claude_credentials
         ensure_external_volumes
@@ -426,6 +428,38 @@ case "${1:-up}" in
         fi
         python3 "$DEV_MAIN_TREE/.devcontainer/audit-report.py" "$audit_log" "${1:---summary}"
         ;;
+    unlock)
+        if [ ! -f "$DEV_LOCKFILE" ]; then
+            echo "No lockfile found ($DEV_LOCKFILE)"
+            exit 0
+        fi
+        # Test whether any process still holds the flock
+        if flock -n "$DEV_LOCKFILE" true 2>/dev/null; then
+            rm -f "$DEV_LOCKFILE"
+            echo "Removed stale lockfile: $DEV_LOCKFILE"
+        else
+            pids="$(fuser "$DEV_LOCKFILE" 2>/dev/null | tr -s ' ')" || true
+            if [ -z "$pids" ]; then
+                echo "Lock is actively held by unknown PID" >&2
+                exit 1
+            fi
+            echo "Lock is actively held:" >&2
+            for pid in $pids; do
+                cmd="$(ps -p "$pid" -o cmd= 2>/dev/null)" || cmd="(exited)"
+                printf "  PID %-8s %s\n" "$pid" "$cmd" >&2
+            done
+            echo ""
+            read -rp "Kill these processes and remove lockfile? [y/N] " answer
+            if [[ "$answer" != [yY]* ]]; then
+                exit 1
+            fi
+            for pid in $pids; do
+                kill "$pid" 2>/dev/null && echo "Killed PID $pid" || echo "PID $pid already exited"
+            done
+            rm -f "$DEV_LOCKFILE"
+            echo "Removed lockfile: $DEV_LOCKFILE"
+        fi
+        ;;
     status)
         if is_running; then
             echo "running: $DEV_CONTAINER_NAME (workspace: $DEV_WORKSPACE)"
@@ -457,6 +491,7 @@ Commands:
                                         use standalone when host gpg-agent restarts)
   fix-credentials                     repair credentials symlink in a running container
                                         (needed after upgrading from pre-shared-credentials build)
+  unlock                                remove stale lockfile (safe — refuses if lock is actively held)
   audit [--summary|--new|--all|--clear]  show permission audit log (default: --summary)
   completions [bash|zsh|fish]         emit shell completions
 USAGE

--- a/dev/devcontainer-completions
+++ b/dev/devcontainer-completions
@@ -10,7 +10,7 @@ _devcontainer() {
     local cur prev words cword
     _init_completion || return
 
-    local subcmds="up down reset clean status logs exec claude claude-dangerously-skip-permissions refresh-ssh refresh-gpg fix-credentials audit completions"
+    local subcmds="up down reset clean status logs exec claude claude-dangerously-skip-permissions refresh-ssh refresh-gpg fix-credentials unlock audit completions"
     local global_opts="-w --workspace"
 
     local i=1 subcmd=""
@@ -63,6 +63,7 @@ _devcontainer() {
         'refresh-ssh:re-forward SSH agent without container restart'
         'refresh-gpg:re-forward GPG agent without container restart'
         'fix-credentials:repair credentials symlink (after upgrading from pre-shared-credentials build)'
+        'unlock:remove stale lockfile'
         'audit:show permission audit log'
         'status:show whether the container is running'
         'logs:show container logs'
@@ -88,7 +89,7 @@ ZSH
         ;;
     fish)
         cat <<'FISH'
-set -l cmds up down reset clean status logs exec claude claude-dangerously-skip-permissions refresh-ssh refresh-gpg fix-credentials audit completions
+set -l cmds up down reset clean status logs exec claude claude-dangerously-skip-permissions refresh-ssh refresh-gpg fix-credentials unlock audit completions
 complete -c devcontainer -f
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -s w -l workspace -ra '(__fish_complete_directories)' -d 'workspace directory'
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a up -d 'start the dev container'
@@ -101,6 +102,7 @@ complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a claude-da
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a refresh-ssh -d 're-forward SSH agent without container restart'
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a refresh-gpg -d 're-forward GPG agent without container restart'
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a fix-credentials -d 'repair credentials symlink'
+complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a unlock -d 'remove stale lockfile'
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a audit -d 'show permission audit log'
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a status -d 'show whether the container is running'
 complete -c devcontainer -n "not __fish_seen_subcommand_from $cmds" -a logs -d 'show container logs'


### PR DESCRIPTION
## Summary
- Adds an `unlock` subcommand to the devcontainer script that safely removes stale lockfiles
- Shows each PID with its command line, then offers to kill and remove the lockfile with confirmation
- Fixes orphaned `flock` process bug: replaces blocking `flock 9` in `ensure_up` with a `flock -n` polling loop, so killing a waiting `devcontainer` process no longer leaves an invisible lock holder

## Context
When a `devcontainer` invocation was killed while waiting for the lock, the child `flock 9` process would get reparented to init and eventually acquire the lock — becoming an orphaned lock holder that blocked all future operations. The polling approach ensures no long-lived child process can outlive its parent.

## Test plan
- [ ] Run `devcontainer unlock` with no lockfile present — should print "No lockfile found" and exit 0
- [ ] Run `devcontainer unlock` with a stale lockfile — should remove it
- [ ] Run `devcontainer unlock` while another process holds the lock — should list PIDs with commands and prompt to kill
- [ ] Kill a `devcontainer` process while it's waiting for the lock — verify no orphaned `flock` process remains
- [ ] Verify completions work: `devcontainer <TAB>` shows `unlock` in bash/zsh/fish

🤖 Generated with [Claude Code](https://claude.com/claude-code)