### PR TITLE
fix(devcontainer): lock host worktrees to prevent container-side prune

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,7 @@
+## Devcontainer safety
+
+This repo is often worked on from inside a devcontainer. The `.git` directory is shared between the host and the container.
+
+Worktrees created via `dev/new-worktree` are automatically locked to prevent `git worktree add` (which runs an implicit
+prune) from destroying their metadata when paths are unreachable from inside a container. `dev/cleanup-worktree` unlocks
+before removing. Always use these scripts to create and remove worktrees.

--- a/.devcontainer/lib/git.sh
+++ b/.devcontainer/lib/git.sh
@@ -12,3 +12,18 @@ dev_main_tree() {
     fi
     printf '%s\n' "$out" | head -1 | sed 's/^worktree //'
 }
+
+# Symlink the committable post-checkout hook into .git/hooks/ so that every
+# `git worktree add` — whether from dev/new-worktree, an agent, or a human —
+# auto-locks the new worktree.  Refuses to clobber a non-symlink hook.
+install_hooks() {
+    local main
+    main="$(dev_main_tree)" || return 1
+    local hook="$main/dev/hooks/post-checkout"
+    local dest="$main/.git/hooks/post-checkout"
+    [ -f "$hook" ] || return 0
+    if [ -e "$dest" ] && ! [ -L "$dest" ]; then
+        return 0
+    fi
+    ln -sf "../../dev/hooks/post-checkout" "$dest"
+}

--- a/.devcontainer/lib/git.sh
+++ b/.devcontainer/lib/git.sh
@@ -20,10 +20,17 @@ install_hooks() {
     local main
     main="$(dev_main_tree)" || return 1
     local hook="$main/dev/hooks/post-checkout"
-    local dest="$main/.git/hooks/post-checkout"
     [ -f "$hook" ] || return 0
-    if [ -e "$dest" ] && ! [ -L "$dest" ]; then
-        return 0
+
+    # Unset core.hooksPath so git uses the default .git/hooks/.
+    # Tools like Claude Code may set this to a linked-worktree path where
+    # .git is a file (not a directory), breaking all hooks. pre-commit also
+    # refuses to install when core.hooksPath is set.
+    git config --unset-all core.hooksPath 2>/dev/null || true
+
+    local hooks_dir="$main/.git/hooks"
+    mkdir -p "$hooks_dir"
+    if ! [ -e "$hooks_dir/post-checkout" ] || [ -L "$hooks_dir/post-checkout" ]; then
+        ln -sf "../../dev/hooks/post-checkout" "$hooks_dir/post-checkout"
     fi
-    ln -sf "../../dev/hooks/post-checkout" "$dest"
 }

--- a/.devcontainer/project/setup-env.sh
+++ b/.devcontainer/project/setup-env.sh
@@ -15,23 +15,6 @@ case "$cmd" in
         uv sync --all-extras --all-groups
         touch .venv/.last-sync
 
-        # Worktrees inherit core.hooksPath from the main repo's .git/config;
-        # pre-commit refuses to install when it's set. Override via env vars
-        # (highest git-config precedence) to the worktree's own hooks dir.
-        if git config core.hooksPath >/dev/null 2>&1; then
-            _hooks_dir="$(git rev-parse --git-dir)/hooks"
-            export GIT_CONFIG_COUNT=1
-            export GIT_CONFIG_KEY_0=core.hooksPath
-            export GIT_CONFIG_VALUE_0="${_hooks_dir}"
-            if ! grep -q 'GIT_CONFIG_KEY_0=core.hooksPath' ~/.bashrc 2>/dev/null; then
-                cat >> ~/.bashrc <<BASH
-export GIT_CONFIG_COUNT=1
-export GIT_CONFIG_KEY_0=core.hooksPath
-export GIT_CONFIG_VALUE_0="${_hooks_dir}"
-BASH
-            fi
-        fi
-
         echo "Installing pre-commit hooks..."
         uv run pre-commit install 2>/dev/null || true
 

--- a/dev/cleanup-worktree
+++ b/dev/cleanup-worktree
@@ -18,4 +18,9 @@ if [ -f "$manifest" ]; then
 fi
 
 cd "$main"
-git worktree remove "$here"
+git worktree unlock "$here" 2>/dev/null || true
+git worktree remove "$here" || {
+    git worktree lock "$here" \
+        --reason "re-locked after failed remove" 2>/dev/null || true
+    exit 1
+}

--- a/dev/cleanup-worktree
+++ b/dev/cleanup-worktree
@@ -8,7 +8,16 @@ manifest="$here/.envrcs/.worktree-manifest"
 
 if [ -f "$manifest" ]; then
     cd "$here"
-    xargs -d '\n' -r rm -v < "$manifest"
+    while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        if [ -L "$entry" ]; then
+            rm -v "$entry"
+        elif [ -f "$entry" ]; then
+            rm -v "$entry" || true
+        elif [ -d "$entry" ]; then
+            echo "skipping $entry (expected symlink, found directory)" >&2
+        fi
+    done < "$manifest"
     # Remove any empty parent directories created by setup
     while IFS= read -r entry; do
         dir=$(dirname "$entry")

