### PR TITLE
feat(cli): add `xorq serve` for already-unbound expressions

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -627,6 +627,61 @@ def unbind_and_serve_command(
     server.wait()
 
 
+@_lazy_span("cli.serve_unbound_expr_command")
+def serve_unbound_expr_command(
+    expr_path,
+    host=None,
+    port=None,
+    prometheus_port=None,
+    cache_dir=None,
+):
+    import xorq.expr.relations
+    from xorq.common.utils.graph_utils import walk_nodes
+    from xorq.common.utils.logging_utils import get_print_logger
+    from xorq.ibis_yaml.compiler import load_expr
+    from xorq.vendor.ibis.expr.operations import UnboundTable
+
+    logger = get_print_logger()
+    cache_dir = _get_cache_dir(cache_dir)
+
+    expr_path = ensure_build_dir(expr_path)
+    logger.info(f"Loading expression from {expr_path}")
+    try:
+        from xorq.flight.metrics import setup_console_metrics
+
+        setup_console_metrics(prometheus_port=prometheus_port)
+    except ImportError:
+        logger.warning(
+            "Metrics support requires 'opentelemetry-sdk' and console exporter"
+        )
+
+    unbound_expr = load_expr(expr_path, cache_dir=cache_dir)
+    match walk_nodes(UnboundTable, unbound_expr):
+        case []:
+            raise click.ClickException(
+                f"expression at {expr_path} is not unbound (no UnboundTable found); "
+                "use `xorq serve-unbound` instead"
+            )
+        case [_]:
+            pass
+        case nodes:
+            raise click.ClickException(
+                f"expression at {expr_path} contains {len(nodes)} UnboundTable nodes; "
+                "expected exactly one"
+            )
+
+    flight_url = xorq.flight.FlightUrl(host=host, port=port)
+    make_server = partial(
+        xorq.flight.FlightServer,
+        flight_url=flight_url,
+    )
+    server, _ = xorq.expr.relations.flight_serve_unbound(
+        unbound_expr, make_server=make_server
+    )
+    logger.info(f"Serving expression from '{expr_path}' on {flight_url.to_location()}")
+    server.wait()
+
+
 @_lazy_span("cli.serve_command")
 def serve_command(
     expr_path,
@@ -1087,6 +1142,47 @@ def serve_unbound(
         prometheus_port,
         cache_dir,
         typ,
+    )
+
+
+@cli.command("serve")
+@click.argument("build_path")
+@click.option(
+    "--host",
+    default="localhost",
+    help="Host to bind Flight Server (default: localhost)",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=None,
+    help="Port to bind Flight Server (default: random)",
+)
+@click.option(
+    "--cache-dir",
+    default=None,
+    help="Directory for all generated parquet files cache",
+)
+@click.option(
+    "--prometheus-port",
+    type=int,
+    default=None,
+    help="Port to expose Prometheus metrics (default: disabled)",
+)
+def serve(
+    build_path,
+    host,
+    port,
+    cache_dir,
+    prometheus_port,
+):
+    """Serve an already-unbound expr via Flight Server."""
+    serve_unbound_expr_command(
+        build_path,
+        host,
+        port,
+        prometheus_port,
+        cache_dir,
     )
 
 

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -23,6 +23,7 @@ from xorq.cli import (
 from xorq.common.utils.io_utils import Peeker
 from xorq.common.utils.logging_utils import Run, Runs
 from xorq.common.utils.node_utils import (
+    expr_to_unbound,
     find_node,
 )
 from xorq.common.utils.process_utils import (
@@ -1063,6 +1064,57 @@ def test_serve_unbound_tag_get_exchange_udf(fixture_dir, tmp_path):
         actual = xo.connect().register(df).select("x").pipe(f).execute()
 
         assert not actual.empty
+
+
+@pytest.mark.slow(level=1)
+@pytest.mark.xdist_group(name="serve")
+def test_serve_unbound_expr(pipeline_https_build, tmp_path):
+    batting_url = "https://storage.googleapis.com/letsql-pins/batting/20240711T171118Z-431ef/batting.parquet"
+    serve_tag = "read-batting"
+
+    expr = load_expr(pipeline_https_build)
+    unbound_expr = expr_to_unbound(
+        expr,
+        hash=None,
+        tag=serve_tag,
+        typs=None,
+        strategy=SnapshotStrategy(),
+    ).to_expr()
+    builds_dir = tmp_path / "builds"
+    build_dir = build_expr(unbound_expr, builds_dir=builds_dir)
+
+    serve_args = (
+        "xorq",
+        "serve",
+        str(build_dir),
+    )
+    with serve_process(serve_args) as (proc, peeker):
+        port = peek_port(proc, peeker)
+
+        flight_backend = xo.flight.connect(port=port)
+        f = flight_backend.get_exchange("default")
+        actual = xo.deferred_read_parquet(batting_url).pipe(f).execute()
+
+        expected = expr.execute()
+        (actual, expected) = (
+            df.sort_values(list(df.columns), ignore_index=True)
+            for df in (actual, expected)
+        )
+        assert actual.equals(expected)
+
+
+@pytest.mark.slow(level=1)
+@pytest.mark.xdist_group(name="serve")
+def test_serve_rejects_bound_expr(pipeline_https_build):
+    serve_args = (
+        "xorq",
+        "serve",
+        str(pipeline_https_build),
+    )
+    proc = _subprocess.run(serve_args, capture_output=True, timeout=60)
+    assert proc.returncode != 0
+    stderr = proc.stderr.decode("ascii")
+    assert "not unbound" in stderr
 
 
 @pytest.mark.slow(level=3)


### PR DESCRIPTION
Serves a build that already contains an UnboundTable without requiring a hash/tag, complementing `serve-unbound`. Pre-validates exactly one UnboundTable and errors with a CLI-friendly message otherwise.