### PR TITLE
fix(deps): bump xorq-datafusion 0.2.5 >> 0.2.7 to fix Py_Finalize hang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "py-yaml12",
     "cloudpickle>=3.1.1",
     "envyaml>=1.10.211231",
-    "xorq-datafusion==0.2.5",
+    "xorq-datafusion==0.2.7",
     "opentelemetry-sdk>=1.32.1",
     "opentelemetry-exporter-otlp>=1.32.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",

--- a/python/xorq/backends/xorq_datafusion/tests/test_cli_compat.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_cli_compat.py
@@ -88,7 +88,7 @@ def test_python_udf_process_exits_cleanly(tmp_path):
         timeout=30,
         capture_output=True,
     )
-    assert result.returncode == 0, result.stderr.decode()
+    assert result.returncode == 0, result.stderr.decode(errors="replace")
     assert sentinel.exists(), (
         "atexit did not run — process likely hung or called os._exit"
     )

--- a/python/xorq/backends/xorq_datafusion/tests/test_cli_compat.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_cli_compat.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 
 import pytest
@@ -62,3 +63,32 @@ def test_output_format_accepted_by_cli(tmp_path, fmt):
     runner = CliRunner()
     result = runner.invoke(cli, ["run", str(tmp_path), "--format", fmt.value])
     assert "Invalid value for '-f' / '--format'" not in (result.output or "")
