### PR TITLE
feat(cli,logging): add version visibility to CLI and run metadata

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -752,6 +752,7 @@ class PdbGroup(click.Group):
 
 
 @click.group(cls=PdbGroup)
+@click.version_option(package_name="xorq")
 @click.option("--pdb", "use_pdb", is_flag=True, help="Drop into pdb on failure")
 @click.option(
     "--pdb-runcall", "pdb_runcall", is_flag=True, help="Invoke with pdb.runcall"

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import hashlib
 import importlib.metadata
 import json
@@ -170,6 +171,14 @@ def get_xorq_runs_dir() -> Path:
     return Path("~/.local/share/xorq/runs").expanduser()
 
 
+@functools.cache
+def _get_xorq_version() -> str:
+    try:
+        return importlib.metadata.version("xorq")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 @frozen
 class RunLogger:
     """Writes structured events to run.jsonl and a summary to meta.json."""
@@ -231,14 +240,9 @@ class RunLogger:
         if self._finalized:
             return
 
-        try:
-            xorq_version = importlib.metadata.version("xorq")
-        except importlib.metadata.PackageNotFoundError:
-            xorq_version = "unknown"
-
         meta = {
             "run_id": self.run_id,
-            "xorq_version": xorq_version,
+            "xorq_version": _get_xorq_version(),
             "started_at": self._started_at,
             "completed_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "status": status,

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import importlib.metadata
 import json
 import logging.handlers
 import pathlib
@@ -230,8 +231,14 @@ class RunLogger:
         if self._finalized:
             return
 
+        try:
+            xorq_version = importlib.metadata.version("xorq")
+        except importlib.metadata.PackageNotFoundError:
+            xorq_version = "unknown"
+
         meta = {
             "run_id": self.run_id,
+            "xorq_version": xorq_version,
             "started_at": self._started_at,
             "completed_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "status": status,

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -12,12 +12,15 @@ from unittest.mock import patch
 import pandas as pd
 import pyarrow.parquet as pq
 import pytest
+from click.testing import CliRunner
 
+import xorq
 import xorq.api as xo
 from xorq.caching.strategy import SnapshotStrategy
 from xorq.cli import (
     OutputFormats,
     build_command,
+    cli,
     run_command,
 )
 from xorq.common.utils.io_utils import Peeker
@@ -56,6 +59,12 @@ build_run_examples_expr_names = (
     ("pyiceberg_backend_simple.py", "expr"),
     ("python_udwf.py", "expr"),
 )
+
+
+def test_version():
+    result = CliRunner().invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert xorq.__version__ in result.output
 
 
 def test_build_command_function(tmp_path, fixture_dir):

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -550,6 +550,7 @@ def test_run_command_writes_run_logger(tmp_path):
         assert meta["output_format"] == "parquet"
         assert "started_at" in meta
         assert "completed_at" in meta
+        assert meta["xorq_version"] == xorq.__version__
 
         events = run.read_events()
         event_names = [e["event"] for e in events]


### PR DESCRIPTION
- `xorq --version` via click.version_option(package_name=...) — zero import-time overhead, version lookup deferred to invocation
- `xorq_version` field in meta.json written by RunLogger.finalize(), resolved via importlib.metadata with "unknown" fallback
- test_version() asserts --version exits 0 and emits correct version