### PR TITLE
fix(packager): surface stderr/stdout in uv_tool_run failures

### DIFF
--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -44,7 +44,7 @@ class UvToolRunError(subprocess.CalledProcessError):
             parts.append(f"stderr:\n{self.stderr.rstrip()}")
         if self.stdout:
             parts.append(f"stdout:\n{self.stdout.rstrip()}")
-        return "\n".join(parts)
+        return "\n\n".join(parts)
 
 
 PYPROJECT_NAME = "pyproject.toml"
@@ -503,7 +503,9 @@ def uv_tool_run(
         try:
             return subprocess.run(run_args, check=check, **kwargs)
         except subprocess.CalledProcessError as e:
-            raise UvToolRunError(e.returncode, e.cmd, e.stdout, e.stderr) from e
+            raise UvToolRunError(
+                e.returncode, e.cmd, output=e.output, stderr=e.stderr
+            ) from e
 
 
 def uv_export_requirements(project_dir, python_version, extras=(), all_extras=True):

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -490,7 +490,13 @@ def uv_tool_run(
         env = _nix_env()
         if env is not None:
             kwargs["env"] = env
-        return subprocess.run(run_args, check=check, **kwargs)
+        try:
+            return subprocess.run(run_args, check=check, **kwargs)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"uv tool run failed (exit {e.returncode}):\n"
+                f"{e.stderr or ''}{e.stdout or ''}"
+            ) from e
 
 
 def uv_export_requirements(project_dir, python_version, extras=(), all_extras=True):

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -37,6 +37,16 @@ from xorq.common.utils.process_utils import in_nix_shell
 from xorq.ibis_yaml.enums import DumpFiles
 
 
+class UvToolRunError(subprocess.CalledProcessError):
+    def __str__(self):
+        parts = [super().__str__()]
+        if self.stderr:
+            parts.append(f"stderr:\n{self.stderr.rstrip()}")
+        if self.stdout:
+            parts.append(f"stdout:\n{self.stdout.rstrip()}")
+        return "\n".join(parts)
+
+
 PYPROJECT_NAME = "pyproject.toml"
 UVLOCK_NAME = "uv.lock"
 DEFAULT_REQUIRES_PYTHON = ">=3.10"
@@ -493,10 +503,7 @@ def uv_tool_run(
         try:
             return subprocess.run(run_args, check=check, **kwargs)
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                f"uv tool run failed (exit {e.returncode}):\n"
-                f"{e.stderr or ''}{e.stdout or ''}"
-            ) from e
+            raise UvToolRunError(e.returncode, e.cmd, e.stdout, e.stderr) from e
 
 
 def uv_export_requirements(project_dir, python_version, extras=(), all_extras=True):

--- a/python/xorq/ibis_yaml/tests/test_packager.py
+++ b/python/xorq/ibis_yaml/tests/test_packager.py
@@ -1,4 +1,5 @@
 import functools
+import subprocess
 import sys
 import tempfile
 import zipfile
@@ -27,6 +28,7 @@ from xorq.ibis_yaml.packager import (
     UVLOCK_NAME,
     PackagedBuilder,
     PackagedRunner,
+    UvToolRunError,
     WheelBundle,
     WheelPackager,
     _link_mode_args,
@@ -609,3 +611,41 @@ def test_uv_export_requirements_surfaces_stderr_on_failure(monkeypatch):
     with pytest.raises(RuntimeError, match="uv export failed") as exc_info:
         uv_export_requirements("/proj", ">=3.10")
     assert "project has no lock" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# uv_tool_run: error surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_uv_tool_run_surfaces_stderr_and_stdout_on_failure(monkeypatch):
+    def _raise(args, **kw):
+        raise subprocess.CalledProcessError(
+            1, args, output="build output\n", stderr="resolver error\n"
+        )
+
+    monkeypatch.setattr("xorq.ibis_yaml.packager.subprocess.run", _raise)
+    with pytest.raises(UvToolRunError) as exc_info:
+        uv_tool_run("xorq", "--version", capture_output=False)
+    err = exc_info.value
+    assert isinstance(err, subprocess.CalledProcessError)
+    assert err.returncode == 1
+    assert err.cmd is not None
+    msg = str(err)
+    assert "stderr:" in msg
+    assert "resolver error" in msg
+    assert "stdout:" in msg
+    assert "build output" in msg
+
+
+def test_uv_tool_run_error_omits_empty_streams(monkeypatch):
+    def _raise(args, **kw):
+        raise subprocess.CalledProcessError(2, args)
+
+    monkeypatch.setattr("xorq.ibis_yaml.packager.subprocess.run", _raise)
+    with pytest.raises(UvToolRunError) as exc_info:
+        uv_tool_run("xorq", "--version", capture_output=False)
+    msg = str(exc_info.value)
+    assert "stderr:" not in msg
+    assert "stdout:" not in msg
+    assert "exit status 2" in msg


### PR DESCRIPTION
## Summary

- When `uv tool run` fails, `CalledProcessError` only shows the exit code because output is captured. This introduces a `UvToolRunError(CalledProcessError)` subclass whose `__str__` appends labeled stderr/stdout sections, preserving structured attributes (`.cmd`, `.returncode`, `.stdout`, `.stderr`) and `isinstance` checks while surfacing the root cause.

## Test plan

- [x] Trigger a `uv tool run` failure (e.g. missing dependency) and verify the error message includes the actual stderr output
- [x] Verify empty streams are omitted from the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)