### PR TITLE
fix(packager): trust uv.lock; stop byte-comparing on-disk requirements.txt (#1941)

### DIFF
--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -217,23 +217,19 @@ class WheelPackager:
         existing = self.project_path / DumpFiles.requirements
 
         if has_lockfile:
+            # uv.lock is authoritative. We regenerate `requirements.txt`
+            # from the lock here and bundle it in the build artifact.
+            # We don't compare against the user's on-disk file --- `uv
+            # export` output is not stable across uv versions, and any
+            # template shipped with a pre-baked requirements.txt would
+            # otherwise break the build on the first invocation by a
+            # user whose local uv differs (see #1941).
             with tracer.start_as_current_span("packager.uv_export_requirements"):
                 exported = uv_export_requirements(
                     self.project_path,
                     self.python_version,
                     extras=self.extras,
                     all_extras=self.all_extras,
-                )
-            if existing.exists() and existing.read_text() != exported:
-                raise RuntimeError(
-                    f"{DumpFiles.requirements} in {self.project_path} does not match "
-                    f"`uv export` output from {UVLOCK_NAME} (byte-exact comparison). "
-                    f"This happens when {UVLOCK_NAME} changes, or when the in-tree "
-                    f"{DumpFiles.requirements} was produced by a different uv version "
-                    f"than the one running now. To resolve: delete "
-                    f"{existing} and let the packager regenerate it, "
-                    f"or re-export manually with `uv export --locked --no-dev "
-                    f"--no-emit-project --no-header --no-annotate > {existing.name}`."
                 )
             (self.tmpdir / DumpFiles.requirements).write_text(exported)
         else:

--- a/python/xorq/ibis_yaml/tests/test_packager.py
+++ b/python/xorq/ibis_yaml/tests/test_packager.py
@@ -348,7 +348,14 @@ def test_wheel_bundle_from_build_path_no_wheel(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_write_requirements_path_rejects_stale_requirements(tmp_path, monkeypatch):
+@pytest.mark.library
+def test_write_requirements_path_prefers_export_over_stale_on_disk(
+    tmp_path, monkeypatch
+):
+    """When uv.lock exists, the lockfile is authoritative. An on-disk
+    `requirements.txt` exported by a different uv version must not break
+    the build --- the packager regenerates from the lock and uses that.
+    Regression for #1941."""
     _make_pyproject(tmp_path)
     (tmp_path / UVLOCK_NAME).write_text("# lockfile")
     (tmp_path / DumpFiles.requirements).write_text("requests==2.31.0\n")
@@ -357,12 +364,15 @@ def test_write_requirements_path_rejects_stale_requirements(tmp_path, monkeypatc
         "xorq.ibis_yaml.packager.uv_export_requirements",
         lambda *a, **kw: "flask==3.0.0\n",
     )
-    with pytest.raises(RuntimeError, match="does not match") as exc_info:
-        packager._write_requirements_path()
-    message = str(exc_info.value)
-    # Error must name the remediation paths explicitly so the user can act.
-    assert str(tmp_path / DumpFiles.requirements) in message
-    assert "uv export" in message
+
+    packager._write_requirements_path()
+
+    bundled = (packager.tmpdir / DumpFiles.requirements).read_text()
+    assert bundled == "flask==3.0.0\n"
+    # The user's on-disk requirements.txt is left untouched (we don't
+    # rewrite their working tree); only the build artifact reflects the
+    # authoritative lockfile export.
+    assert (tmp_path / DumpFiles.requirements).read_text() == "requests==2.31.0\n"
 
 
 # ---------------------------------------------------------------------------

--- a/python/xorq/ibis_yaml/tests/test_packager.py
+++ b/python/xorq/ibis_yaml/tests/test_packager.py
@@ -349,6 +349,22 @@ def test_wheel_bundle_from_build_path_no_wheel(tmp_path):
 
 
 @pytest.mark.library
+def test_write_requirements_path_copies_existing_when_no_lockfile(tmp_path):
+    """When uv.lock is absent, the packager has no authoritative source
+    of truth, so it copies the user's on-disk `requirements.txt` into
+    the build verbatim. Regression guard against accidentally re-routing
+    this branch through `uv export` (which would fail without a lock)."""
+    _make_pyproject(tmp_path)
+    (tmp_path / DumpFiles.requirements).write_text("requests==2.31.0\n")
+    packager = WheelPackager(tmp_path)
+
+    packager._write_requirements_path()
+
+    bundled = (packager.tmpdir / DumpFiles.requirements).read_text()
+    assert bundled == "requests==2.31.0\n"
+
+
+@pytest.mark.library
 def test_write_requirements_path_prefers_export_over_stale_on_disk(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

`xorq uv build` currently fails with a `RuntimeError: requirements.txt
... does not match` whenever the local `uv` version exports a slightly
different `requirements.txt` than the one shipped with the template.
This is the first command in the init tutorial after `xorq init` and
forces every reader to `rm requirements.txt` as a setup step.

The byte-comparison was a "did you forget to re-export?" safety check.
The cost is much higher than the benefit: `uv export` output is not
stable across uv versions, so the check breaks first-run reproducibly
across nearly any machine that wasn't used to publish the template.

## Fix

When `uv.lock` exists, the lockfile is authoritative. The packager
now generates a fresh export from the lock and bundles it in the
build directly. The user's on-disk `requirements.txt` is left
untouched — we don't rewrite their working tree.

## Why this is safe

- The build artifact already contains the freshly exported requirements
  pinned to `uv.lock`. Reproducibility comes from the lockfile, not
  from a stale on-disk export.
- The packager's existing test infra already worked around this bug by
  `unlink()`-ing `requirements.txt` before each invocation
  (`test_packager.py:prep_template_tmpdir`). That workaround can be
  removed in a follow-up; the slow-marker tests start exercising the
  new code path naturally.
- `_ensure_wheel_artifacts` and downstream consumers all read from the
  bundle's `requirements_path` (in the build dir), not from the user's
  working tree.

## Test plan

- [x] Failing test pushed first (TDD); confirmed failing on CI before fix.
- [x] After the fix, `test_write_requirements_path_prefers_export_over_stale_on_disk` passes.
- [x] Existing `@pytest.mark.slow` end-to-end packager tests
  (`test_wheel_packager`, `test_wheel_builder`, `test_wheel_runner`)
  continue to pass against all three templates.
- [ ] Manual: run `xorq init` then `xorq uv build` without the
  `rm requirements.txt` workaround. Build should succeed.

## Follow-up not in this PR

- `prep_template_tmpdir` still calls `stale_reqs.unlink()`. The
  workaround is no longer required after this fix — worth a quick
  cleanup in a separate change once this lands.
- The init tutorial currently documents the `rm requirements.txt`
  workaround with a link to #1941; that paragraph can come out once
  this ships in a release.

Fixes #1941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)