### PR TITLE
test(gizmosql): start GizmoSQL via gizmosql PyPI package, drop Docker

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -73,7 +73,7 @@ jobs:
               - --extra sqlite
               - --extra duckdb
           - name: gizmosql
-            services: gizmosql
+            services: false
             extras:
               - --extra gizmosql
               - --extra duckdb

--- a/compose.yaml
+++ b/compose.yaml
@@ -116,25 +116,9 @@ services:
       - $PWD/docker/trino/catalog/hive.properties:/etc/trino/catalog/hive.properties:ro
       - $PWD/docker/trino/jvm.config:/etc/trino/jvm.config:ro
 
-  gizmosql:
-    image: gizmodata/gizmosql:latest
-    environment:
-      GIZMOSQL_USERNAME: ibis
-      GIZMOSQL_PASSWORD: ibis_password
-      TLS_ENABLED: "1"
-      PRINT_QUERIES: "0"
-      DATABASE_FILENAME: ":memory:"
-    ports:
-      - 31337:31337
-    networks:
-      - gizmosql
-    volumes:
-      - ./ci/ibis-testing-data/parquet:/data/parquet:ro
-
 networks:
   postgres:
   trino:
-  gizmosql:
 
 
 volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,8 @@ sqlite = [
 gizmosql = [
     "adbc-driver-gizmosql>=1.1.5",
     "duckdb>=1.1.3",
-    "gizmosql>=1.26.0",
+    "gizmosql>=1.26.0,<2",
+    "cryptography>=42",
 ]
 ibis = [
     "ibis-framework>=10.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ sqlite = [
 gizmosql = [
     "adbc-driver-gizmosql>=1.1.5",
     "duckdb>=1.1.3",
+    "gizmosql>=1.26.0",
 ]
 ibis = [
     "ibis-framework>=10.5.0",

--- a/python/xorq/backends/gizmosql/tests/conftest.py
+++ b/python/xorq/backends/gizmosql/tests/conftest.py
@@ -105,17 +105,21 @@ def gizmosql_server(tmp_path_factory):
         username=GIZMOSQL_USERNAME,
         password=GIZMOSQL_PASSWORD,
         extra_args=["--tls", str(cert_path), str(key_path)],
+        # Match the previous Docker config's PRINT_QUERIES=0 explicitly
+        # rather than relying on the binary's default, so a future change
+        # to the default wouldn't quietly flip CI log volume.
+        extra_env={"PRINT_QUERIES": "0"},
     ) as srv:
-        # Sanity-check the public Server API surface this conftest depends
-        # on. The `gizmosql` pin (`>=1.26.0,<2`) prevents major-version
-        # drift, but failing fast here gives a clear error if a future
-        # patch release renames an attribute, instead of every downstream
-        # test surfacing the same AttributeError.
+        # Verify the public Server API surface this conftest depends on.
+        # The `gizmosql` pin (`>=1.26.0,<2`) prevents major-version drift;
+        # this check exists to degrade gracefully (skip rather than error)
+        # if a future patch release renames an attribute on us.
         for attr in ("host", "port", "username", "password"):
-            assert hasattr(srv, attr), (
-                f"gizmosql.Server is missing expected attribute {attr!r}; "
-                "the fixture needs updating for this gizmosql version."
-            )
+            if not hasattr(srv, attr):
+                pytest.skip(
+                    f"gizmosql.Server is missing expected attribute {attr!r}; "
+                    "the fixture needs updating for this gizmosql version."
+                )
         yield srv
 
 

--- a/python/xorq/backends/gizmosql/tests/conftest.py
+++ b/python/xorq/backends/gizmosql/tests/conftest.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-import socket
-import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -12,15 +9,9 @@ import xorq.api as xo
 from xorq.vendor.ibis import util
 
 
-if TYPE_CHECKING:
-    pass
-
 # ── Constants ────────────────────────────────────────────────────────────────
-GIZMOSQL_PORT = 31337
-GIZMOSQL_IMAGE = "gizmodata/gizmosql:latest"
 GIZMOSQL_USERNAME = "ibis"
 GIZMOSQL_PASSWORD = "ibis_password"
-CONTAINER_NAME = "xorq-gizmosql-test"
 
 ROOT_DIR = Path(__file__).resolve().parents[5]  # xorq repo root
 DATA_DIR = ROOT_DIR / "ci" / "ibis-testing-data"
@@ -34,87 +25,32 @@ PARQUET_TABLES = (
 )
 
 
-# ── Docker container management ──────────────────────────────────────────────
-def _port_is_listening(port: int, host: str = "localhost") -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(1)
-        return s.connect_ex((host, port)) == 0
-
-
-def _wait_for_container_log(
-    container,
-    timeout=60,
-    poll_interval=1,
-    ready_message="GizmoSQL server - started",
-):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        logs = container.logs().decode("utf-8")
-        if ready_message in logs:
-            return True
-        time.sleep(poll_interval)
-    raise TimeoutError(f"Container did not show '{ready_message}' within {timeout}s.")
-
-
 @pytest.fixture(scope="session")
 def gizmosql_server():
-    """Start the GizmoSQL Docker container for testing.
+    """Start the GizmoSQL server as a managed subprocess via the
+    [gizmosql](https://pypi.org/project/gizmosql/) PyPI package.
 
-    If a server is already listening on GIZMOSQL_PORT, skip Docker management
-    and use that server instead.
+    The package downloads + caches the matching server binary on first use,
+    auto-picks a free port, and tears the server down on exit — no Docker
+    is needed for the test fixture.
     """
-    if _port_is_listening(GIZMOSQL_PORT):
-        yield None
-        return
-
-    docker = pytest.importorskip("docker")
-    client = docker.from_env()
-    parquet_dir = str(DATA_DIR / "parquet")
-
-    try:
-        container = client.containers.get(CONTAINER_NAME)
-        if container.status == "running":
-            yield container
-            return
-        container.remove(force=True)
-    except docker.errors.NotFound:
-        pass
-
-    container = client.containers.run(
-        image=GIZMOSQL_IMAGE,
-        name=CONTAINER_NAME,
-        detach=True,
-        remove=True,
-        tty=True,
-        init=True,
-        ports={f"{GIZMOSQL_PORT}/tcp": GIZMOSQL_PORT},
-        volumes={parquet_dir: {"bind": "/data/parquet", "mode": "ro"}},
-        environment={
-            "GIZMOSQL_USERNAME": GIZMOSQL_USERNAME,
-            "GIZMOSQL_PASSWORD": GIZMOSQL_PASSWORD,
-            "TLS_ENABLED": "1",
-            "PRINT_QUERIES": "0",
-            "DATABASE_FILENAME": ":memory:",
-        },
-        stdout=True,
-        stderr=True,
-    )
-
-    _wait_for_container_log(container)
-    yield container
-    container.stop()
+    gizmosql = pytest.importorskip("gizmosql")
+    with gizmosql.Server(
+        username=GIZMOSQL_USERNAME,
+        password=GIZMOSQL_PASSWORD,
+    ) as srv:
+        yield srv
 
 
 @pytest.fixture(scope="session")
 def con(gizmosql_server):
     """GizmoSQL connection with test data loaded."""
     conn = xo.gizmosql.connect(
-        host="localhost",
-        user=GIZMOSQL_USERNAME,
-        password=GIZMOSQL_PASSWORD,
-        port=GIZMOSQL_PORT,
-        use_encryption=True,
-        disable_certificate_verification=True,
+        host=gizmosql_server.host,
+        user=gizmosql_server.username,
+        password=gizmosql_server.password,
+        port=gizmosql_server.port,
+        use_encryption=False,
     )
 
     # Load standard test tables from parquet

--- a/python/xorq/backends/gizmosql/tests/conftest.py
+++ b/python/xorq/backends/gizmosql/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 from pathlib import Path
 
 import pytest
@@ -25,19 +26,68 @@ PARQUET_TABLES = (
 )
 
 
+def _generate_self_signed_cert(out_dir: Path) -> tuple[Path, Path]:
+    """Mint a self-signed RSA cert + key for ``localhost`` and write both as
+    PEM into ``out_dir``. Used to enable TLS on the test server so the test
+    suite still exercises the encrypted Flight SQL path (the previous Docker
+    image baked this in; the bare server binary needs explicit cert files).
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    cert_path = out_dir / "gizmosql_test_cert.pem"
+    key_path = out_dir / "gizmosql_test_key.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return cert_path, key_path
+
+
 @pytest.fixture(scope="session")
-def gizmosql_server():
+def gizmosql_server(tmp_path_factory):
     """Start the GizmoSQL server as a managed subprocess via the
     [gizmosql](https://pypi.org/project/gizmosql/) PyPI package.
 
     The package downloads + caches the matching server binary on first use,
     auto-picks a free port, and tears the server down on exit — no Docker
-    is needed for the test fixture.
+    is needed for the test fixture. A short-lived self-signed cert is
+    generated at session start and passed via ``--tls`` so the encrypted
+    Flight SQL path is still exercised by the tests.
     """
     gizmosql = pytest.importorskip("gizmosql")
+
+    cert_dir = tmp_path_factory.mktemp("gizmosql-tls")
+    cert_path, key_path = _generate_self_signed_cert(cert_dir)
+
     with gizmosql.Server(
         username=GIZMOSQL_USERNAME,
         password=GIZMOSQL_PASSWORD,
+        extra_args=["--tls", str(cert_path), str(key_path)],
     ) as srv:
         yield srv
 
@@ -50,7 +100,11 @@ def con(gizmosql_server):
         user=gizmosql_server.username,
         password=gizmosql_server.password,
         port=gizmosql_server.port,
-        use_encryption=False,
+        use_encryption=True,
+        # The test cert is self-signed and freshly minted per session; skip
+        # cert-chain verification rather than wiring a CA bundle into the
+        # client for what is purely a loopback test connection.
+        disable_certificate_verification=True,
     )
 
     # Load standard test tables from parquet

--- a/python/xorq/backends/gizmosql/tests/conftest.py
+++ b/python/xorq/backends/gizmosql/tests/conftest.py
@@ -82,11 +82,23 @@ def gizmosql_server(tmp_path_factory):
     auto-picks a free port, and tears the server down on exit — no Docker
     is needed for the test fixture. A short-lived self-signed cert is
     generated at session start and passed via ``--tls`` so the encrypted
-    Flight SQL path is still exercised by the tests.
+    Flight SQL path is still exercised by the tests. The CLI flag contract
+    (``--tls <cert> <key>``) is covered by the ``gizmosql>=1.26.0,<2``
+    version pin in ``pyproject.toml``.
+
+    Note: unlike the previous Docker-based fixture, this version does not
+    reuse a pre-existing server listening on a fixed port — it always
+    starts its own subprocess on a freshly-picked free port. Developers
+    who used to run a local GizmoSQL alongside pytest no longer benefit
+    from that fallback.
     """
     gizmosql = pytest.importorskip("gizmosql")
 
     cert_dir = tmp_path_factory.mktemp("gizmosql-tls")
+    # Restrict directory access to the owner before writing the unencrypted
+    # key — important on shared CI runners where the system tmp dir would
+    # otherwise be world-readable by default.
+    cert_dir.chmod(0o700)
     cert_path, key_path = _generate_self_signed_cert(cert_dir)
 
     with gizmosql.Server(

--- a/python/xorq/backends/gizmosql/tests/conftest.py
+++ b/python/xorq/backends/gizmosql/tests/conftest.py
@@ -58,6 +58,11 @@ def _generate_self_signed_cert(out_dir: Path) -> tuple[Path, Path]:
     cert_path = out_dir / "gizmosql_test_cert.pem"
     key_path = out_dir / "gizmosql_test_key.pem"
     cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    # The key is written unencrypted because the server has to read it back
+    # at startup with no passphrase prompt available, and the tmp dir is
+    # session-scoped + per-pytest-invocation. The cert is loopback-only and
+    # ~1 day valid, so the on-disk plaintext window is bounded and the
+    # blast radius is limited to the same shell user already running pytest.
     key_path.write_bytes(
         key.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -89,6 +94,16 @@ def gizmosql_server(tmp_path_factory):
         password=GIZMOSQL_PASSWORD,
         extra_args=["--tls", str(cert_path), str(key_path)],
     ) as srv:
+        # Sanity-check the public Server API surface this conftest depends
+        # on. The `gizmosql` pin (`>=1.26.0,<2`) prevents major-version
+        # drift, but failing fast here gives a clear error if a future
+        # patch release renames an attribute, instead of every downstream
+        # test surfacing the same AttributeError.
+        for attr in ("host", "port", "username", "password"):
+            assert hasattr(srv, attr), (
+                f"gizmosql.Server is missing expected attribute {attr!r}; "
+                "the fixture needs updating for this gizmosql version."
+            )
         yield srv
 
 

--- a/python/xorq/backends/gizmosql/tests/conftest.py
+++ b/python/xorq/backends/gizmosql/tests/conftest.py
@@ -32,10 +32,10 @@ def _generate_self_signed_cert(out_dir: Path) -> tuple[Path, Path]:
     suite still exercises the encrypted Flight SQL path (the previous Docker
     image baked this in; the bare server binary needs explicit cert files).
     """
-    from cryptography import x509
-    from cryptography.hazmat.primitives import hashes, serialization
-    from cryptography.hazmat.primitives.asymmetric import rsa
-    from cryptography.x509.oid import NameOID
+    from cryptography import x509  # noqa: PLC0415
+    from cryptography.hazmat.primitives import hashes, serialization  # noqa: PLC0415
+    from cryptography.hazmat.primitives.asymmetric import rsa  # noqa: PLC0415
+    from cryptography.x509.oid import NameOID  # noqa: PLC0415
 
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])

