### PR TITLE
ci: skip docs-only PRs via paths-filter, always run on push to main

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -13,7 +13,15 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   benchmark:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -2,14 +2,6 @@ name: ci-lint
 
 on:
   push:
-    # Skip the backend suite if all changes are docs
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
       - master
@@ -23,7 +15,15 @@ permissions:
 
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-test-catalog.yml
+++ b/.github/workflows/ci-test-catalog.yml
@@ -2,13 +2,6 @@ name: ci-test-catalog
 
 on:
   push:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
     tags:
@@ -21,7 +14,15 @@ permissions:
 
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       # Run both partitions to completion even if one fails — they're

--- a/.github/workflows/ci-test-examples.yml
+++ b/.github/workflows/ci-test-examples.yml
@@ -2,14 +2,6 @@ name: ci-test-examples
 
 on:
   push:
-    # Skip the backend suite if all changes are docs
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
       - master
@@ -23,7 +15,15 @@ permissions:
 
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-test-ibis-compatibility.yml
+++ b/.github/workflows/ci-test-ibis-compatibility.yml
@@ -2,13 +2,6 @@ name: ci-test-ibis-compatibility
 
 on:
   push:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
     tags:
@@ -20,7 +13,15 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -2,14 +2,6 @@ name: ci-test-library
 
 on:
   push:
-    # Skip the backend suite if all changes are docs
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
       - master
@@ -23,7 +15,15 @@ permissions:
 
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-test-slow.yml
+++ b/.github/workflows/ci-test-slow.yml
@@ -2,14 +2,6 @@ name: ci-test-slow
 
 on:
   push:
-    # Skip the backend suite if all changes are docs
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
       - master
@@ -23,7 +15,15 @@ permissions:
 
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: bigger-runner
     strategy:
       matrix:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,14 +2,6 @@ name: ci-test
 
 on:
   push:
-    # Skip the backend suite if all changes are docs
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "**/*.qmd"
-      - "*.md"
-      - "codecov.yml"
-      - ".envrc"
     branches:
       - main
     tags:
@@ -22,7 +14,15 @@ permissions:
 
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
+
   linux:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -23,3 +23,5 @@ jobs:
               - '!docs/**'
               - '!**/*.md'
               - '!**/*.qmd'
+              - '!codecov.yml'
+              - '!.envrc'

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,25 @@
+name: detect-changes
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: "true if any non-docs files changed (always true for push/dispatch)"
+        value: ${{ jobs.changes.outputs.code }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.qmd'


### PR DESCRIPTION
paths-ignore on push skipped CI even after merging to main, masking
regressions introduced alongside doc edits. Skipped workflows also
produce no status check, leaving branch protection pending forever.

- remove paths-ignore from all push and pull_request triggers
- add reusable detect-changes.yml (dorny/paths-filter) that outputs
  code=true unconditionally on push/dispatch, false on doc-only PRs
- gate each workflow's main job on needs.changes.outputs.code == 'true'
  (skipped jobs satisfy required checks; absent workflows do not)
- grant pull-requests: read at job level so paths-filter can call
  the GitHub API without a checkout step