+
+
+@pytest.mark.xorq_datafusion
+def test_python_udf_process_exits_cleanly(tmp_path):
+    """Regression XOR-357: tokio blocking-pool must not race Py_Finalize at exit."""
+    sentinel = tmp_path / "atexit_ran"
+    script = (
+        "import atexit, sys\n"
+        "from pathlib import Path\n"
+        f"atexit.register(lambda: Path({str(sentinel)!r}).touch())\n"
+        "import xorq.api as xo\n"
+        "import xorq.expr.datatypes as dt\n"
+        "import pyarrow.compute as pc\n"
+        "@xo.udf.scalar.pyarrow\n"
+        "def double_it(arr: dt.int64) -> dt.int64:\n"
+        "    return pc.multiply(arr, 2)\n"
+        "con = xo.connect()\n"
+        "t = con.create_table('t', {'x': [1, 2, 3]})\n"
+        "assert double_it(t.x).execute().tolist() == [2, 4, 6]\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        timeout=30,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr.decode()
+    assert sentinel.exists(), (
+        "atexit did not run — process likely hung or called os._exit"
+    )

--- a/python/xorq/common/utils/ibis_utils.py
+++ b/python/xorq/common/utils/ibis_utils.py
@@ -83,9 +83,7 @@ def map_cast(cast, kwargs=None):
 def map_sort_key(key, kwargs=None):
     # ibis 12 renamed SortKey.expr → SortKey.arg; support both upstream
     # versions since the vendored copy still uses expr.
-    src = getattr(key, "arg", None)
-    if src is None:
-        src = key.expr
+    src = key.arg if hasattr(key, "arg") else key.expr
     return ops.SortKey(
         expr=map_ibis(src, None),
         ascending=key.ascending,

--- a/python/xorq/common/utils/ibis_utils.py
+++ b/python/xorq/common/utils/ibis_utils.py
@@ -14,6 +14,7 @@ from ibis.expr.datatypes import DataType as IbisDataType
 from ibis.expr.datatypes.core import Interval as IbisInterval
 from ibis.expr.operations.generic import Cast as IbisCast
 from ibis.expr.operations.relations import Namespace as IbisNamespace
+from ibis.expr.operations.sortkeys import SortKey as IbisSortKey
 from ibis.formats.pandas import PandasDataFrameProxy as IbisPandasDataFrameProxy
 from ibis.formats.pyarrow import PyArrowTableProxy as IbisPyArrowTableProxy
 
@@ -76,6 +77,20 @@ def map_builtin_dict(op, kwargs=None):
 @map_ibis.register(IbisCast)
 def map_cast(cast, kwargs=None):
     return ops.Cast(arg=map_ibis(cast.arg, None), to=map_ibis(cast.to, None))
+
+
+@map_ibis.register(IbisSortKey)
+def map_sort_key(key, kwargs=None):
+    # ibis 12 renamed SortKey.expr → SortKey.arg; support both upstream
+    # versions since the vendored copy still uses expr.
+    src = getattr(key, "arg", None)
+    if src is None:
+        src = key.expr
+    return ops.SortKey(
+        expr=map_ibis(src, None),
+        ascending=key.ascending,
+        nulls_first=key.nulls_first,
+    )
 
 
 @map_ibis.register(IbisSchema)

--- a/uv.lock
+++ b/uv.lock
@@ -6017,7 +6017,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.3.0" },
     { name = "uv", specifier = ">=0.7.20" },
     { name = "xgboost", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'examples'", specifier = ">=1.6.1" },
-    { name = "xorq-datafusion", specifier = "==0.2.5" },
+    { name = "xorq-datafusion", specifier = "==0.2.7" },
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
 ]
@@ -6063,23 +6063,20 @@ test = [
 
 [[package]]
 name = "xorq-datafusion"
-version = "0.2.5"
+version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/f0/cdf7aea073b2bc1f5864e3792d9e8b3003b3147a6164b33bb2dd56bc2de6/xorq_datafusion-0.2.5.tar.gz", hash = "sha256:3e81e69c58556494ad3728f8e27fbdbf779ca67fce33980c84e97dbb66883e70", size = 20626755, upload-time = "2025-12-17T14:41:52.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/d01aaf4b6f6940f8709321d356ca29490280a0bce85b90f4247b13256725/xorq_datafusion-0.2.7.tar.gz", hash = "sha256:be1dbdbef6ea513df1aae189fe5fa6e54a8e8556dc824a74a888473b4c1929cb", size = 20639907, upload-time = "2026-05-14T11:00:22.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/cc/3dd6148e7f8c3b59cad2f1efd09922dd7089a379a06821540529d9a9d17c/xorq_datafusion-0.2.5-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a6c295b438966fa4257443d0635d8c346d462afaf319831966a0908b064b14ec", size = 42405161, upload-time = "2025-12-17T14:41:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/28/7ecd70e09f078298e30ec94fa605ce8b678d2e83453c9c7aa917ca812ccf/xorq_datafusion-0.2.5-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:e4717d8fdfce89ee500750bf189bf1719ba324c277381eeb1e5b2feb21ec53e6", size = 40068779, upload-time = "2025-12-17T14:41:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/01/03/7b23347f54825b30960a7691e2483c88294201e44471d8153d600906fe84/xorq_datafusion-0.2.5-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c32d30baaeec30f761771934d8e9b62b3d3436b474a413542927f9cc051fec", size = 50202159, upload-time = "2025-12-17T14:41:30.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/93/8083bba0fd205ca811984fc71f18a06ecbd4a857351c3de0948dca026a3b/xorq_datafusion-0.2.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:948a783380bb51dd0de827433414c01c28ed6660eaaa246faa0040e6daddb246", size = 45667583, upload-time = "2025-12-17T14:41:33.11Z" },
-    { url = "https://files.pythonhosted.org/packages/38/b7/0550a8c694b419eda36c6e6c7f60fd2a9e032189586fac0bb073182c4d99/xorq_datafusion-0.2.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bc9b92ed0e09f53feb8049eab0d5c02bb75204fbaf8f80a96ee6ae33f239683d", size = 44002341, upload-time = "2025-12-17T14:41:35.981Z" },
-    { url = "https://files.pythonhosted.org/packages/04/0d/2d3a2c5f929528bdfe3afbd15ad28813d5d01820dc88bf9fd1079f601b8d/xorq_datafusion-0.2.5-cp38-abi3-win32.whl", hash = "sha256:e0d6b63766c43e3c36c66d38ba71b40699065bd1ce795efc22e1f9e91cb2479a", size = 34385556, upload-time = "2025-12-17T14:41:38.566Z" },
-    { url = "https://files.pythonhosted.org/packages/64/89/d6811880f3a9b381fa4e50df7f27bbeccccd6985ff05f85ee3added3225b/xorq_datafusion-0.2.5-cp38-abi3-win_amd64.whl", hash = "sha256:e7206853ef20c48a38ed7b24fce0a743fdcd12de40c2015a034ae37a76e72573", size = 39385564, upload-time = "2025-12-17T14:41:41.029Z" },
-    { url = "https://files.pythonhosted.org/packages/72/6c/a1b83f292cef9ea95646a69a8b3a58a856892cb8a8e8d36671f02108b849/xorq_datafusion-0.2.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c456e4cff93e76abcc3b30c888d9c0a5fbdb77553bc8f22ff36dbbb1b5b4d7df", size = 43994555, upload-time = "2025-12-17T14:41:43.805Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/bb/eef7a76c612f95a47da5573f593879513f13ee84cc770e09aa47b80e767f/xorq_datafusion-0.2.5-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e4354979c60164fb6f6aff7b116fc938fd5b204629033f7275f29370d18f860", size = 50196801, upload-time = "2025-12-17T14:41:46.534Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a2/74faac562c4ec9cb930f9a73a1a89ee6fb5a53fdf57e2da597a54eb6f450/xorq_datafusion-0.2.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e88801cd628f39be1db2bdbc7443c80157c7f2441b41bacbd1576eb4e723b83", size = 45655221, upload-time = "2025-12-17T14:41:49.368Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/84/e514a0e1d63197817de49da5d940136060e57447396c69748ebae210c291/xorq_datafusion-0.2.7-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5152aabfc7452ef5e7f7469d7ed835cb6d478696745ce98eccac1abf9cb04112", size = 48099334, upload-time = "2026-05-14T10:59:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/51/98/5f8a1555af37c4a814c69231015ac08dea4ade4e8b250509bb65cdc56ae3/xorq_datafusion-0.2.7-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:3874fc7e0186e53dcce7fe5390a71be97c8c386f5044063cb96327a64d6a9112", size = 45730841, upload-time = "2026-05-14T10:59:54.741Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/8137598bf67c40ea0b75d39adfe8a3b6824440a56e9bc201f3d26992c355/xorq_datafusion-0.2.7-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:225b612874ee2da79c2a7d80ec4e7040baaf6db0f1fa364dc79b16b320fb17c0", size = 58486501, upload-time = "2026-05-14T10:59:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/23/2fa5c4eb26d3755cf34df95aeb79af76647e04159c88897232a561b46fdd/xorq_datafusion-0.2.7-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fec22bd24018410152fc5f8582033e86046f0f31e581aaa2f29103d3dacb35ef", size = 51751418, upload-time = "2026-05-14T11:00:04.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4c/1309100ba3e21be388d8dec28c4560481447cada4f409da1ea0863b7bd70/xorq_datafusion-0.2.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b1177c5dcd9ea3b519d2c9d2db16296740463f2302319dda88983a9204463a32", size = 49958539, upload-time = "2026-05-14T11:00:09.619Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6a/5dcf6d9db0d7b94afc9851f309c505b9edd4c4c571c11efd301a4dad12cc/xorq_datafusion-0.2.7-cp38-abi3-win32.whl", hash = "sha256:36193827af0c134b14dcf6229ffe9d064e8e8a94888373e6ecaf4c47a5ef6587", size = 40319107, upload-time = "2026-05-14T11:00:14.359Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/35/e820dba4c884f3eb6aaec6a8a53b94db0a4a7d9ec1b2cc4bbfde45df26fd/xorq_datafusion-0.2.7-cp38-abi3-win_amd64.whl", hash = "sha256:b018b51dc8d1a4c9336cb3a477885fe5224e376b8ba83a2fa191c43dde90e6fe", size = 44687714, upload-time = "2026-05-14T11:00:18.889Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1889,7 +1889,7 @@ wheels = [
 
 [[package]]
 name = "ibis-framework"
-version = "11.0.0"
+version = "12.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "atpublic" },
@@ -1900,9 +1900,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/c8/f03c7c6e8ab96e5efd67ea5ce6eaf575bde78b4bfb9115f283d5e6e19ea2/ibis_framework-11.0.0.tar.gz", hash = "sha256:0249185eaabb800e224f448cc06ce8ba168df00b269e132d62629f462eca8842", size = 1237767, upload-time = "2025-10-15T13:12:10.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/8e/2e7ad9bdeaf45350da7beeb67a0d4317d400dac882825eb7c3bd4d3c6ae1/ibis_framework-12.0.0.tar.gz", hash = "sha256:238624f2c14fdab8382ca2f4f667c3cdb81e29844cd5f8db8a325d0743767c61", size = 1351369, upload-time = "2026-02-07T14:31:13.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/c0/2851a8a55d0fea03b80fd45815069b686e032938fc68fa9d91ac776c148c/ibis_framework-11.0.0-py3-none-any.whl", hash = "sha256:92ff82a96f4eac7f86fa9b6a315e04b5a8f9ed3d186539d88f48e628363f2e72", size = 1935652, upload-time = "2025-10-15T13:12:07.954Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/b3/11d406849715b47c9d69bb22f50874f80caee96bd1cbe7b61abbebbf5a05/ibis_framework-12.0.0-py3-none-any.whl", hash = "sha256:0bbd790f268da9cb87926d5eaad2b827a573927113c4ed3be5095efa89b9e512", size = 2079219, upload-time = "2026-02-07T14:31:10.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Root cause (XOR-357)

xorq-datafusion held a process-wide tokio multi-thread runtime. At exit, CPython's Py_Finalize raced with tokio's blocking-pool shutdown: workers mid-Python-callback re-entered pyo3 on a finalizing interpreter → panic → process hung forever. The workaround was os._exit() in cli.py main().

## Fix

xorq-datafusion 0.2.7 registers xorq_datafusion.close() via atexit on import. close() calls shutdown_runtime() which takes the runtime out of the process-wide Option<Runtime> before Py_Finalize starts. Runtime::drop during finalization is then a no-op (unit struct), no more hang.

Verified: explicit close(0) in main() is redundant — the atexit handler is the real fix. main() stays as a bare cli() call.

## Tests added

- test_main_atexit_runs_without_os_exit (test_cli.py): subprocess guards against future os._exit regression; sentinel file proves atexit fired.

- test_python_udf_process_exits_cleanly (test_cli_compat.py): subprocess loads real xorq_datafusion, registers + executes a Python UDF through DataFusion (spawns tokio blocking workers), then exits. Asserts process completes within 30s and atexit fires. Catches both the hang and any future os._exit regression. Verified it fails when os._exit is injected.

Closes XOR-357