### PR TITLE
feat(cli): add xorq uv run-cached and xorq uv run-unbound (Phase 3)

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -866,9 +866,95 @@ def uv_run(build_path, cache_dir, output_path, output_format, limit, raw_params)
     )
 
 
+@uv_group.command("run-cached")
+@click.argument("build_path")
+@cache_dir_option
+@output_options
+@limit_option
+@cache_strategy_options
+@params_options
+def uv_run_cached(
+    build_path,
+    cache_dir,
+    output_path,
+    output_format,
+    limit,
+    cache_type,
+    ttl,
+    raw_params,
+):
+    """Run a cached expression with a custom Python environment."""
+    from xorq.ibis_yaml.packager import PackagedCachedRunner, validate_params_early
+
+    try:
+        validate_params_early(build_path, raw_params)
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from None
+    runner = PackagedCachedRunner(
+        build_path,
+        cache_dir=cache_dir,
+        output_path=output_path,
+        output_format=output_format,
+        cache_type=cache_type,
+        ttl=ttl,
+        limit=limit,
+        raw_params=raw_params,
+    )
+    runner.run()
+
+
 _UNBOUND_OUTPUT_PATH_HELP = (
     f"Path to write output (default: stdout for arrow, {os.devnull} otherwise)."
 )
+
+
+@uv_group.command("run-unbound")
+@click.argument("build_path")
+@unbind_options
+@output_options(output_path_help=_UNBOUND_OUTPUT_PATH_HELP)
+@limit_option
+@click.option(
+    "--batch-size",
+    type=int,
+    default=None,
+    help="Batch size for Arrow streaming output (default: use table default).",
+)
+@cache_dir_option
+@click.option(
+    "-i",
+    "--instream",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to file with Arrow IPC data (default: read from stdin).",
+)
+def uv_run_unbound(
+    build_path,
+    to_unbind_hash,
+    to_unbind_tag,
+    typ,
+    output_path,
+    output_format,
+    limit,
+    batch_size,
+    cache_dir,
+    instream,
+):
+    """Run an unbound expr with a custom Python environment."""
+    from xorq.ibis_yaml.packager import PackagedUnboundRunner
+
+    runner = PackagedUnboundRunner(
+        build_path,
+        cache_dir=cache_dir,
+        output_path=output_path,
+        output_format=output_format,
+        to_unbind_hash=to_unbind_hash,
+        to_unbind_tag=to_unbind_tag,
+        typ=typ,
+        limit=limit,
+        batch_size=batch_size,
+        instream=instream,
+    )
+    runner.run()
 
 
 @cli.command("build")

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pyarrow.parquet as pq
 import pytest
+from click.testing import CliRunner
 
 import xorq.api as xo
 from xorq.caching.strategy import SnapshotStrategy
@@ -19,6 +20,7 @@ from xorq.cli import (
     OutputFormats,
     arbitrate_output_format,
     build_command,
+    cli,
     run_command,
 )
 from xorq.common.utils.io_utils import Peeker
@@ -1163,6 +1165,43 @@ def test_serve_penguins_template(tmpdir, tmp_path):
             assert len(actual) == len(sample_data)
     else:
         raise AssertionError("No expression hash")
+
+
+# ---------------------------------------------------------------------------
+# uv run-cached / uv run-unbound: help-text tests
+# ---------------------------------------------------------------------------
+
+
+def test_uv_run_cached_help():
+    result = CliRunner().invoke(cli, ["uv", "run-cached", "--help"])
+    assert result.exit_code == 0
+    for flag in (
+        "--cache-type",
+        "--ttl",
+        "--limit",
+        "--params",
+        "--cache-dir",
+        "--output-path",
+        "--format",
+    ):
+        assert flag in result.output, f"missing {flag}"
+
+
+def test_uv_run_unbound_help():
+    result = CliRunner().invoke(cli, ["uv", "run-unbound", "--help"])
+    assert result.exit_code == 0
+    for flag in (
+        "--to_unbind_hash",
+        "--to_unbind_tag",
+        "--typ",
+        "--batch-size",
+        "--instream",
+        "--limit",
+        "--output-path",
+        "--format",
+    ):
+        assert flag in result.output, f"missing {flag}"
+    assert "stdout" in result.output, "--output-path help text should mention stdout"
 
 
 def test_batch_size_forwarded_to_pyarrow_stream(monkeypatch):


### PR DESCRIPTION
## Summary

- Add `xorq uv run-cached` command: cached execution via `PackagedCachedRunner` with `--cache-type`, `--ttl`, `--limit`, `--params`, and pre-subprocess param validation
- Add `xorq uv run-unbound` command: unbound execution via `PackagedUnboundRunner` with stdin passthrough (`capture_output=False`), `--instream` file path, `--batch-size`, and custom `--output-path` help text
- Help-text tests for both commands

Stacked on #1965 (Phases 1–2). Implements Phase 3 of `plans/cli-parity-and-reusable-options.md`.

## Test plan

- [ ] `xorq uv run-cached --help` shows `--cache-type`, `--ttl`, `--limit`, `--params`, `--cache-dir`, `--output-path`, `--format`
- [ ] `xorq uv run-unbound --help` shows `--to_unbind_hash`, `--to_unbind_tag`, `--typ`, `--batch-size`, `--instream`, `--limit`, and `--output-path` help text mentions "stdout"
- [ ] Help-text tests pass (`test_uv_run_cached_help`, `test_uv_run_unbound_help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)