### PR TITLE
docs: how xorq uses environments and uv

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -80,6 +80,7 @@ website:
           contents:
             - concepts/understanding_xorq/why_deferred_execution.qmd
             - concepts/understanding_xorq/expression_format.qmd
+            - concepts/understanding_xorq/environments_and_uv.qmd
         - id: execution-backends-section
           section: "Execution and backends"
           contents:

--- a/docs/concepts/understanding_xorq/environments_and_uv.qmd
+++ b/docs/concepts/understanding_xorq/environments_and_uv.qmd
@@ -37,7 +37,7 @@ This is the environment your editor sees, the one `uv run python -c "import xorq
 
 `xorq uv build` is the one that gets interesting. It does four things:
 
-1. Builds a wheel of your project's `src/` package.
+1. Builds a wheel of your project (typically the `src/` layout `xorq init` scaffolds; a flat layout works the same way).
 2. Runs `uv export` against your project's `uv.lock` to produce a `requirements.txt`.
 3. Invokes `uv tool run --isolated --with <wheel> --with-requirements <requirements.txt> xorq build …` to compile the expression in *that* ephemeral environment.
 4. Copies the wheel and `requirements.txt` into the build directory next to the serialized expression.
@@ -70,7 +70,12 @@ The `requirements.txt` that `xorq init` ships and that lives at the top of every
 
 There are two ways the in-tree copy can fall out of sync with the lock:
 
-1. **You changed `pyproject.toml` and re-locked.** Re-run `uv export --locked --no-dev --no-emit-project --no-header --no-annotate > requirements.txt` to refresh it, or just delete it.
+1. **You changed `pyproject.toml` and re-locked.** Re-export from the lock, or just delete the in-tree file and let the next build regenerate it:
+
+   ```bash
+   uv export --locked --no-dev --no-emit-project --no-header --no-annotate > requirements.txt
+   ```
+
 2. **A different uv version produced it.** `uv export` formatting (whitespace, ordering, marker syntax) drifts between uv releases. The exported text from uv `0.5.x` is not byte-identical to the same lock exported under `0.6.x`.
 
 The second case is the trap behind [#1941](https://github.com/xorq-labs/xorq/issues/1941)/[#1945](https://github.com/xorq-labs/xorq/pull/1945): the packager used to abort if the in-tree `requirements.txt` didn't match the live `uv export` byte-for-byte, which made first-run `xorq uv build` fail on any machine whose uv differed from the one that shipped the template. The current behavior trusts `uv.lock`, regenerates the requirements for the build, and leaves your working-tree copy alone.
@@ -79,6 +84,27 @@ The second case is the trap behind [#1941](https://github.com/xorq-labs/xorq/iss
 ### If you only remember one rule
 The lockfile is the source of truth. Everything else --- the in-tree `requirements.txt`, the build's `requirements.txt`, the synthesized runtime env --- is derived from it.
 :::
+
+## Adding a new package
+
+Because the lock is authoritative, adding a dependency is a single step regardless of which environment you ultimately care about. Run `uv add` from the project root:
+
+```bash
+uv add scikit-learn             # runtime dep -> env 2 and (next build) env 3
+uv add --dev pytest             # dev-only dep -> env 2; not exported to env 3
+```
+
+`uv add` updates `pyproject.toml`, refreshes `uv.lock`, and syncs `.venv`. Your editor and `uv run python …` see the new package immediately (env 2). Env 3 needs no separate command --- the next `xorq uv build` re-exports `requirements.txt` from the refreshed lock and bakes the new pin into the build directory.
+
+`--dev` dependencies stay in env 2 only; `xorq uv build` passes `--no-dev` when exporting, so test-only packages don't get shipped with the build.
+
+The CLI environment (env 1) is separate and rarely needs new packages, but if you want a plugin loaded alongside the `xorq` CLI itself, attach it at install time:
+
+```bash
+uv tool install xorq --with <plugin>     # or: uv tool upgrade xorq --with <plugin>
+```
+
+Plugins installed this way only affect env 1 --- they have no effect on the project venv or on what gets baked into a build.
 
 ## Putting it together
 

--- a/docs/concepts/understanding_xorq/environments_and_uv.qmd
+++ b/docs/concepts/understanding_xorq/environments_and_uv.qmd
@@ -1,0 +1,103 @@
+---
+title: "Environments and uv"
+---
+
+xorq leans on [uv](https://docs.astral.sh/uv/) for everything Python-environment-shaped: installing the CLI, locking the project, and rebuilding a frozen runtime out of a build directory. Once you've used xorq for half an hour you've already crossed three different Python environments without ever typing `pip` --- they look identical from the prompt but they answer the question "*which* xorq is running my code?" three different ways.
+
+This page names them, says when each one is active, and explains why `xorq run` and `xorq uv run` are not synonyms.
+
+## A 30-second uv primer
+
+[uv](https://docs.astral.sh/uv/) is Astral's package manager. The pieces that xorq actually touches:
+
+- **`uv tool install <pkg>`** --- installs `<pkg>` into a dedicated venv that uv owns, and puts its console scripts on your `PATH`. This is how you get the `xorq` command.
+- **`uvx <pkg>`** --- shorthand for `uv tool run <pkg>`: download `<pkg>` into a one-shot ephemeral environment, run it, throw the environment away. xorq's packager uses this form internally (with `--with-requirements` to pin the env) every time you run `xorq uv build` or `xorq uv run`.
+- **`uv lock`** --- resolves your project's dependencies and writes `uv.lock`. `uv sync` materializes a `.venv` from that lock. `uv run python …` runs a command inside that `.venv`, syncing first if needed.
+- **`uv export`** --- regenerates a `requirements.txt` from `uv.lock`. xorq uses this to build the pinned runtime that ships inside every build directory.
+
+If you've seen `pipx`, `pip-tools`, `virtualenv`, and `pyenv`, uv is roughly all of them, fast and one binary.
+
+## The three environments xorq uses
+
+After `xorq init my-project && cd my-project` you have a single working directory, but three environments are involved when you build and run.
+
+### 1. The CLI environment --- where the `xorq` command lives
+
+When you ran `uv tool install xorq`, uv created an isolated venv outside your project and dropped the `xorq` executable onto your `PATH`. That venv is what runs every `xorq …` invocation. It's stable across projects: you can `cd` between five different xorq projects and the same CLI runs in all of them.
+
+It's also pinned. Whatever xorq version you installed at `uv tool install` time is what handles your `xorq init`, `xorq build`, and `xorq run` calls until you `uv tool upgrade xorq`.
+
+### 2. The project environment --- `pyproject.toml` + `uv.lock` + `.venv`
+
+`xorq init` scaffolds a real Python project: `pyproject.toml` lists your direct dependencies, `uv.lock` records the full resolved graph (xorq and every transitive package, with hashes), and the first time you run `uv run python …` in the directory, uv materializes `.venv` from the lock.
+
+This is the environment your editor sees, the one `uv run python -c "import xorq.api as xo"` uses, and the one that anchors reproducibility for everything downstream. The lockfile is the source of truth --- whenever something downstream wants a `requirements.txt`, it's regenerated from `uv.lock`.
+
+### 3. The build-runtime environment --- the wheel + `requirements.txt` inside `builds/<hash>/`
+
+`xorq uv build` is the one that gets interesting. It does four things:
+
+1. Builds a wheel of your project's `src/` package.
+2. Runs `uv export` against your project's `uv.lock` to produce a `requirements.txt`.
+3. Invokes `uv tool run --isolated --with <wheel> --with-requirements <requirements.txt> xorq build …` to compile the expression in *that* ephemeral environment.
+4. Copies the wheel and `requirements.txt` into the build directory next to the serialized expression.
+
+The artifact in `builds/<hash>/` is therefore self-describing: it contains its own pinned dependency list and its own wheel. `xorq uv run <build>` reconstructs that environment on demand --- `uv tool run --isolated --with <wheel from build> --with-requirements <requirements.txt from build> xorq run <build>` --- and executes inside it. A build run on your laptop and the same build run on a teammate's machine resolve to byte-identical package versions.
+
+## `xorq run` vs `xorq uv run`
+
+Both commands take a build directory and execute the expression inside it. The difference is which environment they execute *in*:
+
+| Command | Python env | xorq version |
+|---|---|---|
+| `xorq run <build>` | CLI environment (env 1) | whatever you installed via `uv tool install` |
+| `xorq uv run <build>` | freshly synthesized from the build's pinned `requirements.txt` (env 3) | the xorq version pinned by the build's lockfile |
+
+`xorq run` is faster --- no env synthesis --- and fine for iterating against the build you just produced on the same machine with the same CLI. `xorq uv run` is what you reach for when reproducibility matters: handing a build to a teammate, running it from CI, running an older build with a newer CLI installed, or chasing a bug that smells environmental.
+
+::: {.callout-tip}
+### The reproducibility test
+If `xorq run <build>` and `xorq uv run <build>` produce different output for the same build, you've found a version skew between your CLI environment and the build's pinned environment. The build directory is the authoritative description of the runtime; the skew is in env 1.
+:::
+
+This split is also how an old bug in a pinned xorq can survive into a session where your *installed* xorq has the fix. The OTel `None`-attribute warning tracked in [#1940](https://github.com/xorq-labs/xorq/issues/1940)/[#1944](https://github.com/xorq-labs/xorq/pull/1944) showed up under `xorq uv run` against builds whose `requirements.txt` pinned a pre-fix xorq, even though `xorq run` from a newer install was clean --- because `xorq uv run` runs the version named in the build, not the version on your `PATH`.
+
+## `requirements.txt` --- generated, not authored
+
+The `requirements.txt` that `xorq init` ships and that lives at the top of every project is **not** something you edit. It's an export of `uv.lock`, kept around so the packager has a fast on-disk copy and so external tools can read pinned deps without parsing the lock format. The lock is authoritative; the export mirrors it.
+
+`xorq uv build` re-exports from `uv.lock` on every build, and bundles the freshly generated copy into `builds/<hash>/requirements.txt`. The in-tree `requirements.txt` is informational --- if you delete it the next build will regenerate it from the lock.
+
+There are two ways the in-tree copy can fall out of sync with the lock:
+
+1. **You changed `pyproject.toml` and re-locked.** Re-run `uv export --locked --no-dev --no-emit-project --no-header --no-annotate > requirements.txt` to refresh it, or just delete it.
+2. **A different uv version produced it.** `uv export` formatting (whitespace, ordering, marker syntax) drifts between uv releases. The exported text from uv `0.5.x` is not byte-identical to the same lock exported under `0.6.x`.
+
+The second case is the trap behind [#1941](https://github.com/xorq-labs/xorq/issues/1941)/[#1945](https://github.com/xorq-labs/xorq/pull/1945): the packager used to abort if the in-tree `requirements.txt` didn't match the live `uv export` byte-for-byte, which made first-run `xorq uv build` fail on any machine whose uv differed from the one that shipped the template. The current behavior trusts `uv.lock`, regenerates the requirements for the build, and leaves your working-tree copy alone.
+
+::: {.callout-note}
+### If you only remember one rule
+The lockfile is the source of truth. Everything else --- the in-tree `requirements.txt`, the build's `requirements.txt`, the synthesized runtime env --- is derived from it.
+:::
+
+## Putting it together
+
+A typical session crosses all three environments:
+
+```bash
+uv tool install xorq                                  # env 1: install CLI
+xorq init my-project && cd my-project                 # scaffold env 2 (uv.lock + pyproject.toml)
+uv run python -c "import xorq.api as xo"              # exercise env 2
+BUILD=$(xorq uv build expr.py -e expr | tail -1)      # env 1 -> spawns env 3 -> writes build dir
+xorq run    "$BUILD" --output-path out.parquet        # env 1 executes the build
+xorq uv run "$BUILD" --output-path out.parquet        # env 3 executes the build
+```
+
+The `xorq` command at every step is the env-1 binary. What changes is where the actual expression code runs --- in env 1 (your installed xorq, fast, less reproducible) or in env 3 (the build's pinned environment, slower first time, byte-reproducible across machines).
+
+## Further reading
+
+- [`uv` documentation](https://docs.astral.sh/uv/) --- especially the tools and projects sections
+- [`xorq build` reference](/api_reference/cli/build.qmd) and [`xorq uv build` reference](/api_reference/cli/uv-build.qmd)
+- [`xorq run` reference](/api_reference/cli/run.qmd) and [`xorq uv run` reference](/api_reference/cli/uv-run.qmd)
+- [Getting started with `xorq init`](/getting_started/get-started-with-xorq-init.qmd) --- the tutorial that walks through this end-to-end


### PR DESCRIPTION
## Summary

Adds a concept page — `docs/concepts/understanding_xorq/environments_and_uv.qmd` — that names the three Python environments a typical xorq session crosses and explains how `xorq run`, `xorq uv run`, `requirements.txt`, and `uv.lock` relate.

- **Env 1 (CLI):** `uv tool install xorq` creates an isolated venv outside any project; this is what `xorq …` always runs in.
- **Env 2 (project):** `pyproject.toml` + `uv.lock` + `.venv`. Editor + `uv run python` use this. Source of truth for reproducibility.
- **Env 3 (build runtime):** the `requirements.txt` + wheel that `xorq uv build` ships inside `builds/<hash>/`. `xorq uv run` rebuilds this env on demand via `uv tool run --with-requirements …`.

Driven by spending a long time understanding the bugs behind #1940/#1944 (which xorq is *actually* running my code?) and #1941/#1945 (why is `requirements.txt` failing the byte check?) — both are easy once you've internalized the three-env model, and the doc puts that model in one place.

## Why this lives under Concepts → Fundamentals

It explains a mental model that crosses several CLI commands rather than documenting any one of them; the CLI reference pages already exist and are linked from the bottom of the page.

## Test plan

- [ ] Render the site locally (`quarto preview docs`) and confirm the new page shows up under Concepts → Fundamentals between *Expression format* and the next section.
- [ ] Sanity-check the cross-references to `/api_reference/cli/build.qmd`, `/api_reference/cli/uv-build.qmd`, `/api_reference/cli/run.qmd`, `/api_reference/cli/uv-run.qmd`, and `/getting_started/get-started-with-xorq-init.qmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)