### PR TITLE
fix(ci): add missing pytestmark to 163 test files skipped by CI

### DIFF
--- a/python/xorq/backends/databricks/tests/test_basic.py
+++ b/python/xorq/backends/databricks/tests/test_basic.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
+
+
+pytestmark = pytest.mark.databricks
 
 
 def test_execute_returns_dataframe(functional_alltypes):

--- a/python/xorq/backends/databricks/tests/test_datatypes.py
+++ b/python/xorq/backends/databricks/tests/test_datatypes.py
@@ -7,6 +7,9 @@ import xorq.vendor.ibis.expr.schema as sch
 from xorq.vendor.ibis.util import gen_name
 
 
+pytestmark = pytest.mark.databricks
+
+
 @pytest.fixture
 def tmp_table(con):
     name = gen_name("databricks_tmp_table")

--- a/python/xorq/backends/databricks/tests/test_into_backend_and_cache.py
+++ b/python/xorq/backends/databricks/tests/test_into_backend_and_cache.py
@@ -6,6 +6,9 @@ import xorq.api as xo
 from xorq.caching import ParquetCache, SourceCache
 
 
+pytestmark = pytest.mark.databricks
+
+
 @pytest.fixture
 def ddb_batting(data_dir):
     ddb = xo.duckdb.connect()

--- a/python/xorq/backends/databricks/tests/test_json.py
+++ b/python/xorq/backends/databricks/tests/test_json.py
@@ -5,6 +5,9 @@ import pytest
 from xorq.vendor.ibis.util import gen_name
 
 
+pytestmark = pytest.mark.databricks
+
+
 @pytest.fixture
 def tmp_table(con):
     """Create a temporary table in the Databricks backend."""

--- a/python/xorq/backends/datafusion/tests/test_cache.py
+++ b/python/xorq/backends/datafusion/tests/test_cache.py
@@ -9,6 +9,9 @@ from xorq.caching import (
 )
 
 