--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -286,6 +286,7 @@ ensure_up() {
         }
 
         setup_claude_credentials
+        install_hooks
         ensure_external_volumes
         if [ "$DEV_WORKSPACE" != "$DEV_MAIN_TREE" ]; then
             (cd "$DEV_WORKSPACE" && "$DEV_MAIN_TREE/dev/setup-worktree")

--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -344,7 +344,7 @@ case "${1:-up}" in
         dc down --volumes
         ;;
     clean)
-        read -rp "This will destroy the container, volumes, images, and host-side artifacts. Continue? [y/N] " answer
+        read -rp "This will destroy $DEV_CONTAINER_NAME (container, volumes, images, and host-side artifacts). Continue? [y/N] " answer
         if [[ "$answer" != [yY]* ]]; then
             exit 0
         fi

--- a/dev/hooks/post-checkout
+++ b/dev/hooks/post-checkout
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Auto-lock worktrees on creation to prevent container-side prune.
+#
+# git worktree add runs an implicit prune; inside a container, host-side
+# worktree paths are unreachable and get destroyed. Locking prevents this.
+
+# $3: 1 = branch checkout, 0 = file checkout
+[ "${3:-}" = "1" ] || exit 0
+
+# Detect linked worktree: git-dir differs from git-common-dir in worktrees
+git_dir="$(cd "$(git rev-parse --git-dir 2>/dev/null)" && pwd)" || exit 0
+git_common="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" && pwd)" || exit 0
+[ "$git_dir" = "$git_common" ] && exit 0
+
+wt="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+git worktree lock "$wt" \
+    --reason "auto-locked by post-checkout hook to prevent container-side prune" \
+    2>/dev/null || true

--- a/dev/new-worktree
+++ b/dev/new-worktree
@@ -10,7 +10,11 @@ DEV_PROJECT_NAME="${PROJECT_NAME:-$(basename "$main_tree")}"
 unset PROJECT_NAME
 dest="$(dirname "$main_tree")/${DEV_PROJECT_NAME}-${branch//\//-}"
 
+install_hooks
 git worktree add "$dest" "$branch" >&2
+git worktree lock "$dest" \
+    --reason "locked by dev/new-worktree to prevent container-side prune" \
+    2>/dev/null || true
 cd "$dest"
 "$main_tree/dev/setup-worktree" >&2
 direnv allow >&2


### PR DESCRIPTION
## Summary
- `git worktree add` inside a container runs an implicit prune that destroys host-side worktree metadata (host paths are unreachable from the container's mount namespace)
- `dev/new-worktree` now locks each worktree immediately after creation; `dev/cleanup-worktree` unlocks before removal (re-locking if remove fails)
- Adds a committable `post-checkout` hook (`dev/hooks/post-checkout`) that auto-locks worktrees created via raw `git worktree add`, closing the gap for agents or humans bypassing the scripts
- Adds `install_hooks()` to `.devcontainer/lib/git.sh` — called from `dev/new-worktree` and `dev/devcontainer` to symlink the hook into `.git/hooks/`
- `install_hooks()` unsets `core.hooksPath` before installing — tools like Claude Code set this to a linked-worktree path where `.git` is a file, breaking all hooks and causing `pre-commit install` to refuse
- Removes the `GIT_CONFIG_COUNT` workaround from `setup-env.sh` (no longer needed)
- `cleanup-worktree` handles manifest entries that were replaced from symlinks to directories (skips with warning instead of failing on `rm`), ensuring `git worktree remove` always executes
- `devcontainer clean` prompt now shows the container name
- Adds `.claude/CLAUDE.md` with devcontainer safety instructions for Claude Code agents

## Context
Discovered after a Claude Code sub-agent inside a devcontainer created a worktree on `integrate-xorq-dasher`, which auto-pruned the existing host worktree's metadata at `/home/dan/repos/github/xorq-integrate-xorq-dasher/` — orphaning the directory while the branch was re-checked-out in a container-only path.

The `core.hooksPath` issue was found when testing the post-checkout hook inside a container — Claude Code had set it to `/workspaces/src/.git/hooks`, but `/workspaces/src` is a linked worktree where `.git` is a file (not a directory), so the hooks directory didn't exist and no hooks fired.

## Test plan
- [x] Run `devcontainer up` with existing host worktrees — verify they get locked (`git worktree list` shows `locked`)
- [x] Run `cleanup-worktree` from a locked worktree — verify it unlocks and removes cleanly
- [x] Run `git worktree add` inside the container — verify the post-checkout hook auto-locks the new worktree (requires `core.hooksPath` to be unset)
- [x] Run `cleanup-worktree` on a dirty worktree — verify it re-locks and exits 1
- [x] Run `cleanup-worktree` when `.claude` symlink was replaced with a directory — verify it skips and `git worktree remove` succeeds
- [x] Run `devcontainer clean` — verify prompt shows container name

🤖 Generated with [Claude Code](https://claude.com/claude-code)