### PR TITLE
fix: add expr_builder to KIND_ORDER, bump bsl 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ trino = [
     "trino==0.336.0",
 ]
 bsl = [
-    "boring-semantic-layer>=0.1.0",
+    "boring-semantic-layer>=0.3.13",
 ]
 databricks = [
     "databricks-sql-connector>=3.0.0",

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -142,7 +142,7 @@ def test_revision_row_columns_display_zero():
     assert RevisionRowData(column_count=0).columns_display == "0 cols"
 
 
-@pytest.mark.parametrize("kind", [str(k) for k in ExprKind])
+@pytest.mark.parametrize("kind", list(ExprKind))
 def test_kind_order_and_styles_cover_every_expr_kind(kind):
     """KIND_ORDER and KIND_STYLES must include every ExprKind value.
 
@@ -153,7 +153,7 @@ def test_kind_order_and_styles_cover_every_expr_kind(kind):
     assert kind in KIND_STYLES
 
 
-@pytest.mark.parametrize("kind", [str(k) for k in ExprKind])
+@pytest.mark.parametrize("kind", list(ExprKind))
 def test_styled_branch_label_renders_every_kind(kind):
     label = _styled_branch_label(kind, 1)
     assert kind in label.plain

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -32,6 +32,8 @@ from xorq.catalog.tests.testing import (
 )
 from xorq.catalog.tui import (
     GIT_LOG_COLUMNS,
+    KIND_ORDER,
+    KIND_STYLES,
     CatalogRowData,
     CatalogScreen,
     CatalogTUI,
@@ -43,11 +45,13 @@ from xorq.catalog.tui import (
     _build_git_log_rows,
     _entry_info,
     _format_cached,
+    _styled_branch_label,
     get_cache_key_path,
 )
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.env_utils import EnvConfigable, env_templates_dir
 from xorq.config import TUI, options
+from xorq.ibis_yaml.enums import ExprKind
 
 
 def _run(coro):
@@ -136,6 +140,24 @@ def test_revision_row_columns_display_int():
 
 def test_revision_row_columns_display_zero():
     assert RevisionRowData(column_count=0).columns_display == "0 cols"
+
+
+@pytest.mark.parametrize("kind", [str(k) for k in ExprKind])
+def test_kind_order_and_styles_cover_every_expr_kind(kind):
+    """KIND_ORDER and KIND_STYLES must include every ExprKind value.
+
+    Drift here causes branch ordering to drop the kind and
+    _styled_branch_label to KeyError at render time.
+    """
+    assert kind in KIND_ORDER
+    assert kind in KIND_STYLES
+
+
+@pytest.mark.parametrize("kind", [str(k) for k in ExprKind])
+def test_styled_branch_label_renders_every_kind(kind):
+    label = _styled_branch_label(kind, 1)
+    assert kind in label.plain
+    assert "(1)" in label.plain
 
 
 # ---------------------------------------------------------------------------

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -95,7 +95,7 @@ XORQ_DARK = Theme(
     },
 )
 
-KIND_ORDER = ("source", "expr", "unbound_expr", "composed")
+KIND_ORDER = ("source", "expr", "unbound_expr", "composed", "expr_builder")
 
 
 @frozen
@@ -109,6 +109,7 @@ KIND_STYLES: dict[str, KindStyle] = {
     "expr": KindStyle(icon="⊕", color=XORQ_DARK.success),
     "unbound_expr": KindStyle(icon="⊘", color=XORQ_DARK.warning),
     "composed": KindStyle(icon="⊛", color=XORQ_DARK.secondary),
+    "expr_builder": KindStyle(icon="⊡", color=XORQ_DARK.secondary),
 }
 
 CACHE_STYLE: dict[bool | None, tuple[str, str]] = {

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -44,6 +44,7 @@ from xorq.catalog.catalog import CatalogEntry
 from xorq.common.utils.caching_utils import CacheKey
 from xorq.common.utils.logging_utils import get_logger
 from xorq.config import options
+from xorq.ibis_yaml.enums import ExprKind
 
 
 logger = get_logger(__name__)
@@ -95,7 +96,13 @@ XORQ_DARK = Theme(
     },
 )
 
-KIND_ORDER = ("source", "expr", "unbound_expr", "composed", "expr_builder")
+KIND_ORDER: tuple[ExprKind, ...] = (
+    ExprKind.Source,
+    ExprKind.Expr,
+    ExprKind.UnboundExpr,
+    ExprKind.Composed,
+    ExprKind.ExprBuilder,
+)
 
 
 @frozen
@@ -104,12 +111,12 @@ class KindStyle:
     color: str = field(validator=instance_of(str))
 
 
-KIND_STYLES: dict[str, KindStyle] = {
-    "source": KindStyle(icon="⊞", color=XORQ_DARK.primary),
-    "expr": KindStyle(icon="⊕", color=XORQ_DARK.success),
-    "unbound_expr": KindStyle(icon="⊘", color=XORQ_DARK.warning),
-    "composed": KindStyle(icon="⊛", color=XORQ_DARK.secondary),
-    "expr_builder": KindStyle(icon="⊡", color=XORQ_DARK.secondary),
+KIND_STYLES: dict[ExprKind, KindStyle] = {
+    ExprKind.Source:      KindStyle(icon="⊞", color=XORQ_DARK.primary),
+    ExprKind.Expr:        KindStyle(icon="⊕", color=XORQ_DARK.success),
+    ExprKind.UnboundExpr: KindStyle(icon="⊘", color=XORQ_DARK.warning),
+    ExprKind.Composed:    KindStyle(icon="⊛", color=XORQ_DARK.secondary),
+    ExprKind.ExprBuilder: KindStyle(icon="⊡", color=XORQ_DARK.secondary),
 }
 
 CACHE_STYLE: dict[bool | None, tuple[str, str]] = {

--- a/uv.lock
+++ b/uv.lock
@@ -500,7 +500,7 @@ css = [
 
 [[package]]
 name = "boring-semantic-layer"
-version = "0.3.10"
+version = "0.3.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -511,9 +511,9 @@ dependencies = [
     { name = "toolz" },
     { name = "xorq" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/48/01440da4ff1917269fed653d8eb7ad42c5efa47471e90342491fddc92ef2/boring_semantic_layer-0.3.10.tar.gz", hash = "sha256:83b1d366bad34db9e671213848ee53555a96b6983ce59ddbbe6ad611088459be", size = 1327965, upload-time = "2026-03-25T19:21:48.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/bd/a4a2c27a088c19998ce4902e4dbc9ed25e264c2a406571b4a7638eaf147f/boring_semantic_layer-0.3.13.tar.gz", hash = "sha256:5ae96d1fd3d73260129a303c45d64e7a7199aa023896bc9d1e6c9b00c082ef07", size = 1367075, upload-time = "2026-05-05T11:23:32.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/6e/e0ecaad9fdf1f9ede6c3f5ab8b6fb69e4f4f9cfcbe31d725974ffa57bcb7/boring_semantic_layer-0.3.10-py3-none-any.whl", hash = "sha256:187285889c9e5d48267671f318335da0f395e15a2c6dc97f91a91d71ac605b9c", size = 545133, upload-time = "2026-03-25T19:21:46.684Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5c/fa7a989bd87e0e61451cf668bc8a3eb41da90a57bbbc158090043294457f/boring_semantic_layer-0.3.13-py3-none-any.whl", hash = "sha256:d00e58da9f0870d41c621aee7abb95fff0bf63522ff2a80c0a1acb7a65920864", size = 587435, upload-time = "2026-05-05T11:23:30.923Z" },
 ]
 
 [[package]]
@@ -5966,7 +5966,7 @@ requires-dist = [
     { name = "adbc-driver-sqlite", marker = "extra == 'sqlite'", specifier = ">=1.4.0" },
     { name = "atpublic", specifier = ">=5.1" },
     { name = "attrs", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=24.1.0" },
-    { name = "boring-semantic-layer", marker = "extra == 'bsl'", specifier = ">=0.1.0" },
+    { name = "boring-semantic-layer", marker = "extra == 'bsl'", specifier = ">=0.3.13" },
     { name = "cityhash", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=0.4.7,<1" },
     { name = "click", specifier = ">=8.0" },
     { name = "cloudpickle", specifier = ">=3.1.1" },


### PR DESCRIPTION
  Summary                                                                                     
                                                                                              
  - python/xorq/catalog/tui.py: add "expr_builder" to KIND_ORDER and add a matching           
  KIND_STYLES entry (⊡, secondary color). Without the styles entry, _styled_branch_label would
   KeyError for expr_builder rows.                                                            
  - pyproject.toml: bump the bsl extra from boring-semantic-layer>=0.1.0 to >=0.3.13. 0.3.13
  is the first BSL release that ships the xorq.from_tag_node entry point for the bsl tag;
  older versions silently degrade BSL entries to ExprKind.Expr.
  - uv.lock: refreshed (BSL 0.3.10 → 0.3.13).