+pytestmark = pytest.mark.datafusion
+
+
 @pytest.mark.parametrize(
     "get_expr",
     [

--- a/python/xorq/backends/datafusion/tests/test_udwf.py
+++ b/python/xorq/backends/datafusion/tests/test_udwf.py
@@ -1,10 +1,14 @@
 import pandas as pd
 import pyarrow as pa
+import pytest
 from datafusion import udwf
 from datafusion.user_defined import WindowEvaluator
 
 import xorq.api as xo
 from xorq.expr.relations import into_backend
+
+
+pytestmark = pytest.mark.datafusion
 
 
 class SmoothTwoColumn(WindowEvaluator):

--- a/python/xorq/backends/duckdb/tests/test_asof_join.py
+++ b/python/xorq/backends/duckdb/tests/test_asof_join.py
@@ -5,6 +5,9 @@ import pytest
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.duckdb
+
+
 try:
     from duckdb import InvalidInputException as DuckDBInvalidInputException
 except ImportError:

--- a/python/xorq/backends/duckdb/tests/test_basic.py
+++ b/python/xorq/backends/duckdb/tests/test_basic.py
@@ -14,6 +14,9 @@ from xorq.tests.util import assert_frame_equal, check_eq
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.duckdb
+
+
 KEY_PREFIX = xo.config.options.cache.key_prefix
 
 

--- a/python/xorq/backends/pandas/tests/test_arrays.py
+++ b/python/xorq/backends/pandas/tests/test_arrays.py
@@ -9,6 +9,9 @@ from xorq.tests.util import assert_frame_equal, assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize("arr", [[1, 3, 5], np.array([1, 3, 5])])
 @pytest.mark.parametrize("create_arr_expr", [ibis.literal, ibis.array])
 def test_array_literal(client, arr, create_arr_expr):

--- a/python/xorq/backends/pandas/tests/test_caching.py
+++ b/python/xorq/backends/pandas/tests/test_caching.py
@@ -1,11 +1,15 @@
 import dask
 import pandas as pd
+import pytest
 
 import xorq.api as xo
 from xorq.backends.conftest import KEY_PREFIX, get_cache_uncached
 from xorq.caching import SourceCache, SourceSnapshotCache
 from xorq.expr.relations import into_backend
 from xorq.vendor import ibis
+
+
+pytestmark = pytest.mark.pandas
 
 
 def test_pandas_snapshot(xo_con, alltypes_df):

--- a/python/xorq/backends/pandas/tests/test_cast.py
+++ b/python/xorq/backends/pandas/tests/test_cast.py
@@ -12,6 +12,9 @@ from xorq.tests.util import assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 TIMESTAMP = "2022-03-13 06:59:10.467417"
 
 

--- a/python/xorq/backends/pandas/tests/test_client.py
+++ b/python/xorq/backends/pandas/tests/test_client.py
@@ -11,6 +11,9 @@ import xorq.vendor.ibis.expr.operations as ops
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.fixture
 def client():
     return xo.pandas.connect(

--- a/python/xorq/backends/pandas/tests/test_core.py
+++ b/python/xorq/backends/pandas/tests/test_core.py
@@ -9,6 +9,9 @@ from xorq.backends.pandas import Backend
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.fixture
 def dataframe():
     return pd.DataFrame(

--- a/python/xorq/backends/pandas/tests/test_format.py
+++ b/python/xorq/backends/pandas/tests/test_format.py
@@ -1,8 +1,13 @@
 import re
 
+import pytest
+
 import xorq.api as xo
 from xorq.api import _
 from xorq.common.utils.defer_utils import deferred_read_csv
+
+
+pytestmark = pytest.mark.pandas
 
 
 def test_read(csv_dir):

--- a/python/xorq/backends/pandas/tests/test_functions.py
+++ b/python/xorq/backends/pandas/tests/test_functions.py
@@ -18,6 +18,9 @@ from xorq.tests.util import assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize(
     "op",
     [

--- a/python/xorq/backends/pandas/tests/test_helpers.py
+++ b/python/xorq/backends/pandas/tests/test_helpers.py
@@ -5,6 +5,9 @@ import pytest
 from xorq.backends.pandas.helpers import RowsFrame
 
 
+pytestmark = pytest.mark.pandas
+
+
 lst = list(range(10))
 
 

--- a/python/xorq/backends/pandas/tests/test_join.py
+++ b/python/xorq/backends/pandas/tests/test_join.py
@@ -9,6 +9,9 @@ from xorq.backends.pandas.tests.conftest import is_older_than
 from xorq.tests.util import assert_frame_equal, assert_series_equal
 
 
+pytestmark = pytest.mark.pandas
+
+
 # SEMI and ANTI are checked in backend tests
 mutating_join_type = pytest.mark.parametrize(
     "how",

--- a/python/xorq/backends/pandas/tests/test_maps.py
+++ b/python/xorq/backends/pandas/tests/test_maps.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from xorq.tests.util import assert_series_equal
 from xorq.vendor import ibis
+
+
+pytestmark = pytest.mark.pandas
 
 
 def test_map_length_expr(t):

--- a/python/xorq/backends/pandas/tests/test_operations.py
+++ b/python/xorq/backends/pandas/tests/test_operations.py
@@ -16,6 +16,9 @@ from xorq.tests.util import assert_frame_equal, assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 def test_table_column(t, df):
     expr = t.plain_int64
     result = expr.execute()

--- a/python/xorq/backends/pandas/tests/test_ops.py
+++ b/python/xorq/backends/pandas/tests/test_ops.py
@@ -8,6 +8,9 @@ from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.expr import datatypes as dt
 
 
+pytestmark = pytest.mark.pandas
+
+
 table_name = "test"
 
 

--- a/python/xorq/backends/pandas/tests/test_strings.py
+++ b/python/xorq/backends/pandas/tests/test_strings.py
@@ -12,6 +12,9 @@ from xorq.tests.util import assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize(
     ("case_func", "expected_func"),
     [

--- a/python/xorq/backends/pandas/tests/test_structs.py
+++ b/python/xorq/backends/pandas/tests/test_structs.py
@@ -12,6 +12,9 @@ from xorq.tests.util import assert_frame_equal, assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.fixture(scope="module")
 def value():
     return OrderedDict([("fruit", "pear"), ("weight", 0)])

--- a/python/xorq/backends/pandas/tests/test_temporal.py
+++ b/python/xorq/backends/pandas/tests/test_temporal.py
@@ -16,6 +16,9 @@ from xorq.tests.util import assert_series_equal
 from xorq.vendor.ibis import literal as L
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize(
     ("case_func", "expected_func"),
     [

--- a/python/xorq/backends/pandas/tests/test_udf.py
+++ b/python/xorq/backends/pandas/tests/test_udf.py
@@ -15,6 +15,9 @@ from xorq.tests.util import assert_frame_equal, assert_series_equal
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.fixture
 def df():
     return pd.DataFrame(

--- a/python/xorq/backends/pandas/tests/test_window.py
+++ b/python/xorq/backends/pandas/tests/test_window.py
@@ -16,6 +16,9 @@ from xorq.vendor import ibis
 from xorq.vendor.ibis.legacy.udf.vectorized import reduction
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.fixture(scope="session")
 def sort_kind():
     return "mergesort"

--- a/python/xorq/backends/postgres/tests/test_cache.py
+++ b/python/xorq/backends/postgres/tests/test_cache.py
@@ -14,6 +14,9 @@ from xorq.common.utils.postgres_utils import (
 )
 
 
+pytestmark = pytest.mark.postgres
+
+
 @pytest.mark.parametrize(
     "name",
     (

--- a/python/xorq/backends/postgres/tests/test_read.py
+++ b/python/xorq/backends/postgres/tests/test_read.py
@@ -5,6 +5,9 @@ from adbc_driver_manager._lib import OperationalError
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.postgres
+
+
 def test_read_csv(pg, iris_path):
     name = "iris"
     table_name = f"testing-{name}"

--- a/python/xorq/backends/pyiceberg/tests/test_basic.py
+++ b/python/xorq/backends/pyiceberg/tests/test_basic.py
@@ -4,6 +4,9 @@ from xorq.backends.pyiceberg.tests.conftest import QUOTES_TABLE_NAME
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.pyiceberg
+
+
 def test_create_table(iceberg_con, quotes_df):
     # the iceberg_con fixture creates the table
     assert QUOTES_TABLE_NAME in iceberg_con.list_tables()

--- a/python/xorq/backends/pyiceberg/tests/test_connect.py
+++ b/python/xorq/backends/pyiceberg/tests/test_connect.py
@@ -5,6 +5,9 @@ import pytest
 from xorq.backends.pyiceberg import Backend as PyIcebergBackend
 
 
+pytestmark = pytest.mark.pyiceberg
+
+
 def test_can_connect(iceberg_con):
     assert iceberg_con is not None
 

--- a/python/xorq/backends/pyiceberg/tests/test_extra.py
+++ b/python/xorq/backends/pyiceberg/tests/test_extra.py
@@ -1,9 +1,13 @@
 import pyarrow as pa
+import pytest
 
 import xorq.api as xo
 from xorq.backends.pyiceberg.tests.conftest import QUOTES_TABLE_NAME
 from xorq.caching import SourceCache
 from xorq.tests.util import assert_frame_equal
+
+
+pytestmark = pytest.mark.pyiceberg
 
 
 def test_into_backend(iceberg_con, trades_df):

--- a/python/xorq/backends/pyiceberg/tests/test_table_ops.py
+++ b/python/xorq/backends/pyiceberg/tests/test_table_ops.py
@@ -5,6 +5,9 @@ from xorq.backends.pyiceberg.tests.conftest import QUOTES_TABLE_NAME
 from xorq.vendor.ibis import Schema
 
 
+pytestmark = pytest.mark.pyiceberg
+
+
 def test_create_table_from_expr(iceberg_con, quotes_table):
     t = quotes_table.select("timestamp", "bid", "ask").limit(10).as_table()
 

--- a/python/xorq/backends/snowflake/tests/test_cache.py
+++ b/python/xorq/backends/snowflake/tests/test_cache.py
@@ -27,6 +27,9 @@ from xorq.vendor import ibis
 from xorq.vendor.ibis.util import gen_name
 
 
+pytestmark = pytest.mark.snowflake
+
+
 KEY_PREFIX = xo.config.options.cache.key_prefix
 
 

--- a/python/xorq/backends/snowflake/tests/test_client.py
+++ b/python/xorq/backends/snowflake/tests/test_client.py
@@ -9,6 +9,9 @@ from xorq.backends.snowflake.tests.conftest import (
 from xorq.vendor.ibis.util import gen_name
 
 
+pytestmark = pytest.mark.snowflake
+
+
 SU = pytest.importorskip("xorq.common.utils.snowflake_utils")
 
 

--- a/python/xorq/backends/snowflake/tests/test_generic.py
+++ b/python/xorq/backends/snowflake/tests/test_generic.py
@@ -9,6 +9,9 @@ from xorq.tests.util import assert_series_equal
 from xorq.vendor.ibis import literal as L
 
 
+pytestmark = pytest.mark.snowflake
+
+
 def calc_hexdigest(string, how):
     return hashlib.new(how, string.encode()).hexdigest()
 

--- a/python/xorq/backends/snowflake/tests/test_lazy.py
+++ b/python/xorq/backends/snowflake/tests/test_lazy.py
@@ -6,6 +6,9 @@ from xorq.backends.snowflake.tests.conftest import inside_temp_schema
 from xorq.vendor.ibis.backends.profiles import Profile
 
 
+pytestmark = pytest.mark.snowflake
+
+
 SU = pytest.importorskip("xorq.common.utils.snowflake_utils")
 
 

--- a/python/xorq/backends/sqlite/tests/test_basic.py
+++ b/python/xorq/backends/sqlite/tests/test_basic.py
@@ -14,6 +14,9 @@ from xorq.caching import (
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.sqlite
+
+
 def test_can_connect(sqlite_con):
     assert sqlite_con is not None
     assert sqlite_con.list_tables() is not None

--- a/python/xorq/backends/sqlite/tests/test_basic_on_disk.py
+++ b/python/xorq/backends/sqlite/tests/test_basic_on_disk.py
@@ -1,6 +1,11 @@
+import pytest
+
 import xorq.api as xo
 from xorq.caching import SourceCache
 from xorq.tests.util import assert_frame_equal
+
+
+pytestmark = pytest.mark.sqlite
 
 
 def test_read_parquet(persistent_sqlite_con, astronauts_parquet_path):

--- a/python/xorq/backends/sqlite/tests/test_client.py
+++ b/python/xorq/backends/sqlite/tests/test_client.py
@@ -12,6 +12,9 @@ import xorq.vendor.ibis.expr.operations as ops
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.sqlite
+
+
 def test_attach_file(tmp_path):
     dbpath = str(tmp_path / "attached.db")
     path_client = xo.sqlite.connect(dbpath)

--- a/python/xorq/backends/sqlite/tests/test_types.py
+++ b/python/xorq/backends/sqlite/tests/test_types.py
@@ -12,6 +12,9 @@ import xorq.vendor.ibis.expr.datatypes as dt
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.sqlite
+
+
 # Test with formats 1-7 (with T, Z, and offset modifiers) from:
 # https://sqlite.org/lang_datefunc.html#time_values
 TIMESTAMPS = [

--- a/python/xorq/backends/sqlite/tests/test_udf.py
+++ b/python/xorq/backends/sqlite/tests/test_udf.py
@@ -1,3 +1,9 @@
+import pytest
+
+
+pytestmark = pytest.mark.sqlite
+
+
 def test_hash(sqlite_con, df):
     t = sqlite_con.create_table("test", df)
     expr = t.mutate(my_hash=t.c.hash())

--- a/python/xorq/backends/tests/test_backend.py
+++ b/python/xorq/backends/tests/test_backend.py
@@ -10,6 +10,9 @@ from xorq.common.utils.graph_utils import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 pytest.importorskip("psycopg")
 
 

--- a/python/xorq/backends/tests/test_lazy_backend.py
+++ b/python/xorq/backends/tests/test_lazy_backend.py
@@ -14,6 +14,9 @@ from xorq.backends._lazy import LazyBackend
 from xorq.vendor.ibis.backends import BaseBackend
 
 
+pytestmark = pytest.mark.core
+
+
 def make_duckdb_lazy(**kwargs):
     return LazyBackend(duckdb.Backend().connect, database=":memory:", **kwargs)
 

--- a/python/xorq/backends/xorq_datafusion/datafusion/tests/test_provider.py
+++ b/python/xorq/backends/xorq_datafusion/datafusion/tests/test_provider.py
@@ -5,6 +5,9 @@ import xorq.api as xo
 from xorq.backends.xorq_datafusion.datafusion.provider import IbisTableProvider
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.fixture
 def tmp_model_dir(tmpdir):
     # Create a temporary directory for the model

--- a/python/xorq/backends/xorq_datafusion/datafusion/tests/test_version.py
+++ b/python/xorq/backends/xorq_datafusion/datafusion/tests/test_version.py
@@ -1,6 +1,11 @@
+import pytest
+
 import xorq
 import xorq.api as xo
 from xorq.backends.xorq_datafusion.datafusion import Backend
+
+
+pytestmark = pytest.mark.xorq_datafusion
 
 
 def test_version():

--- a/python/xorq/backends/xorq_datafusion/tests/test_aggregation.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_aggregation.py
@@ -13,6 +13,9 @@ from xorq.vendor.ibis import _
 from xorq.vendor.ibis import literal as L
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @xo.udf.agg.builtin
 def mean_udf(s: dt.double) -> dt.double:
     return s.mean()

--- a/python/xorq/backends/xorq_datafusion/tests/test_api.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_api.py
@@ -5,6 +5,9 @@ import xorq.api as xo
 from xorq.api import SessionConfig
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.xfail(reason="No purpose with no registration api")
 def test_executed_on_original_backend(parquet_dir, csv_dir, mocker):
     con = xo.config.default_backend()

--- a/python/xorq/backends/xorq_datafusion/tests/test_array.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_array.py
@@ -13,6 +13,9 @@ import xorq.vendor.ibis.expr.types as ir
 from xorq.tests.util import assert_frame_equal, assert_series_equal
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.fixture(scope="module")
 def flatten_data():
     return {

--- a/python/xorq/backends/xorq_datafusion/tests/test_cache.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_cache.py
@@ -31,6 +31,9 @@ from xorq.vendor.ibis import _
 from xorq.vendor.ibis.expr.types.relations import CACHED_NODE_NAME_PLACEHOLDER
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 KEY_PREFIX = xo.config.options.cache.key_prefix
 
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_cli_compat.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_cli_compat.py
@@ -6,6 +6,9 @@ from click.testing import CliRunner
 from xorq.cli import OutputFormats, cli, uv_group
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.skipif(
     sys.version_info > (3, 10), reason="compatibility test for Python 3.10"
 )

--- a/python/xorq/backends/xorq_datafusion/tests/test_client.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_client.py
@@ -10,6 +10,9 @@ from xorq.tests.util import (
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 def test_register_record_batch_reader(alltypes_df):
     con = xo.connect()
     t = con.register(alltypes_df, "alltypes")

--- a/python/xorq/backends/xorq_datafusion/tests/test_execute.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_execute.py
@@ -7,6 +7,9 @@ from xorq.tests.util import (
 )
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.fixture(scope="function")
 def ddb_batting(duckdb_con):
     return duckdb_con.create_table(

--- a/python/xorq/backends/xorq_datafusion/tests/test_generic.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_generic.py
@@ -18,6 +18,9 @@ from xorq.vendor.ibis import _
 from xorq.vendor.ibis.common.annotations import ValidationError
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 def test_null_literal(con):
     expr = xo.null()
     assert pd.isna(con.execute(expr))

--- a/python/xorq/backends/xorq_datafusion/tests/test_join.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_join.py
@@ -10,6 +10,9 @@ import xorq.vendor.ibis.expr.schema as sch
 from xorq.tests.util import assert_frame_equal, check_eq
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.parametrize(
     "how",
     [

--- a/python/xorq/backends/xorq_datafusion/tests/test_map.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_map.py
@@ -6,6 +6,9 @@ import xorq.api as xo
 from xorq.tests.util import assert_series_equal
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 def test_map_get_with_compatible_value_smaller(con):
     value = xo.literal({"A": 1000, "B": 2000})
     expr = value.get("C", 3)

--- a/python/xorq/backends/xorq_datafusion/tests/test_numeric.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_numeric.py
@@ -19,6 +19,9 @@ from xorq.vendor.ibis import literal as L
 from xorq.vendor.ibis.expr import datatypes as dt
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.parametrize(
     ("expr",),
     [

--- a/python/xorq/backends/xorq_datafusion/tests/test_param.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_param.py
@@ -7,6 +7,9 @@ import xorq.expr.datatypes as dt
 from xorq.tests.util import assert_series_equal, default_series_rename
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.parametrize(
     ("column", "raw_value"),
     [

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -1,6 +1,10 @@
 import pandas as pd
+import pytest
 
 import xorq.api as xo
+
+
+pytestmark = pytest.mark.xorq_datafusion
 
 
 def test_no_name_register():

--- a/python/xorq/backends/xorq_datafusion/tests/test_select.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_select.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from xorq.tests.util import assert_frame_equal
+
+
+pytestmark = pytest.mark.xorq_datafusion
 
 
 def test_where_multiple_conditions(alltypes, alltypes_df):

--- a/python/xorq/backends/xorq_datafusion/tests/test_set_ops.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_set_ops.py
@@ -12,6 +12,9 @@ from xorq.api import _
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.fixture
 def union_subsets(alltypes, alltypes_df):
     cols_a, cols_b, cols_c = (alltypes.columns.copy() for _ in range(3))

--- a/python/xorq/backends/xorq_datafusion/tests/test_string.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_string.py
@@ -9,6 +9,9 @@ import xorq.expr.datatypes as dt
 from xorq.tests.util import assert_frame_equal, assert_series_equal
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.parametrize(
     "text_value",
     [

--- a/python/xorq/backends/xorq_datafusion/tests/test_struct.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_struct.py
@@ -13,6 +13,9 @@ from xorq.tests.util import assert_frame_equal, assert_series_equal
 from xorq.vendor.ibis import _
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 @pytest.mark.parametrize(
     ("field", "expected"),
     [

--- a/python/xorq/backends/xorq_datafusion/tests/test_temporal.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_temporal.py
@@ -21,6 +21,9 @@ from xorq.tests.util import (
 )
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 pa = pytest.importorskip("pyarrow")
 
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_udf.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_udf.py
@@ -16,6 +16,9 @@ from xorq.vendor.ibis import literal as L
 from xorq.vendor.ibis.selectors import of_type
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 pc = pytest.importorskip("pyarrow.compute")
 xgb = pytest.importorskip("xgboost")
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_udwf.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_udwf.py
@@ -1,8 +1,12 @@
 import numpy as np
 import pyarrow as pa
+import pytest
 
 import xorq.api as xo
 from xorq.internal import WindowEvaluator, udwf
+
+
+pytestmark = pytest.mark.xorq_datafusion
 
 
 class ExponentialSmoothDefault(WindowEvaluator):

--- a/python/xorq/backends/xorq_datafusion/tests/test_udwf_dataframe.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_udwf_dataframe.py
@@ -9,6 +9,9 @@ from xorq.vendor import ibis
 from xorq.vendor.ibis import _
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 class SmoothBoundedFromPreviousRow(WindowEvaluator):
     """Smooth over from the previous to current row only."""
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_window.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_window.py
@@ -14,6 +14,9 @@ from xorq.vendor import ibis
 from xorq.vendor.ibis.legacy.udf.vectorized import analytic, reduction
 
 
+pytestmark = pytest.mark.xorq_datafusion
+
+
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 

--- a/python/xorq/caching/tests/test_storage.py
+++ b/python/xorq/caching/tests/test_storage.py
@@ -1,4 +1,9 @@
+import pytest
+
 from xorq.caching.storage import resolve_parquet_cache_path
+
+
+pytestmark = pytest.mark.core
 
 
 def test_resolve_parquet_cache_path_uses_xorq_cache_dir(tmp_path, monkeypatch):

--- a/python/xorq/common/tests/test_cache.py
+++ b/python/xorq/common/tests/test_cache.py
@@ -8,6 +8,9 @@ from xorq.caching.strategy import ModificationTimeStrategy, SnapshotStrategy
 from xorq.expr.relations import RemoteTable
 
 
+pytestmark = pytest.mark.core
+
+
 def test_put_get_drop(tmp_path, parquet_dir):
     astronauts_path = parquet_dir.joinpath("astronauts.parquet")
 

--- a/python/xorq/common/tests/test_io_utils.py
+++ b/python/xorq/common/tests/test_io_utils.py
@@ -6,6 +6,9 @@ import toolz
 from xorq.common.utils.io_utils import Peeker
 
 
+pytestmark = pytest.mark.core
+
+
 make_bytes_contains = toolz.flip(bytes.__contains__)
 
 

--- a/python/xorq/common/utils/tests/test_benchmark_dask_normalize.py
+++ b/python/xorq/common/utils/tests/test_benchmark_dask_normalize.py
@@ -12,6 +12,9 @@ from xorq.common.utils.dask_normalize.dask_normalize_expr import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 def _make_simple():
     con = xo.connect()
     con.create_table("t", pd.DataFrame({"a": range(100), "b": range(100)}))

--- a/python/xorq/common/utils/tests/test_caching_utils.py
+++ b/python/xorq/common/utils/tests/test_caching_utils.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
+import pytest
+
 from xorq.common.utils.caching_utils import get_xorq_cache_dir
+
+
+pytestmark = pytest.mark.core
 
 
 def test_default_caching_dir():

--- a/python/xorq/common/utils/tests/test_dask_normalize.py
+++ b/python/xorq/common/utils/tests/test_dask_normalize.py
@@ -51,6 +51,9 @@ from xorq.ibis_yaml.compiler import build_expr
 from xorq.vendor.ibis.expr.operations.relations import Filter
 
 
+pytestmark = pytest.mark.core
+
+
 def test_ensure_deterministic():
     assert dask.config.get("tokenize.ensure-deterministic")
 

--- a/python/xorq/common/utils/tests/test_deferred_read.py
+++ b/python/xorq/common/utils/tests/test_deferred_read.py
@@ -28,6 +28,9 @@ from xorq.common.utils.inspect_utils import (
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.core
+
+
 duckdb = pytest.importorskip("duckdb")
 ProgrammingError = pytest.importorskip("adbc_driver_manager").ProgrammingError
 

--- a/python/xorq/common/utils/tests/test_env_utils.py
+++ b/python/xorq/common/utils/tests/test_env_utils.py
@@ -10,6 +10,9 @@ from xorq.common.utils.env_utils import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/python/xorq/common/utils/tests/test_gen_downstream_performance.py
+++ b/python/xorq/common/utils/tests/test_gen_downstream_performance.py
@@ -7,6 +7,9 @@ from xorq.common.utils.node_utils import gen_downstream
 from xorq.vendor.ibis.expr.operations import InMemoryTable
 
 
+pytestmark = pytest.mark.core
+
+
 def create_expr(depth=3):
     df = pd.DataFrame(
         {

--- a/python/xorq/common/utils/tests/test_graph_utils.py
+++ b/python/xorq/common/utils/tests/test_graph_utils.py
@@ -17,6 +17,9 @@ from xorq.expr.relations import Tag
 from xorq.ml import deferred_fit_predict_sklearn
 
 
+pytestmark = pytest.mark.core
+
+
 LinearRegression = pytest.importorskip("sklearn").linear_model.LinearRegression
 
 

--- a/python/xorq/common/utils/tests/test_hashing_tag.py
+++ b/python/xorq/common/utils/tests/test_hashing_tag.py
@@ -12,6 +12,9 @@ from xorq.ibis_yaml.compiler import YamlExpressionTranslator
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture
 def t():
     return ibis.table(

--- a/python/xorq/common/utils/tests/test_io_utils.py
+++ b/python/xorq/common/utils/tests/test_io_utils.py
@@ -5,6 +5,9 @@ import pytest
 from xorq.common.utils.io_utils import extract_suffix
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     "input_path,expected",
     [

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -23,6 +23,9 @@ from xorq.vendor.ibis.expr.operations.reductions import Sum
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
 
 
+pytestmark = pytest.mark.core
+
+
 @xo.udf.make_pandas_udf(
     schema=xo.schema({"price": float, "discount": float}),
     return_type=dt.float,

--- a/python/xorq/common/utils/tests/test_logging.py
+++ b/python/xorq/common/utils/tests/test_logging.py
@@ -17,6 +17,9 @@ from xorq.common.utils.logging_utils import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(name="log_output")
 def fixture_log_output():
     return LogCapture()

--- a/python/xorq/common/utils/tests/test_node_utils.py
+++ b/python/xorq/common/utils/tests/test_node_utils.py
@@ -19,6 +19,9 @@ from xorq.common.utils.node_utils import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 try_find_by_expr_hash = toolz.excepts(Exception, find_by_expr_hash)
 
 

--- a/python/xorq/common/utils/tests/test_otel_utils.py
+++ b/python/xorq/common/utils/tests/test_otel_utils.py
@@ -1,9 +1,14 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from xorq.common.utils.otel_utils import (
     _should_use_otlp_exporter,
     is_localhost_collector_listening,
 )
+
+
+pytestmark = pytest.mark.core
 
 
 # -- is_localhost_collector_listening ------------------------------------------

--- a/python/xorq/common/utils/tests/test_provenance_utils.py
+++ b/python/xorq/common/utils/tests/test_provenance_utils.py
@@ -4,6 +4,7 @@ import datetime
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 import xorq.api as xo
 from xorq.caching.storage import ParquetStorage, ParquetTTLStorage
@@ -15,6 +16,9 @@ from xorq.common.utils.provenance_utils import (
     inject_metadata_into_schema,
     read_parquet_provenance,
 )
+
+
+pytestmark = pytest.mark.core
 
 
 def test_build_provenance_metadata():

--- a/python/xorq/common/utils/tests/test_replace_sources.py
+++ b/python/xorq/common/utils/tests/test_replace_sources.py
@@ -15,6 +15,9 @@ from xorq.common.utils.graph_utils import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 def assert_result_equal(left, right):
     """Compare DataFrames ignoring row order (backends may return different orderings)."""
     left = left.sort_values(left.columns.tolist()).reset_index(drop=True)

--- a/python/xorq/common/utils/tests/test_tls_utils.py
+++ b/python/xorq/common/utils/tests/test_tls_utils.py
@@ -20,6 +20,9 @@ from xorq.common.utils.tls_utils import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 def test_single_creation():
     TLSCert.from_common_name()
 

--- a/python/xorq/examples/tests/test_examples.py
+++ b/python/xorq/examples/tests/test_examples.py
@@ -5,6 +5,9 @@ from xorq.examples import Example, get_name_to_suffix
 from xorq.examples.core import whitelist
 
 
+pytestmark = pytest.mark.core
+
+
 def test_whitelist():
     assert [name in dir(xo.examples) for name in whitelist]
 

--- a/python/xorq/expr/builders/tests/test_builders.py
+++ b/python/xorq/expr/builders/tests/test_builders.py
@@ -336,6 +336,9 @@ def test_zip_rejects_invalid():
 from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: E402
 
 
+pytestmark = pytest.mark.core
+
+
 def test_register_duplicate_raises(saved_registry):
     handler = TagHandler(
         tag_names=("dup_test",), from_tag_node=lambda tag_node: "first"

--- a/python/xorq/expr/datatypes/tests/test_large_string.py
+++ b/python/xorq/expr/datatypes/tests/test_large_string.py
@@ -1,9 +1,13 @@
 import pandas as pd
+import pytest
 
 import xorq.api as xo
 from xorq.expr.datatypes import Int64, LargeString, String
 from xorq.tests.util import assert_frame_equal, assert_series_equal
 from xorq.vendor import ibis
+
+
+pytestmark = pytest.mark.core
 
 
 def test_can_create_table(utf8_data):

--- a/python/xorq/expr/ml/tests/test_build_pipeline.py
+++ b/python/xorq/expr/ml/tests/test_build_pipeline.py
@@ -19,6 +19,9 @@ from sklearn.datasets import make_regression  # noqa: E402
 from sklearn.model_selection import TimeSeriesSplit  # noqa: E402
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="module")
 def lasso_timeseries_fold_expr(tmp_path_factory):
     """Build a TimeSeriesSplit fold expression using deferred_read_parquet.

--- a/python/xorq/expr/ml/tests/test_cross_validation.py
+++ b/python/xorq/expr/ml/tests/test_cross_validation.py
@@ -34,6 +34,9 @@ from xorq.expr.ml.pipeline_lib import Pipeline  # noqa: E402
 from xorq.vendor.ibis.expr.types import Expr  # noqa: E402
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="module")
 def classification_data():
     """Generate a classification dataset as an ibis table."""

--- a/python/xorq/expr/ml/tests/test_fit_lib.py
+++ b/python/xorq/expr/ml/tests/test_fit_lib.py
@@ -23,6 +23,9 @@ from xorq.ml import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 sk_linear_model = pytest.importorskip("sklearn.linear_model")
 sk_preprocessing = pytest.importorskip("sklearn.preprocessing")
 sk_feature_selection = pytest.importorskip("sklearn.feature_selection")

--- a/python/xorq/expr/ml/tests/test_metrics.py
+++ b/python/xorq/expr/ml/tests/test_metrics.py
@@ -18,6 +18,9 @@ from xorq.expr.ml.metrics import (
 from xorq.expr.ml.pipeline_lib import Pipeline
 
 
+pytestmark = pytest.mark.core
+
+
 # Skip all tests in this module if sklearn is not installed
 sklearn = pytest.importorskip("sklearn")
 

--- a/python/xorq/expr/ml/tests/test_ml.py
+++ b/python/xorq/expr/ml/tests/test_ml.py
@@ -5,6 +5,9 @@ import pytest
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     "method",
     [

--- a/python/xorq/expr/ml/tests/test_pipeline_lib.py
+++ b/python/xorq/expr/ml/tests/test_pipeline_lib.py
@@ -20,6 +20,9 @@ sklearn = pytest.importorskip("sklearn")
 from xorq.expr.ml.sklearn_utils import ColumnRemapper  # noqa: E402
 
 
+pytestmark = pytest.mark.core
+
+
 # sklearn submodule imports
 KMeans = sklearn.cluster.KMeans
 MiniBatchKMeans = sklearn.cluster.MiniBatchKMeans

--- a/python/xorq/expr/ml/tests/test_split_lib.py
+++ b/python/xorq/expr/ml/tests/test_split_lib.py
@@ -12,6 +12,9 @@ from xorq.expr.ml import _calculate_bounds
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.core
+
+
 pytest.importorskip("duckdb")
 pytest.importorskip("psycopg")
 pytest.importorskip("datafusion")

--- a/python/xorq/expr/ml/tests/test_step.py
+++ b/python/xorq/expr/ml/tests/test_step.py
@@ -10,6 +10,9 @@ from xorq.expr.ml.pipeline_lib import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 sklearn = pytest.importorskip("sklearn")
 load_iris = sklearn.datasets.load_iris
 train_test_split = sklearn.model_selection.train_test_split

--- a/python/xorq/expr/ml/tests/test_structer.py
+++ b/python/xorq/expr/ml/tests/test_structer.py
@@ -53,6 +53,9 @@ from xorq.expr.ml.structer import (  # noqa: E402
 )
 
 
+pytestmark = pytest.mark.core
+
+
 def test_kvfield_is_strenum():
     """Test KVField inherits from StrEnum."""
     assert issubclass(KVField, StrEnum)

--- a/python/xorq/expr/tests/test_operations.py
+++ b/python/xorq/expr/tests/test_operations.py
@@ -5,6 +5,9 @@ from xorq.expr.operations import NamedScalarParameter
 from xorq.vendor.ibis.expr.operations.generic import ScalarParameter
 
 
+pytestmark = pytest.mark.core
+
+
 def test_named_scalar_parameter_creation():
     op = NamedScalarParameter(dtype=dt.float64(), label="threshold")
     assert op.label == "threshold"

--- a/python/xorq/expr/tests/test_param.py
+++ b/python/xorq/expr/tests/test_param.py
@@ -10,6 +10,9 @@ import xorq.vendor.ibis.expr.types as ir
 from xorq.expr.operations import _MISSING, NamedScalarParameter
 
 
+pytestmark = pytest.mark.core
+
+
 def test_param_returns_scalar():
     p = xo.param("threshold", "float64")
     assert isinstance(p, ir.Expr)

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -8,6 +8,9 @@ from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     "schema_val,pattern",
     [

--- a/python/xorq/flight/tests/test_actions.py
+++ b/python/xorq/flight/tests/test_actions.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 import xorq.api as xo
 import xorq.flight.exchanger as E
@@ -10,6 +11,9 @@ from xorq.flight.action import (
     GetSchemaQueryAction,
     ListTablesAction,
 )
+
+
+pytestmark = pytest.mark.core
 
 
 def test_list_tables_kwargs():

--- a/python/xorq/flight/tests/test_backend.py
+++ b/python/xorq/flight/tests/test_backend.py
@@ -13,6 +13,9 @@ from xorq.flight.exchanger import make_udxf
 from xorq.flight.tests.test_server import make_flight_url
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="module")
 def flight_server():
     flight_url = make_flight_url(None)

--- a/python/xorq/flight/tests/test_basic.py
+++ b/python/xorq/flight/tests/test_basic.py
@@ -6,6 +6,9 @@ from xorq.flight import BasicAuth, FlightServer
 from xorq.flight.tests.test_server import make_flight_url
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize("auth", [None, BasicAuth("username", "password")])
 @pytest.mark.parametrize("verify_client", [False, True])
 def test_connect(auth, verify_client):

--- a/python/xorq/flight/tests/test_cache.py
+++ b/python/xorq/flight/tests/test_cache.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import pytest
 import toolz
 
 import xorq.api as xo
@@ -9,6 +10,9 @@ from xorq.caching import (
 from xorq.common.utils.func_utils import (
     return_constant,
 )
+
+
+pytestmark = pytest.mark.core
 
 
 echo_udxf = xo.expr.relations.flight_udxf(

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -21,6 +21,9 @@ from xorq.flight.tests.conftest import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 def test_unbound_exchanger_command_stable_across_reduce(tmp_path):
     """`UnboundExprExchanger.command` embeds the expression's token.
 

--- a/python/xorq/flight/tests/test_metrics.py
+++ b/python/xorq/flight/tests/test_metrics.py
@@ -2,8 +2,12 @@ import time
 
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 from xorq.flight.metrics import instrument_rpc, setup_console_metrics
+
+
+pytestmark = pytest.mark.core
 
 
 @instrument_rpc("dummy_do_get")

--- a/python/xorq/flight/tests/test_server.py
+++ b/python/xorq/flight/tests/test_server.py
@@ -29,6 +29,9 @@ from xorq.loader import load_backend
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.core
+
+
 def make_flight_url(port, scheme="grpc", auth=None):
     if port is not None:
         assert not FlightUrl.port_in_use(port), f"Port {port} already in use"

--- a/python/xorq/ibis_yaml/tests/test_aggregation.py
+++ b/python/xorq/ibis_yaml/tests/test_aggregation.py
@@ -4,6 +4,9 @@ from pytest import param
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     "metrics",
     [

--- a/python/xorq/ibis_yaml/tests/test_arithmetic.py
+++ b/python/xorq/ibis_yaml/tests/test_arithmetic.py
@@ -1,5 +1,10 @@
+import pytest
+
 import xorq.vendor.ibis as ibis
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+
+
+pytestmark = pytest.mark.core
 
 
 def test_add(compiler):

--- a/python/xorq/ibis_yaml/tests/test_basic.py
+++ b/python/xorq/ibis_yaml/tests/test_basic.py
@@ -11,6 +11,9 @@ from xorq.ibis_yaml.common import (
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
+pytestmark = pytest.mark.core
+
+
 def test_unbound_table(t, compiler):
     yaml_dict = compiler.to_yaml(t)
     node_ref = yaml_dict["expression"][RefEnum.node_ref]

--- a/python/xorq/ibis_yaml/tests/test_benchmark.py
+++ b/python/xorq/ibis_yaml/tests/test_benchmark.py
@@ -5,6 +5,9 @@ from xorq.api import _
 from xorq.ibis_yaml.compiler import build_expr
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.benchmark
 def test_baseball_stats_compilation(builds_dir):
     pg = xo.postgres.connect_env()

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -49,6 +49,9 @@ from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.common.collections import FrozenOrderedDict
 
 
+pytestmark = pytest.mark.core
+
+
 do_roundtrip_expr = toolz.compose(load_expr, build_expr)
 
 

--- a/python/xorq/ibis_yaml/tests/test_config.py
+++ b/python/xorq/ibis_yaml/tests/test_config.py
@@ -1,8 +1,13 @@
 import pathlib
 
+import pytest
+
 from xorq.ibis_yaml.config import (
     BuildConfig,  # Replace 'your_module' with the appropriate module name
 )
+
+
+pytestmark = pytest.mark.core
 
 
 def test_default_hash_length():

--- a/python/xorq/ibis_yaml/tests/test_flight_udxf.py
+++ b/python/xorq/ibis_yaml/tests/test_flight_udxf.py
@@ -12,6 +12,9 @@ from xorq.ibis_yaml.compiler import YamlExpressionTranslator
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.core
+
+
 field_name = "price_per_carat"
 schema = xo.schema({"sum_price": "float64", "sum_carat": "float64"})
 return_type = xo.dtype("float64")

--- a/python/xorq/ibis_yaml/tests/test_generic.py
+++ b/python/xorq/ibis_yaml/tests/test_generic.py
@@ -5,6 +5,9 @@ import xorq.api as xo
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="function")
 def con():
     return xo.connect()

--- a/python/xorq/ibis_yaml/tests/test_join_chain.py
+++ b/python/xorq/ibis_yaml/tests/test_join_chain.py
@@ -3,6 +3,9 @@ import pytest
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="session")
 def con():
     return xo.duckdb.connect()

--- a/python/xorq/ibis_yaml/tests/test_lazy_load_expr.py
+++ b/python/xorq/ibis_yaml/tests/test_lazy_load_expr.py
@@ -18,6 +18,9 @@ from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.backends.profiles import Profile
 
 
+pytestmark = pytest.mark.core
+
+
 def _all_sources_lazy(expr):
     return all(isinstance(src, LazyBackend) for src in find_all_sources(expr))
 

--- a/python/xorq/ibis_yaml/tests/test_letsql_ops.py
+++ b/python/xorq/ibis_yaml/tests/test_letsql_ops.py
@@ -10,6 +10,9 @@ from xorq.expr.relations import into_backend
 from xorq.ibis_yaml.compiler import YamlExpressionTranslator
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="session")
 def duckdb_path(tmp_path_factory):
     db_path = tmp_path_factory.mktemp("duckdb") / "test.db"

--- a/python/xorq/ibis_yaml/tests/test_named_scalar_parameter.py
+++ b/python/xorq/ibis_yaml/tests/test_named_scalar_parameter.py
@@ -10,6 +10,9 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.operations import _MISSING, NamedScalarParameter
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture
 def t():
     return ibis.table({"x": "float64", "y": "int64", "s": "string"}, name="t")

--- a/python/xorq/ibis_yaml/tests/test_operations_boolean.py
+++ b/python/xorq/ibis_yaml/tests/test_operations_boolean.py
@@ -1,7 +1,12 @@
 from math import isnan
 
+import pytest
+
 import xorq.vendor.ibis as ibis
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+
+
+pytestmark = pytest.mark.core
 
 
 def test_equals(compiler):

--- a/python/xorq/ibis_yaml/tests/test_operations_cast.py
+++ b/python/xorq/ibis_yaml/tests/test_operations_cast.py
@@ -1,5 +1,10 @@
+import pytest
+
 import xorq.vendor.ibis as ibis
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+
+
+pytestmark = pytest.mark.core
 
 
 def test_explicit_cast(compiler):

--- a/python/xorq/ibis_yaml/tests/test_operations_datetime.py
+++ b/python/xorq/ibis_yaml/tests/test_operations_datetime.py
@@ -11,6 +11,9 @@ from xorq.ibis_yaml.common import TranslationContext, translate_to_yaml
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
+pytestmark = pytest.mark.core
+
+
 def test_date_extract(compiler):
     dt_expr = ibis.literal(datetime(2024, 3, 14, 15, 9, 26))
 

--- a/python/xorq/ibis_yaml/tests/test_packager.py
+++ b/python/xorq/ibis_yaml/tests/test_packager.py
@@ -40,6 +40,9 @@ from xorq.ibis_yaml.packager import (
 from xorq.init_templates import InitTemplates
 
 
+pytestmark = pytest.mark.core
+
+
 @functools.cache
 def get_template_bytes(template=InitTemplates.default):
     with tempfile.TemporaryDirectory() as td:

--- a/python/xorq/ibis_yaml/tests/test_relations.py
+++ b/python/xorq/ibis_yaml/tests/test_relations.py
@@ -1,7 +1,12 @@
+import pytest
+
 from xorq.ibis_yaml.common import (
     RefEnum,
     RegistryEnum,
 )
+
+
+pytestmark = pytest.mark.core
 
 
 def test_filter(compiler, t):

--- a/python/xorq/ibis_yaml/tests/test_selection.py
+++ b/python/xorq/ibis_yaml/tests/test_selection.py
@@ -1,4 +1,9 @@
+import pytest
+
 import xorq.vendor.ibis as ibis
+
+
+pytestmark = pytest.mark.core
 
 
 def test_selection_on_view(compiler):

--- a/python/xorq/ibis_yaml/tests/test_set_ops.py
+++ b/python/xorq/ibis_yaml/tests/test_set_ops.py
@@ -7,6 +7,9 @@ import xorq.api as xo
 from xorq.api import _
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture
 def union_subsets(alltypes):
     randomizer = random.Random(42)

--- a/python/xorq/ibis_yaml/tests/test_sql.py
+++ b/python/xorq/ibis_yaml/tests/test_sql.py
@@ -1,6 +1,11 @@
+import pytest
+
 import xorq.api as xo
 from xorq.expr.relations import gen_name_namespace, into_backend
 from xorq.ibis_yaml.sql import find_tables, generate_sql_plans
+
+
+pytestmark = pytest.mark.core
 
 
 def test_find_tables_simple():

--- a/python/xorq/ibis_yaml/tests/test_string_ops.py
+++ b/python/xorq/ibis_yaml/tests/test_string_ops.py
@@ -6,6 +6,9 @@ import xorq.vendor.ibis as ibis
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
+pytestmark = pytest.mark.core
+
+
 def test_string_concat(compiler):
     s1 = ibis.literal("hello")
     s2 = ibis.literal("world")

--- a/python/xorq/ibis_yaml/tests/test_subquery.py
+++ b/python/xorq/ibis_yaml/tests/test_subquery.py
@@ -1,9 +1,14 @@
+import pytest
+
 import xorq.vendor.ibis.expr.operations as ops
 from xorq.ibis_yaml.common import (
     RefEnum,
     RegistryEnum,
 )
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+
+
+pytestmark = pytest.mark.core
 
 
 def test_scalar_subquery(compiler, t):

--- a/python/xorq/ibis_yaml/tests/test_synthetic_cache_keys.py
+++ b/python/xorq/ibis_yaml/tests/test_synthetic_cache_keys.py
@@ -1,3 +1,5 @@
+import pytest
+
 import xorq.vendor.ibis as ibis
 from xorq.caching import ParquetSnapshotCache
 from xorq.caching.storage import resolve_parquet_cache_path
@@ -5,6 +7,9 @@ from xorq.cli import run_cached_command
 from xorq.common.utils.caching_utils import CacheKey
 from xorq.ibis_yaml.compiler import build_expr, load_expr
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
+
+
+pytestmark = pytest.mark.core
 
 
 def test_synthetic_key_always_present_for_uncached_expr():

--- a/python/xorq/ibis_yaml/tests/test_temporal.py
+++ b/python/xorq/ibis_yaml/tests/test_temporal.py
@@ -10,6 +10,9 @@ import xorq.api as xo
 from xorq.tests.util import assert_frame_equal, assert_series_equal
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="session")
 def con():
     return xo.connect()

--- a/python/xorq/ibis_yaml/tests/test_tpch.py
+++ b/python/xorq/ibis_yaml/tests/test_tpch.py
@@ -1,6 +1,9 @@
 import pytest
 
 
+pytestmark = pytest.mark.core
+
+
 TPC_H = [
     "tpc_h01",
     "tpc_h02",

--- a/python/xorq/ibis_yaml/tests/test_udf.py
+++ b/python/xorq/ibis_yaml/tests/test_udf.py
@@ -8,6 +8,9 @@ from xorq.expr.udf import pyarrow_udwf
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.core
+
+
 def test_built_in_udf_properties(compiler):
     t = xo.table({"a": "int64"}, name="t")
 

--- a/python/xorq/ibis_yaml/tests/test_window_functions.py
+++ b/python/xorq/ibis_yaml/tests/test_window_functions.py
@@ -1,5 +1,10 @@
+import pytest
+
 import xorq.vendor.ibis as ibis
 from xorq.ibis_yaml.common import RefEnum, RegistryEnum
+
+
+pytestmark = pytest.mark.core
 
 
 def test_window_function_roundtrip(compiler, t):

--- a/python/xorq/sql/tests/test_parse.py
+++ b/python/xorq/sql/tests/test_parse.py
@@ -8,6 +8,9 @@ from xorq.sql import parser
 from xorq.vendor import ibis
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture(scope="session")
 def con():
     return ibis.connect("duckdb://")

--- a/python/xorq/tests/params/test_bind_params.py
+++ b/python/xorq/tests/params/test_bind_params.py
@@ -9,6 +9,9 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.operations import NamedScalarParameter
 
 
+pytestmark = pytest.mark.core
+
+
 def test_bind_replaces_all_params():
     threshold = xo.param("threshold", "float64")
     t = xo.memtable({"x": [1.0, 2.0, 3.0]})

--- a/python/xorq/tests/params/test_cli_params.py
+++ b/python/xorq/tests/params/test_cli_params.py
@@ -11,6 +11,9 @@ from xorq.cli import _click_type_for_dtype, _ClickDate, _parse_cli_params
 from xorq.expr.api import bind_params
 
 
+pytestmark = pytest.mark.core
+
+
 # --- _ClickDate ---
 
 

--- a/python/xorq/tests/params/test_deterministic_counter.py
+++ b/python/xorq/tests/params/test_deterministic_counter.py
@@ -7,6 +7,9 @@ from xorq.common.utils.name_utils import tokenize_to_int
 from xorq.expr.operations import NamedScalarParameter
 
 
+pytestmark = pytest.mark.core
+
+
 def test_counter_is_deterministic_for_same_label():
     a = NamedScalarParameter(dtype="float64", label="threshold")
     b = NamedScalarParameter(dtype="float64", label="threshold")

--- a/python/xorq/tests/params/test_expr_metadata_params.py
+++ b/python/xorq/tests/params/test_expr_metadata_params.py
@@ -8,6 +8,9 @@ from xorq.ibis_yaml.compiler import build_expr
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
 
 
+pytestmark = pytest.mark.core
+
+
 def test_params_empty_when_no_named_params():
     t = ibis.memtable({"x": [1.0, 2.0]})
     assert ExprMetadata.from_expr(t).params == ()

--- a/python/xorq/tests/params/test_param_advanced.py
+++ b/python/xorq/tests/params/test_param_advanced.py
@@ -10,6 +10,9 @@ from xorq.expr.operations import NamedScalarParameter
 from xorq.expr.relations import CachedNode
 
 
+pytestmark = pytest.mark.core
+
+
 def test_param_behind_cached_node():
     """Test parameters work behind CachedNode."""
     threshold = xo.param("threshold", "float64", default=1.5)

--- a/python/xorq/tests/params/test_param_functional.py
+++ b/python/xorq/tests/params/test_param_functional.py
@@ -12,6 +12,9 @@ from xorq.expr.operations import _MISSING, NamedScalarParameter
 from xorq.ibis_yaml.compiler import build_expr, load_expr
 
 
+pytestmark = pytest.mark.core
+
+
 def test_param_creation_basic():
     threshold = xo.param("threshold", "float64")
     assert threshold.op().label == "threshold"

--- a/python/xorq/tests/params/test_param_output_methods.py
+++ b/python/xorq/tests/params/test_param_output_methods.py
@@ -11,6 +11,9 @@ import pytest
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.core
+
+
 # ---------------------------------------------------------------------------
 # Helpers — one callable per output method, uniform signature (expr, params, tmp_path)
 # ---------------------------------------------------------------------------

--- a/python/xorq/tests/params/test_rename_params.py
+++ b/python/xorq/tests/params/test_rename_params.py
@@ -1,9 +1,14 @@
 """Tests for rename_params() utility."""
 
+import pytest
+
 import xorq.api as xo
 import xorq.vendor.ibis as ibis
 from xorq.common.utils.graph_utils import rename_params, walk_nodes
 from xorq.expr.operations import NamedScalarParameter
+
+
+pytestmark = pytest.mark.core
 
 
 def test_rename_single_param():

--- a/python/xorq/tests/params/test_replace_parameter.py
+++ b/python/xorq/tests/params/test_replace_parameter.py
@@ -8,6 +8,9 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.operations import NamedScalarParameter
 
 
+pytestmark = pytest.mark.core
+
+
 def test_bound_param_replaced_with_literal():
     p = xo.param("x", "float64")
     t = ibis.table({"v": "float64"}, name="t")

--- a/python/xorq/tests/test_api.py
+++ b/python/xorq/tests/test_api.py
@@ -14,6 +14,9 @@ from xorq.config import default_backend, options
 from xorq.tests.conftest import TEST_TABLES
 
 
+pytestmark = pytest.mark.core
+
+
 def test_list_tables(con):
     tables = con.list_tables()
     assert isinstance(tables, list)

--- a/python/xorq/tests/test_backend.py
+++ b/python/xorq/tests/test_backend.py
@@ -5,6 +5,9 @@ import pytest
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     "make_connection",
     (

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -39,6 +39,9 @@ from xorq.ibis_yaml.compiler import (
 from xorq.init_templates import InitTemplates
 
 
+pytestmark = pytest.mark.core
+
+
 build_run_examples_expr_names = (
     ("local_cache.py", "expr"),
     ("multi_engine.py", "expr"),

--- a/python/xorq/tests/test_cli_arrow.py
+++ b/python/xorq/tests/test_cli_arrow.py
@@ -10,6 +10,9 @@ import xorq.api as xo
 from xorq.common.utils.process_utils import subprocess_run
 
 
+pytestmark = pytest.mark.core
+
+
 def test_to_pyarrow_stream():
     """Test writing Arrow IPC stream to a buffer."""
     # Create test data

--- a/python/xorq/tests/test_client.py
+++ b/python/xorq/tests/test_client.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     pass
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture
 def new_schema():
     return xo.schema([("a", "string"), ("b", "bool"), ("c", "int32")])

--- a/python/xorq/tests/test_complex_exprs.py
+++ b/python/xorq/tests/test_complex_exprs.py
@@ -12,6 +12,9 @@ from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.expr.relations import into_backend
 
 
+pytestmark = pytest.mark.core
+
+
 rate_to_rate_str = toolz.compose(operator.methodcaller("replace", ".", "p"), str)
 
 

--- a/python/xorq/tests/test_examples.py
+++ b/python/xorq/tests/test_examples.py
@@ -8,6 +8,9 @@ import xorq.api as xo
 from xorq.tests.test_cli import build_run_examples_expr_names
 
 
+pytestmark = pytest.mark.core
+
+
 KEY_PREFIX = xo.config.options.cache.key_prefix
 LIBRARY_SCRIPTS = (
     "pandas_example",

--- a/python/xorq/tests/test_format.py
+++ b/python/xorq/tests/test_format.py
@@ -11,6 +11,9 @@ from xorq.caching import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 def test_into_backend(batting):
     xo.options.interactive = False
 

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -21,6 +21,9 @@ from xorq.vendor.ibis import _
 from xorq.vendor.ibis.expr.types.relations import CACHED_NODE_NAME_PLACEHOLDER
 
 
+pytestmark = pytest.mark.core
+
+
 expected_tables = (
     "array_types",
     "astronauts",

--- a/python/xorq/tests/test_ls_accessor.py
+++ b/python/xorq/tests/test_ls_accessor.py
@@ -10,6 +10,9 @@ from xorq.caching import (
 )
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture
 def cached_two(con, pg, tmp_path):
     parquet_cache = ParquetCache.from_kwargs(source=con, relative_path=tmp_path)

--- a/python/xorq/tests/test_numeric.py
+++ b/python/xorq/tests/test_numeric.py
@@ -19,6 +19,9 @@ from xorq.vendor.ibis import literal as L
 from xorq.vendor.ibis.expr import datatypes as dt
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     ("expr",),
     [

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -9,6 +9,9 @@ from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.backends.profiles import Profile, Profiles
 
 
+pytestmark = pytest.mark.core
+
+
 local_con_names = ("duckdb", "xorq_datafusion", "datafusion", "pandas", "pyiceberg")
 remote_connectors = (lambda: xo.postgres.connect_env(),)
 local_connectors = tuple(

--- a/python/xorq/tests/test_register_read.py
+++ b/python/xorq/tests/test_register_read.py
@@ -17,6 +17,9 @@ from xorq.vendor.ibis.common.collections import FrozenDict
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.fixture
 def gzip_csv(data_dir, tmp_path):
     basename = "diamonds.csv"

--- a/python/xorq/tests/test_sql.py
+++ b/python/xorq/tests/test_sql.py
@@ -3,6 +3,9 @@ import pytest
 import xorq.api as xo
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize("file_format", ["parquet", "csv"])
 def test_sql_on_deferred_read(file_format, request):
     ddb = xo.duckdb.connect()

--- a/python/xorq/tests/test_tutorial_snippets.py
+++ b/python/xorq/tests/test_tutorial_snippets.py
@@ -17,6 +17,9 @@ from pathlib import Path
 import pytest
 
 
+pytestmark = pytest.mark.core
+
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TUTORIALS_DIR = REPO_ROOT / "docs" / "tutorials"
 SCRIPTS = sorted(TUTORIALS_DIR.rglob("*.snippets.py"))

--- a/python/xorq/tests/test_udf.py
+++ b/python/xorq/tests/test_udf.py
@@ -10,6 +10,9 @@ import xorq.vendor.ibis.expr.types as ir
 from xorq import udf
 
 
+pytestmark = pytest.mark.core
+
+
 pc = pytest.importorskip("pyarrow.compute")
 
 

--- a/python/xorq/tests/test_wrapper.py
+++ b/python/xorq/tests/test_wrapper.py
@@ -6,6 +6,9 @@ import xorq.api as xo
 from xorq.tests.util import assert_frame_equal
 
 
+pytestmark = pytest.mark.core
+
+
 def test_simple_agg_ops_read_parquet(data_dir):
     path = data_dir / "parquet" / "functional_alltypes.parquet"
 

--- a/python/xorq/vendor/ibis/backends/sql/compilers/test_drop_columns.py
+++ b/python/xorq/vendor/ibis/backends/sql/compilers/test_drop_columns.py
@@ -6,6 +6,9 @@ from xorq.vendor.ibis.backends.sql.compilers.duckdb import DuckDBCompiler
 from xorq.vendor.ibis.backends.sql.compilers.snowflake import SnowflakeCompiler
 
 
+pytestmark = pytest.mark.core
+
+
 def _wide_table(n_cols=10):
     """Create an unbound table wide enough that DropColumns survives the rewrite.
 

--- a/python/xorq/vendor/ibis/tests/test_dtype_parse.py
+++ b/python/xorq/vendor/ibis/tests/test_dtype_parse.py
@@ -7,6 +7,9 @@ from xorq.vendor.ibis.common.temporal import IntervalUnit
 from xorq.vendor.ibis.expr.datatypes.parse import parse
 
 
+pytestmark = pytest.mark.core
+
+
 @pytest.mark.parametrize(
     "text,expected",
     [


### PR DESCRIPTION
## Summary

- CI runs `pytest -m <backend>` per matrix job, so any test file without a module-level `pytestmark` is silently skipped — never runs in CI, never contributes to coverage
- **163 of 199 test files (82%)** had no CI-selectable marker and were invisible to CI
- Added `pytestmark = pytest.mark.<backend>` to all 163 orphaned files, with the marker chosen by directory:
  - Backend test dirs get their backend marker (`duckdb`, `pandas`, `postgres`, `sqlite`, `pyiceberg`, `databricks`, `datafusion`, `xorq_datafusion`, `snowflake`)
  - Non-backend dirs (`ibis_yaml`, `flight`, `expr`, `common`, `tests/`, etc.) get `core`
  - `catalog/tests/` and `common/utils/tests/ibis_utils/` are **skipped** (covered by dedicated workflows)
- Follows the canonical pattern from `backends/gizmosql/tests/` (the only directory that had this right)
- All 199 test files now compile cleanly and pass the validation grep (0 orphaned files remaining)

## Test plan

- [ ] CI matrix jobs should now collect significantly more tests per backend
- [ ] Verify `core` job picks up ibis_yaml, flight, expr, common, params tests
- [ ] Verify per-backend jobs (duckdb, pandas, sqlite, etc.) pick up their backend tests
- [ ] Monitor Codecov — coverage should increase from the current 83% baseline
- [ ] Spot-check a few files to confirm `pytestmark` is placed after the top-level import block

🤖 Generated with [Claude Code](https://claude.com/claude-code)