### PR TITLE
chore(init): bump template pins to pin-uv branches

### DIFF
--- a/python/xorq/init_templates.py
+++ b/python/xorq/init_templates.py
@@ -25,7 +25,7 @@ class InitTemplates(StrEnum):
 
 # NOTE: These are commit hashes from when the template update occurred
 templates_branches = (
-    (InitTemplates.cached_fetcher, "2c6c69f62e29ffd762d95b440a013de3a11c4750"),
-    (InitTemplates.sklearn, "f63e5658d250f5b42b24ddbd1bcdb2f0d2e0d830"),
-    (InitTemplates.penguins, "6ef79e76c27ef1f2cfd396c7424b976d06df4770"),
+    (InitTemplates.cached_fetcher, "023ffe1fa1e3f317d2830bfffc9d542f27aaa1fb"),
+    (InitTemplates.sklearn, "d94dd60fe2328af70ba5652effb442e022719186"),
+    (InitTemplates.penguins, "152a99294d502dacc9fcce8bd33904948f089f39"),
 )

--- a/python/xorq/init_templates.py
+++ b/python/xorq/init_templates.py
@@ -25,7 +25,7 @@ class InitTemplates(StrEnum):
 
 # NOTE: These are commit hashes from when the template update occurred
 templates_branches = (
-    (InitTemplates.cached_fetcher, "574dbc1d8eb5636633592bda43e5f2e92ae94f46"),
-    (InitTemplates.sklearn, "3449258697314e12e3473044a3fabcc3a0b8cbad"),
-    (InitTemplates.penguins, "9424469bf9128a39f9c58f6904fb747b721eaaf1"),
+    (InitTemplates.cached_fetcher, "2c6c69f62e29ffd762d95b440a013de3a11c4750"),
+    (InitTemplates.sklearn, "f63e5658d250f5b42b24ddbd1bcdb2f0d2e0d830"),
+    (InitTemplates.penguins, "6ef79e76c27ef1f2cfd396c7424b976d06df4770"),
 )

--- a/python/xorq/init_templates.py
+++ b/python/xorq/init_templates.py
@@ -25,7 +25,7 @@ class InitTemplates(StrEnum):
 
 # NOTE: These are commit hashes from when the template update occurred
 templates_branches = (
-    (InitTemplates.cached_fetcher, "13696303173f138853cc77ae09f8e82a1e17afd4"),
-    (InitTemplates.sklearn, "a915733da8fe69408e3254aa51e539017e0ac92a"),
-    (InitTemplates.penguins, "034e12236e4935a62616253a7b096f7f29b92134"),
+    (InitTemplates.cached_fetcher, "574dbc1d8eb5636633592bda43e5f2e92ae94f46"),
+    (InitTemplates.sklearn, "3449258697314e12e3473044a3fabcc3a0b8cbad"),
+    (InitTemplates.penguins, "9424469bf9128a39f9c58f6904fb747b721eaaf1"),
 )


### PR DESCRIPTION
## Summary
- Bump `cached_fetcher`, `sklearn`, and `penguins` template pins in `init_templates.py` to the latest template commits.
- The new template commits pin `uv>=0.9.18`, export `requirements.txt` with the flags xorq's packager compares against (`--locked --no-dev --no-emit-project --no-header --no-annotate`), and bump xorq to v0.3.24 in the templates' `uv.lock`.

Without this bump, fresh `xorq init` projects fail the packager's byte-exact `requirements.txt` check on first `xorq uv build` (#1941).

Companion PRs:
- xorq-labs/xorq-template-cached-fetcher#7
- xorq-labs/xorq-template-sklearn#12
- xorq-labs/xorq-template-penguins#13

## Test plan
- [x] `uv run pytest python/xorq/tests/test_cli.py::test_init_command_sklearn` — passes (downloads each new SHA from GitHub)
- [ ] Manual `xorq init --template <each>` smoke
- [ ] Slow test: `test_init_uv_build_uv_run` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)