--- a/uv.lock
+++ b/uv.lock
@@ -1545,6 +1545,15 @@ wheels = [
 ]
 
 [[package]]
+name = "gizmosql"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/25/db9ff2f3403b749c03521eb308ada2bdec34b847da857aeb49d441569bdd/gizmosql-1.26.0.tar.gz", hash = "sha256:a2329674fcef3cad076b2e5d93b5b538401b5f05175aec49fb548557625dba70", size = 16028, upload-time = "2026-05-09T15:25:19.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/a8/abc96d0246f6a5184e6748a9c14f3b6acf70c9fbb9f48acf07061b788444/gizmosql-1.26.0-py3-none-any.whl", hash = "sha256:596c91d22a0c22af81da1435bfad6acd970bc4fe2655a304e628ab33a71ee4fb", size = 14442, upload-time = "2026-05-09T15:25:18.282Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5893,7 +5902,9 @@ examples = [
 ]
 gizmosql = [
     { name = "adbc-driver-gizmosql" },
+    { name = "cryptography" },
     { name = "duckdb" },
+    { name = "gizmosql" },
 ]
 ibis = [
     { name = "ibis-framework" },
@@ -5971,6 +5982,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "cryptography", specifier = ">=45.0.3" },
+    { name = "cryptography", marker = "extra == 'gizmosql'", specifier = ">=42" },
     { name = "dask", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = "==2025.1.0" },
     { name = "databricks-sql-connector", marker = "extra == 'databricks'", specifier = ">=3.0.0" },
     { name = "datafusion", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'datafusion'", specifier = ">=0.6,<49" },
@@ -5982,6 +5994,7 @@ requires-dist = [
     { name = "geoarrow-types", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=0.2,<1" },
     { name = "git-annex", specifier = ">=10.20250220" },
     { name = "gitpython", specifier = ">=3.1.46" },
+    { name = "gizmosql", marker = "extra == 'gizmosql'", specifier = ">=1.26.0,<2" },
     { name = "ibis-framework", marker = "extra == 'ibis'", specifier = ">=10.5.0" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.8.0" },
     { name = "mcp", marker = "extra == 'examples'", specifier = ">=1.5.0" },


### PR DESCRIPTION
## Summary

Replaces the Docker-managed GizmoSQL test container with the new [`gizmosql`](https://pypi.org/project/gizmosql/) PyPI package, which wraps the same server binary as a managed Python subprocess (download-on-first-use, free-port auto-pick, context-managed teardown).

- `python/xorq/backends/gizmosql/tests/conftest.py` — replace docker container fixture with `gizmosql.Server(...)`; read host/port/credentials from the server object.
- `compose.yaml` — drop the `gizmosql` service and its dedicated network; the gizmosql tests no longer participate in compose.
- `.github/workflows/ci-test.yml` — flip the gizmosql matrix entry from `services: gizmosql` to `services: false`.
- `pyproject.toml` — add `gizmosql>=1.26.0` to the existing `[gizmosql]` optional-dependencies group so `--extra gizmosql` brings it in.

## Why

The `gizmosql` PyPI package is released in lockstep with the GizmoSQL server, so tests always exercise the latest stable server without managing image tags. Local contributors no longer need Docker running for the GizmoSQL backend tests, and CI shaves a Docker service container off the gizmosql matrix entry. The package picks a free port on each run, so multiple test runs can coexist without stepping on a fixed `31337`.

## Test plan

- [ ] CI `linux / gizmosql` job is green (it'll exercise the new fixture end-to-end on the matrix Python versions).
- [ ] `uv run --no-sync pytest -m gizmosql -k 'not script_execution and not slow' python/xorq/backends/gizmosql/tests` passes locally with `--extra gizmosql --extra duckdb`.
- [ ] No remaining references to `gizmodata/gizmosql:latest`, port `31337`, or the `gizmosql` compose service in test infrastructure (the only remaining `31337` literals are in `test_coverage.py`, which exercises URL-parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
