### PR TITLE
fix(logging): make file handler resilient and log path configurable

### DIFF
--- a/.devcontainer/project/setup-env.sh
+++ b/.devcontainer/project/setup-env.sh
@@ -11,6 +11,8 @@ cmd="${1:-first-run}"
 
 case "$cmd" in
     first-run)
+        mkdir -p "$(dirname "${XORQ_LOG_PATH:-$HOME/.config/xorq/xorq.log}")"
+
         echo "Installing dependencies..."
         uv sync --all-extras --all-groups
         touch .venv/.last-sync

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -122,8 +122,10 @@ if _log_level_str != "OFF":
             )
         )
         _xorq_logger.addHandler(_rfh)
-    except Exception:
-        pass
+    except Exception as e:
+        import warnings  # noqa: PLC0415
+
+        warnings.warn(f"xorq: file logging disabled: {e}", stacklevel=2)
 else:
     log_level = logging.CRITICAL
 

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -101,25 +101,29 @@ def get_print_logger():
 
 
 # https://betterstack.com/community/guides/logging/structlog/
-log_path = get_log_path(log_path=default_log_path)
+_configured_log_path = pathlib.Path(_log_env_config.log_path).expanduser()
+log_path = get_log_path(log_path=_configured_log_path)
 _log_level_str = _log_env_config.log_level.upper()
 
 if _log_level_str != "OFF":
     log_level = getattr(logging, _log_level_str)
     _xorq_logger = logging.getLogger("xorq")
     _xorq_logger.setLevel(log_level)
-    _rfh = logging.handlers.RotatingFileHandler(
-        log_path, maxBytes=50 * 2**20, backupCount=3
-    )
-    _rfh.setFormatter(
-        structlog.stdlib.ProcessorFormatter(
-            processors=[
-                structlog.processors.dict_tracebacks,
-                structlog.processors.JSONRenderer(),
-            ],
+    try:
+        _rfh = logging.handlers.RotatingFileHandler(
+            log_path, maxBytes=50 * 2**20, backupCount=3
         )
-    )
-    _xorq_logger.addHandler(_rfh)
+        _rfh.setFormatter(
+            structlog.stdlib.ProcessorFormatter(
+                processors=[
+                    structlog.processors.dict_tracebacks,
+                    structlog.processors.JSONRenderer(),
+                ],
+            )
+        )
+        _xorq_logger.addHandler(_rfh)
+    except Exception:
+        pass
 else:
     log_level = logging.CRITICAL
 

--- a/python/xorq/env_templates/.env.xorq.template
+++ b/python/xorq/env_templates/.env.xorq.template
@@ -4,6 +4,7 @@ XORQ_PROFILE_DIR=~/.config/xorq/profiles
 XORQ_DEBUG=False
 XORQ_CACHE_KEY_PREFIX=letsql_cache-
 XORQ_LOG_LEVEL=INFO
+XORQ_LOG_PATH=~/.config/xorq/xorq.log
 XORQ_RUNS_LOGS_DIR=~/.local/share/xorq/runs
 XORQ_DEFAULT_CATALOG=
 XORQ_TUI_LEFT_RATIO=2


### PR DESCRIPTION
## Summary
- Wrap `RotatingFileHandler` creation in try/except so a logging failure never crashes the import chain (was causing `ImportError` in devcontainers where `~/.config/xorq` didn't exist)
- Add `XORQ_LOG_PATH` env var (via `.env.xorq.template`) so the log file location is configurable
- Create the log directory in devcontainer `setup-env.sh` first-run, derived from `XORQ_LOG_PATH`

## Test plan
- [x] `XORQ_LOG_PATH=/tmp/xorq-test.log python -c "import xorq.common.utils.logging_utils as lu; print(lu.log_path)"` → uses configured path
- [x] Default path unchanged when env var unset
- [x] Broken path (`/nonexistent/...`) falls back to tempfile and import succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)