### PR TITLE
fix(logging): drop None attribute values from RunLogger.log_span_event (#1940)

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -305,9 +305,11 @@ def run_command(
         ("limit", limit),
     )
 
+    span.add_event("run.params", {k: v for k, v in run_params if v is not None})  # see PR review
+
     try:
         with RunLogger.from_expr_hash(expr_hash, params_tuple=run_params) as rl:
-            rl.log_span_event(span, "run.start", dict(run_params))
+            rl.log_event("run.start", dict(run_params))  # see PR review
 
             with timed() as get_elapsed:
                 try:

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -307,6 +307,7 @@ def run_command(
 
     try:
         with RunLogger.from_expr_hash(expr_hash, params_tuple=run_params) as rl:
+            # here to hang PR comment off of
             rl.log_span_event(span, "run.params", dict(run_params))
 
             with timed() as get_elapsed:
@@ -538,6 +539,7 @@ def run_unbound_command(
     cache_dir = _get_cache_dir(cache_dir)
 
     span = trace.get_current_span()
+    # here to hang PR comment off of
     params = {
         "expr_path": str(expr_path),
         "output_format": str(output_format),

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -307,7 +307,7 @@ def run_command(
 
     try:
         with RunLogger.from_expr_hash(expr_hash, params_tuple=run_params) as rl:
-            rl.log_span_event(span, "run.start", dict(run_params))
+            rl.log_span_event(span, "run.params", dict(run_params))
 
             with timed() as get_elapsed:
                 try:
@@ -538,15 +538,15 @@ def run_unbound_command(
     cache_dir = _get_cache_dir(cache_dir)
 
     span = trace.get_current_span()
-    span.add_event(
-        "run_unbound.params",
-        {
-            "expr_path": str(expr_path),
-            "to_unbind_hash": str(to_unbind_hash),
-            "to_unbind_tag": str(to_unbind_tag),
-            "output_format": str(output_format),
-        },
-    )
+    params = {
+        "expr_path": str(expr_path),
+        "output_format": str(output_format),
+    }
+    if to_unbind_hash is not None:
+        params["to_unbind_hash"] = to_unbind_hash
+    if to_unbind_tag is not None:
+        params["to_unbind_tag"] = to_unbind_tag
+    span.add_event("run_unbound.params", params)
 
     # Resolve build identifier
     expr_path = ensure_build_dir(expr_path)

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -305,11 +305,9 @@ def run_command(
         ("limit", limit),
     )
 
-    span.add_event("run.params", {k: v for k, v in run_params if v is not None})
-
     try:
         with RunLogger.from_expr_hash(expr_hash, params_tuple=run_params) as rl:
-            rl.log_event("run.start", dict(run_params))
+            rl.log_span_event(span, "run.start", dict(run_params))
 
             with timed() as get_elapsed:
                 try:

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -305,11 +305,11 @@ def run_command(
         ("limit", limit),
     )
 
-    span.add_event("run.params", {k: v for k, v in run_params if v is not None})  # see PR review
+    span.add_event("run.params", {k: v for k, v in run_params if v is not None})
 
     try:
         with RunLogger.from_expr_hash(expr_hash, params_tuple=run_params) as rl:
-            rl.log_event("run.start", dict(run_params))  # see PR review
+            rl.log_event("run.start", dict(run_params))
 
             with timed() as get_elapsed:
                 try:

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -307,8 +307,7 @@ def run_command(
 
     try:
         with RunLogger.from_expr_hash(expr_hash, params_tuple=run_params) as rl:
-            # here to hang PR comment off of
-            rl.log_span_event(span, "run.params", dict(run_params))
+            rl.log_span_event(span, "run.start", dict(run_params))
 
             with timed() as get_elapsed:
                 try:
@@ -539,16 +538,15 @@ def run_unbound_command(
     cache_dir = _get_cache_dir(cache_dir)
 
     span = trace.get_current_span()
-    # here to hang PR comment off of
-    params = {
-        "expr_path": str(expr_path),
-        "output_format": str(output_format),
-    }
-    if to_unbind_hash is not None:
-        params["to_unbind_hash"] = to_unbind_hash
-    if to_unbind_tag is not None:
-        params["to_unbind_tag"] = to_unbind_tag
-    span.add_event("run_unbound.params", params)
+    span.add_event(
+        "run_unbound.params",
+        {
+            "expr_path": str(expr_path),
+            "to_unbind_hash": str(to_unbind_hash),
+            "to_unbind_tag": str(to_unbind_tag),
+            "output_format": str(output_format),
+        },
+    )
 
     # Resolve build identifier
     expr_path = ensure_build_dir(expr_path)

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -212,12 +212,7 @@ class RunLogger:
         self._fh.flush()
 
     def log_span_event(self, span, event: str, fields: dict = None):
-        """Log to both the run log and an OTel span.
-
-        The file log keeps every field for audit. The OTel span gets only
-        non-None values --- OTel rejects None attributes with a noisy
-        `Invalid type NoneType for attribute ...` warning (#1940).
-        """
+        """Log to both the run log and an OTel span. Cleans up OTel re #1940."""
         self.log_event(event, fields)
         if span is not None:
             span.add_event(

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -212,10 +212,18 @@ class RunLogger:
         self._fh.flush()
 
     def log_span_event(self, span, event: str, fields: dict = None):
-        """Log to both the run log and an OTel span."""
+        """Log to both the run log and an OTel span.
+
+        The file log keeps every field for audit. The OTel span gets only
+        non-None values --- OTel rejects None attributes with a noisy
+        `Invalid type NoneType for attribute ...` warning (#1940).
+        """
         self.log_event(event, fields)
         if span is not None:
-            span.add_event(event, fields or {})
+            span.add_event(
+                event,
+                {k: v for k, v in (fields or {}).items() if v is not None},
+            )
 
     def finalize(
         self,

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -212,7 +212,7 @@ class RunLogger:
         self._fh.flush()
 
     def log_span_event(self, span, event: str, fields: dict = None):
-        """Log to both the run log and an OTel span. Cleans up OTel re #1940."""
+        """Log to both the run log and an OTel span."""
         self.log_event(event, fields)
         if span is not None:
             span.add_event(

--- a/python/xorq/common/utils/tests/test_logging.py
+++ b/python/xorq/common/utils/tests/test_logging.py
@@ -86,9 +86,8 @@ def test_log_span_event_none_span(tmp_path):
 
 @pytest.mark.library
 def test_log_span_event_drops_none_attributes_from_span(tmp_path):
-    """span.add_event must not receive None-valued attributes (OTel rejects
-    them with `Invalid type NoneType for attribute ...` warnings). The file
-    log keeps everything for audit. Regression for #1940."""
+    # Regression test for #1940: span.add_event must drop None attrs
+    # (OTel rejects them); file log keeps everything for audit.
     run_dir = tmp_path / "test-run"
     run_dir.mkdir()
     rl = RunLogger(run_dir=run_dir)

--- a/python/xorq/common/utils/tests/test_logging.py
+++ b/python/xorq/common/utils/tests/test_logging.py
@@ -84,6 +84,7 @@ def test_log_span_event_none_span(tmp_path):
     assert events[0]["event"] == "my.event"
 
 
+@pytest.mark.library
 def test_log_span_event_drops_none_attributes_from_span(tmp_path):
     """span.add_event must not receive None-valued attributes (OTel rejects
     them with `Invalid type NoneType for attribute ...` warnings). The file

--- a/python/xorq/common/utils/tests/test_logging.py
+++ b/python/xorq/common/utils/tests/test_logging.py
@@ -87,7 +87,6 @@ def test_log_span_event_none_span(tmp_path):
 @pytest.mark.library
 def test_log_span_event_drops_none_attributes_from_span(tmp_path):
     # Regression test for #1940: span.add_event must drop None attrs
-    # (OTel rejects them); file log keeps everything for audit.
     run_dir = tmp_path / "test-run"
     run_dir.mkdir()
     rl = RunLogger(run_dir=run_dir)

--- a/python/xorq/common/utils/tests/test_logging.py
+++ b/python/xorq/common/utils/tests/test_logging.py
@@ -84,6 +84,30 @@ def test_log_span_event_none_span(tmp_path):
     assert events[0]["event"] == "my.event"
 
 
+def test_log_span_event_drops_none_attributes_from_span(tmp_path):
+    """span.add_event must not receive None-valued attributes (OTel rejects
+    them with `Invalid type NoneType for attribute ...` warnings). The file
+    log keeps everything for audit. Regression for #1940."""
+    run_dir = tmp_path / "test-run"
+    run_dir.mkdir()
+    rl = RunLogger(run_dir=run_dir)
+    span = MagicMock()
+
+    rl.log_span_event(
+        span, "my.event", {"good": "val", "limit": None, "ttl": None}
+    )
+
+    span.add_event.assert_called_once_with("my.event", {"good": "val"})
+
+    events = [
+        json.loads(line) for line in (run_dir / "run.jsonl").read_text().splitlines()
+    ]
+    assert len(events) == 1
+    assert events[0]["good"] == "val"
+    assert events[0]["limit"] is None
+    assert events[0]["ttl"] is None
+
+
 def test_log_event_none_fields(tmp_path):
     run_dir = tmp_path / "test-run"
     run_dir.mkdir()


### PR DESCRIPTION
## Summary

When calling `add_event` with a dictionary with `None` values a warning is thrown that a user can't act on of:

```
Invalid type NoneType for attribute 'limit' value. Expected one of
['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

Call sites previously had to protect calls to `log_span_event` with dictionary comprehensions like
```
span.add_event("run.params", {k: v for k, v in run_params if v is not None})
```
This PR builds that dictionary comprehension into `log_span_event`.  it doesn't protect an `add_event` call like above.

