### PR TITLE
feat(relations): replace SafeTee with batchcorder StreamCache

### DIFF
--- a/docs/adr/0013-batchcorder-stream-cache-for-remote-table-fan-out.md
+++ b/docs/adr/0013-batchcorder-stream-cache-for-remote-table-fan-out.md
@@ -3,7 +3,7 @@
 - **Status:** Accepted
 - **Date:** 2026-05-22
 - **Deciders:** Daniel
-- **Context area:** `python/xorq/expr/relations.py`, `python/xorq/expr/api.py`, `python/xorq/backends/pandas/__init__.py`
+- **Context area:** `python/xorq/expr/remote_table_exec.py`, `python/xorq/expr/api.py`, `python/xorq/expr/relations.py`
 
 ## Context
 
@@ -27,7 +27,7 @@ expr.execute()  # empty — should have 5 rows
 
 ### Root cause: multi-scan of a one-shot Arrow iterator
 
-`register_and_transform_remote_tables` (`relations.py`) walks an expression graph,
+`register_and_transform_remote_tables` (`remote_table_exec.py`) walks an expression graph,
 finds every `RemoteTable` node, materialises the remote expression as an Arrow
 `RecordBatchReader`, and registers it with the local DuckDB backend so the expression
 can execute locally.
@@ -94,22 +94,33 @@ batches lazily from the upstream reader and stores them internally. Any number o
 independent `StreamCacheReader` handles can replay the full stream from position zero
 without knowing the total reader count in advance.
 
-In `replacer`, each `RemoteTable` now gets a single `StreamCache`:
+In `replacer` (inside `register_and_transform_remote_tables` in
+`remote_table_exec.py`), each `RemoteTable` gets a single `StreamCache` whose
+resources are tracked by a `RemoteTableScope`:
 
 ```python
-cache = StreamCache(
-    pa.RecordBatchReader.from_batches(schema, remote_expr.to_pyarrow_batches())
+reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+cache = scope.adopt_cache(
+    StreamCache(reader, max_readers=reader_counts.get(node))
 )
-caches.append(cache)
-table_name = gen_name()
-result = node.source.read_record_batches(cache, table_name=table_name)
-created[table_name] = node.source
+table_name = scope.adopt_table(node.source, gen_name())
+result = node.source.read_record_batches(cache, table_name=table_name, **read_kwargs)
 ```
 
 DuckDB acquires a fresh `StreamCacheReader` via `__arrow_c_stream__` each time it
 scans the registered table. Every reader starts at batch 0 and advances
 independently. The upstream remote expression is called exactly once — ingestion is
 lazy and shared across all readers via an internal `Arc<Mutex<DatasetInner>>`.
+
+#### Bounded eviction via `max_readers`
+
+`count_remote_table_readers` compiles the expression to a sqlglot AST with sentinel
+table names and counts how many `Table` nodes bear each sentinel — giving the exact
+physical scan count whatever lowering the backend compiler applies. The count becomes
+`StreamCache`'s `max_readers`, allowing it to evict batches once all readers advance
+past them. This is a memory optimisation, not a correctness requirement: if no AST
+can be produced (non-SQL backend), `max_readers` is omitted and the cache retains all
+batches.
 
 ### Storage modes
 
@@ -125,29 +136,29 @@ streams that exceed available RAM. Because `close()` is already called explicitl
 all executing call sites, enabling disk mode later is a configuration change only —
 no new cleanup logic is required.
 
-### Resource lifecycle
+### Resource lifecycle — `RemoteTableScope`
 
-`register_and_transform_remote_tables` returns `(expr, created, caches)` where
-`caches: list[StreamCache]` is owned by the call site.
+`register_and_transform_remote_tables` returns `(expr, scope)` where
+`scope: RemoteTableScope` owns every resource the transform materialised:
+upstream `RecordBatchReader`s, `StreamCache`s, and placeholder tables.
+`scope.close()` tears down in dependency order (tables → caches → readers),
+LIFO within each category, and is idempotent.
 
-**Executing call sites close caches explicitly:**
+Call sites use one of two patterns depending on whether execution is eager or
+streaming:
 
-- **`_pandas_execute`**: `finally` block immediately after `con.execute()` returns.
-  Pandas execution is synchronous and fully materialises before returning.
-- **`get_plans`**: `finally` block after the `EXPLAIN` SQL completes. The upstream
-  stream is never read during `EXPLAIN`; closing here releases it without waiting
-  for GC.
-- **`to_pyarrow_batches`**: `cache.close()` inside the `clean_up` callback passed
-  to `rbr_wrapper`. The callback fires when the returned `RecordBatchReader` generator
-  exits — either on full exhaustion or when the generator is closed/GCed.
-- **`prepare_create_table_from_expr`**: `finally` block after the transformed
-  expression is returned. Caches are closed before the caller materialises the table.
+- **Eager (fully materialised before returning):**
+  `remote_table_scope` is a context manager in `api.py` that yields the
+  transformed expression and closes the scope on exit.  Used by
+  `_pandas_execute`, `get_plans`, and any backend whose
+  `read_record_batches` eagerly ingests the stream (Snowflake, Postgres via
+  ADBC through `prepare_create_table_from_expr`).
 
-### Effect on `created`
-
-`created` maps `table_name → backend`. For a self-join that previously generated
-three `SafeTee` copies, `len(created)` drops from 3 to 1 — one entry per unique
-`RemoteTable` node.
+- **Streaming (`to_pyarrow_batches`):**
+  `bind_scope_to_reader` wraps the result `RecordBatchReader` in a generator
+  whose `finally` block calls `scope.close()`.  A `weakref.finalize`
+  backstop covers readers abandoned before the first read (a never-started
+  generator never runs its `finally`).
 
 ## Alternatives considered
 
@@ -182,13 +193,15 @@ ingestion and an optional disk spill path.
 
 ### Positive
 
-- **No pre-counting.** `replacer` creates one `StreamCache` per `RemoteTable` node
-  without knowing how many times DuckDB will scan it.
+- **No pre-counting for correctness.** `replacer` creates one `StreamCache` per
+  `RemoteTable` node without knowing how many times DuckDB will scan it.
+  `max_readers` is a memory-eviction hint derived from the sqlglot AST; omitting
+  it is safe — the cache simply retains all batches.
 - **Thread-safe reads.** Concurrent `StreamCacheReader` handles share an
   `Arc<Mutex<DatasetInner>>` and are designed for concurrent use.
-- **Prompt resource release.** Explicit `close()` at execution boundaries releases
-  memory immediately rather than waiting for GC.
-- **`created` cardinality is natural.** One entry per unique `RemoteTable` node.
+- **Prompt resource release.** `RemoteTableScope.close()` releases tables, caches,
+  and readers in dependency order. Eager call sites use `remote_table_scope`;
+  streaming call sites use `bind_scope_to_reader`.
 - **Fixes #983 and the full multi-scan class.** ASOF join with `tolerance` and
   self-join both work correctly.
 
@@ -196,17 +209,17 @@ ingestion and an optional disk spill path.
 
 - **New runtime dependency.** `batchcorder >= 0.1.2` is now required. It ships
   pre-built wheels, requires only `pyarrow` (no `arro3`), and supports Python ≥ 3.10.
-- **Abandoned reader leak (generator close path).** `clean_up` in `to_pyarrow_batches`
-  fires inside the generator's `finally` block. Python guarantees this runs when the
-  generator is closed or GCed, but the timing is non-deterministic for callers that
-  drop the reader early. In memory-only mode this is acceptable; disk mode would
-  require deterministic cleanup (e.g. wrapping the reader in a context manager).
+- **Abandoned reader leak (streaming path).** `bind_scope_to_reader` defers cleanup
+  to a wrapping generator's `finally` block, with a `weakref.finalize` backstop.
+  Python guarantees the finaliser runs when the reader is GCed, but the timing is
+  non-deterministic for callers that drop the reader early. In memory-only mode this
+  is acceptable; disk mode would require deterministic cleanup (e.g. wrapping the
+  reader in a context manager).
 
 ## References
 
 - [Issue #983](https://github.com/xorq-labs/xorq/issues/983) — `asof_join` with `tolerance` and `into_backend` gives empty result
-- `python/xorq/expr/relations.py` — `register_and_transform_remote_tables`, `replacer`, `prepare_create_table_from_expr`
-- `python/xorq/expr/api.py` — `_transform_expr`, `to_pyarrow_batches`, `_pandas_execute`, `get_plans`
-- `python/xorq/backends/pandas/__init__.py` — `read_record_batches` StreamCache branch
-- `python/xorq/common/utils/defer_utils.py` — `rbr_wrapper`
+- `python/xorq/expr/remote_table_exec.py` — `RemoteTableScope`, `bind_scope_to_reader`, `register_and_transform_remote_tables`, `count_remote_table_readers`, `prepare_create_table_from_expr`
+- `python/xorq/expr/api.py` — `_transform_expr`, `remote_table_scope`, `to_pyarrow_batches`, `_pandas_execute`, `get_plans`
+- `python/xorq/expr/relations.py` — `RemoteTable`
 - [batchcorder on PyPI](https://pypi.org/project/batchcorder/)

--- a/docs/adr/0013-batchcorder-stream-cache-for-remote-table-fan-out.md
+++ b/docs/adr/0013-batchcorder-stream-cache-for-remote-table-fan-out.md
@@ -1,0 +1,212 @@
+# ADR-0013: Replace SafeTee with batchcorder StreamCache for RemoteTable fan-out
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** Daniel
+- **Context area:** `python/xorq/expr/relations.py`, `python/xorq/expr/api.py`, `python/xorq/backends/pandas/__init__.py`
+
+## Context
+
+### Motivating bug
+
+[Issue #983](https://github.com/xorq-labs/xorq/issues/983): `asof_join` with `tolerance` and `into_backend` returns an empty result.
+
+```python
+con = xo.duckdb.connect()
+sensors_bt = sensors.into_backend(con)
+events_bt  = events.into_backend(con)
+
+expr = (
+    sensors_bt
+    .asof_join(events_bt, on="event_time", predicates="site", tolerance=timedelta(seconds=1))
+    .drop("event_time_right")
+    .order_by("event_time")
+)
+expr.execute()  # empty — should have 5 rows
+```
+
+### Root cause: multi-scan of a one-shot Arrow iterator
+
+`register_and_transform_remote_tables` (`relations.py`) walks an expression graph,
+finds every `RemoteTable` node, materialises the remote expression as an Arrow
+`RecordBatchReader`, and registers it with the local DuckDB backend so the expression
+can execute locally.
+
+The upstream reader is a one-shot iterator. DuckDB's ASOF join with `tolerance`
+internally scans the registered Arrow source more than once. The first scan exhausts
+the iterator; subsequent scans find nothing and produce an empty result.
+
+This is a class of bug, not a single query shape. Any DuckDB operation that re-scans
+a registered Arrow source hits it. Two confirmed cases:
+
+1. **ASOF join with `tolerance`** — DuckDB re-scans to apply the tolerance filter
+   (issue #983).
+2. **Self-join** — both sides of the join point to the same `RemoteTable`; each side
+   tries to advance the same iterator.
+
+### Previous solution: SafeTee
+
+```python
+class SafeTee:
+    def __init__(self, iterable, n):
+        with threading.Lock():
+            self._tees = itertools.tee(iterable, n)
+    def __iter__(self):
+        return iter(self._tees.pop())
+```
+
+`SafeTee` required the caller to know `n` — the total number of times the same
+`RemoteTable` would be consumed — before allocating the tee copies. This forced a
+two-pass graph walk:
+
+1. Walk the full graph, counting occurrences of each `RemoteTable` expression hash.
+2. Walk again, allocating `SafeTee(upstream, count)` on first encounter and popping
+   one tee copy per subsequent encounter.
+
+Problems:
+
+- **Pre-counting is fragile.** DuckDB can scan a registered source more than once
+  inside a single query (ASOF joins, self-joins, joins with intermediate aggregations).
+  The scan count is not part of DuckDB's public API and varies by query shape,
+  DuckDB version, and optimiser decisions. Undercounting exhausted the tee pool;
+  overcounting leaked unconsumed iterators.
+- **Thread safety is incomplete.** `itertools.tee` is explicitly documented as not
+  thread-safe. DuckDB scans registered tables from parallel threads within a single
+  query.
+- **`created` cardinality was inflated.** The function returned one entry per tee
+  copy, so a self-join with `n=3` copies produced `len(created) == 3` even though
+  only one remote table was involved.
+
+## Decision drivers
+
+- Multi-scan must be transparent — no pre-counting at call sites.
+- Concurrent reads (DuckDB scanning from multiple threads) must be safe.
+- Memory and disk resources must be released promptly after execution.
+
+## Decision
+
+### Replace SafeTee with batchcorder StreamCache
+
+[batchcorder](https://pypi.org/project/batchcorder/) is a Rust-backed library
+authored by Daniel Mesejo specifically to solve this class of problem. Its
+`StreamCache` wraps any Arrow stream source in a replayable cache: it ingests
+batches lazily from the upstream reader and stores them internally. Any number of
+independent `StreamCacheReader` handles can replay the full stream from position zero
+without knowing the total reader count in advance.
+
+In `replacer`, each `RemoteTable` now gets a single `StreamCache`:
+
+```python
+cache = StreamCache(
+    pa.RecordBatchReader.from_batches(schema, remote_expr.to_pyarrow_batches())
+)
+caches.append(cache)
+table_name = gen_name()
+result = node.source.read_record_batches(cache, table_name=table_name)
+created[table_name] = node.source
+```
+
+DuckDB acquires a fresh `StreamCacheReader` via `__arrow_c_stream__` each time it
+scans the registered table. Every reader starts at batch 0 and advances
+independently. The upstream remote expression is called exactly once — ingestion is
+lazy and shared across all readers via an internal `Arc<Mutex<DatasetInner>>`.
+
+### Storage modes
+
+`StreamCache` supports two modes:
+
+- **Memory-only** (default): batches stored as `Arc<RecordBatch>` in a Rust `Vec`.
+  Reads are zero-copy Arc clones. xorq uses this mode today.
+- **Disk** (`disk_path` + `disk_capacity` both provided): batches serialised to an
+  append-only Arrow IPC file with a configurable hot layer in RAM.
+
+Disk mode is not currently used but is planned as a future configuration option for
+streams that exceed available RAM. Because `close()` is already called explicitly at
+all executing call sites, enabling disk mode later is a configuration change only —
+no new cleanup logic is required.
+
+### Resource lifecycle
+
+`register_and_transform_remote_tables` returns `(expr, created, caches)` where
+`caches: list[StreamCache]` is owned by the call site.
+
+**Executing call sites close caches explicitly:**
+
+- **`_pandas_execute`**: `finally` block immediately after `con.execute()` returns.
+  Pandas execution is synchronous and fully materialises before returning.
+- **`get_plans`**: `finally` block after the `EXPLAIN` SQL completes. The upstream
+  stream is never read during `EXPLAIN`; closing here releases it without waiting
+  for GC.
+- **`to_pyarrow_batches`**: `cache.close()` inside the `clean_up` callback passed
+  to `rbr_wrapper`. The callback fires when the returned `RecordBatchReader` generator
+  exits — either on full exhaustion or when the generator is closed/GCed.
+- **`prepare_create_table_from_expr`**: `finally` block after the transformed
+  expression is returned. Caches are closed before the caller materialises the table.
+
+### Effect on `created`
+
+`created` maps `table_name → backend`. For a self-join that previously generated
+three `SafeTee` copies, `len(created)` drops from 3 to 1 — one entry per unique
+`RemoteTable` node.
+
+## Alternatives considered
+
+### Keep SafeTee with accurate pre-counting
+
+Audit every DuckDB code path to determine the exact scan count per query shape and
+increase it to account for internal re-scans.
+
+Rejected: DuckDB's scan count is not part of its public API and varies by query
+shape, DuckDB version, and optimiser. Any hardcoded count breaks silently on upgrade.
+Even with a correct count, concurrent scans require per-copy locking that `SafeTee`
+did not provide.
+
+### `itertools.tee` directly
+
+Drop the `SafeTee` class and call `tee` directly.
+
+Rejected: `itertools.tee` is explicitly documented as not thread-safe. DuckDB scans
+registered tables from parallel threads within a single query.
+
+### Pre-ingest into a `pa.Table`
+
+Call `remote_expr.to_pyarrow()` to materialise the full result, register the table
+once, and let DuckDB read from it N times.
+
+Rejected: forces full materialisation before any execution begins, eliminating lazy
+streaming. For large remote results the full table must fit in memory before DuckDB
+can begin processing. `StreamCache` provides the same multi-read behaviour with lazy
+ingestion and an optional disk spill path.
+
+## Consequences
+
+### Positive
+
+- **No pre-counting.** `replacer` creates one `StreamCache` per `RemoteTable` node
+  without knowing how many times DuckDB will scan it.
+- **Thread-safe reads.** Concurrent `StreamCacheReader` handles share an
+  `Arc<Mutex<DatasetInner>>` and are designed for concurrent use.
+- **Prompt resource release.** Explicit `close()` at execution boundaries releases
+  memory immediately rather than waiting for GC.
+- **`created` cardinality is natural.** One entry per unique `RemoteTable` node.
+- **Fixes #983 and the full multi-scan class.** ASOF join with `tolerance` and
+  self-join both work correctly.
+
+### Negative
+
+- **New runtime dependency.** `batchcorder >= 0.1.2` is now required. It ships
+  pre-built wheels, requires only `pyarrow` (no `arro3`), and supports Python ≥ 3.10.
+- **Abandoned reader leak (generator close path).** `clean_up` in `to_pyarrow_batches`
+  fires inside the generator's `finally` block. Python guarantees this runs when the
+  generator is closed or GCed, but the timing is non-deterministic for callers that
+  drop the reader early. In memory-only mode this is acceptable; disk mode would
+  require deterministic cleanup (e.g. wrapping the reader in a context manager).
+
+## References
+
+- [Issue #983](https://github.com/xorq-labs/xorq/issues/983) — `asof_join` with `tolerance` and `into_backend` gives empty result
+- `python/xorq/expr/relations.py` — `register_and_transform_remote_tables`, `replacer`, `prepare_create_table_from_expr`
+- `python/xorq/expr/api.py` — `_transform_expr`, `to_pyarrow_batches`, `_pandas_execute`, `get_plans`
+- `python/xorq/backends/pandas/__init__.py` — `read_record_batches` StreamCache branch
+- `python/xorq/common/utils/defer_utils.py` — `rbr_wrapper`
+- [batchcorder on PyPI](https://pypi.org/project/batchcorder/)

--- a/docs/adr/0013-batchcorder-stream-cache-for-remote-table-fan-out.md
+++ b/docs/adr/0013-batchcorder-stream-cache-for-remote-table-fan-out.md
@@ -25,6 +25,15 @@ expr = (
 expr.execute()  # empty — should have 5 rows
 ```
 
+This `asof_join`-with-`tolerance` shape is what first surfaced the bug. Its lowering
+re-scanned the left input to apply the tolerance filter, and that specific lowering has
+since been rewritten to a single pass in
+[#2086](https://github.com/xorq-labs/xorq/pull/2086) (one ASOF join plus a null-out
+projection), so this shape is no longer multi-scan. But the underlying problem — a
+one-shot Arrow iterator read more than once — is a *class* of bug, and the replay
+machinery this ADR describes is what handles it. The **self-join** (below) is the
+canonical multi-scan shape that motivates the decision.
+
 ### Root cause: multi-scan of a one-shot Arrow iterator
 
 `register_and_transform_remote_tables` (`remote_table_exec.py`) walks an expression graph,
@@ -37,12 +46,15 @@ internally scans the registered Arrow source more than once. The first scan exha
 the iterator; subsequent scans find nothing and produce an empty result.
 
 This is a class of bug, not a single query shape. Any DuckDB operation that re-scans
-a registered Arrow source hits it. Two confirmed cases:
+a registered Arrow source hits it:
 
-1. **ASOF join with `tolerance`** — DuckDB re-scans to apply the tolerance filter
-   (issue #983).
-2. **Self-join** — both sides of the join point to the same `RemoteTable`; each side
-   tries to advance the same iterator.
+1. **Self-join** — both sides of the join point to the same `RemoteTable`; each side
+   tries to advance the same iterator. This is the canonical multi-scan shape the replay
+   machinery handles.
+2. **ASOF join with `tolerance`** — the old lowering re-scanned the left input to apply
+   the tolerance filter (issue #983). Rewritten to a single pass in #2086, so this shape
+   no longer multi-scans; it is listed here as the bug's original trigger, not a current
+   multi-scan case.
 
 ### Previous solution: SafeTee
 
@@ -65,11 +77,14 @@ two-pass graph walk:
 
 Problems:
 
-- **Pre-counting is fragile.** DuckDB can scan a registered source more than once
-  inside a single query (ASOF joins, self-joins, joins with intermediate aggregations).
-  The scan count is not part of DuckDB's public API and varies by query shape,
-  DuckDB version, and optimiser decisions. Undercounting exhausted the tee pool;
-  overcounting leaked unconsumed iterators.
+- **Correctness depended on an exact pre-count.** `SafeTee` allocated exactly `n`
+  tee copies up front, so an inaccurate `n` was a *correctness* bug, not a tuning
+  miss: undercounting exhausted the tee pool (empty results), overcounting leaked
+  unconsumed iterators. But the scan count is not part of DuckDB's public API — it
+  varies by query shape, DuckDB version, and optimiser decisions (ASOF joins,
+  self-joins, and joins with intermediate aggregations all re-scan). A count that
+  cannot be known exactly must not gate correctness. (We still pre-count under
+  batchcorder, but only as an eviction hint — see `max_readers` below.)
 - **Thread safety is incomplete.** `itertools.tee` is explicitly documented as not
   thread-safe. DuckDB scans registered tables from parallel threads within a single
   query.
@@ -79,7 +94,6 @@ Problems:
 
 ## Decision drivers
 
-- Multi-scan must be transparent — no pre-counting at call sites.
 - Concurrent reads (DuckDB scanning from multiple threads) must be safe.
 - Memory and disk resources must be released promptly after execution.
 
@@ -99,28 +113,73 @@ In `replacer` (inside `register_and_transform_remote_tables` in
 resources are tracked by a `RemoteTableScope`:
 
 ```python
-reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+raw_reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+logical_schema = node.schema.to_pyarrow()
+casting_reader = project_and_cast_reader(raw_reader, logical_schema)
 cache = scope.adopt_cache(
-    StreamCache(reader, max_readers=reader_counts.get(node))
+    StreamCache(casting_reader, max_readers=reader_counts.get(node))
 )
 table_name = scope.adopt_table(node.source, gen_name())
-result = node.source.read_record_batches(cache, table_name=table_name, **read_kwargs)
+result = node.source.read_record_batches(
+    cache, table_name=table_name, schema=logical_schema, **read_kwargs
+)
 ```
+
+The `project_and_cast_reader` step is not incidental — see "Schema invariant" below.
 
 DuckDB acquires a fresh `StreamCacheReader` via `__arrow_c_stream__` each time it
 scans the registered table. Every reader starts at batch 0 and advances
 independently. The upstream remote expression is called exactly once — ingestion is
 lazy and shared across all readers via an internal `Arc<Mutex<DatasetInner>>`.
 
+This is what makes `SafeTee` unnecessary. Because the registered table is replayable,
+a self-join over a `RemoteTable` works without any caller-side tee allocation: each
+join side acquires its own `StreamCacheReader` and replays the same stream from
+batch 0. The same holds for any other genuine multi-scan shape (e.g. a backend re-scan
+introduced by an intermediate aggregation).
+
+#### Schema invariant — project and cast *before* the cache
+
+The raw upstream reader is not registered directly. A remote expression's
+`RecordBatchReader` may carry extra physical columns (e.g. a `row_number` added
+by the backend) or mismatched types (`large_utf8` vs `utf8`) relative to the
+node's logical schema. `project_and_cast_reader` selects exactly the logical
+columns and casts them to the logical types *before* the stream reaches
+`StreamCache`.
+
+This is a correctness requirement, not a tidiness one. `StreamCache` replays
+through the Arrow C Data Interface using the *declared* schema, so a batch whose
+physical layout does not match that schema is read back as silently corrupt
+data — not an error. The backend casting wrapper (`StreamCache.cast`) only
+retypes; it cannot drop columns. Projecting and casting once, ahead of the
+cache, keeps a single invariant: the cache holds exactly the logical columns in
+the logical types, and every backend can register it with a type-only cast. The
+same `logical_schema` is also threaded through `read_record_batches(...,
+schema=logical_schema, ...)` so the placeholder table is declared with the
+logical columns rather than the reader's physical ones.
+
 #### Bounded eviction via `max_readers`
 
 `count_remote_table_readers` compiles the expression to a sqlglot AST with sentinel
-table names and counts how many `Table` nodes bear each sentinel — giving the exact
-physical scan count whatever lowering the backend compiler applies. The count becomes
+table names and counts how many `Table` nodes bear each sentinel. The count becomes
 `StreamCache`'s `max_readers`, allowing it to evict batches once all readers advance
-past them. This is a memory optimisation, not a correctness requirement: if no AST
-can be produced (non-SQL backend), `max_readers` is omitted and the cache retains all
-batches.
+past them. When no AST can be produced (non-SQL backend), `max_readers` is omitted and
+the cache retains all batches.
+
+This count is a best-effort *lower bound*, not an exact physical scan count. It sees
+only the scans the compiled SQL spells out; it cannot see re-scans the backend's
+optimiser introduces *below* the SQL layer. The known gap: DuckDB lowers a
+`PARTITION BY`-only aggregate window (`sum(v) OVER (PARTITION BY k)`, no `ORDER BY`)
+into a `GROUP BY` self-join — `HASH_JOIN(SEQ_SCAN, GROUP_BY(SEQ_SCAN))`, no `WINDOW`
+operator — that scans its input twice, while the AST counts one `Table` node.
+
+`max_readers` is enforced as a **hard cap**: a reader beyond the cap raises
+`ValueError: Maximum number of readers reached`. So an *undercount* is not merely a
+missed memory optimisation — it is a correctness bug for the query shapes it misses
+(the partition-window case above is one). Omitting the count entirely is always safe
+(unbounded cache); deriving a count that is too low is not. This is the one place the
+batchcorder design still depends on getting a scan count right, and the AST heuristic
+does not get it right for every shape. (See "Counting accuracy" under Negative.)
 
 ### Storage modes
 
@@ -140,9 +199,18 @@ no new cleanup logic is required.
 
 `register_and_transform_remote_tables` returns `(expr, scope)` where
 `scope: RemoteTableScope` owns every resource the transform materialised:
-upstream `RecordBatchReader`s, `StreamCache`s, and placeholder tables.
-`scope.close()` tears down in dependency order (tables → caches → readers),
-LIFO within each category, and is idempotent.
+upstream `RecordBatchReader`s, `StreamCache`s, and placeholder tables. The same
+scope is also handed the tee-node write-through drains (`DrainingIterator`s)
+that `_transform_expr` produces, so a single `close()` tears everything down
+(see ADR-0014).
+
+`scope.close()` runs in dependency order: **drains first** (close-then-join, so
+every write-through writer stops pulling and finishes landing its stream before
+any table it feeds is dropped), then tables → caches → readers, LIFO within each
+category. It is idempotent. Drain failures are correctness signals — a failed
+join means a tee/WAP write never landed — so `close(raise_drain_errors=True)`
+raises them on the eager path once the result is consumed; teardown-after-failure
+and finalizer paths log instead.
 
 Call sites use one of two patterns depending on whether execution is eager or
 streaming:
@@ -193,22 +261,33 @@ ingestion and an optional disk spill path.
 
 ### Positive
 
-- **No pre-counting for correctness.** `replacer` creates one `StreamCache` per
-  `RemoteTable` node without knowing how many times DuckDB will scan it.
-  `max_readers` is a memory-eviction hint derived from the sqlglot AST; omitting
-  it is safe — the cache simply retains all batches.
+- **Replay is decoupled from the count.** `replacer` creates one `StreamCache` per
+  `RemoteTable` node, and any reader can replay the full stream from batch 0. The
+  sqlglot-AST count feeds only `max_readers`, which bounds eviction; omitting it is
+  always safe — the cache simply retains all batches. (The count is *not* free of
+  correctness consequences when supplied — see "Counting accuracy" below.)
 - **Thread-safe reads.** Concurrent `StreamCacheReader` handles share an
   `Arc<Mutex<DatasetInner>>` and are designed for concurrent use.
-- **Prompt resource release.** `RemoteTableScope.close()` releases tables, caches,
-  and readers in dependency order. Eager call sites use `remote_table_scope`;
-  streaming call sites use `bind_scope_to_reader`.
-- **Fixes #983 and the full multi-scan class.** ASOF join with `tolerance` and
-  self-join both work correctly.
+- **Prompt resource release.** `RemoteTableScope.close()` releases drains, then
+  tables, caches, and readers in dependency order. Eager call sites use
+  `remote_table_scope`; streaming call sites use `bind_scope_to_reader`.
+- **Handles the multi-scan class.** Self-join over a `RemoteTable` works correctly, as
+  does any shape that re-scans a registered source. The replay mechanism itself handles
+  any number of scans; the remaining gap is purely in `max_readers` undercounting certain
+  shapes (see "Counting accuracy").
 
 ### Negative
 
-- **New runtime dependency.** `batchcorder >= 0.1.2` is now required. It ships
+- **New runtime dependency.** `batchcorder == 0.1.3` is now required. It ships
   pre-built wheels, requires only `pyarrow` (no `arro3`), and supports Python ≥ 3.10.
+- **Counting accuracy (`max_readers`).** The sqlglot-AST scan count is a heuristic
+  lower bound, and `max_readers` is a hard cap, so any query whose backend re-scans a
+  source below the SQL layer can undercount and raise `ValueError: Maximum number of
+  readers reached`. The known case is a `PARTITION BY`-only aggregate window on DuckDB
+  (lowered to a `GROUP BY` self-join). Reading the backend's physical `EXPLAIN` plan
+  would give the exact count, but that plan is data-dependent (the optimiser prunes
+  scans of provably-empty placeholder tables), so it cannot be reproduced offline
+  without representative data; pending a fix, the AST count stands.
 - **Abandoned reader leak (streaming path).** `bind_scope_to_reader` defers cleanup
   to a wrapping generator's `finally` block, with a `weakref.finalize` backstop.
   Python guarantees the finaliser runs when the reader is GCed, but the timing is
@@ -219,6 +298,7 @@ ingestion and an optional disk spill path.
 ## References
 
 - [Issue #983](https://github.com/xorq-labs/xorq/issues/983) — `asof_join` with `tolerance` and `into_backend` gives empty result
+- [PR #2086](https://github.com/xorq-labs/xorq/pull/2086) — single-pass ASOF-with-`tolerance` lowering; fixes #983 at the lowering level, so this shape is no longer multi-scan
 - `python/xorq/expr/remote_table_exec.py` — `RemoteTableScope`, `bind_scope_to_reader`, `register_and_transform_remote_tables`, `count_remote_table_readers`, `prepare_create_table_from_expr`
 - `python/xorq/expr/api.py` — `_transform_expr`, `remote_table_scope`, `to_pyarrow_batches`, `_pandas_execute`, `get_plans`
 - `python/xorq/expr/relations.py` — `RemoteTable`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "typing-extensions>=4.3.0",
     "py-yaml12",
     "cloudpickle>=3.1.1",
-    "xorq-datafusion==0.2.7",
+    "xorq-datafusion==0.2.8",
     "opentelemetry-sdk>=1.32.1",
     "opentelemetry-exporter-otlp>=1.32.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",
@@ -57,6 +57,7 @@ dependencies = [
     "textual>=1.0.0",
     "filelock>=3.13",
     "xorq-dasher>=0.1.1",
+    "batchcorder>=0.1.2",
 ]
 requires-python = ">=3.10,<3.14"
 authors = [
@@ -92,7 +93,7 @@ pyiceberg = [
     "pyiceberg[sql-sqlite,sql-postgres]>=0.9.0",
 ]
 duckdb = [
-    "duckdb>=1.1.3",
+    "duckdb>=1.5",  # 1.5 required for stable Arrow stream registration used by StreamCache
 ]
 datafusion = [
     "datafusion>=0.6,<49; python_version >= '3.10' and python_version < '4.0'"
@@ -126,7 +127,7 @@ sqlite = [
 ]
 gizmosql = [
     "adbc-driver-gizmosql>=1.1.5",
-    "duckdb>=1.1.3",
+    "duckdb>=1.5",  # see duckdb extra above
     "gizmosql>=1.26.0,<2",
     "cryptography>=42",
 ]
@@ -164,7 +165,7 @@ dev = [
     "vendoring>=1.2.0",
     "xorq-style~=0.3.0",
     "pyopenssl>=24.3.0",
-    "duckdb>=1.1.3",
+    "duckdb>=1.5",  # see duckdb extra above
     "datafusion>=43.1.0",
     "adbc-driver-sqlite>=1.4.0",
     "scikit-learn<2.0.0,>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "typing-extensions>=4.3.0",
     "py-yaml12",
     "cloudpickle>=3.1.1",
-    "xorq-datafusion==0.2.8",
+    "xorq-datafusion==0.2.9",
     "opentelemetry-sdk>=1.32.1",
     "opentelemetry-exporter-otlp>=1.32.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",
@@ -57,7 +57,7 @@ dependencies = [
     "textual>=1.0.0",
     "filelock>=3.13",
     "xorq-dasher>=0.1.1",
-    "batchcorder>=0.1.2",
+    "batchcorder==0.1.3",
 ]
 requires-python = ">=3.10,<3.14"
 authors = [

--- a/python/xorq/backends/databricks/__init__.py
+++ b/python/xorq/backends/databricks/__init__.py
@@ -506,13 +506,8 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         record_batches: pa.RecordBatchReader,
         table_name: str | None = None,
         mode: str = "create",
-        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
-        # ``schema`` is accepted-and-ignored: the stream is already projected and
-        # cast to the logical schema upstream, before the StreamCache, in
-        # register_and_transform_remote_tables. Bind it here so it is not
-        # forwarded into adbc_ingest via **kwargs.
         from xorq.common.utils.databricks_utils import DatabricksADBC  # noqa: PLC0415
 
         table_name = table_name or util.gen_name("databricks_record_batches")

--- a/python/xorq/backends/databricks/__init__.py
+++ b/python/xorq/backends/databricks/__init__.py
@@ -506,8 +506,13 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         record_batches: pa.RecordBatchReader,
         table_name: str | None = None,
         mode: str = "create",
+        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
+        # ``schema`` is accepted-and-ignored: the stream is already projected and
+        # cast to the logical schema upstream, before the StreamCache, in
+        # register_and_transform_remote_tables. Bind it here so it is not
+        # forwarded into adbc_ingest via **kwargs.
         from xorq.common.utils.databricks_utils import DatabricksADBC  # noqa: PLC0415
 
         table_name = table_name or util.gen_name("databricks_record_batches")

--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -20,7 +20,12 @@ class Backend(IbisDuckDBBackend):
             batch_reader.read_pandas(timestamp_as_object=True)
         )
 
-    def read_record_batches(self, source, table_name=None):
+    def read_record_batches(
+        self,
+        source: pa.Table | pa.RecordBatchReader,
+        table_name: str | None = None,
+        schema: pa.Schema | None = None,
+    ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
         self.con.register(table_name, source)
         return self.table(table_name)

--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from typing import Any, Mapping
 
 import pyarrow as pa
+from batchcorder import StreamCache
 
 from xorq.vendor.ibis.backends.duckdb import Backend as IbisDuckDBBackend
 from xorq.vendor.ibis.expr import types as ir
@@ -22,10 +25,15 @@ class Backend(IbisDuckDBBackend):
 
     def read_record_batches(
         self,
-        source: pa.Table | pa.RecordBatchReader,
+        source: pa.Table | pa.RecordBatchReader | StreamCache,
         table_name: str | None = None,
         schema: pa.Schema | None = None,
     ) -> ir.Table:
+        # ``schema`` is intentionally accepted-and-ignored: duckdb registers
+        # ``source`` (typically a StreamCache) directly so it can replay the
+        # stream across scans, and a casting wrapper would not be replayable.
+        # Casting to the logical schema therefore happens upstream, before the
+        # StreamCache, in register_and_transform_remote_tables.
         table_name = table_name or gen_name("read_record_batches")
         self.con.register(table_name, source)
         return self.table(table_name)

--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -27,13 +27,11 @@ class Backend(IbisDuckDBBackend):
         self,
         source: pa.Table | pa.RecordBatchReader | StreamCache,
         table_name: str | None = None,
-        schema: pa.Schema | None = None,
     ) -> ir.Table:
-        # ``schema`` is intentionally accepted-and-ignored: duckdb registers
-        # ``source`` (typically a StreamCache) directly so it can replay the
-        # stream across scans, and a casting wrapper would not be replayable.
-        # Casting to the logical schema therefore happens upstream, before the
-        # StreamCache, in register_and_transform_remote_tables.
+        # duckdb registers ``source`` (typically a StreamCache) directly so it
+        # can replay the stream across scans; a casting wrapper would not be
+        # replayable, so casting to the logical schema happens upstream, before
+        # the StreamCache, in register_and_transform_remote_tables.
         table_name = table_name or gen_name("read_record_batches")
         self.con.register(table_name, source)
         return self.table(table_name)

--- a/python/xorq/backends/duckdb/tests/test_asof_join.py
+++ b/python/xorq/backends/duckdb/tests/test_asof_join.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import operator
 from datetime import datetime, timedelta
 

--- a/python/xorq/backends/duckdb/tests/test_into_backend.py
+++ b/python/xorq/backends/duckdb/tests/test_into_backend.py
@@ -1,0 +1,138 @@
+"""into_backend fan-out edge cases for the duckdb backend.
+
+The duckdb backend scans the StreamCache built by
+``register_and_transform_remote_tables`` directly, once per physical table
+reference in the compiled SQL. ``max_readers`` must equal that scan count
+exactly: an under-count crashes with "Maximum number of readers reached", an
+over-count silently disables eviction. These tests pin the count for each
+fan-out shape and assert the query still produces correct results.
+"""
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+import xorq.api as xo
+from xorq.expr.relations import count_remote_table_readers
+from xorq.tests.util import assert_frame_equal
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "k": ["a", "a", "b", "b"],
+            "v": [10, 20, 30, 40],
+        }
+    )
+
+
+@pytest.fixture
+def target():
+    return xo.duckdb.connect()
+
+
+def reader_counts(expr):
+    return sorted(count_remote_table_readers(expr).values())
+
+
+def test_into_backend_bare_single_reader(df, target):
+    expr = xo.memtable(df).into_backend(target, "t")
+    assert reader_counts(expr) == [1]
+    result = expr.execute().sort_values("id").reset_index(drop=True)
+    assert_frame_equal(result, df, check_like=True)
+
+
+def test_into_backend_filter_single_scan(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.filter(rt.v > 15)
+    assert reader_counts(expr) == [1]
+    assert sorted(expr.execute()["v"]) == [20, 30, 40]
+
+
+def test_into_backend_many_columns_one_scan(df, target):
+    # several column refs over one table resolve within a single scan
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.select(s=rt.id + rt.v, d=rt.v - rt.id)
+    assert reader_counts(expr) == [1]
+    assert not expr.execute().empty
+
+
+def test_into_backend_self_join_two_readers(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.join(rt.view(), "k")
+    assert reader_counts(expr) == [2]
+    # k='a' -> 2x2, k='b' -> 2x2
+    assert len(expr.execute()) == 8
+
+
+def test_into_backend_two_scalar_subqueries_two_readers(df, target):
+    # the StreamCache deadlock shape: two concurrent scans of one cache
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.v.sum().as_scalar().as_table().mutate(cnt=rt.v.count().as_scalar())
+    assert reader_counts(expr) == [2]
+    result = expr.execute()
+    assert int(result.iloc[0, 0]) == 100
+    assert int(result["cnt"].iloc[0]) == 4
+
+
+def test_into_backend_threeway_fanout_three_readers(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = (
+        rt.filter(rt.v < 15).union(rt.filter(rt.v > 35)).union(rt.filter(rt.k == "b"))
+    )
+    assert reader_counts(expr) == [3]
+    assert sorted(expr.execute()["v"]) == [10, 30, 40, 40]
+
+
+def test_into_backend_asof_tolerance_double_scan(df, target):
+    # #983: tolerance lowering scans the left input twice, right once
+    left = pd.DataFrame(
+        {"site": ["a", "b"], "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)]}
+    )
+    right = pd.DataFrame(
+        {
+            "site": ["a", "b"],
+            "ev": ["x", "y"],
+            "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+        }
+    )
+    lt = xo.memtable(left).into_backend(target, "l")
+    rt = xo.memtable(right).into_backend(target, "r")
+    expr = lt.asof_join(
+        rt, on="ts", predicates="site", tolerance=timedelta(seconds=1)
+    ).drop("ts_right")
+    assert reader_counts(expr) == [1, 2]
+    assert not expr.execute().empty
+
+
+def test_into_backend_two_distinct_tables(df, target):
+    left = xo.memtable(df).into_backend(target, "l")
+    right = xo.memtable(df.assign(v=df.v * 2)).into_backend(target, "r")
+    expr = left.join(right, "k")
+    counts = count_remote_table_readers(expr)
+    assert len(counts) == 2
+    assert sorted(counts.values()) == [1, 1]
+    assert len(expr.execute()) == 8
+
+
+def test_into_backend_empty_table_fanout(target):
+    empty = pd.DataFrame(
+        {"id": pd.Series([], dtype="int64"), "v": pd.Series([], dtype="int64")}
+    )
+    rt = xo.memtable(empty).into_backend(target, "e")
+    expr = rt.join(rt.view(), "id")
+    assert reader_counts(expr) == [2]
+    assert expr.execute().empty
+
+
+def test_into_backend_nested_chain(df, target):
+    # data flows memtable -> datafusion -> duckdb, then fans out on duckdb
+    inner = xo.memtable(df).into_backend(xo.connect(), "inner")
+    rt = inner.into_backend(target, "outer")
+    expr = rt.join(rt.view(), "id")
+    # only the outer RemoteTable is resolved in this pass (inner is recursive)
+    assert reader_counts(expr) == [2]
+    assert len(expr.execute()) == 4

--- a/python/xorq/backends/duckdb/tests/test_into_backend.py
+++ b/python/xorq/backends/duckdb/tests/test_into_backend.py
@@ -108,6 +108,14 @@ def test_into_backend_asof_tolerance_double_scan(df, target):
     assert not expr.execute().empty
 
 
+def test_into_backend_self_join_limit_early_termination(df, target):
+    # fan-out (2 readers) + limit: the scan stops before exhausting the cache
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.join(rt.view(), "k").limit(2)
+    assert reader_counts(expr) == [2]
+    assert len(expr.execute()) == 2
+
+
 def test_into_backend_two_distinct_tables(df, target):
     left = xo.memtable(df).into_backend(target, "l")
     right = xo.memtable(df.assign(v=df.v * 2)).into_backend(target, "r")

--- a/python/xorq/backends/duckdb/tests/test_into_backend.py
+++ b/python/xorq/backends/duckdb/tests/test_into_backend.py
@@ -8,18 +8,22 @@ over-count silently disables eviction. These tests pin the count for each
 fan-out shape and assert the query still produces correct results.
 """
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 
 import pandas as pd
 import pytest
 
 import xorq.api as xo
-from xorq.expr.relations import count_remote_table_readers
+import xorq.vendor.ibis.expr.types as ir
+from xorq.backends.duckdb import Backend
+from xorq.expr.remote_table_exec import count_remote_table_readers
 from xorq.tests.util import assert_frame_equal
 
 
 @pytest.fixture
-def df():
+def df() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
@@ -30,29 +34,29 @@ def df():
 
 
 @pytest.fixture
-def target():
+def target() -> Backend:
     return xo.duckdb.connect()
 
 
-def reader_counts(expr):
+def reader_counts(expr: ir.Table) -> list[int]:
     return sorted(count_remote_table_readers(expr).values())
 
 
-def test_into_backend_bare_single_reader(df, target):
+def test_into_backend_bare_single_reader(df: pd.DataFrame, target: Backend) -> None:
     expr = xo.memtable(df).into_backend(target, "t")
     assert reader_counts(expr) == [1]
     result = expr.execute().sort_values("id").reset_index(drop=True)
     assert_frame_equal(result, df, check_like=True)
 
 
-def test_into_backend_filter_single_scan(df, target):
+def test_into_backend_filter_single_scan(df: pd.DataFrame, target: Backend) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.filter(rt.v > 15)
     assert reader_counts(expr) == [1]
     assert sorted(expr.execute()["v"]) == [20, 30, 40]
 
 
-def test_into_backend_many_columns_one_scan(df, target):
+def test_into_backend_many_columns_one_scan(df: pd.DataFrame, target: Backend) -> None:
     # several column refs over one table resolve within a single scan
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.select(s=rt.id + rt.v, d=rt.v - rt.id)
@@ -60,7 +64,7 @@ def test_into_backend_many_columns_one_scan(df, target):
     assert not expr.execute().empty
 
 
-def test_into_backend_self_join_two_readers(df, target):
+def test_into_backend_self_join_two_readers(df: pd.DataFrame, target: Backend) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.join(rt.view(), "k")
     assert reader_counts(expr) == [2]
@@ -68,7 +72,9 @@ def test_into_backend_self_join_two_readers(df, target):
     assert len(expr.execute()) == 8
 
 
-def test_into_backend_two_scalar_subqueries_two_readers(df, target):
+def test_into_backend_two_scalar_subqueries_two_readers(
+    df: pd.DataFrame, target: Backend
+) -> None:
     # the StreamCache deadlock shape: two concurrent scans of one cache
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.v.sum().as_scalar().as_table().mutate(cnt=rt.v.count().as_scalar())
@@ -78,7 +84,9 @@ def test_into_backend_two_scalar_subqueries_two_readers(df, target):
     assert int(result["cnt"].iloc[0]) == 4
 
 
-def test_into_backend_threeway_fanout_three_readers(df, target):
+def test_into_backend_threeway_fanout_three_readers(
+    df: pd.DataFrame, target: Backend
+) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = (
         rt.filter(rt.v < 15).union(rt.filter(rt.v > 35)).union(rt.filter(rt.k == "b"))
@@ -87,7 +95,9 @@ def test_into_backend_threeway_fanout_three_readers(df, target):
     assert sorted(expr.execute()["v"]) == [10, 30, 40, 40]
 
 
-def test_into_backend_asof_tolerance_double_scan(df, target):
+def test_into_backend_asof_tolerance_double_scan(
+    df: pd.DataFrame, target: Backend
+) -> None:
     # #983: tolerance lowering scans the left input twice, right once
     left = pd.DataFrame(
         {"site": ["a", "b"], "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)]}
@@ -108,7 +118,9 @@ def test_into_backend_asof_tolerance_double_scan(df, target):
     assert not expr.execute().empty
 
 
-def test_into_backend_self_join_limit_early_termination(df, target):
+def test_into_backend_self_join_limit_early_termination(
+    df: pd.DataFrame, target: Backend
+) -> None:
     # fan-out (2 readers) + limit: the scan stops before exhausting the cache
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.join(rt.view(), "k").limit(2)
@@ -116,7 +128,7 @@ def test_into_backend_self_join_limit_early_termination(df, target):
     assert len(expr.execute()) == 2
 
 
-def test_into_backend_two_distinct_tables(df, target):
+def test_into_backend_two_distinct_tables(df: pd.DataFrame, target: Backend) -> None:
     left = xo.memtable(df).into_backend(target, "l")
     right = xo.memtable(df.assign(v=df.v * 2)).into_backend(target, "r")
     expr = left.join(right, "k")
@@ -126,7 +138,7 @@ def test_into_backend_two_distinct_tables(df, target):
     assert len(expr.execute()) == 8
 
 
-def test_into_backend_empty_table_fanout(target):
+def test_into_backend_empty_table_fanout(target: Backend) -> None:
     empty = pd.DataFrame(
         {"id": pd.Series([], dtype="int64"), "v": pd.Series([], dtype="int64")}
     )
@@ -136,7 +148,7 @@ def test_into_backend_empty_table_fanout(target):
     assert expr.execute().empty
 
 
-def test_into_backend_nested_chain(df, target):
+def test_into_backend_nested_chain(df: pd.DataFrame, target: Backend) -> None:
     # data flows memtable -> datafusion -> duckdb, then fans out on duckdb
     inner = xo.memtable(df).into_backend(xo.connect(), "inner")
     rt = inner.into_backend(target, "outer")

--- a/python/xorq/backends/duckdb/tests/test_into_backend.py
+++ b/python/xorq/backends/duckdb/tests/test_into_backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import duckdb
 import pandas as pd
 import pytest
 
@@ -159,3 +160,23 @@ def test_into_backend_nested_chain(df: pd.DataFrame, target: Backend) -> None:
     # only the outer RemoteTable is resolved in this pass (inner is recursive)
     assert reader_counts(expr) == [2]
     assert len(expr.execute()) == 4
+
+
+def test_into_backend_partition_window_undercounts_and_raises(
+    df: pd.DataFrame, target: Backend
+) -> None:
+    # Current-behavior test (not a fix): a PARTITION BY-only aggregate window
+    # with no ORDER BY undercounts. The sqlglot AST sees one Table node, but
+    # duckdb lowers ``sum(v) OVER (PARTITION BY k)`` to a GROUP BY self-join
+    # that scans its input twice, so max_readers=1 is one short and the second
+    # reader trips the hard cap. ``max_readers`` is a best-effort lower bound,
+    # not an exact scan count -- see ADR-0013 ("Counting accuracy").
+    #
+    # This pins the failure exactly: the day the AST count learns this shape
+    # (or duckdb stops re-scanning), this test fails loudly and should be
+    # converted to assert a correct, non-empty result.
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.mutate(s=rt.v.sum().over(xo.window(group_by="k")))
+    assert reader_counts(expr) == [1]
+    with pytest.raises(duckdb.Error, match="Maximum number of readers"):
+        expr.execute()

--- a/python/xorq/backends/duckdb/tests/test_into_backend.py
+++ b/python/xorq/backends/duckdb/tests/test_into_backend.py
@@ -95,10 +95,13 @@ def test_into_backend_threeway_fanout_three_readers(
     assert sorted(expr.execute()["v"]) == [10, 30, 40, 40]
 
 
-def test_into_backend_asof_tolerance_double_scan(
+def test_into_backend_asof_tolerance_single_scan(
     df: pd.DataFrame, target: Backend
 ) -> None:
-    # #983: tolerance lowering scans the left input twice, right once
+    # #983/#2086: the tolerance lowering is a null-out projection over a single
+    # ASOF LEFT JOIN, so each input is scanned once. The old filter+re-join
+    # lowering scanned the left twice, consuming one-shot readers and producing
+    # empty results -- assert both the single scan and a non-empty result.
     left = pd.DataFrame(
         {"site": ["a", "b"], "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)]}
     )
@@ -114,7 +117,7 @@ def test_into_backend_asof_tolerance_double_scan(
     expr = lt.asof_join(
         rt, on="ts", predicates="site", tolerance=timedelta(seconds=1)
     ).drop("ts_right")
-    assert reader_counts(expr) == [1, 2]
+    assert reader_counts(expr) == [1, 1]
     assert not expr.execute().empty
 
 

--- a/python/xorq/backends/gizmosql/__init__.py
+++ b/python/xorq/backends/gizmosql/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any, Mapping
 
 import pyarrow as pa
+from batchcorder import StreamCache
 
 from xorq.vendor.ibis.backends.gizmosql import Backend as IbisGizmoSQLBackend
 from xorq.vendor.ibis.expr import types as ir
@@ -19,7 +20,16 @@ class Backend(IbisGizmoSQLBackend):
         table = self._to_pyarrow_table(expr, params=params, limit=limit)
         return expr.__pandas_result__(table.to_pandas(timestamp_as_object=True))
 
-    def read_record_batches(self, source, table_name=None):
+    def read_record_batches(
+        self,
+        source: pa.Table | pa.RecordBatchReader | StreamCache,
+        table_name: str | None = None,
+        schema: pa.Schema | None = None,
+        **kwargs: Any,
+    ) -> ir.Table:
+        # ``schema`` is accepted-and-ignored (like duckdb): the stream is already
+        # projected and cast to the logical schema upstream, before the
+        # StreamCache, in register_and_transform_remote_tables.
         table_name = table_name or gen_name("read_record_batches")
         source = self._normalize_arrow_schema(pa.Table.from_batches(source))
         batches = source.to_batches(max_chunksize=10_000)

--- a/python/xorq/backends/gizmosql/__init__.py
+++ b/python/xorq/backends/gizmosql/__init__.py
@@ -33,6 +33,12 @@ class Backend(IbisGizmoSQLBackend):
             pa.Table.from_batches(source, schema=source.schema)
         )
         batches = source.to_batches(max_chunksize=10_000)
+        # An empty table yields zero batches, but the ADBC Flight SQL ingest
+        # rejects a stream with no messages ("Stream finished before first
+        # message sent"). Send a single zero-row batch so the table is still
+        # created with the right schema.
+        if not batches:
+            batches = [pa.RecordBatch.from_pylist([], schema=source.schema)]
         reader = pa.RecordBatchReader.from_batches(source.schema, batches)
         with self.con.cursor() as cur:
             cur.adbc_ingest(table_name, reader, mode="replace")

--- a/python/xorq/backends/gizmosql/__init__.py
+++ b/python/xorq/backends/gizmosql/__init__.py
@@ -24,12 +24,7 @@ class Backend(IbisGizmoSQLBackend):
         self,
         source: pa.Table | pa.RecordBatchReader | StreamCache,
         table_name: str | None = None,
-        schema: pa.Schema | None = None,
-        **kwargs: Any,
     ) -> ir.Table:
-        # ``schema`` is accepted-and-ignored (like duckdb): the stream is already
-        # projected and cast to the logical schema upstream, before the
-        # StreamCache, in register_and_transform_remote_tables.
         table_name = table_name or gen_name("read_record_batches")
         source = self._normalize_arrow_schema(pa.Table.from_batches(source))
         batches = source.to_batches(max_chunksize=10_000)

--- a/python/xorq/backends/gizmosql/__init__.py
+++ b/python/xorq/backends/gizmosql/__init__.py
@@ -26,7 +26,12 @@ class Backend(IbisGizmoSQLBackend):
         table_name: str | None = None,
     ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
-        source = self._normalize_arrow_schema(pa.Table.from_batches(source))
+        # Pass schema= so an empty stream (zero batches) still materializes the
+        # declared columns instead of raising "Must pass schema, or at least one
+        # RecordBatch". StreamCache and RecordBatchReader both expose .schema.
+        source = self._normalize_arrow_schema(
+            pa.Table.from_batches(source, schema=source.schema)
+        )
         batches = source.to_batches(max_chunksize=10_000)
         reader = pa.RecordBatchReader.from_batches(source.schema, batches)
         with self.con.cursor() as cur:

--- a/python/xorq/backends/gizmosql/__init__.py
+++ b/python/xorq/backends/gizmosql/__init__.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping
 import pyarrow as pa
 from batchcorder import StreamCache
 
+from xorq.common.utils.rbr_utils import coerce_to_arrow_table
 from xorq.vendor.ibis.backends.gizmosql import Backend as IbisGizmoSQLBackend
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import gen_name
@@ -26,20 +27,18 @@ class Backend(IbisGizmoSQLBackend):
         table_name: str | None = None,
     ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
-        # Pass schema= so an empty stream (zero batches) still materializes the
-        # declared columns instead of raising "Must pass schema, or at least one
-        # RecordBatch". StreamCache and RecordBatchReader both expose .schema.
-        source = self._normalize_arrow_schema(
-            pa.Table.from_batches(source, schema=source.schema)
-        )
-        batches = source.to_batches(max_chunksize=10_000)
+        # coerce_to_arrow_table carries the schema through, so an empty stream
+        # (zero batches) still materializes the declared columns instead of
+        # raising "Must pass schema, or at least one RecordBatch".
+        table = self._normalize_arrow_schema(coerce_to_arrow_table(source))
+        batches = table.to_batches(max_chunksize=10_000)
         # An empty table yields zero batches, but the ADBC Flight SQL ingest
         # rejects a stream with no messages ("Stream finished before first
         # message sent"). Send a single zero-row batch so the table is still
         # created with the right schema.
         if not batches:
-            batches = [pa.RecordBatch.from_pylist([], schema=source.schema)]
-        reader = pa.RecordBatchReader.from_batches(source.schema, batches)
+            batches = [pa.RecordBatch.from_pylist([], schema=table.schema)]
+        reader = pa.RecordBatchReader.from_batches(table.schema, batches)
         with self.con.cursor() as cur:
             cur.adbc_ingest(table_name, reader, mode="replace")
         return self.table(table_name)

--- a/python/xorq/backends/gizmosql/tests/test_read_record_batches.py
+++ b/python/xorq/backends/gizmosql/tests/test_read_record_batches.py
@@ -1,0 +1,73 @@
+"""GizmoSQL read_record_batches coverage, including StreamCache inputs.
+
+register_and_transform_remote_tables feeds a batchcorder StreamCache straight
+into the target backend's read_record_batches, so these pin that gizmosql
+accepts a StreamCache (it exposes __iter__/.schema) and, in particular, that an
+empty stream still materializes the declared columns rather than raising
+"Must pass schema, or at least one RecordBatch".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from batchcorder import StreamCache
+
+import xorq.api as xo
+from xorq.vendor.ibis import _
+
+
+pytestmark = pytest.mark.gizmosql
+
+
+def _stream_cache(schema: pa.Schema, batches: list[pa.RecordBatch]) -> StreamCache:
+    reader = pa.RecordBatchReader.from_batches(schema, iter(batches))
+    return StreamCache(reader)
+
+
+def test_read_record_batches_stream_cache(con: Any, temp_table: str) -> None:
+    """A non-empty StreamCache ingests every row."""
+    schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+    batches = [pa.record_batch({"a": [i], "b": [str(i)]}) for i in range(3)]
+    cache = _stream_cache(schema, batches)
+
+    t = con.read_record_batches(cache, table_name=temp_table)
+    result = t.execute()
+
+    assert len(result) == 3
+    assert sorted(result.columns) == ["a", "b"]
+    assert sorted(result["a"]) == [0, 1, 2]
+
+
+def test_read_record_batches_empty_stream_cache(con: Any, temp_table: str) -> None:
+    """Regression: an empty StreamCache creates the table with zero rows.
+
+    Previously read_record_batches called pa.Table.from_batches(source) with no
+    schema, so a zero-batch stream raised ValueError before the table could be
+    created. Passing schema=source.schema keeps the declared columns.
+    """
+    schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+    cache = _stream_cache(schema, [])
+
+    t = con.read_record_batches(cache, table_name=temp_table)
+    result = t.execute()
+
+    assert len(result) == 0
+    assert sorted(result.columns) == ["a", "b"]
+
+
+def test_into_backend_empty_result_to_gizmosql(con: Any) -> None:
+    """End-to-end: an upstream that filters to zero rows still lands as an empty
+    table on gizmosql, exercising the empty-StreamCache path through the real
+    RemoteTable pipeline."""
+    ddb_con = xo.duckdb.connect()
+    local = ddb_con.create_table(
+        "empty_src", pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    )
+    expr = local.filter(_.a > 100).into_backend(con, "empty_gz")
+    result = expr.execute()
+
+    assert len(result) == 0
+    assert sorted(result.columns) == ["a", "b"]

--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
-from batchcorder import StreamCache
 
 import xorq.common.exceptions as com
 import xorq.vendor.ibis.config
 import xorq.vendor.ibis.expr.operations as ops
 import xorq.vendor.ibis.expr.schema as sch
 import xorq.vendor.ibis.expr.types as ir
+from xorq.common.utils.rbr_utils import coerce_to_arrow_table
 from xorq.vendor import ibis
 from xorq.vendor.ibis import util
 from xorq.vendor.ibis.backends import BaseBackend, NoUrl
@@ -24,6 +24,8 @@ from xorq.vendor.ibis.formats.pyarrow import PyArrowData
 if TYPE_CHECKING:
     import pathlib
     from collections.abc import Mapping, MutableMapping
+
+    from batchcorder import StreamCache
 
 
 class BasePandasBackend(BaseBackend, NoUrl):
@@ -341,19 +343,14 @@ class Backend(BasePandasBackend):
 
     def read_record_batches(
         self,
-        record_batches: pa.RecordBatchReader
+        record_batches: pa.Table
+        | pa.RecordBatchReader
+        | StreamCache
         | list[pa.RecordBatch]
         | tuple[pa.RecordBatch],
         table_name: str | None = None,
     ) -> ir.Table:
-        if isinstance(record_batches, (list, tuple)):
-            record_batches = pa.RecordBatchReader.from_batches(
-                record_batches[0].schema, record_batches
-            )
-        elif isinstance(record_batches, StreamCache):
-            record_batches = pa.RecordBatchReader.from_stream(record_batches)
-
-        self.dictionary[table_name] = record_batches.read_pandas()
+        self.dictionary[table_name] = coerce_to_arrow_table(record_batches).to_pandas()
         return self.table(table_name)
 
 

--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -345,7 +345,8 @@ class Backend(BasePandasBackend):
         | list[pa.RecordBatch]
         | tuple[pa.RecordBatch],
         table_name: str | None = None,
-    ):
+        schema: pa.Schema | None = None,
+    ) -> ir.Table:
         if isinstance(record_batches, (list, tuple)):
             record_batches = pa.RecordBatchReader.from_batches(
                 record_batches[0].schema, record_batches

--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
+from batchcorder import StreamCache
 
 import xorq.common.exceptions as com
 import xorq.vendor.ibis.config
@@ -349,6 +350,8 @@ class Backend(BasePandasBackend):
             record_batches = pa.RecordBatchReader.from_batches(
                 record_batches[0].schema, record_batches
             )
+        elif isinstance(record_batches, StreamCache):
+            record_batches = pa.RecordBatchReader.from_stream(record_batches)
 
         self.dictionary[table_name] = record_batches.read_pandas()
         return self.table(table_name)

--- a/python/xorq/backends/pandas/__init__.py
+++ b/python/xorq/backends/pandas/__init__.py
@@ -345,7 +345,6 @@ class Backend(BasePandasBackend):
         | list[pa.RecordBatch]
         | tuple[pa.RecordBatch],
         table_name: str | None = None,
-        schema: pa.Schema | None = None,
     ) -> ir.Table:
         if isinstance(record_batches, (list, tuple)):
             record_batches = pa.RecordBatchReader.from_batches(

--- a/python/xorq/backends/pandas/tests/test_into_backend.py
+++ b/python/xorq/backends/pandas/tests/test_into_backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pyarrow as pa
 
 import xorq.api as xo
+from xorq.expr.remote_table_exec import count_remote_table_readers
 
 
 def test_into_backend_pandas_executes() -> None:
@@ -21,3 +22,18 @@ def test_into_backend_pandas_filter() -> None:
     expr = t.into_backend(pandas_con, "t").filter(xo._.x > 15)
     result = expr.execute()
     assert sorted(result["x"]) == [20, 30]
+
+
+def test_into_backend_pandas_fanout_unbounded_cache() -> None:
+    # pandas is a non-SQL backend: count_remote_table_readers can produce no
+    # AST, so it returns an empty mapping and the StreamCache is built
+    # unbounded (max_readers=None). This exercises that path and confirms a
+    # fan-out shape (union over the same RemoteTable) still executes. A
+    # self-join is not used: the pandas executor has no SelfReference rule.
+    pandas_con = xo.pandas.connect()
+    rt = xo.memtable(pa.table({"k": ["a", "b", "b"], "v": [10, 30, 40]})).into_backend(
+        pandas_con, "t"
+    )
+    assert count_remote_table_readers(rt) == {}
+    expr = rt.filter(rt.v < 20).union(rt.filter(rt.v > 35))
+    assert sorted(expr.execute()["v"]) == [10, 40]

--- a/python/xorq/backends/pandas/tests/test_into_backend.py
+++ b/python/xorq/backends/pandas/tests/test_into_backend.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+import xorq.api as xo
+
+
+def test_into_backend_pandas_executes() -> None:
+    pandas_con = xo.pandas.connect()
+    t = xo.memtable(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    expr = t.into_backend(pandas_con, "t")
+    result = expr.execute()
+    assert len(result) == 3
+    assert sorted(result.columns) == ["a", "b"]
+    assert list(result.sort_values("a")["a"]) == [1, 2, 3]
+
+
+def test_into_backend_pandas_filter() -> None:
+    pandas_con = xo.pandas.connect()
+    t = xo.memtable(pa.table({"x": [10, 20, 30]}))
+    expr = t.into_backend(pandas_con, "t").filter(xo._.x > 15)
+    result = expr.execute()
+    assert sorted(result["x"]) == [20, 30]

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -173,6 +173,7 @@ class Backend(IbisPostgresBackend):
         password: str | None = None,
         temporary: bool = False,
         mode: str = "create",
+        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
         from xorq.common.utils.postgres_utils import (  # noqa: PLC0415

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -116,19 +116,25 @@ class Backend(IbisPostgresBackend):
 
             if adbc_con is not None:
                 cur = adbc_con.cursor()
+                # ``fall_through`` distinguishes the one recoverable failure
+                # (temp table invisible on a fresh ADBC connection) from every
+                # other error. The ``finally`` always closes both the cursor
+                # and connection, so a non-ADBCProgrammingError raised by
+                # ``execute`` (network, syntax, permission) propagates without
+                # leaking the ADBC resources.
+                fall_through = False
                 try:
-                    cur.execute(query)
-                except ADBCProgrammingError:
-                    # Temp table not visible on fresh ADBC connection — fall through.
-                    cur.close()
-                    adbc_con.close()
-                else:
                     try:
+                        cur.execute(query)
+                    except ADBCProgrammingError:
+                        fall_through = True
+                    if not fall_through:
                         for batch in cur.fetch_record_batch():
                             yield batch.cast(pyarrow_schema)
-                    finally:
-                        cur.close()
-                        adbc_con.close()
+                finally:
+                    cur.close()
+                    adbc_con.close()
+                if not fall_through:
                     return
 
             # Psycopg fallback: session-local temp tables or no ADBC URI.

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -16,6 +16,7 @@ from xorq.backends.postgres.compiler import compiler
 from xorq.common.utils.defer_utils import (
     read_csv_rbr,
 )
+from xorq.common.utils.logging_utils import get_logger
 from xorq.config import default_backend
 from xorq.vendor.ibis import util
 from xorq.vendor.ibis.backends.postgres import Backend as IbisPostgresBackend
@@ -23,6 +24,9 @@ from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import (
     gen_name,
 )
+
+
+logger = get_logger(__name__)
 
 
 class Backend(IbisPostgresBackend):
@@ -114,6 +118,14 @@ class Backend(IbisPostgresBackend):
             try:
                 adbc_con = PgADBC(self).get_conn()
             except Exception:
+                # A genuine config/auth error is indistinguishable here from a
+                # missing ADBC URI; both fall through to the psycopg path, so log
+                # at debug to keep the real cause diagnosable.
+                logger.debug(
+                    "ADBC connection unavailable; falling back to psycopg",
+                    backend=self.name,
+                    exc_info=True,
+                )
                 adbc_con = None
 
             if adbc_con is not None:

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -173,7 +173,6 @@ class Backend(IbisPostgresBackend):
         password: str | None = None,
         temporary: bool = False,
         mode: str = "create",
-        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
         from xorq.common.utils.postgres_utils import (  # noqa: PLC0415

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -6,6 +7,7 @@ import pyarrow as pa
 import sqlglot as sg
 import sqlglot.expressions as sge
 import toolz
+from adbc_driver_manager import ProgrammingError as ADBCProgrammingError
 
 import xorq.vendor.ibis.expr.schema as sch
 from xorq.backends.postgres.compiler import compiler
@@ -13,6 +15,7 @@ from xorq.common.utils.defer_utils import (
     read_csv_rbr,
 )
 from xorq.config import default_backend
+from xorq.vendor.ibis import util
 from xorq.vendor.ibis.backends.postgres import Backend as IbisPostgresBackend
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import (
@@ -88,6 +91,72 @@ class Backend(IbisPostgresBackend):
                 else None
             ),
         ).sql(self.dialect)
+
+    @util.experimental
+    def to_pyarrow_batches(
+        self,
+        expr: ir.Expr,
+        /,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        chunk_size: int = 1_000_000,
+        **_: Any,
+    ) -> pa.ipc.RecordBatchReader:
+        from xorq.common.utils.postgres_utils import PgADBC  # noqa: PLC0415
+
+        def _batches(self, *, pyarrow_schema, struct_type, query):
+            # Primary path: ADBC opens its own independent postgres connection
+            # per call, so concurrent generators never share psycopg connection
+            # state (eliminates OutOfOrderTransactionNesting).
+            try:
+                adbc_con = PgADBC(self).get_conn()
+            except Exception:
+                adbc_con = None
+
+            if adbc_con is not None:
+                cur = adbc_con.cursor()
+                try:
+                    cur.execute(query)
+                except ADBCProgrammingError:
+                    # Temp table not visible on fresh ADBC connection — fall through.
+                    cur.close()
+                    adbc_con.close()
+                else:
+                    try:
+                        for batch in cur.fetch_record_batch():
+                            yield batch.cast(pyarrow_schema)
+                    finally:
+                        cur.close()
+                        adbc_con.close()
+                    return
+
+            # Psycopg fallback: session-local temp tables or no ADBC URI.
+            con = self.con
+            with (
+                con.cursor(name=util.gen_name("postgres_cursor")) as cursor,
+                con.transaction(),
+            ):
+                cur = cursor.execute(query)
+                while batch := cur.fetchmany(chunk_size):
+                    yield pa.RecordBatch.from_struct_array(
+                        pa.array(batch, type=struct_type)
+                    )
+
+        self._run_pre_execute_hooks(expr)
+
+        raw_schema = expr.as_table().schema()
+        query = self.compile(expr, limit=limit, params=params)
+        pyarrow_schema = raw_schema.to_pyarrow()
+        return pa.RecordBatchReader.from_batches(
+            pyarrow_schema,
+            _batches(
+                self,
+                pyarrow_schema=pyarrow_schema,
+                struct_type=raw_schema.as_struct().to_pyarrow(),
+                query=query,
+            ),
+        )
 
     def read_record_batches(
         self,

--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from functools import partial
 from pathlib import Path

--- a/python/xorq/backends/postgres/tests/test_to_pyarrow_batches.py
+++ b/python/xorq/backends/postgres/tests/test_to_pyarrow_batches.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import xorq.api as xo
+from xorq.backends.postgres import Backend as PostgresBackend
+
+
+@pytest.mark.postgres
+def test_to_pyarrow_batches_simple(pg: PostgresBackend) -> None:
+    expr = pg.table("batting").limit(100)
+    reader = pg.to_pyarrow_batches(expr)
+    assert isinstance(reader, pa.RecordBatchReader)
+    table = reader.read_all()
+    assert table.num_rows == 100
+    assert table.num_columns > 0
+
+
+@pytest.mark.postgres
+def test_to_pyarrow_batches_with_filter(pg: PostgresBackend) -> None:
+    expr = pg.table("batting").filter(pg.table("batting").yearID == 2015)
+    reader = pg.to_pyarrow_batches(expr)
+    table = reader.read_all()
+    assert table.num_rows > 0
+    assert all(v == 2015 for v in table.column("yearID").to_pylist())
+
+
+@pytest.mark.postgres
+def test_to_pyarrow_batches_into_backend_roundtrip(pg: PostgresBackend) -> None:
+    con = xo.connect()
+    expr = pg.table("batting").limit(50).into_backend(con, "pg_bat")
+    result = expr.execute()
+    assert len(result) == 50

--- a/python/xorq/backends/postgres/tests/test_to_pyarrow_batches.py
+++ b/python/xorq/backends/postgres/tests/test_to_pyarrow_batches.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import pyarrow as pa
 import pytest
+from adbc_driver_manager import ProgrammingError as ADBCProgrammingError
 
 import xorq.api as xo
 from xorq.backends.postgres import Backend as PostgresBackend
+from xorq.common.utils.postgres_utils import PgADBC
 
 
 @pytest.mark.postgres
@@ -32,3 +34,52 @@ def test_to_pyarrow_batches_into_backend_roundtrip(pg: PostgresBackend) -> None:
     expr = pg.table("batting").limit(50).into_backend(con, "pg_bat")
     result = expr.execute()
     assert len(result) == 50
+
+
+@pytest.mark.postgres
+def test_to_pyarrow_batches_falls_back_when_adbc_unavailable(
+    pg: PostgresBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # When PgADBC.get_conn raises (no ADBC URI / config error), the swallowed
+    # exception must route to the psycopg fallback and still return correct data.
+    def boom(self, **kwargs):
+        raise RuntimeError("no adbc uri")
+
+    monkeypatch.setattr(PgADBC, "get_conn", boom)
+    expr = pg.table("batting").limit(10)
+    table = pg.to_pyarrow_batches(expr).read_all()
+    assert table.num_rows == 10
+    assert table.num_columns > 0
+
+
+@pytest.mark.postgres
+def test_to_pyarrow_batches_falls_through_on_adbc_programming_error(
+    pg: PostgresBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ADBC connects but execute raises ADBCProgrammingError (the temp-table-
+    # invisible case): fall_through routes to psycopg, and the finally block
+    # must still close both the cursor and the ADBC connection.
+    closed = {"cursor": False, "conn": False}
+
+    class FakeCursor:
+        def execute(self, query):
+            raise ADBCProgrammingError("relation does not exist")
+
+        def fetch_record_batch(self):  # pragma: no cover - never reached
+            raise AssertionError("should not fetch after a programming error")
+
+        def close(self):
+            closed["cursor"] = True
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def close(self):
+            closed["conn"] = True
+
+    monkeypatch.setattr(PgADBC, "get_conn", lambda self, **kwargs: FakeConn())
+    expr = pg.table("batting").limit(10)
+    table = pg.to_pyarrow_batches(expr).read_all()
+    assert table.num_rows == 10
+    assert closed == {"cursor": True, "conn": True}

--- a/python/xorq/backends/postgres/tests/test_to_pyarrow_batches.py
+++ b/python/xorq/backends/postgres/tests/test_to_pyarrow_batches.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pyarrow as pa
 import pytest
+from adbc_driver_manager import AdbcStatusCode
 from adbc_driver_manager import ProgrammingError as ADBCProgrammingError
 
 import xorq.api as xo
@@ -63,7 +64,9 @@ def test_to_pyarrow_batches_falls_through_on_adbc_programming_error(
 
     class FakeCursor:
         def execute(self, query):
-            raise ADBCProgrammingError("relation does not exist")
+            raise ADBCProgrammingError(
+                "relation does not exist", status_code=AdbcStatusCode.NOT_FOUND
+            )
 
         def fetch_record_batch(self):  # pragma: no cover - never reached
             raise AssertionError("should not fetch after a programming error")

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -318,16 +318,15 @@ class Backend(SQLBackend):
         mode: WriteMode | str = WriteMode.CREATE,
         branch: Optional[str] = None,
         schema: Optional[pa.Schema] = None,
-        **kwargs: Any,
     ) -> ir.Table:
         # Callers on the write-through path hand us the wire string (mode.value);
         # normalize at the boundary so the body always works with the enum.
         mode = WriteMode(mode)
         table_name = table_name or gen_name("read_record_batches")
         full_name = f"{self.namespace}.{table_name}"
-        # ``reader`` is already projected and cast to the logical schema upstream
-        # (register_and_transform_remote_tables), so reader.schema == the passed
-        # schema; fall back to it when the caller does not supply one.
+        # ``schema`` lets a direct caller override the table schema; on the
+        # remote-table path it is omitted and we fall back to the reader's own
+        # schema (already projected and cast upstream of the cache).
         schema = schema or reader.schema
         exists = self.catalog.table_exists(full_name)
 

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -317,13 +317,18 @@ class Backend(SQLBackend):
         table_name: Optional[str] = None,
         mode: WriteMode | str = WriteMode.CREATE,
         branch: Optional[str] = None,
+        schema: Optional[pa.Schema] = None,
+        **kwargs: Any,
     ) -> ir.Table:
         # Callers on the write-through path hand us the wire string (mode.value);
         # normalize at the boundary so the body always works with the enum.
         mode = WriteMode(mode)
         table_name = table_name or gen_name("read_record_batches")
         full_name = f"{self.namespace}.{table_name}"
-        schema = reader.schema
+        # ``reader`` is already projected and cast to the logical schema upstream
+        # (register_and_transform_remote_tables), so reader.schema == the passed
+        # schema; fall back to it when the caller does not supply one.
+        schema = schema or reader.schema
         exists = self.catalog.table_exists(full_name)
 
         if branch is None:

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -170,12 +170,12 @@ class Backend(IbisSnowflakeBackend):
                     )
                 else:
                     (table, scope) = prepare_create_table_from_expr(self, obj)
-            case pd.DataFrame() | pa.Table():
-                table = api.memtable(obj)
             case None:
                 table = None
             case _:
-                raise TypeError(f"unsupported obj type: {type(obj)}")
+                # Delegate to memtable (accepts DataFrame, Arrow table, dict,
+                # list, ...) rather than narrowing to DataFrame | Table.
+                table = api.memtable(obj)
 
         try:
             if table is not None:

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -284,13 +284,8 @@ class Backend(IbisSnowflakeBackend):
         temporary: bool = False,
         mode: str = "create",
         database=None,
-        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
-        # ``schema`` is accepted-and-ignored: the stream is already projected and
-        # cast to the logical schema upstream, before the StreamCache, in
-        # register_and_transform_remote_tables. Bind it here so it is not
-        # forwarded into adbc_ingest via **kwargs.
         logger.info(
             "reading record batches with SnowflakeADBC",
             **{

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -15,7 +15,7 @@ import xorq.vendor.ibis.expr.schema as sch
 import xorq.vendor.ibis.expr.types as ir
 from xorq.backends.snowflake.enums import SnowflakeAuthenticator
 from xorq.common.utils.logging_utils import get_logger
-from xorq.expr.relations import (
+from xorq.expr.remote_table_exec import (
     prepare_create_table_from_expr,
 )
 from xorq.vendor.ibis.backends.snowflake import _SNOWFLAKE_MAP_UDFS
@@ -161,33 +161,40 @@ class Backend(IbisSnowflakeBackend):
         if comment is not None:
             properties.append(sge.SchemaCommentProperty(this=sge.convert(comment)))
 
-        if obj is not None:
-            if not isinstance(obj, ir.Expr):
-                table = api.memtable(obj)
-            else:
+        scope = None
+        match obj:
+            case ir.Expr():
                 if catalog is not None and db is not None:
-                    table = prepare_create_table_from_expr(
+                    (table, scope) = prepare_create_table_from_expr(
                         self, obj, database=(catalog, db)
                     )
                 else:
-                    table = prepare_create_table_from_expr(self, obj)
+                    (table, scope) = prepare_create_table_from_expr(self, obj)
+            case pd.DataFrame() | pa.Table():
+                table = api.memtable(obj)
+            case None:
+                table = None
+            case _:
+                raise TypeError(f"unsupported obj type: {type(obj)}")
 
-            self._run_pre_execute_hooks(table)
-
-            query = self.compiler.to_sqlglot(table)
-        else:
-            query = None
-
-        create_stmt = sge.Create(
-            kind="TABLE",
-            this=target,
-            replace=overwrite,
-            properties=sge.Properties(expressions=properties),
-            expression=query,
-        )
-
-        with self._safe_raw_sql(create_stmt):
-            pass
+        try:
+            if table is not None:
+                self._run_pre_execute_hooks(table)
+                query = self.compiler.to_sqlglot(table)
+            else:
+                query = None
+            create_stmt = sge.Create(
+                kind="TABLE",
+                this=target,
+                replace=overwrite,
+                properties=sge.Properties(expressions=properties),
+                expression=query,
+            )
+            with self._safe_raw_sql(create_stmt):
+                pass
+        finally:
+            if scope is not None:
+                scope.close()
 
         return self.table(name, database=(catalog, db))
 

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -284,8 +284,13 @@ class Backend(IbisSnowflakeBackend):
         temporary: bool = False,
         mode: str = "create",
         database=None,
+        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
+        # ``schema`` is accepted-and-ignored: the stream is already projected and
+        # cast to the logical schema upstream, before the StreamCache, in
+        # register_and_transform_remote_tables. Bind it here so it is not
+        # forwarded into adbc_ingest via **kwargs.
         logger.info(
             "reading record batches with SnowflakeADBC",
             **{

--- a/python/xorq/backends/snowflake/tests/test_backend.py
+++ b/python/xorq/backends/snowflake/tests/test_backend.py
@@ -1,0 +1,55 @@
+import contextlib
+import operator
+
+import pytest
+
+import xorq.api as xo
+import xorq.expr.relations as rel
+from xorq.backends.snowflake.tests.conftest import inside_temp_schema
+from xorq.common.utils.graph_utils import (
+    find_all_sources,
+    walk_nodes,
+)
+
+
+@pytest.mark.snowflake
+def test_con_equality_read(temp_catalog, temp_db, parquet_dir):
+    # moved out of backends/tests/test_backend.py: read_parquet's CREATE TEMP
+    # STAGE is rejected on the read-only SNOWFLAKE_SAMPLE_DATA default database,
+    # so each connection is switched into a writable temp schema. A fresh
+    # connection per call keeps the Read ops (and their sources) distinct.
+    on = "playerID"
+    name = "batting"
+    with contextlib.ExitStack() as stack:
+
+        def connect():
+            con = xo.snowflake.connect_env_keypair(
+                database="SNOWFLAKE_SAMPLE_DATA",
+                schema="TPCH_SF1",
+                create_object_udfs=False,
+            )
+            stack.enter_context(inside_temp_schema(con, temp_catalog, temp_db))
+            return con
+
+        ts = t0, t1 = tuple(
+            xo.deferred_read_parquet(
+                parquet_dir.joinpath(f"{name}.parquet"),
+                con=connect(),
+                # must give a name so Read ops could be equal
+                table_name=name,
+            )
+            .filter(operator.eq(xo._.yearID, year))
+            .select(on)
+            for year in (2014, 2015)
+        )
+        joined = t0.join(t1.into_backend(t0._find_backend()), on)
+
+        result = joined.execute()
+        assert len(result) == 1270
+
+        actual = find_all_sources(joined)
+        expected = tuple(t._find_backend() for t in ts)
+        assert actual == expected
+
+        (r0, *rest) = walk_nodes(rel.Read, joined)
+        assert r0 and rest

--- a/python/xorq/backends/snowflake/tests/test_client.py
+++ b/python/xorq/backends/snowflake/tests/test_client.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
 import pytest
 import toolz
 
 import xorq.api as xo
+from xorq.backends.snowflake import Backend as SnowflakeBackend
 from xorq.backends.snowflake.enums import SnowflakeAuthenticator
 from xorq.backends.snowflake.tests.conftest import (
     inside_temp_schema,
@@ -93,8 +99,13 @@ def test_create_table_from_expr_success(sf_con, temp_catalog, temp_db, csv_dir):
 
 @pytest.mark.snowflake
 def test_create_table_from_expr_other(
-    sf_con, temp_catalog, temp_db, temp_catalog2, temp_db2, csv_dir
-):
+    sf_con: SnowflakeBackend,
+    temp_catalog: str,
+    temp_db: str,
+    temp_catalog2: str,
+    temp_db2: str,
+    csv_dir: Path,
+) -> None:
     with inside_temp_schema(sf_con, temp_catalog, temp_db):
         name = "batting"
         t = xo.deferred_read_csv(
@@ -104,3 +115,43 @@ def test_create_table_from_expr_other(
         assert not sf_con.list_tables()
         sf_con.create_table(name, t, database=f"{temp_catalog2}.{temp_db2}")
         assert name in sf_con.list_tables(database=(temp_catalog2, temp_db2))
+
+
+def test_create_table_requires_obj_or_schema() -> None:
+    # Guard arm: neither obj nor schema raises before any SQL, so it needs no
+    # live connection. Covers the `obj is None and schema is None` branch.
+    with pytest.raises(ValueError, match="Either `obj` or `schema`"):
+        SnowflakeBackend().create_table(gen_name("t"))
+
+
+def test_create_table_rejects_unsupported_obj_type() -> None:
+    # Guard arm: the `match obj` default case raises TypeError before any SQL,
+    # so an unconnected backend is enough to exercise it.
+    with pytest.raises(TypeError, match="unsupported obj type"):
+        SnowflakeBackend().create_table(gen_name("t"), obj=42)
+
+
+@pytest.mark.snowflake
+def test_create_table_from_dataframe(
+    sf_con: SnowflakeBackend, temp_catalog: str, temp_db: str
+) -> None:
+    # The `pd.DataFrame() | pa.Table()` arm wraps obj in a memtable (scope stays
+    # None, so the finally is a no-op). Live-only: it issues a real CREATE.
+    with inside_temp_schema(sf_con, temp_catalog, temp_db):
+        name = gen_name("df_table")
+        sf_con.create_table(name, pd.DataFrame({"a": [1, 2, 3]}))
+        assert name in sf_con.list_tables()
+        assert sf_con.table(name).count().execute() == 3
+
+
+@pytest.mark.snowflake
+def test_create_table_from_schema_only(
+    sf_con: SnowflakeBackend, temp_catalog: str, temp_db: str
+) -> None:
+    # The `None` arm: schema-only create yields table=None (empty table, no
+    # populating query). Live-only: it issues a real CREATE.
+    with inside_temp_schema(sf_con, temp_catalog, temp_db):
+        name = gen_name("schema_only")
+        sf_con.create_table(name, schema=xo.schema({"a": "int64"}))
+        assert name in sf_con.list_tables()
+        assert sf_con.table(name).count().execute() == 0

--- a/python/xorq/backends/snowflake/tests/test_client.py
+++ b/python/xorq/backends/snowflake/tests/test_client.py
@@ -125,9 +125,9 @@ def test_create_table_requires_obj_or_schema() -> None:
 
 
 def test_create_table_rejects_unsupported_obj_type() -> None:
-    # Guard arm: the `match obj` default case raises TypeError before any SQL,
-    # so an unconnected backend is enough to exercise it.
-    with pytest.raises(TypeError, match="unsupported obj type"):
+    # The default arm delegates to api.memtable, which rejects a bare scalar
+    # before any SQL -- so memtable, not a create_table guard, owns rejection.
+    with pytest.raises(ValueError, match="DataFrame constructor"):
         SnowflakeBackend().create_table(gen_name("t"), obj=42)
 
 

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+import pyarrow as pa
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -12,10 +13,6 @@ from xorq.vendor.ibis.backends.sqlite import Backend as IbisSQLiteBackend
 from xorq.vendor.ibis.backends.sqlite import _quote
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import gen_name
-
-
-if TYPE_CHECKING:
-    import pyarrow as pa
 
 
 class Backend(IbisSQLiteBackend):
@@ -75,7 +72,7 @@ class Backend(IbisSQLiteBackend):
         schema = Schema.from_pyarrow(record_batches.schema)
         table = sg.table(table_name, quoted=self.compiler.quoted, catalog="temp")
         create_stmt = self._generate_create_table(table, schema).sql(self.name)
-        df = record_batches.read_pandas()
+        df = pa.RecordBatchReader.from_stream(record_batches).read_pandas()
         data = df.itertuples(index=False)
         insert_stmt = self._build_insert_template(
             table_name, schema=schema, catalog="temp", columns=True

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -25,6 +25,7 @@ class Backend(IbisSQLiteBackend):
         table_name: str | None = None,
         mode: str = "create",
         overwrite: bool = True,
+        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
         from xorq.common.utils.sqlite_utils import SQLiteADBC  # noqa: PLC0415

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -25,7 +25,6 @@ class Backend(IbisSQLiteBackend):
         table_name: str | None = None,
         mode: str = "create",
         overwrite: bool = True,
-        schema: pa.Schema | None = None,
         **kwargs: Any,
     ) -> ir.Table:
         from xorq.common.utils.sqlite_utils import SQLiteADBC  # noqa: PLC0415

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import pyarrow as pa
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -13,6 +12,10 @@ from xorq.vendor.ibis.backends.sqlite import Backend as IbisSQLiteBackend
 from xorq.vendor.ibis.backends.sqlite import _quote
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import gen_name
+
+
+if TYPE_CHECKING:
+    import pyarrow as pa
 
 
 class Backend(IbisSQLiteBackend):
@@ -68,7 +71,11 @@ class Backend(IbisSQLiteBackend):
 
         return self.table(table_name)
 
-    def _into_memory_record_batches(self, record_batches, table_name):
+    def _into_memory_record_batches(
+        self, record_batches: pa.RecordBatchReader, table_name: str
+    ) -> None:
+        import pyarrow as pa  # noqa: PLC0415
+
         schema = Schema.from_pyarrow(record_batches.schema)
         table = sg.table(table_name, quoted=self.compiler.quoted, catalog="temp")
         create_stmt = self._generate_create_table(table, schema).sql(self.name)

--- a/python/xorq/backends/sqlite/__init__.py
+++ b/python/xorq/backends/sqlite/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import sqlglot as sg
 import sqlglot.expressions as sge
 
+from xorq.common.utils.rbr_utils import coerce_to_arrow_table
 from xorq.config import default_backend
 from xorq.vendor.ibis import Schema, util
 from xorq.vendor.ibis.backends.sqlite import Backend as IbisSQLiteBackend
@@ -74,12 +75,10 @@ class Backend(IbisSQLiteBackend):
     def _into_memory_record_batches(
         self, record_batches: pa.RecordBatchReader, table_name: str
     ) -> None:
-        import pyarrow as pa  # noqa: PLC0415
-
         schema = Schema.from_pyarrow(record_batches.schema)
         table = sg.table(table_name, quoted=self.compiler.quoted, catalog="temp")
         create_stmt = self._generate_create_table(table, schema).sql(self.name)
-        df = pa.RecordBatchReader.from_stream(record_batches).read_pandas()
+        df = coerce_to_arrow_table(record_batches).to_pandas()
         data = df.itertuples(index=False)
         insert_stmt = self._build_insert_template(
             table_name, schema=schema, catalog="temp", columns=True

--- a/python/xorq/backends/sqlite/tests/test_into_backend.py
+++ b/python/xorq/backends/sqlite/tests/test_into_backend.py
@@ -21,3 +21,17 @@ def test_into_backend_sqlite_filter() -> None:
     expr = t.into_backend(sqlite_con, "t").filter(xo._.x > 15)
     result = expr.execute()
     assert sorted(result["x"]) == [20, 30]
+
+
+def test_into_backend_sqlite_self_join_fanout() -> None:
+    # sqlite eagerly ingests the StreamCache once into a temp table, so the
+    # self-join re-scans that materialized table rather than the cache. This
+    # pins that fan-out over an eager-ingest backend still produces correct
+    # results (the duckdb/datafusion suites cover the cache-replay path).
+    sqlite_con = xo.sqlite.connect(":memory:")
+    rt = xo.memtable(pa.table({"id": [1, 2], "k": ["a", "a"]})).into_backend(
+        sqlite_con, "t"
+    )
+    result = rt.join(rt.view(), "k").execute()
+    # k='a' on both sides -> 2x2
+    assert len(result) == 4

--- a/python/xorq/backends/sqlite/tests/test_into_backend.py
+++ b/python/xorq/backends/sqlite/tests/test_into_backend.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+import xorq.api as xo
+
+
+def test_into_backend_sqlite_executes() -> None:
+    sqlite_con = xo.sqlite.connect(":memory:")
+    t = xo.memtable(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    expr = t.into_backend(sqlite_con, "t")
+    result = expr.execute()
+    assert len(result) == 3
+    assert sorted(result.columns) == ["a", "b"]
+    assert list(result.sort_values("a")["a"]) == [1, 2, 3]
+
+
+def test_into_backend_sqlite_filter() -> None:
+    sqlite_con = xo.sqlite.connect(":memory:")
+    t = xo.memtable(pa.table({"x": [10, 20, 30]}))
+    expr = t.into_backend(sqlite_con, "t").filter(xo._.x > 15)
+    result = expr.execute()
+    assert sorted(result["x"]) == [20, 30]

--- a/python/xorq/backends/tests/test_backend.py
+++ b/python/xorq/backends/tests/test_backend.py
@@ -63,14 +63,9 @@ def test_con_equality(connect_parts):
         ),
         ("pandas", "connect"),
         ("sqlite", "connect"),
-        pytest.param(
-            # unclear why this works but it gives the correct answer
-            ("snowflake", "connect_env_keypair"),
-            marks=[
-                pytest.mark.snowflake,
-                pytest.mark.slow,
-            ],
-        ),
+        # snowflake lives in backends/snowflake/tests/test_backend.py: it needs a
+        # writable temp schema (read_parquet's CREATE TEMP STAGE is rejected on the
+        # read-only SNOWFLAKE_SAMPLE_DATA default database)
     ),
 )
 def test_con_equality_read(connect_parts, parquet_dir):

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -833,10 +833,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 raise TypeError(f"unsupported source type: {type(source).__name__}")
         self.con.register_record_batch_reader(
             table_ident,
-            pa.RecordBatchReader.from_batches(
-                target_schema,
-                (_select_and_cast(batch, target_schema) for batch in batches),
-            ),
+            _casting_reader(target_schema, batches),
         )
         return self.table(table_name)
 

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -793,17 +793,30 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         match source:
             case StreamCache():
                 target_schema = schema if schema is not None else source.schema
-                reader = pa.RecordBatchReader.from_stream(source)
+                # CastingStreamCache replays and preserves the source's
+                # max_readers bound, so DataFusion's repeated scans evict as
+                # they advance -- but it requires matching field names and so
+                # cannot drop columns. The remote-table path selects the
+                # logical columns upstream (names already match), so this
+                # bounded fast path applies. Direct callers that pass extra
+                # physical columns fall through to a select+recast inner cache,
+                # which is unbounded -- those callers supply no reader count.
+                if list(source.schema.names) == list(target_schema.names):
+                    registered: Any = source.cast(target_schema)
+                else:
+                    reader = pa.RecordBatchReader.from_stream(source)
 
-                def _cast_batches() -> Iterable[pa.RecordBatch]:
-                    with contextlib.closing(reader):
-                        for batch in reader:
-                            yield _select_and_cast(batch, target_schema)
+                    def _cast_batches() -> Iterable[pa.RecordBatch]:
+                        with contextlib.closing(reader):
+                            for batch in reader:
+                                yield _select_and_cast(batch, target_schema)
 
-                inner_cache = StreamCache(
-                    pa.RecordBatchReader.from_batches(target_schema, _cast_batches())
-                )
-                self.con.register_record_batch_reader(table_ident, inner_cache)
+                    registered = StreamCache(
+                        pa.RecordBatchReader.from_batches(
+                            target_schema, _cast_batches()
+                        )
+                    )
+                self.con.register_record_batch_reader(table_ident, registered)
                 try:
                     return self.table(table_name)
                 except Exception:

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -793,6 +793,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
+        registered: Any = None
         match source:
             case StreamCache():
                 target_schema = schema if schema is not None else source.schema
@@ -807,12 +808,6 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 # data and defeat eviction, so we let cast raise on a name
                 # mismatch rather than accommodate it.
                 registered = source.cast(target_schema)
-                self.con.register_record_batch_reader(table_ident, registered)
-                try:
-                    return self.table(table_name)
-                except Exception:
-                    self.con.deregister_table(table_ident)
-                    raise
             case pa.Table():
                 target_schema = schema if schema is not None else source.schema
                 batches = source.to_batches()
@@ -831,11 +826,17 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 batches = itertools.chain([first], it)
             case _:
                 raise TypeError(f"unsupported source type: {type(source).__name__}")
-        self.con.register_record_batch_reader(
-            table_ident,
-            _casting_reader(target_schema, batches),
-        )
-        return self.table(table_name)
+        if registered is None:
+            registered = _casting_reader(target_schema, batches)
+        # Build the ir.Table after registering; if that build fails, deregister
+        # so a failed call never leaves a half-registered table behind. Applies
+        # to every source type, not just the lazy StreamCache path.
+        self.con.register_record_batch_reader(table_ident, registered)
+        try:
+            return self.table(table_name)
+        except Exception:
+            self.con.deregister_table(table_ident)
+            raise
 
     def execute(self, expr: ir.Expr, **kwargs: Any):
         batch_reader = self.to_pyarrow_batches(expr, **kwargs)

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -19,6 +19,7 @@ import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
 import sqlglot as sg
 import sqlglot.expressions as sge
+from batchcorder import StreamCache
 from sqlglot import exp, parse_one
 
 import xorq
@@ -709,7 +710,10 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
     def read_record_batches(
         self,
-        source: pa.Table | pa.RecordBatchReader | Iterable[pa.RecordBatch],
+        source: pa.Table
+        | pa.RecordBatchReader
+        | StreamCache
+        | Iterable[pa.RecordBatch],
         table_name: str | None = None,
     ) -> ir.Table:
         """Register Arrow data as a table in the current database.
@@ -725,11 +729,16 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         source
             The Arrow data to register. Accepts:
 
+            - ``StreamCache`` — multi-scan capable; schema taken from the
+              cache; batches are cast and re-ingested into a new cache.
             - ``pa.Table`` — converted to batches via ``to_batches()``.
             - ``pa.RecordBatchReader`` — consumed directly; schema taken from
               the reader.
             - Any ``Iterable[pa.RecordBatch]`` (list, tuple, generator) —
-              schema inferred from the first batch.
+              schema inferred from the first batch. Empty iterables raise
+              ``ValueError`` because no schema can be inferred. ``pa.Table``
+              and ``pa.RecordBatchReader`` may be empty (schema is already
+              known).
         table_name
             Name for the registered table. Defaults to a sequentially
             generated name.
@@ -767,6 +776,26 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
+        if isinstance(source, StreamCache):
+            schema = source.schema
+            reader = pa.RecordBatchReader.from_stream(source)
+
+            def make_cast_gen():
+                with contextlib.closing(reader):
+                    for batch in reader:
+                        yield _select_and_cast(batch, schema)
+
+            cast_reader = pa.RecordBatchReader.from_batches(schema, make_cast_gen())
+            inner_cache = StreamCache(cast_reader)
+            self.con.register_record_batch_reader(
+                table_ident,
+                inner_cache,
+            )
+            try:
+                return self.table(table_name)
+            except Exception:
+                self.con.deregister_table(table_ident)
+                raise
         if not isinstance(source, (pa.Table, pa.RecordBatchReader)) and (
             isinstance(source, (str, bytes)) or not hasattr(source, "__iter__")
         ):

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -72,7 +72,15 @@ def _select_and_cast(batch: pa.RecordBatch, schema: pa.Schema) -> pa.RecordBatch
     return batch.select(schema.names).cast(schema)
 
 
-def _compile_pyarrow_udwf(udwf_node) -> WindowUDF:
+def _casting_reader(
+    schema: pa.Schema, batches: Iterable[pa.RecordBatch]
+) -> pa.RecordBatchReader:
+    return pa.RecordBatchReader.from_batches(
+        schema, (_select_and_cast(batch, schema) for batch in batches)
+    )
+
+
+def _compile_pyarrow_udwf(udwf_node: Any) -> WindowUDF:
     def make_datafusion_udwf(
         input_types,
         return_type,
@@ -718,19 +726,20 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
     ) -> ir.Table:
         """Register Arrow data as a table in the current database.
 
-        Each batch is cast to the declared schema before being handed to
-        DataFusion. This prevents silent data corruption when physical Arrow
-        types differ from the declared schema (e.g. ``large_utf8`` batches
-        with a ``utf8`` schema), which would otherwise cause DataFusion to
-        misread 64-bit offsets as 32-bit across the C Data Interface boundary.
+        Except for ``StreamCache``, each batch is cast to the declared schema
+        before being handed to DataFusion. This prevents silent data corruption
+        when physical Arrow types differ from the declared schema (e.g.
+        ``large_utf8`` batches with a ``utf8`` schema), which would otherwise
+        cause DataFusion to misread 64-bit offsets as 32-bit across the C Data
+        Interface boundary.
 
         Parameters
         ----------
         source
             The Arrow data to register. Accepts:
 
-            - ``StreamCache`` — multi-scan capable; schema taken from the
-              cache; batches are cast and re-ingested into a new cache.
+            - ``StreamCache`` — replayable and self-describing; registered
+              directly to serve DataFusion's multi-scan plans.
             - ``pa.Table`` — converted to batches via ``to_batches()``.
             - ``pa.RecordBatchReader`` — consumed directly; schema taken from
               the reader.
@@ -776,50 +785,26 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
-        if isinstance(source, StreamCache):
-            # ``cast`` returns a ``CastingStreamCache`` -- a replayable wrapper
-            # that applies the schema cast on every read. Being replayable, it
-            # serves DataFusion's multi-scan plans (self/asof joins) directly,
-            # subsuming both the per-batch cast and the ``inner_cache`` re-wrap
-            # the manual path needed. DataFusion owns it once registered;
-            # ``deregister_table`` drops the provider reference and releases it.
-            casting = source.cast(source.schema)
-            self.con.register_record_batch_reader(
-                table_ident,
-                casting,
-            )
-            try:
-                return self.table(table_name)
-            except Exception:
-                self.con.deregister_table(table_ident)
-                raise
-        if not isinstance(source, (pa.Table, pa.RecordBatchReader)) and (
-            isinstance(source, (str, bytes)) or not hasattr(source, "__iter__")
-        ):
-            raise TypeError(f"unsupported source type: {type(source).__name__}")
-        schema: pa.Schema
-        batches: Iterable[pa.RecordBatch]
         match source:
+            # StreamCache is replayable and self-describing -- register directly.
+            case StreamCache():
+                reader = source
             case pa.Table():
-                schema = source.schema
-                batches = source.to_batches()
+                reader = _casting_reader(source.schema, source.to_batches())
             case pa.RecordBatchReader():
-                schema = source.schema
-                batches = source
-            case _:
+                reader = _casting_reader(source.schema, source)
+            case str() | bytes():
+                raise TypeError(f"unsupported source type: {type(source).__name__}")
+            case _ if hasattr(source, "__iter__"):
                 it = iter(source)
                 try:
                     first = next(it)
                 except StopIteration:
                     raise ValueError("source has no rows") from None
-                schema = first.schema
-                batches = itertools.chain([first], it)
-        self.con.register_record_batch_reader(
-            table_ident,
-            pa.RecordBatchReader.from_batches(
-                schema, (_select_and_cast(batch, schema) for batch in batches)
-            ),
-        )
+                reader = _casting_reader(first.schema, itertools.chain([first], it))
+            case _:
+                raise TypeError(f"unsupported source type: {type(source).__name__}")
+        self.con.register_record_batch_reader(table_ident, reader)
         return self.table(table_name)
 
     def execute(self, expr: ir.Expr, **kwargs: Any):

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -723,23 +723,23 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         | StreamCache
         | Iterable[pa.RecordBatch],
         table_name: str | None = None,
+        schema: pa.Schema | None = None,
     ) -> ir.Table:
         """Register Arrow data as a table in the current database.
 
-        Except for ``StreamCache``, each batch is cast to the declared schema
-        before being handed to DataFusion. This prevents silent data corruption
-        when physical Arrow types differ from the declared schema (e.g.
-        ``large_utf8`` batches with a ``utf8`` schema), which would otherwise
-        cause DataFusion to misread 64-bit offsets as 32-bit across the C Data
-        Interface boundary.
+        Each batch is cast to a target schema before being handed to
+        DataFusion. This prevents silent data corruption when physical Arrow
+        types differ from the declared schema (e.g. ``large_utf8`` batches
+        with a ``utf8`` schema), which would otherwise cause DataFusion to
+        misread 64-bit offsets as 32-bit across the C Data Interface boundary.
 
         Parameters
         ----------
         source
             The Arrow data to register. Accepts:
 
-            - ``StreamCache`` — replayable and self-describing; registered
-              directly to serve DataFusion's multi-scan plans.
+            - ``StreamCache`` — multi-scan capable; batches are cast and
+              re-ingested into a new inner cache.
             - ``pa.Table`` — converted to batches via ``to_batches()``.
             - ``pa.RecordBatchReader`` — consumed directly; schema taken from
               the reader.
@@ -751,6 +751,11 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name
             Name for the registered table. Defaults to a sequentially
             generated name.
+        schema
+            Logical schema to project and cast batches to. When provided,
+            ``_select_and_cast`` uses this schema instead of the source's
+            own schema, dropping any extra physical columns. Defaults to
+            ``None``, which uses the source's declared schema.
 
         Returns
         -------
@@ -786,13 +791,30 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
         match source:
-            # StreamCache is replayable and self-describing -- register directly.
             case StreamCache():
-                reader = source
+                target_schema = schema if schema is not None else source.schema
+                reader = pa.RecordBatchReader.from_stream(source)
+
+                def _cast_batches() -> Iterable[pa.RecordBatch]:
+                    with contextlib.closing(reader):
+                        for batch in reader:
+                            yield _select_and_cast(batch, target_schema)
+
+                inner_cache = StreamCache(
+                    pa.RecordBatchReader.from_batches(target_schema, _cast_batches())
+                )
+                self.con.register_record_batch_reader(table_ident, inner_cache)
+                try:
+                    return self.table(table_name)
+                except Exception:
+                    self.con.deregister_table(table_ident)
+                    raise
             case pa.Table():
-                reader = _casting_reader(source.schema, source.to_batches())
+                target_schema = schema if schema is not None else source.schema
+                batches = source.to_batches()
             case pa.RecordBatchReader():
-                reader = _casting_reader(source.schema, source)
+                target_schema = schema if schema is not None else source.schema
+                batches = source
             case str() | bytes():
                 raise TypeError(f"unsupported source type: {type(source).__name__}")
             case _ if hasattr(source, "__iter__"):
@@ -801,10 +823,17 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                     first = next(it)
                 except StopIteration:
                     raise ValueError("source has no rows") from None
-                reader = _casting_reader(first.schema, itertools.chain([first], it))
+                target_schema = schema if schema is not None else first.schema
+                batches = itertools.chain([first], it)
             case _:
                 raise TypeError(f"unsupported source type: {type(source).__name__}")
-        self.con.register_record_batch_reader(table_ident, reader)
+        self.con.register_record_batch_reader(
+            table_ident,
+            pa.RecordBatchReader.from_batches(
+                target_schema,
+                (_select_and_cast(batch, target_schema) for batch in batches),
+            ),
+        )
         return self.table(table_name)
 
     def execute(self, expr: ir.Expr, **kwargs: Any):

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -777,19 +777,16 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
         if isinstance(source, StreamCache):
-            schema = source.schema
-            reader = pa.RecordBatchReader.from_stream(source)
-
-            def make_cast_gen():
-                with contextlib.closing(reader):
-                    for batch in reader:
-                        yield _select_and_cast(batch, schema)
-
-            cast_reader = pa.RecordBatchReader.from_batches(schema, make_cast_gen())
-            inner_cache = StreamCache(cast_reader)
+            # ``cast`` returns a ``CastingStreamCache`` -- a replayable wrapper
+            # that applies the schema cast on every read. Being replayable, it
+            # serves DataFusion's multi-scan plans (self/asof joins) directly,
+            # subsuming both the per-batch cast and the ``inner_cache`` re-wrap
+            # the manual path needed. DataFusion owns it once registered;
+            # ``deregister_table`` drops the provider reference and releases it.
+            casting = source.cast(source.schema)
             self.con.register_record_batch_reader(
                 table_ident,
-                inner_cache,
+                casting,
             )
             try:
                 return self.table(table_name)

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -752,9 +752,12 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             Name for the registered table. Defaults to a sequentially
             generated name.
         schema
-            Logical schema to project and cast batches to. When provided,
-            ``_select_and_cast`` uses this schema instead of the source's
-            own schema, dropping any extra physical columns. Defaults to
+            Logical schema to project and cast batches to. For one-shot
+            sources (``pa.Table``, ``pa.RecordBatchReader``, iterables) this
+            both drops extra physical columns and retypes via
+            ``_select_and_cast``. For a ``StreamCache`` source it only retypes
+            (``cast`` requires matching field names): column projection must
+            already have happened upstream, before the cache. Defaults to
             ``None``, which uses the source's declared schema.
 
         Returns
@@ -793,29 +796,17 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         match source:
             case StreamCache():
                 target_schema = schema if schema is not None else source.schema
-                # CastingStreamCache replays and preserves the source's
-                # max_readers bound, so DataFusion's repeated scans evict as
-                # they advance -- but it requires matching field names and so
-                # cannot drop columns. The remote-table path selects the
-                # logical columns upstream (names already match), so this
-                # bounded fast path applies. Direct callers that pass extra
-                # physical columns fall through to a select+recast inner cache,
-                # which is unbounded -- those callers supply no reader count.
-                if list(source.schema.names) == list(target_schema.names):
-                    registered: Any = source.cast(target_schema)
-                else:
-                    reader = pa.RecordBatchReader.from_stream(source)
-
-                    def _cast_batches() -> Iterable[pa.RecordBatch]:
-                        with contextlib.closing(reader):
-                            for batch in reader:
-                                yield _select_and_cast(batch, target_schema)
-
-                    registered = StreamCache(
-                        pa.RecordBatchReader.from_batches(
-                            target_schema, _cast_batches()
-                        )
-                    )
+                # source.cast returns a CastingStreamCache: a replayable view
+                # over the *same* cache that retypes on each read, so DataFusion's
+                # repeated scans share one buffer and the source's max_readers
+                # bound still drives eviction. cast only retypes -- it requires
+                # matching field names -- so column projection must already have
+                # happened upstream, before the cache (the remote-table path does
+                # this; see register_and_transform_remote_tables). Wrapping a
+                # second StreamCache here to drop columns would double-buffer the
+                # data and defeat eviction, so we let cast raise on a name
+                # mismatch rather than accommodate it.
+                registered = source.cast(target_schema)
                 self.con.register_record_batch_reader(table_ident, registered)
                 try:
                     return self.table(table_name)

--- a/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
@@ -85,6 +85,14 @@ def test_into_backend_threeway_fanout_three_readers(df, target):
     assert sorted(expr.execute()["v"]) == [10, 30, 40, 40]
 
 
+def test_into_backend_self_join_limit_early_termination(df, target):
+    # fan-out (2 readers) + limit: the scan stops before exhausting the cache
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.join(rt.view(), "k").limit(2)
+    assert reader_counts(expr) == [2]
+    assert len(expr.execute()) == 2
+
+
 def test_into_backend_two_distinct_tables(df, target):
     left = xo.memtable(df).into_backend(target, "l")
     right = xo.memtable(df.assign(v=df.v * 2)).into_backend(target, "r")

--- a/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
@@ -10,16 +10,19 @@ fan-out queries execute correctly and without the GIL/mutex deadlock that
 concurrent StreamCache scans previously triggered.
 """
 
+from __future__ import annotations
+
 import pandas as pd
 import pytest
 
 import xorq.api as xo
-from xorq.expr.relations import count_remote_table_readers
+import xorq.vendor.ibis.expr.types as ir
+from xorq.expr.remote_table_exec import count_remote_table_readers
 from xorq.tests.util import assert_frame_equal
 
 
 @pytest.fixture
-def df():
+def df() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
@@ -30,43 +33,49 @@ def df():
 
 
 @pytest.fixture
-def target():
+def target() -> xo.Backend:
     return xo.connect()
 
 
-def reader_counts(expr):
+def reader_counts(expr: ir.Expr) -> list[int]:
     return sorted(count_remote_table_readers(expr).values())
 
 
-def test_into_backend_bare_single_reader(df, target):
+def test_into_backend_bare_single_reader(df: pd.DataFrame, target: xo.Backend) -> None:
     expr = xo.memtable(df).into_backend(target, "t")
     assert reader_counts(expr) == [1]
     result = expr.execute().sort_values("id").reset_index(drop=True)
     assert_frame_equal(result, df, check_like=True)
 
 
-def test_into_backend_filter_single_scan(df, target):
+def test_into_backend_filter_single_scan(df: pd.DataFrame, target: xo.Backend) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.filter(rt.v > 15)
     assert reader_counts(expr) == [1]
     assert sorted(expr.execute()["v"]) == [20, 30, 40]
 
 
-def test_into_backend_many_columns_one_scan(df, target):
+def test_into_backend_many_columns_one_scan(
+    df: pd.DataFrame, target: xo.Backend
+) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.select(s=rt.id + rt.v, d=rt.v - rt.id)
     assert reader_counts(expr) == [1]
     assert not expr.execute().empty
 
 
-def test_into_backend_self_join_two_readers(df, target):
+def test_into_backend_self_join_two_readers(
+    df: pd.DataFrame, target: xo.Backend
+) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.join(rt.view(), "k")
     assert reader_counts(expr) == [2]
     assert len(expr.execute()) == 8
 
 
-def test_into_backend_two_scalar_subqueries_no_deadlock(df, target):
+def test_into_backend_two_scalar_subqueries_no_deadlock(
+    df: pd.DataFrame, target: xo.Backend
+) -> None:
     # two concurrent scans of one cache: the GIL/mutex deadlock regression
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.v.sum().as_scalar().as_table().mutate(cnt=rt.v.count().as_scalar())
@@ -76,7 +85,9 @@ def test_into_backend_two_scalar_subqueries_no_deadlock(df, target):
     assert int(result["cnt"].iloc[0]) == 4
 
 
-def test_into_backend_threeway_fanout_three_readers(df, target):
+def test_into_backend_threeway_fanout_three_readers(
+    df: pd.DataFrame, target: xo.Backend
+) -> None:
     rt = xo.memtable(df).into_backend(target, "t")
     expr = (
         rt.filter(rt.v < 15).union(rt.filter(rt.v > 35)).union(rt.filter(rt.k == "b"))
@@ -85,7 +96,9 @@ def test_into_backend_threeway_fanout_three_readers(df, target):
     assert sorted(expr.execute()["v"]) == [10, 30, 40, 40]
 
 
-def test_into_backend_self_join_limit_early_termination(df, target):
+def test_into_backend_self_join_limit_early_termination(
+    df: pd.DataFrame, target: xo.Backend
+) -> None:
     # fan-out (2 readers) + limit: the scan stops before exhausting the cache
     rt = xo.memtable(df).into_backend(target, "t")
     expr = rt.join(rt.view(), "k").limit(2)
@@ -93,7 +106,7 @@ def test_into_backend_self_join_limit_early_termination(df, target):
     assert len(expr.execute()) == 2
 
 
-def test_into_backend_two_distinct_tables(df, target):
+def test_into_backend_two_distinct_tables(df: pd.DataFrame, target: xo.Backend) -> None:
     left = xo.memtable(df).into_backend(target, "l")
     right = xo.memtable(df.assign(v=df.v * 2)).into_backend(target, "r")
     expr = left.join(right, "k")
@@ -103,7 +116,9 @@ def test_into_backend_two_distinct_tables(df, target):
     assert len(expr.execute()) == 8
 
 
-def test_into_backend_empty_table_fanout(target):
+def test_into_backend_empty_table_fanout(
+    target: xo.Backend,
+) -> None:
     empty = pd.DataFrame(
         {"id": pd.Series([], dtype="int64"), "v": pd.Series([], dtype="int64")}
     )
@@ -113,7 +128,7 @@ def test_into_backend_empty_table_fanout(target):
     assert expr.execute().empty
 
 
-def test_into_backend_nested_chain(df, target):
+def test_into_backend_nested_chain(df: pd.DataFrame, target: xo.Backend) -> None:
     # data flows memtable -> duckdb -> datafusion, then fans out on datafusion
     inner = xo.memtable(df).into_backend(xo.duckdb.connect(), "inner")
     rt = inner.into_backend(target, "outer")

--- a/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
@@ -1,0 +1,114 @@
+"""into_backend fan-out edge cases for the xorq_datafusion backend.
+
+Unlike duckdb, the datafusion backend reads the StreamCache built by
+``register_and_transform_remote_tables`` exactly once (``from_stream``) and
+re-wraps it into an inner cache that DataFusion scans per reference. So the
+outer cache's ``max_readers`` (the value computed here) only ever sees one
+reader — an over-count merely disables eviction, never crashes. These tests
+confirm the reader count is computed correctly and, more importantly, that
+fan-out queries execute correctly and without the GIL/mutex deadlock that
+concurrent StreamCache scans previously triggered.
+"""
+
+import pandas as pd
+import pytest
+
+import xorq.api as xo
+from xorq.expr.relations import count_remote_table_readers
+from xorq.tests.util import assert_frame_equal
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "k": ["a", "a", "b", "b"],
+            "v": [10, 20, 30, 40],
+        }
+    )
+
+
+@pytest.fixture
+def target():
+    return xo.connect()
+
+
+def reader_counts(expr):
+    return sorted(count_remote_table_readers(expr).values())
+
+
+def test_into_backend_bare_single_reader(df, target):
+    expr = xo.memtable(df).into_backend(target, "t")
+    assert reader_counts(expr) == [1]
+    result = expr.execute().sort_values("id").reset_index(drop=True)
+    assert_frame_equal(result, df, check_like=True)
+
+
+def test_into_backend_filter_single_scan(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.filter(rt.v > 15)
+    assert reader_counts(expr) == [1]
+    assert sorted(expr.execute()["v"]) == [20, 30, 40]
+
+
+def test_into_backend_many_columns_one_scan(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.select(s=rt.id + rt.v, d=rt.v - rt.id)
+    assert reader_counts(expr) == [1]
+    assert not expr.execute().empty
+
+
+def test_into_backend_self_join_two_readers(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.join(rt.view(), "k")
+    assert reader_counts(expr) == [2]
+    assert len(expr.execute()) == 8
+
+
+def test_into_backend_two_scalar_subqueries_no_deadlock(df, target):
+    # two concurrent scans of one cache: the GIL/mutex deadlock regression
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = rt.v.sum().as_scalar().as_table().mutate(cnt=rt.v.count().as_scalar())
+    assert reader_counts(expr) == [2]
+    result = expr.execute()
+    assert int(result.iloc[0, 0]) == 100
+    assert int(result["cnt"].iloc[0]) == 4
+
+
+def test_into_backend_threeway_fanout_three_readers(df, target):
+    rt = xo.memtable(df).into_backend(target, "t")
+    expr = (
+        rt.filter(rt.v < 15).union(rt.filter(rt.v > 35)).union(rt.filter(rt.k == "b"))
+    )
+    assert reader_counts(expr) == [3]
+    assert sorted(expr.execute()["v"]) == [10, 30, 40, 40]
+
+
+def test_into_backend_two_distinct_tables(df, target):
+    left = xo.memtable(df).into_backend(target, "l")
+    right = xo.memtable(df.assign(v=df.v * 2)).into_backend(target, "r")
+    expr = left.join(right, "k")
+    counts = count_remote_table_readers(expr)
+    assert len(counts) == 2
+    assert sorted(counts.values()) == [1, 1]
+    assert len(expr.execute()) == 8
+
+
+def test_into_backend_empty_table_fanout(target):
+    empty = pd.DataFrame(
+        {"id": pd.Series([], dtype="int64"), "v": pd.Series([], dtype="int64")}
+    )
+    rt = xo.memtable(empty).into_backend(target, "e")
+    expr = rt.join(rt.view(), "id")
+    assert reader_counts(expr) == [2]
+    assert expr.execute().empty
+
+
+def test_into_backend_nested_chain(df, target):
+    # data flows memtable -> duckdb -> datafusion, then fans out on datafusion
+    inner = xo.memtable(df).into_backend(xo.duckdb.connect(), "inner")
+    rt = inner.into_backend(target, "outer")
+    expr = rt.join(rt.view(), "id")
+    assert reader_counts(expr) == [2]
+    assert len(expr.execute()) == 4

--- a/python/xorq/backends/xorq_datafusion/tests/test_reentrancy.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_reentrancy.py
@@ -2,7 +2,7 @@
 
 xorq's execution teardown drops the views it registered from inside the result
 ``RecordBatchReader``'s generator ``finally`` block (see
-``rbr_wrapper``/``clean_up`` in ``xorq/expr/api.py``). That fires
+``bind_scope_to_reader`` in ``xorq/expr/remote_table_exec.py``). That fires
 ``con.sql("DROP VIEW ...")`` while the reader from the same datafusion
 ``SessionContext`` is still draining. When the context method held an exclusive
 borrow across the GIL-releasing future, the re-entrant ``sql()`` raised
@@ -16,6 +16,8 @@ eviction never shifts the stream-exhaustion timing that made this deterministic.
 These tests guard against reintroducing the hazard from the xorq side.
 """
 
+from __future__ import annotations
+
 import gc
 import io
 import threading
@@ -26,7 +28,7 @@ import xorq.api as xo
 from xorq.vendor.ibis.expr import types as ir
 
 
-def _teardown_expr(con) -> ir.Table:
+def _teardown_expr(con: xo.Backend) -> ir.Table:
     """An expr whose execution registers datafusion views that the result
     reader's ``finally`` drops while the reader is still draining."""
     df = pa.table({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})

--- a/python/xorq/backends/xorq_datafusion/tests/test_reentrancy.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_reentrancy.py
@@ -1,0 +1,112 @@
+"""Regression tests for the SessionContext re-entrancy hazard.
+
+xorq's execution teardown drops the views it registered from inside the result
+``RecordBatchReader``'s generator ``finally`` block (see
+``rbr_wrapper``/``clean_up`` in ``xorq/expr/api.py``). That fires
+``con.sql("DROP VIEW ...")`` while the reader from the same datafusion
+``SessionContext`` is still draining. When the context method held an exclusive
+borrow across the GIL-releasing future, the re-entrant ``sql()`` raised
+``RuntimeError: Already borrowed``.
+
+Fixed upstream in xorq-labs/xorq-datafusion#37 (methods take ``&self``); xorq
+additionally only bounds a ``StreamCache`` with ``max_readers`` on backends that
+scan it directly (DuckDB), leaving datafusion-fed caches unbounded so cache
+eviction never shifts the stream-exhaustion timing that made this deterministic.
+
+These tests guard against reintroducing the hazard from the xorq side.
+"""
+
+import gc
+import io
+import threading
+
+import pyarrow as pa
+
+import xorq.api as xo
+from xorq.vendor.ibis.expr import types as ir
+
+
+def _teardown_expr(con) -> ir.Table:
+    """An expr whose execution registers datafusion views that the result
+    reader's ``finally`` drops while the reader is still draining."""
+    df = pa.table({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    rt = xo.memtable(df).into_backend(con, "src")
+    trn = rt.filter(rt.amount > 0).select("user_id", "amount").into_backend(con, "trn")
+    return trn.limit(1)
+
+
+def test_execute_teardown_no_already_borrowed() -> None:
+    """Repeated execute on one shared context must not raise 'Already borrowed'.
+
+    Reusing the context is what made the borrow race deterministic: teardown
+    re-enters ``con.sql`` (DROP VIEW) while the prior reader is finalizing.
+    """
+    con = xo.connect()
+    for _ in range(50):
+        result = _teardown_expr(con).execute()
+        assert len(result) == 1
+
+
+def test_concurrent_execute_on_shared_context() -> None:
+    """Many threads executing on one shared datafusion backend must not panic."""
+    con = xo.connect()
+    errors = []
+    barrier = threading.Barrier(6)
+
+    def worker():
+        try:
+            barrier.wait()
+            for _ in range(15):
+                assert len(_teardown_expr(con).execute()) == 1
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"execute raised under concurrency: {errors}"
+
+
+def test_abandoned_reader_teardown_no_already_borrowed() -> None:
+    """A reader read partially then dropped runs cleanup on GC.
+
+    The generator's ``finally`` (DROP VIEW) fires from ``__del__``/GC while the
+    underlying datafusion stream is mid-flight — the borrow is still live.
+    """
+    con = xo.connect()
+    for _ in range(50):
+        reader = _teardown_expr(con).to_pyarrow_batches()
+        next(reader)  # read one batch, leave the stream undrained
+        del reader
+        gc.collect()  # finally -> clean_up -> ctx.sql("DROP VIEW ...")
+
+
+def test_nested_datafusion_teardown_no_already_borrowed() -> None:
+    """Chained into_backend on one context registers several views; the result
+    reader's teardown drops them all while the stream is still finalizing."""
+    con = xo.connect()
+    df = pa.table({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
+    for _ in range(50):
+        a = xo.memtable(df).into_backend(con, "a")
+        b = a.filter(a.amount > 0).into_backend(con, "b")
+        c = b.select("user_id").into_backend(con, "c")
+        assert len(c.limit(1).execute()) == 1
+
+
+def test_to_pyarrow_teardown_no_already_borrowed() -> None:
+    """The to_pyarrow (read_all) entry point shares the same teardown path."""
+    con = xo.connect()
+    for _ in range(50):
+        assert _teardown_expr(con).to_pyarrow().num_rows == 1
+
+
+def test_to_pyarrow_stream_teardown_no_already_borrowed() -> None:
+    """The to_pyarrow_stream entry point shares the same teardown path."""
+    con = xo.connect()
+    for _ in range(50):
+        sink = io.BytesIO()
+        xo.to_pyarrow_stream(_teardown_expr(con), sink)
+        assert sink.getbuffer().nbytes > 0

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -59,30 +59,7 @@ def test_register_table_provider():
     assert t.get_name() in con.list_tables()
 
 
-def test_read_record_batches_type_mismatch():
-    # register_and_transform_remote_tables builds a RecordBatchReader with
-    # schema from ex.as_table().schema().to_pyarrow() (ibis-declared, e.g.
-    # utf8 for VARCHAR) but batches from ex.to_pyarrow_batches() which may
-    # emit a different physical type (e.g. large_utf8 for DuckDB VARCHAR).
-    # Passing this "lying reader" directly to DataFusion via C Data Interface
-    # silently corrupts data: the utf8 offset buffer is 32-bit but large_utf8
-    # data uses 64-bit offsets, so DataFusion misreads row boundaries.
-    # read_record_batches must cast each batch to the declared schema before
-    # handing the reader to DataFusion.
-    con = xo.connect()
-    utf8_schema = pa.schema([("x", pa.utf8())])
-    batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
-    # RecordBatchReader.from_batches does not validate batch types against the
-    # declared schema, reproducing the lying reader from production code paths.
-    lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])
-    assert lying_reader.schema.field("x").type == pa.utf8()
-
-    # read_record_batches casts each batch before crossing the C boundary:
-    t = con.read_record_batches(lying_reader)
-    assert t.execute()["x"].tolist() == ["hello", "world"]
-
-
-def test_read_record_batches_from_table():
+def test_read_record_batches_from_table() -> None:
     con = xo.connect()
     t = con.read_record_batches(pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
     result = t.execute()

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -3,6 +3,7 @@ import warnings
 import pandas as pd
 import pyarrow as pa
 import pytest
+from batchcorder import StreamCache
 
 import xorq.api as xo
 from xorq.backends.xorq_datafusion import _select_and_cast
@@ -57,6 +58,43 @@ def test_register_table_provider():
     # None table_name generates a name; returned table reflects it
     t = con.register_table_provider(source)
     assert t.get_name() in con.list_tables()
+
+
+def test_read_record_batches_type_mismatch() -> None:
+    con = xo.connect()
+    utf8_schema = pa.schema([("x", pa.utf8())])
+    batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
+    lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])
+    assert lying_reader.schema.field("x").type == pa.utf8()
+    t = con.read_record_batches(lying_reader)
+    assert t.execute()["x"].tolist() == ["hello", "world"]
+
+
+def test_read_record_batches_stream_cache_casts_to_logical_schema() -> None:
+    con = xo.connect()
+    logical_schema = pa.schema([("x", pa.utf8())])
+    batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
+    # Cast before entering StreamCache (as remote_table_exec does) to avoid
+    # C Data Interface corruption from large_utf8-vs-utf8 offset mismatch.
+    cast_reader = pa.RecordBatchReader.from_batches(
+        logical_schema,
+        (b.select(logical_schema.names).cast(logical_schema) for b in [batch]),
+    )
+    cache = StreamCache(cast_reader)
+    t = con.read_record_batches(cache, schema=logical_schema)
+    assert t.execute()["x"].tolist() == ["hello", "world"]
+
+
+def test_read_record_batches_stream_cache_schema_drops_extra_columns() -> None:
+    con = xo.connect()
+    batch = pa.record_batch({"a": [1, 2], "extra": [9, 9]})
+    reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])
+    cache = StreamCache(reader)
+    logical_schema = pa.schema([("a", pa.int64())])
+    t = con.read_record_batches(cache, schema=logical_schema)
+    result = t.execute()
+    assert result.columns.tolist() == ["a"]
+    assert result["a"].tolist() == [1, 2]
 
 
 def test_read_record_batches_from_table() -> None:

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -102,6 +102,29 @@ def test_read_record_batches_stream_cache_extra_columns_raises() -> None:
         t.execute()
 
 
+def test_read_record_batches_stream_cache_rollback_on_table_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # StreamCache registers the reader, then builds the ir.Table. If that
+    # build raises, the reader must be deregistered so a failed call leaves no
+    # half-registered table behind.
+    con = xo.connect()
+    logical_schema = pa.schema([("x", pa.int64())])
+    reader = pa.RecordBatchReader.from_batches(
+        logical_schema, [pa.record_batch({"x": [1, 2]})]
+    )
+    cache = StreamCache(reader)
+
+    def boom(self, *args, **kwargs):
+        raise RuntimeError("table build failed")
+
+    monkeypatch.setattr(type(con), "table", boom)
+    with pytest.raises(RuntimeError, match="table build failed"):
+        con.read_record_batches(cache, table_name="rollback_t", schema=logical_schema)
+    monkeypatch.undo()
+    assert "rollback_t" not in con.list_tables()
+
+
 def test_read_record_batches_stream_cache_projected_upstream() -> None:
     # The supported path: project to the logical columns before the cache,
     # then read_record_batches only retypes via the replayable CastingStreamCache.

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -85,12 +85,34 @@ def test_read_record_batches_stream_cache_casts_to_logical_schema() -> None:
     assert t.execute()["x"].tolist() == ["hello", "world"]
 
 
-def test_read_record_batches_stream_cache_schema_drops_extra_columns() -> None:
+def test_read_record_batches_stream_cache_extra_columns_raises() -> None:
+    # A StreamCache must already hold the logical columns: cast only retypes,
+    # it cannot drop columns, and wrapping a second cache to project would
+    # double-buffer and defeat eviction. Column projection belongs upstream,
+    # before the cache (as register_and_transform_remote_tables does).
     con = xo.connect()
     batch = pa.record_batch({"a": [1, 2], "extra": [9, 9]})
     reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])
     cache = StreamCache(reader)
     logical_schema = pa.schema([("a", pa.int64())])
+    # cast is lazy: the name mismatch surfaces when DataFusion reads, not at
+    # registration (same deferral as type-cast errors).
+    t = con.read_record_batches(cache, schema=logical_schema)
+    with pytest.raises(Exception, match="field names"):
+        t.execute()
+
+
+def test_read_record_batches_stream_cache_projected_upstream() -> None:
+    # The supported path: project to the logical columns before the cache,
+    # then read_record_batches only retypes via the replayable CastingStreamCache.
+    con = xo.connect()
+    batch = pa.record_batch({"a": [1, 2], "extra": [9, 9]})
+    logical_schema = pa.schema([("a", pa.int64())])
+    projected = pa.RecordBatchReader.from_batches(
+        logical_schema,
+        (b.select(logical_schema.names).cast(logical_schema) for b in [batch]),
+    )
+    cache = StreamCache(projected)
     t = con.read_record_batches(cache, schema=logical_schema)
     result = t.execute()
     assert result.columns.tolist() == ["a"]

--- a/python/xorq/backends/xorq_datafusion/tests/test_stream_cache_deadlock.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_stream_cache_deadlock.py
@@ -1,0 +1,75 @@
+"""
+Regression test for GIL+mutex deadlock in StreamCache fan-out via DataFusion.
+
+Root cause:
+  DataFusion executes two concurrent scans over the same Python-backed table
+  (e.g. two scalar subqueries from .as_scalar().as_table().mutate(...)) by
+  spawning Tokio async worker threads.  Each worker thread called
+  Python::attach (GIL acquisition) inside PyRecordBatchProviderExec::execute()
+  in order to pull the next batch from the Python-backed StreamCache reader.
+  At the same time, batchcorder's ingest_up_to() holds the DatasetInner mutex
+  while reading batches.  This produces a classic A-B / B-A circular wait:
+
+    Worker thread A: holds GIL, blocks waiting for DatasetInner mutex
+    Worker thread B: holds DatasetInner mutex, blocks on PyGILState_Ensure()
+
+  → deadlock.
+
+Fix (xorq-datafusion ef86e2b):
+  Move Python::attach into spawn_blocking (a dedicated thread pool) so the
+  GIL is never acquired on Tokio async worker threads.  Also drop the GIL
+  across reader.next() calls so a blocking reader never starves the async
+  executor while holding the GIL.  With these changes no async worker thread
+  ever holds the GIL, breaking the circular wait.
+  See: https://github.com/xorq-labs/xorq-datafusion/commit/ef86e2b10190c5f0276d4d4aa4dd9135a8dcb82a
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+_DEADLOCK_SCRIPT = """
+import pyarrow as pa
+import xorq.api as xo
+from batchcorder import StreamCache
+
+schema = pa.schema([("x", pa.int64())])
+
+def gen():
+    for i in range(5):
+        yield pa.record_batch({"x": [i]})
+
+cache = StreamCache(pa.RecordBatchReader.from_batches(schema, gen()))
+con = xo.connect()
+t = con.read_record_batches(cache, table_name="deadlock_t")
+
+# Two scalar subqueries over the same StreamCache-backed table.
+# DataFusion executes both via Tokio worker threads that each call
+# ingest_up_to() -> with_gil_acquired() while holding the inner Mutex.
+s1 = t.x.sum().as_scalar()
+s2 = t.x.count().as_scalar()
+result = s1.as_table().mutate(cnt=s2).execute()
+assert result["cnt"].iloc[0] == 5
+assert result.iloc[0, 0] == 10
+print("ok")
+"""
+
+
+def test_stream_cache_two_scan_no_deadlock():
+    """Two scalar subqueries over a StreamCache-backed table must not deadlock."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _DEADLOCK_SCRIPT],
+            timeout=8,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            "deadlock detected: two-scan StreamCache query hung for 8 s "
+            "(GIL + Mutex inversion in ingest_up_to / with_gil_acquired)"
+        )
+
+    assert proc.returncode == 0, proc.stderr

--- a/python/xorq/backends/xorq_datafusion/tests/test_stream_cache_deadlock.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_stream_cache_deadlock.py
@@ -24,6 +24,8 @@ Fix (xorq-datafusion ef86e2b):
   See: https://github.com/xorq-labs/xorq-datafusion/commit/ef86e2b10190c5f0276d4d4aa4dd9135a8dcb82a
 """
 
+from __future__ import annotations
+
 import subprocess
 import sys
 
@@ -57,7 +59,7 @@ print("ok")
 """
 
 
-def test_stream_cache_two_scan_no_deadlock():
+def test_stream_cache_two_scan_no_deadlock() -> None:
     """Two scalar subqueries over a StreamCache-backed table must not deadlock."""
     try:
         proc = subprocess.run(

--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -215,8 +215,12 @@ class SourceStorage(CacheStorage):
                 from xorq.expr.api import _transform_expr  # noqa: PLC0415
 
                 # must transform for Read ops: create_table expects a vanilla ibis expr
-                (transformed, _, _) = _transform_expr(value.to_expr())
-                self.source.create_table(key, transformed)
+                (transformed, _, _, _caches) = _transform_expr(value.to_expr())
+                try:
+                    self.source.create_table(key, transformed)
+                finally:
+                    for cache in _caches:
+                        cache.close()
             else:
                 assert hasattr(self.source, "read_record_batches")
                 # read_record_batches will create durable table in out-of-core fashion

--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -212,12 +212,12 @@ class SourceStorage(CacheStorage):
 
         if is_remote(value):
             if is_single_backend(self, value):
-                from xorq.expr.api import transformed  # noqa: PLC0415
+                from xorq.expr.api import remote_table_scope  # noqa: PLC0415
 
                 # must transform for Read ops: create_table expects a vanilla ibis expr
                 # full close is safe here: create_table is an eager server-side
                 # CTAS and get(key) below never references the placeholders
-                with transformed(value.to_expr()) as transformed_expr:
+                with remote_table_scope(value.to_expr()) as transformed_expr:
                     self.source.create_table(key, transformed_expr)
             else:
                 assert hasattr(self.source, "read_record_batches")

--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -212,15 +212,13 @@ class SourceStorage(CacheStorage):
 
         if is_remote(value):
             if is_single_backend(self, value):
-                from xorq.expr.api import _transform_expr  # noqa: PLC0415
+                from xorq.expr.api import transformed  # noqa: PLC0415
 
                 # must transform for Read ops: create_table expects a vanilla ibis expr
-                (transformed, _, _, _caches) = _transform_expr(value.to_expr())
-                try:
-                    self.source.create_table(key, transformed)
-                finally:
-                    for cache in _caches:
-                        cache.close()
+                # full close is safe here: create_table is an eager server-side
+                # CTAS and get(key) below never references the placeholders
+                with transformed(value.to_expr()) as transformed_expr:
+                    self.source.create_table(key, transformed_expr)
             else:
                 assert hasattr(self.source, "read_record_batches")
                 # read_record_batches will create durable table in out-of-core fashion

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -33,8 +33,11 @@ if TYPE_CHECKING:
 
 DEFAULT_CHUNKSIZE = 10_000
 
-# Backends that use ADBC and require mode="replace" to avoid "relation already exists" errors.
-_ADBC_BACKENDS = frozenset(("sqlite", "postgres", "snowflake", "databricks"))
+# Backends whose read_parquet/read_csv route through ADBC read_record_batches
+# (so they accept ``mode="replace"`` to avoid "relation already exists" errors).
+# Snowflake is excluded: its read_record_batches is ADBC, but read_parquet/read_csv
+# are native (kwargs become FILE_FORMAT options, where ``mode`` is invalid).
+_ADBC_BACKENDS = frozenset(("sqlite", "postgres", "databricks"))
 
 # Backend-specific parameter names for the file path argument.
 _PATH_PARAM_NAMES = frozenset(("path", "paths", "source", "source_list"))

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -280,7 +280,9 @@ def rbr_wrapper(reader, clean_up):
     import pyarrow as pa  # noqa: PLC0415
 
     def gen():
-        yield from reader
-        clean_up()
+        try:
+            yield from reader
+        finally:
+            clean_up()
 
     return pa.RecordBatchReader.from_batches(reader.schema, gen())

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -274,15 +274,3 @@ def deferred_read_parquet(
         read_kwargs=read_kwargs,
         normalize_method=normalize_method,
     ).to_expr()
-
-
-def rbr_wrapper(reader, clean_up):
-    import pyarrow as pa  # noqa: PLC0415
-
-    def gen():
-        try:
-            yield from reader
-        finally:
-            clean_up()
-
-    return pa.RecordBatchReader.from_batches(reader.schema, gen())

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import itertools
 import traceback
+from collections.abc import Iterable
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -52,7 +55,33 @@ def otel_instrument_reader(reader):
     return pa.RecordBatchReader.from_batches(reader.schema, instrument_reader(reader))
 
 
-def copy_rbr_batches(reader):
+def coerce_to_arrow_table(
+    source: pa.Table | pa.RecordBatchReader | Iterable[pa.RecordBatch],
+    schema: pa.Schema | None = None,
+) -> pa.Table:
+    """Materialize any Arrow batch source into a ``pa.Table``.
+
+    Accepts a ``pa.Table``, a ``pa.RecordBatchReader``, a batchcorder
+    ``StreamCache``, or any iterable of ``pa.RecordBatch``. The schema is taken
+    from ``schema`` if given, otherwise from the source, so a zero-batch stream
+    still yields a table with the declared columns instead of raising.
+    """
+    if isinstance(source, pa.Table):
+        return source.cast(schema) if schema is not None else source
+    if schema is None:
+        schema = getattr(source, "schema", None)
+    if isinstance(source, (list, tuple)) and schema is None:
+        if not source:
+            raise ValueError("cannot infer schema from an empty batch sequence")
+        schema = source[0].schema
+    if schema is None:
+        raise ValueError(
+            "schema is required to coerce a schemaless batch iterable to a table"
+        )
+    return pa.Table.from_batches(source, schema=schema)
+
+
+def copy_rbr_batches(reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
     manager = pa.default_cpu_memory_manager()
     gen = (batch.copy_to(manager) for batch in reader)
     return pa.RecordBatchReader.from_batches(reader.schema, gen)

--- a/python/xorq/common/utils/snowflake_utils.py
+++ b/python/xorq/common/utils/snowflake_utils.py
@@ -205,7 +205,11 @@ class SnowflakeADBC:
             keypair = SnowflakeKeypair.from_bytes_der(self.con.con._private_key)
             return {
                 DatabaseOptions.AUTH_TYPE.value: "auth_jwt",
-                DatabaseOptions.JWT_PRIVATE_KEY_VALUE.value: keypair.private_bytes,
+                # PEM string, not bytes: adbc_driver_manager>=1.11 routes bytes
+                # option values through AdbcDatabaseSetOptionBytes, which the
+                # Snowflake driver rejects pre-init ("database not initialized").
+                # String values use AdbcDatabaseSetOption, which works.
+                DatabaseOptions.JWT_PRIVATE_KEY_VALUE.value: keypair.private_str,
                 DatabaseOptions.JWT_PRIVATE_KEY_PASSWORD.value: keypair.private_key_pwd,
             }
         else:

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -288,7 +288,7 @@ def _transform_deferred_reads(expr):
     # deferred read at this execution boundary; reads inside opaque sub-exprs
     # are resolved when those sub-exprs execute, so descending here is wrong.
     expr = expr.op().replace(replace_read).to_expr()
-    return expr, dt_to_read
+    return expr
 
 
 @tracer.start_as_current_span("execute")
@@ -509,7 +509,7 @@ def _transform_expr(expr, params=None, **kwargs):
     for drain in drains:
         scope.adopt_drain(drain)
     try:
-        expr, _dt_to_read = _transform_deferred_reads(expr)
+        expr = _transform_deferred_reads(expr)
     except Exception:
         scope.close()
         raise

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -463,11 +463,11 @@ def _drop_created_tables(created: dict) -> None:
     raise_collected_errors("failed to drop created tables", errors)
 
 
-def _run_cleanup(drains: list, created: dict) -> None:
-    """Close/join drains and drop created tables, surfacing every failure.
+def _run_cleanup(drains: list, created: dict, caches: list = ()) -> None:
+    """Close/join drains, drop created tables, close caches; surface every failure.
 
-    Both steps always run even if the first raises, so a drain failure never
-    leaks the temp tables and a drop failure never hides a drain failure.
+    All steps always run even if an earlier one raises, so a drain failure never
+    leaks temp tables or caches, and a later failure never hides an earlier one.
     """
     cleanup_errors: list[BaseException] = []
     try:
@@ -478,6 +478,11 @@ def _run_cleanup(drains: list, created: dict) -> None:
         _drop_created_tables(created)
     except BaseException as exc:  # noqa: BLE001
         cleanup_errors.append(exc)
+    for cache in caches:
+        try:
+            cache.close()
+        except BaseException as exc:  # noqa: BLE001
+            cleanup_errors.append(exc)
     raise_collected_errors("execution cleanup failed", cleanup_errors)
 
 
@@ -493,10 +498,10 @@ def _transform_expr(expr, params=None, **kwargs):
     expr = _remove_tag_nodes(expr)
     expr = _register_and_transform_cache_tables(expr)
     expr, tee_created, drains = register_and_transform_tee_nodes(expr)
-    expr, created = register_and_transform_remote_tables(expr, **kwargs)
+    expr, created, caches = register_and_transform_remote_tables(expr, **kwargs)
     expr, dt_to_read = _transform_deferred_reads(expr)
     created = {**created, **tee_created}
-    return (expr, created, drains)
+    return (expr, created, drains, caches)
 
 
 def _pandas_execute(con, expr: ir.Expr, **kwargs):
@@ -509,14 +514,14 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
         df = node.to_rbr().read_pandas(timestamp_as_object=True)
         return expr.__pandas_result__(df)
     params = kwargs.pop("params", None)
-    expr, created, drains = _transform_expr(expr, params=params)
+    expr, created, drains, caches = _transform_expr(expr, params=params)
 
     span.set_attribute("engine", "pandas")
     try:
         result = con.execute(expr, **kwargs)
     except BaseException as primary:
         try:
-            _run_cleanup(drains, created)
+            _run_cleanup(drains, created, caches)
         except BaseException as cleanup_exc:  # noqa: BLE001
             raise_collected_errors(
                 "execute failed and cleanup failed",
@@ -524,7 +529,7 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
             )
         raise
     else:
-        _run_cleanup(drains, created)
+        _run_cleanup(drains, created, caches)
         return result
 
 
@@ -565,13 +570,13 @@ def to_pyarrow_batches(
         span.set_attribute("engine", "flight")
         return expr.op().to_rbr()
     params = kwargs.pop("params", None)
-    expr, created, drains = _transform_expr(expr, params=params)
+    expr, created, drains, caches = _transform_expr(expr, params=params)
     con, _ = find_backend(expr.op(), use_default=True)
 
     span.set_attribute("engine", con.name)
 
     def clean_up():
-        _run_cleanup(drains, created)
+        _run_cleanup(drains, created, caches)
 
     try:
         reader = con.to_pyarrow_batches(expr, chunk_size=chunk_size, **kwargs)
@@ -736,10 +741,14 @@ def to_json(
 def get_plans(expr: ir.Expr) -> dict:
     # Strip tee nodes first (like to_sql): EXPLAIN is a non-executing path, so
     # it must not register a pass-through table or fire the side-effect write.
-    _expr, _, _ = _transform_expr(_remove_tee_nodes(expr))
-    con, _ = find_backend(_expr.op())
-    sql = f"EXPLAIN {to_sql(_expr)}"
-    return con.con.sql(sql).to_pandas().set_index("plan_type")["plan"].to_dict()
+    _expr, _created, _drains, _caches = _transform_expr(_remove_tee_nodes(expr))
+    try:
+        con, _ = find_backend(_expr.op())
+        sql = f"EXPLAIN {to_sql(_expr)}"
+        return con.con.sql(sql).to_pandas().set_index("plan_type")["plan"].to_dict()
+    finally:
+        for cache in _caches:
+            cache.close()
 
 
 def get_object_metadata(path: str, **kwargs: Any) -> dict:

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -260,8 +260,6 @@ def _register_and_transform_cache_tables(expr):
 
 @tracer.start_as_current_span("_transform_deferred_reads")
 def _transform_deferred_reads(expr):
-    dt_to_read = {}
-
     span = get_current_span()
 
     def replace_read(node, _kwargs):

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -522,10 +522,20 @@ def remote_table_scope(expr: ir.Expr, **kwargs: Any) -> Generator[ir.Expr]:
 
     For eager call sites only: the body must fully materialize the result
     before exiting (placeholder tables are dropped on exit).
+
+    Drain (write-through) failures are surfaced only when the body returns
+    normally: a successful query whose tee/WAP write failed is a correctness
+    error worth raising. If the body itself raised, that exception propagates
+    and drain failures are swallowed so they cannot mask the original error.
     """
     (expr, scope) = _transform_expr(expr, **kwargs)
-    with scope:
+    try:
         yield expr
+    except BaseException:
+        scope.close()
+        raise
+    else:
+        scope.close(raise_drain_errors=True)
 
 
 def _pandas_execute(con, expr: ir.Expr, **kwargs):

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -19,7 +20,6 @@ from xorq.common.utils.caching_utils import find_backend
 from xorq.common.utils.defer_utils import (  # noqa: F403
     deferred_read_csv,
     deferred_read_parquet,
-    rbr_wrapper,
 )
 from xorq.common.utils.graph_utils import replace_nodes, walk_nodes
 from xorq.common.utils.io_utils import (
@@ -463,11 +463,11 @@ def _drop_created_tables(created: dict) -> None:
     raise_collected_errors("failed to drop created tables", errors)
 
 
-def _run_cleanup(drains: list, created: dict, caches: list = ()) -> None:
-    """Close/join drains, drop created tables, close caches; surface every failure.
+def _run_cleanup(drains: list, created: dict) -> None:
+    """Close/join drains and drop created tables, surfacing every failure.
 
-    All steps always run even if an earlier one raises, so a drain failure never
-    leaks temp tables or caches, and a later failure never hides an earlier one.
+    Both steps always run even if the first raises, so a drain failure never
+    leaks the temp tables and a drop failure never hides a drain failure.
     """
     cleanup_errors: list[BaseException] = []
     try:
@@ -478,17 +478,17 @@ def _run_cleanup(drains: list, created: dict, caches: list = ()) -> None:
         _drop_created_tables(created)
     except BaseException as exc:  # noqa: BLE001
         cleanup_errors.append(exc)
-    for cache in caches:
-        try:
-            cache.close()
-        except BaseException as exc:  # noqa: BLE001
-            cleanup_errors.append(exc)
     raise_collected_errors("execution cleanup failed", cleanup_errors)
 
 
 @tracer.start_as_current_span("_transform_expr")
 def _transform_expr(expr, params=None, **kwargs):
-    """Transform an expression for execution, binding any named scalar parameters."""
+    """Transform an expression for execution, binding any named scalar parameters.
+
+    Returns ``(expr, scope)``: the scope owns every resource the transform
+    materialized (upstream readers, StreamCaches, placeholder tables) and the
+    caller must close it once the transformed expr is consumed.
+    """
     name_values = _resolve_params(params)
     expr = (
         bind_params(expr, name_values)
@@ -498,10 +498,32 @@ def _transform_expr(expr, params=None, **kwargs):
     expr = _remove_tag_nodes(expr)
     expr = _register_and_transform_cache_tables(expr)
     expr, tee_created, drains = register_and_transform_tee_nodes(expr)
-    expr, created, caches = register_and_transform_remote_tables(expr, **kwargs)
-    expr, dt_to_read = _transform_deferred_reads(expr)
-    created = {**created, **tee_created}
-    return (expr, created, drains, caches)
+    expr, scope = register_and_transform_remote_tables(expr, **kwargs)
+    # Fold the tee-node materializations (placeholder tables + write-through
+    # drains) into the same scope so a single close() tears everything down.
+    # Drains close-then-join before any table drops (see TransformScope.close).
+    for table_name, con in tee_created.items():
+        scope.adopt_table(con, table_name)
+    for drain in drains:
+        scope.adopt_drain(drain)
+    try:
+        expr, dt_to_read = _transform_deferred_reads(expr)
+    except Exception:
+        scope.close()
+        raise
+    return (expr, scope)
+
+
+@contextmanager
+def transformed(expr, **kwargs):
+    """Transform ``expr`` and yield it with a guaranteed full scope close.
+
+    For eager call sites only: the body must fully materialize the result
+    before exiting (placeholder tables are dropped on exit).
+    """
+    (expr, scope) = _transform_expr(expr, **kwargs)
+    with scope:
+        yield expr
 
 
 def _pandas_execute(con, expr: ir.Expr, **kwargs):
@@ -514,23 +536,11 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
         df = node.to_rbr().read_pandas(timestamp_as_object=True)
         return expr.__pandas_result__(df)
     params = kwargs.pop("params", None)
-    expr, created, drains, caches = _transform_expr(expr, params=params)
 
     span.set_attribute("engine", "pandas")
-    try:
-        result = con.execute(expr, **kwargs)
-    except BaseException as primary:
-        try:
-            _run_cleanup(drains, created, caches)
-        except BaseException as cleanup_exc:  # noqa: BLE001
-            raise_collected_errors(
-                "execute failed and cleanup failed",
-                [primary, cleanup_exc],
-            )
-        raise
-    else:
-        _run_cleanup(drains, created, caches)
-        return result
+    # full close is safe here: con.execute returns a materialized DataFrame
+    with transformed(expr, params=params) as expr:
+        return con.execute(expr, **kwargs)
 
 
 @tracer.start_as_current_span("to_pyarrow_batches")
@@ -570,27 +580,18 @@ def to_pyarrow_batches(
         span.set_attribute("engine", "flight")
         return expr.op().to_rbr()
     params = kwargs.pop("params", None)
-    expr, created, drains, caches = _transform_expr(expr, params=params)
-    con, _ = find_backend(expr.op(), use_default=True)
-
-    span.set_attribute("engine", con.name)
-
-    def clean_up():
-        _run_cleanup(drains, created, caches)
-
+    expr, scope = _transform_expr(expr, params=params)
     try:
+        con, _ = find_backend(expr.op(), use_default=True)
+        span.set_attribute("engine", con.name)
         reader = con.to_pyarrow_batches(expr, chunk_size=chunk_size, **kwargs)
-    except BaseException as primary:
-        try:
-            clean_up()
-        except BaseException as cleanup_exc:  # noqa: BLE001
-            raise_collected_errors(
-                "to_pyarrow_batches failed and cleanup failed",
-                [primary, cleanup_exc],
-            )
+    except Exception:
+        scope.close()
         raise
 
-    return otel_instrument_reader(rbr_wrapper(reader, clean_up))
+    # cleanup stays deferred to the result reader's exhaustion/collection:
+    # the backends scan the placeholders lazily while the reader drains
+    return otel_instrument_reader(scope.bind(reader))
 
 
 def to_pyarrow(expr: ir.Expr, **kwargs: Any):
@@ -741,14 +742,11 @@ def to_json(
 def get_plans(expr: ir.Expr) -> dict:
     # Strip tee nodes first (like to_sql): EXPLAIN is a non-executing path, so
     # it must not register a pass-through table or fire the side-effect write.
-    _expr, _created, _drains, _caches = _transform_expr(_remove_tee_nodes(expr))
-    try:
+    # Full close is safe here: EXPLAIN is materialized via to_pandas inside.
+    with transformed(_remove_tee_nodes(expr)) as _expr:
         con, _ = find_backend(_expr.op())
         sql = f"EXPLAIN {to_sql(_expr)}"
         return con.con.sql(sql).to_pandas().set_index("plan_type")["plan"].to_dict()
-    finally:
-        for cache in _caches:
-            cache.close()
 
 
 def get_object_metadata(path: str, **kwargs: Any) -> dict:

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -15,7 +15,6 @@ import xorq.vendor.ibis.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
 import xorq.vendor.ibis.expr.types as ir
 from xorq.backends.xorq_datafusion import Backend
-from xorq.common.compat import raise_collected_errors
 from xorq.common.exceptions import XorqError
 from xorq.common.utils.caching_utils import find_backend
 from xorq.common.utils.defer_utils import (  # noqa: F403
@@ -433,54 +432,6 @@ def _resolve_params(params):
     if errors:
         raise TypeError("\n".join(errors))
     return name_values
-
-
-def _close_and_join_drains(drains: list) -> None:
-    errors: list[BaseException] = []
-    for d in drains:
-        try:
-            d.close()
-        except BaseException as exc:  # noqa: BLE001
-            errors.append(exc)
-    for d in drains:
-        try:
-            d.join()
-        except BaseException as exc:  # noqa: BLE001
-            errors.append(exc)
-    raise_collected_errors("drain failures", errors)
-
-
-def _drop_created_tables(created: dict) -> None:
-    # Drop every table even if one fails, so a single bad drop never strands the
-    # rest (created may hold several entries: tee + remote-table placeholders).
-    errors: list[BaseException] = []
-    for table_name, conn in created.items():
-        try:
-            conn.drop_table(table_name, force=True)
-        except Exception:
-            try:
-                conn.drop_view(table_name)
-            except BaseException as exc:  # noqa: BLE001
-                errors.append(exc)
-    raise_collected_errors("failed to drop created tables", errors)
-
-
-def _run_cleanup(drains: list, created: dict) -> None:
-    """Close/join drains and drop created tables, surfacing every failure.
-
-    Both steps always run even if the first raises, so a drain failure never
-    leaks the temp tables and a drop failure never hides a drain failure.
-    """
-    cleanup_errors: list[BaseException] = []
-    try:
-        _close_and_join_drains(drains)
-    except BaseException as exc:  # noqa: BLE001
-        cleanup_errors.append(exc)
-    try:
-        _drop_created_tables(created)
-    except BaseException as exc:  # noqa: BLE001
-        cleanup_errors.append(exc)
-    raise_collected_errors("execution cleanup failed", cleanup_errors)
 
 
 @tracer.start_as_current_span("_transform_expr")

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
@@ -41,8 +42,11 @@ from xorq.expr.relations import (
     Read,
     Tag,
     TeeNode,
-    register_and_transform_remote_tables,
     register_and_transform_tee_nodes,
+)
+from xorq.expr.remote_table_exec import (
+    bind_scope_to_reader,
+    register_and_transform_remote_tables,
 )
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import api
@@ -276,7 +280,7 @@ def _transform_deferred_reads(expr):
                 },
             )
             # FIXME: pandas read is not lazy, leave it to the pandas executor to do
-            node = dt_to_read[node] = node.make_dt()
+            node = node.make_dt()
         else:
             if _kwargs:
                 node = node.__recreate__(_kwargs)
@@ -501,13 +505,13 @@ def _transform_expr(expr, params=None, **kwargs):
     expr, scope = register_and_transform_remote_tables(expr, **kwargs)
     # Fold the tee-node materializations (placeholder tables + write-through
     # drains) into the same scope so a single close() tears everything down.
-    # Drains close-then-join before any table drops (see TransformScope.close).
+    # Drains close-then-join before any table drops (see RemoteTableScope.close).
     for table_name, con in tee_created.items():
         scope.adopt_table(con, table_name)
     for drain in drains:
         scope.adopt_drain(drain)
     try:
-        expr, dt_to_read = _transform_deferred_reads(expr)
+        expr, _dt_to_read = _transform_deferred_reads(expr)
     except Exception:
         scope.close()
         raise
@@ -515,7 +519,7 @@ def _transform_expr(expr, params=None, **kwargs):
 
 
 @contextmanager
-def transformed(expr, **kwargs):
+def remote_table_scope(expr: ir.Expr, **kwargs: Any) -> Generator[ir.Expr]:
     """Transform ``expr`` and yield it with a guaranteed full scope close.
 
     For eager call sites only: the body must fully materialize the result
@@ -539,7 +543,7 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
 
     span.set_attribute("engine", "pandas")
     # full close is safe here: con.execute returns a materialized DataFrame
-    with transformed(expr, params=params) as expr:
+    with remote_table_scope(expr, params=params) as expr:
         return con.execute(expr, **kwargs)
 
 
@@ -591,7 +595,7 @@ def to_pyarrow_batches(
 
     # cleanup stays deferred to the result reader's exhaustion/collection:
     # the backends scan the placeholders lazily while the reader drains
-    return otel_instrument_reader(scope.bind(reader))
+    return otel_instrument_reader(bind_scope_to_reader(scope, reader))
 
 
 def to_pyarrow(expr: ir.Expr, **kwargs: Any):
@@ -743,7 +747,7 @@ def get_plans(expr: ir.Expr) -> dict:
     # Strip tee nodes first (like to_sql): EXPLAIN is a non-executing path, so
     # it must not register a pass-through table or fire the side-effect write.
     # Full close is safe here: EXPLAIN is materialized via to_pandas inside.
-    with transformed(_remove_tee_nodes(expr)) as _expr:
+    with remote_table_scope(_remove_tee_nodes(expr)) as _expr:
         con, _ = find_backend(_expr.op())
         sql = f"EXPLAIN {to_sql(_expr)}"
         return con.con.sql(sql).to_pandas().set_index("plan_type")["plan"].to_dict()

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import operator
 import warnings
+import weakref
 from collections import Counter
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -13,7 +14,8 @@ from opentelemetry import trace
 
 from xorq.backends.xorq_datafusion import connect as xo_connect
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.otel_utils import tracer
+from xorq.common.utils.logging_utils import get_logger
+from xorq.common.utils.otel_utils import get_current_span, tracer
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
     instrument_reader,
@@ -32,6 +34,9 @@ from xorq.writes import DrainingIterator, WriteThrough
 
 if TYPE_CHECKING:
     from xorq.vendor.ibis.backends import BaseBackend
+
+
+logger = get_logger(__name__)
 
 
 def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
@@ -638,12 +643,157 @@ def count_remote_table_readers(expr):
     return {node: max(1, counts[name]) for node, name in sentinels.items()}
 
 
+def drop_placeholder(con, table_name):
+    """Best-effort drop of a placeholder registered by ``read_record_batches``.
+
+    duckdb registers the StreamCache as a VIEW, so ``drop_table`` always
+    raises a kind-mismatch there (``force=True`` does not suppress it) and
+    ``drop_view`` is the real path; pandas raises KeyError on a missing
+    table even with ``force=True``, hence the inner suppression --
+    ``force=True`` alone cannot make this idempotent across backends.
+    """
+    try:
+        con.drop_table(table_name, force=True)
+    except Exception:
+        try:
+            con.drop_view(table_name, force=True)
+        except Exception:
+            pass
+
+
+class TransformScope:
+    """Owns every resource materialized while transforming an expr.
+
+    Upstream readers, StreamCaches and registered placeholder tables enter
+    the scope at acquisition time via the ``adopt*`` methods; ``close`` runs
+    the cleanups in LIFO order (drop placeholder, close cache, close
+    upstream reader per RemoteTable), is idempotent, and step-isolated: a
+    failing cleanup is logged and never skips the others. Closing drops the
+    scope's references to the adopted objects so refcount-zero finalization
+    can release generator-backed readers (pyarrow's
+    ``RecordBatchReader.close`` does not finalize a wrapped generator).
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[tuple[str, str, Callable[[], None]]] = []
+        self._drains: list[DrainingIterator] = []
+        self._closed = False
+        self.created: dict[str, Any] = {}
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def adopt(
+        self, label: str, cleanup: Callable[[], None], kind: str = "resource"
+    ) -> None:
+        self._entries.append((kind, label, cleanup))
+
+    def adopt_drain(self, drain: DrainingIterator) -> DrainingIterator:
+        # Drains are tracked separately from the LIFO entries: every drain
+        # must close-then-join (so the write-through generator finishes
+        # feeding its placeholder table) BEFORE any placeholder is dropped,
+        # regardless of adoption order.
+        self._drains.append(drain)
+        return drain
+
+    def adopt_reader(self, reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
+        self.adopt("reader", reader.close)
+        return reader
+
+    def adopt_cache(self, cache: StreamCache) -> StreamCache:
+        self.adopt("cache", cache.close)
+        return cache
+
+    def adopt_table(self, con: Any, table_name: str) -> str:
+        self.created[table_name] = con
+        self.adopt(
+            table_name, functools.partial(drop_placeholder, con, table_name), "table"
+        )
+        return table_name
+
+    def _drain_step(self) -> None:
+        # Mirror api._close_and_join_drains: start every drain thread, then
+        # join them, so concurrent write-through generators all finish before
+        # the placeholders they feed get dropped. Step-isolated and logged so
+        # one failure never strands the rest (the scope never raises).
+        for drain in self._drains:
+            try:
+                drain.close()
+            except Exception:
+                logger.warning("transform scope drain close failed", exc_info=True)
+        for drain in self._drains:
+            try:
+                drain.join()
+            except Exception:
+                logger.warning("transform scope drain join failed", exc_info=True)
+        self._drains = []
+
+    def close(self, drop_tables: bool = True) -> None:
+        """Release everything the scope owns; idempotent, never raises.
+
+        ``drop_tables=False`` leaves the placeholder tables registered for
+        callers whose result still references them after this returns
+        (see ``prepare_create_table_from_expr``).
+        """
+        if self._closed:
+            return
+        self._closed = True
+        # Drains first: a write-through must finish feeding its placeholder
+        # table before that table is dropped below.
+        self._drain_step()
+        (entries, self._entries) = (self._entries, [])
+        for kind, label, cleanup in reversed(entries):
+            if kind == "table" and not drop_tables:
+                continue
+            try:
+                cleanup()
+            except Exception:
+                logger.warning(
+                    "transform scope cleanup step failed",
+                    kind=kind,
+                    label=label,
+                    exc_info=True,
+                )
+
+    def bind(self, reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
+        """Defer this scope's close to ``reader``'s exhaustion or collection.
+
+        Cleanup must stay deferred on the streaming path: duckdb/datafusion
+        scan the placeholder when the result reader is drained, and dropping
+        the duckdb view mid-drain silently truncates results. The wrapping
+        generator's ``finally`` fires on full drain; the ``weakref.finalize``
+        backstop covers readers abandoned before the first read (a
+        never-started generator never runs its ``finally``). Note that on
+        pyarrow 21 ``reader.close()`` alone does not finalize the wrapped
+        generator -- cleanup then fires when the last reference drops.
+        """
+
+        def gen():
+            try:
+                yield from reader
+            finally:
+                self.close()
+
+        out = pa.RecordBatchReader.from_batches(reader.schema, gen())
+        # NB: the finalize registry holds ``self`` via ``self.close``; the
+        # scope must never hold a strong reference to ``out`` or both become
+        # immortal.
+        weakref.finalize(out, self.close)
+        return out
+
+    def __enter__(self) -> TransformScope:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
     expr: Expr, **kwargs: Any
-) -> tuple[Expr, dict, list]:
-    created = {}
-    caches = []
+) -> tuple[Expr, TransformScope]:
+    scope = TransformScope()
     # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
     # outer ``**kwargs``; capture the through-kwargs here so they reach
     # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
@@ -663,16 +813,21 @@ def register_and_transform_remote_tables(
             # (``fields.len() == num_children``). The reader already carries the
             # true schema; column coercion is the consumer's job
             # (``read_record_batches`` -> ``_select_and_cast``).
-            cache = StreamCache(
-                remote_expr.to_pyarrow_batches(),
-                max_readers=reader_counts.get(node),
+            reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+            cache = scope.adopt_cache(
+                StreamCache(
+                    reader,
+                    max_readers=reader_counts.get(node),
+                )
             )
-            caches.append(cache)
-            table_name = gen_name()
+            # adopt before registering: a partial failure inside
+            # read_record_batches (register, then raise) can't strand the
+            # placeholder, and drop_placeholder is a no-op if it never
+            # registered
+            table_name = scope.adopt_table(node.source, gen_name())
             result = node.source.read_record_batches(
                 cache, table_name=table_name, **read_kwargs
             )
-            created[table_name] = node.source
             return result.op()
 
         if kwargs:
@@ -685,14 +840,13 @@ def register_and_transform_remote_tables(
     try:
         expr = op.replace(replacer).to_expr()
     except Exception:
-        for cache in caches:
-            cache.close()
+        scope.close()
         raise
-    if caches:
+    if scope.created:
         trace.get_current_span().add_event(
-            "remote_table.replace", {"remote_table.count": len(caches)}
+            "remote_table.replace", {"remote_table.count": len(scope.created)}
         )
-    return expr, created, caches
+    return expr, scope
 
 
 # Backends whose single, non-re-entrant connection deadlocks the streaming tee
@@ -827,9 +981,13 @@ def prepare_create_table_from_expr(con: Any, expr: Expr, **kwargs: Any) -> Expr:
     expr_backend = expr._find_backend()  # xorq-style: disable=protected-access
     if expr_backend != con:
         raise ValueError(f"expr backend must be {con}, is {expr_backend}")
-    (table, _created, _drains, _caches) = _transform_expr(expr, **kwargs)
+    (table, scope) = _transform_expr(expr, **kwargs)
     try:
         return table
     finally:
-        for cache in _caches:
-            cache.close()
+        # The sole caller (snowflake create_table) compiles and runs CTAS
+        # against the returned expr -- and thus its placeholder tables --
+        # AFTER this returns, so the placeholders must stay registered;
+        # snowflake's eager adbc_ingest drained the caches during the
+        # transform, which is what makes closing them here safe.
+        scope.close(drop_tables=False)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -10,7 +10,7 @@ import toolz
 
 from xorq.backends.xorq_datafusion import connect as xo_connect
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.otel_utils import get_current_span, tracer
+from xorq.common.utils.otel_utils import tracer
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
     instrument_reader,

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -3,18 +3,13 @@ from __future__ import annotations
 import functools
 import operator
 import warnings
-import weakref
-from collections import Counter
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 import pyarrow as pa
 import toolz
-from batchcorder import StreamCache
-from opentelemetry import trace
 
 from xorq.backends.xorq_datafusion import connect as xo_connect
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.logging_utils import get_logger
 from xorq.common.utils.otel_utils import get_current_span, tracer
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
@@ -22,6 +17,7 @@ from xorq.common.utils.rbr_utils import (
 )
 from xorq.vendor import ibis
 from xorq.vendor.ibis import Expr, Schema
+from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.common.collections import (
     FrozenDict,
     FrozenOrderedDict,
@@ -30,13 +26,6 @@ from xorq.vendor.ibis.expr import operations as ops
 from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node
 from xorq.writes import DrainingIterator, WriteThrough
-
-
-if TYPE_CHECKING:
-    from xorq.vendor.ibis.backends import BaseBackend
-
-
-logger = get_logger(__name__)
 
 
 def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
@@ -587,268 +576,6 @@ class Read(ops.DatabaseTable):
         )
 
 
-def count_remote_table_readers(expr):
-    """Count how many times each ``RemoteTable`` is physically scanned.
-
-    The scan count is not visible in the expression graph: a single graph
-    reference can compile to several physical table scans. The asof-join with
-    tolerance lowering, for one, scans an input twice (xorq #983). Each
-    ``RemoteTable`` is rewritten to a placeholder table under a freshly
-    generated, unique name, the placeholder expression is compiled to a sqlglot
-    AST, and the ``Table`` nodes bearing that name are counted — giving the
-    exact per-table scan count whatever lowering the backend compiler applies.
-    Counting ``Table`` AST nodes (rather than substrings of the rendered SQL)
-    ignores column references, aliases, and string literals, so even a short or
-    shared user-supplied table name cannot inflate the count.
-
-    The counts become each ``StreamCache``'s ``max_readers``, bounding memory:
-    batches are evicted once all readers advance past them. Each count is
-    floored at 1 — a bare ``RemoteTable`` is still scanned once, and
-    ``max_readers=0`` would forbid the reader that is in fact created.
-
-    Returns an empty mapping when no SQL AST can be produced (e.g. a non-SQL
-    backend); the caller then builds an unbounded cache — safe, but without
-    eviction.
-    """
-    import sqlglot as sg  # noqa: PLC0415
-
-    op = expr.op()
-    sentinels = {}
-
-    def replacer(node, kwargs):
-        if isinstance(node, RemoteTable):
-            name = gen_name()
-            sentinels[node] = name
-            return ops.DatabaseTable(name=name, schema=node.schema, source=node.source)
-        if kwargs:
-            node = node.__recreate__(kwargs)
-        return node
-
-    placeholder = op.replace(replacer).to_expr()
-    if not sentinels:
-        return {}
-    try:
-        provider = placeholder._find_backend(use_default=True)
-        compiler = getattr(provider, "compiler", None)
-        if compiler is None:
-            return {}
-        out = compiler.to_sqlglot(placeholder.unbind())
-    except Exception:
-        return {}
-
-    counts = Counter()
-    for query in out if isinstance(out, list) else [out]:
-        for table in query.find_all(sg.exp.Table):
-            counts[table.name] += 1
-    return {node: max(1, counts[name]) for node, name in sentinels.items()}
-
-
-def drop_placeholder(con, table_name):
-    """Best-effort drop of a placeholder registered by ``read_record_batches``.
-
-    duckdb registers the StreamCache as a VIEW, so ``drop_table`` always
-    raises a kind-mismatch there (``force=True`` does not suppress it) and
-    ``drop_view`` is the real path; pandas raises KeyError on a missing
-    table even with ``force=True``, hence the inner suppression --
-    ``force=True`` alone cannot make this idempotent across backends.
-    """
-    try:
-        con.drop_table(table_name, force=True)
-    except Exception:
-        try:
-            con.drop_view(table_name, force=True)
-        except Exception:
-            pass
-
-
-class TransformScope:
-    """Owns every resource materialized while transforming an expr.
-
-    Upstream readers, StreamCaches and registered placeholder tables enter
-    the scope at acquisition time via the ``adopt*`` methods; ``close`` runs
-    the cleanups in LIFO order (drop placeholder, close cache, close
-    upstream reader per RemoteTable), is idempotent, and step-isolated: a
-    failing cleanup is logged and never skips the others. Closing drops the
-    scope's references to the adopted objects so refcount-zero finalization
-    can release generator-backed readers (pyarrow's
-    ``RecordBatchReader.close`` does not finalize a wrapped generator).
-    """
-
-    def __init__(self) -> None:
-        self._entries: list[tuple[str, str, Callable[[], None]]] = []
-        self._drains: list[DrainingIterator] = []
-        self._closed = False
-        self.created: dict[str, Any] = {}
-
-    @property
-    def closed(self) -> bool:
-        return self._closed
-
-    def adopt(
-        self, label: str, cleanup: Callable[[], None], kind: str = "resource"
-    ) -> None:
-        self._entries.append((kind, label, cleanup))
-
-    def adopt_drain(self, drain: DrainingIterator) -> DrainingIterator:
-        # Drains are tracked separately from the LIFO entries: every drain
-        # must close-then-join (so the write-through generator finishes
-        # feeding its placeholder table) BEFORE any placeholder is dropped,
-        # regardless of adoption order.
-        self._drains.append(drain)
-        return drain
-
-    def adopt_reader(self, reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
-        self.adopt("reader", reader.close)
-        return reader
-
-    def adopt_cache(self, cache: StreamCache) -> StreamCache:
-        self.adopt("cache", cache.close)
-        return cache
-
-    def adopt_table(self, con: Any, table_name: str) -> str:
-        self.created[table_name] = con
-        self.adopt(
-            table_name, functools.partial(drop_placeholder, con, table_name), "table"
-        )
-        return table_name
-
-    def _drain_step(self) -> None:
-        # Mirror api._close_and_join_drains: start every drain thread, then
-        # join them, so concurrent write-through generators all finish before
-        # the placeholders they feed get dropped. Step-isolated and logged so
-        # one failure never strands the rest (the scope never raises).
-        for drain in self._drains:
-            try:
-                drain.close()
-            except Exception:
-                logger.warning("transform scope drain close failed", exc_info=True)
-        for drain in self._drains:
-            try:
-                drain.join()
-            except Exception:
-                logger.warning("transform scope drain join failed", exc_info=True)
-        self._drains = []
-
-    def close(self, drop_tables: bool = True) -> None:
-        """Release everything the scope owns; idempotent, never raises.
-
-        ``drop_tables=False`` leaves the placeholder tables registered for
-        callers whose result still references them after this returns
-        (see ``prepare_create_table_from_expr``).
-        """
-        if self._closed:
-            return
-        self._closed = True
-        # Drains first: a write-through must finish feeding its placeholder
-        # table before that table is dropped below.
-        self._drain_step()
-        (entries, self._entries) = (self._entries, [])
-        for kind, label, cleanup in reversed(entries):
-            if kind == "table" and not drop_tables:
-                continue
-            try:
-                cleanup()
-            except Exception:
-                logger.warning(
-                    "transform scope cleanup step failed",
-                    kind=kind,
-                    label=label,
-                    exc_info=True,
-                )
-
-    def bind(self, reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
-        """Defer this scope's close to ``reader``'s exhaustion or collection.
-
-        Cleanup must stay deferred on the streaming path: duckdb/datafusion
-        scan the placeholder when the result reader is drained, and dropping
-        the duckdb view mid-drain silently truncates results. The wrapping
-        generator's ``finally`` fires on full drain; the ``weakref.finalize``
-        backstop covers readers abandoned before the first read (a
-        never-started generator never runs its ``finally``). Note that on
-        pyarrow 21 ``reader.close()`` alone does not finalize the wrapped
-        generator -- cleanup then fires when the last reference drops.
-        """
-
-        def gen():
-            try:
-                yield from reader
-            finally:
-                self.close()
-
-        out = pa.RecordBatchReader.from_batches(reader.schema, gen())
-        # NB: the finalize registry holds ``self`` via ``self.close``; the
-        # scope must never hold a strong reference to ``out`` or both become
-        # immortal.
-        weakref.finalize(out, self.close)
-        return out
-
-    def __enter__(self) -> TransformScope:
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        self.close()
-
-
-@tracer.start_as_current_span("register_and_transform_remote_tables")
-def register_and_transform_remote_tables(
-    expr: Expr, **kwargs: Any
-) -> tuple[Expr, TransformScope]:
-    scope = TransformScope()
-    # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
-    # outer ``**kwargs``; capture the through-kwargs here so they reach
-    # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
-    read_kwargs = kwargs
-
-    op = expr.op()
-    reader_counts = count_remote_table_readers(expr)
-
-    def replacer(node, kwargs):
-        if isinstance(node, RemoteTable):
-            remote_expr = node.remote_expr
-            # Cache the reader's own (physical) schema, not the logical
-            # ``as_table().schema()``. The two can diverge -- e.g. a dropped
-            # ``row_number`` still rides along in the stream -- and StreamCache
-            # exports the declared schema over the Arrow C stream FFI, where a
-            # batch with extra children aborts the process
-            # (``fields.len() == num_children``). The reader already carries the
-            # true schema; column coercion is the consumer's job
-            # (``read_record_batches`` -> ``_select_and_cast``).
-            reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
-            cache = scope.adopt_cache(
-                StreamCache(
-                    reader,
-                    max_readers=reader_counts.get(node),
-                )
-            )
-            # adopt before registering: a partial failure inside
-            # read_record_batches (register, then raise) can't strand the
-            # placeholder, and drop_placeholder is a no-op if it never
-            # registered
-            table_name = scope.adopt_table(node.source, gen_name())
-            result = node.source.read_record_batches(
-                cache, table_name=table_name, **read_kwargs
-            )
-            return result.op()
-
-        if kwargs:
-            node = node.__recreate__(kwargs)
-
-        return node
-
-    # Intentionally op.replace, not replace_nodes: replacer has side effects
-    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr)
-    try:
-        expr = op.replace(replacer).to_expr()
-    except Exception:
-        scope.close()
-        raise
-    if scope.created:
-        trace.get_current_span().add_event(
-            "remote_table.replace", {"remote_table.count": len(scope.created)}
-        )
-    return expr, scope
-
-
 # Backends whose single, non-re-entrant connection deadlocks the streaming tee
 # transport (it pulls the parent reader while that connection serves the outer
 # query). See ADR-0014.
@@ -922,7 +649,7 @@ def register_and_transform_tee_nodes(
     return op.replace(replacer).to_expr(), created, drains
 
 
-def render_backend(con):
+def render_backend(con: BaseBackend) -> str:
     return f"{con.name}-{id(con)}"
 
 
@@ -965,29 +692,3 @@ def _fmt_read(op, name, method_name, source, **kwargs):
     backend = render_backend(source)
     name = f"{op.__class__.__name__}[name={name}, method_name={method_name}, source={backend}]\n"
     return name + render_schema(op.schema, 1)
-
-
-def prepare_create_table_from_expr(con: Any, expr: Expr, **kwargs: Any) -> Expr:
-    """Transform ``expr`` into a table on ``con``, then close its stream caches.
-
-    Only safe for backends whose ``read_record_batches`` eagerly ingests the
-    stream synchronously (Snowflake, Postgres via ADBC): the caches are closed
-    in the ``finally`` before returning, so a lazy-scan backend (DuckDB,
-    DataFusion) that still holds a live dependency on a cache would read an
-    empty result. Do not call with a lazy-ingestion backend.
-    """
-    from xorq.expr.api import _transform_expr  # noqa: PLC0415
-
-    expr_backend = expr._find_backend()  # xorq-style: disable=protected-access
-    if expr_backend != con:
-        raise ValueError(f"expr backend must be {con}, is {expr_backend}")
-    (table, scope) = _transform_expr(expr, **kwargs)
-    try:
-        return table
-    finally:
-        # The sole caller (snowflake create_table) compiles and runs CTAS
-        # against the returned expr -- and thus its placeholder tables --
-        # AFTER this returns, so the placeholders must stay registered;
-        # snowflake's eager adbc_ingest drained the caches during the
-        # transform, which is what makes closing them here safe.
-        scope.close(drop_tables=False)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -641,9 +641,13 @@ def count_remote_table_readers(expr):
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
     expr: Expr, **kwargs: Any
-) -> tuple[Expr, dict]:
+) -> tuple[Expr, dict, list]:
     created = {}
     caches = []
+    # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
+    # outer ``**kwargs``; capture the through-kwargs here so they reach
+    # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
+    read_kwargs = kwargs
 
     op = expr.op()
     reader_counts = count_remote_table_readers(expr)
@@ -665,7 +669,9 @@ def register_and_transform_remote_tables(
             )
             caches.append(cache)
             table_name = gen_name()
-            result = node.source.read_record_batches(cache, table_name=table_name)
+            result = node.source.read_record_batches(
+                cache, table_name=table_name, **read_kwargs
+            )
             created[table_name] = node.source
             return result.op()
 
@@ -807,10 +813,19 @@ def _fmt_read(op, name, method_name, source, **kwargs):
     return name + render_schema(op.schema, 1)
 
 
-def prepare_create_table_from_expr(con, expr, **kwargs):
+def prepare_create_table_from_expr(con: Any, expr: Expr, **kwargs: Any) -> Expr:
+    """Transform ``expr`` into a table on ``con``, then close its stream caches.
+
+    Only safe for backends whose ``read_record_batches`` eagerly ingests the
+    stream synchronously (Snowflake, Postgres via ADBC): the caches are closed
+    in the ``finally`` before returning, so a lazy-scan backend (DuckDB,
+    DataFusion) that still holds a live dependency on a cache would read an
+    empty result. Do not call with a lazy-ingestion backend.
+    """
     from xorq.expr.api import _transform_expr  # noqa: PLC0415
 
-    if (expr_backend := expr._find_backend()) != con:
+    expr_backend = expr._find_backend()  # xorq-style: disable=protected-access
+    if expr_backend != con:
         raise ValueError(f"expr backend must be {con}, is {expr_backend}")
     (table, _created, _drains, _caches) = _transform_expr(expr, **kwargs)
     try:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import operator
 import warnings
+from collections import Counter
 from typing import TYPE_CHECKING, Any, Callable
 
 import pyarrow as pa
@@ -588,21 +589,24 @@ def count_remote_table_readers(expr):
     reference can compile to several physical table scans. The asof-join with
     tolerance lowering, for one, scans an input twice (xorq #983). Each
     ``RemoteTable`` is rewritten to a placeholder table under a freshly
-    generated, unique name, the placeholder expression is compiled to SQL, and
-    that name's occurrences are counted — giving the exact per-table scan count
-    whatever lowering the backend compiler applies. The fresh name (rather than
-    the possibly short or shared user-supplied one) keeps the substring count
-    unambiguous.
+    generated, unique name, the placeholder expression is compiled to a sqlglot
+    AST, and the ``Table`` nodes bearing that name are counted — giving the
+    exact per-table scan count whatever lowering the backend compiler applies.
+    Counting ``Table`` AST nodes (rather than substrings of the rendered SQL)
+    ignores column references, aliases, and string literals, so even a short or
+    shared user-supplied table name cannot inflate the count.
 
     The counts become each ``StreamCache``'s ``max_readers``, bounding memory:
     batches are evicted once all readers advance past them. Each count is
     floored at 1 — a bare ``RemoteTable`` is still scanned once, and
     ``max_readers=0`` would forbid the reader that is in fact created.
 
-    Returns an empty mapping when the SQL cannot be produced (e.g. a non-SQL
+    Returns an empty mapping when no SQL AST can be produced (e.g. a non-SQL
     backend); the caller then builds an unbounded cache — safe, but without
     eviction.
     """
+    import sqlglot as sg  # noqa: PLC0415
+
     op = expr.op()
     sentinels = {}
 
@@ -619,10 +623,19 @@ def count_remote_table_readers(expr):
     if not sentinels:
         return {}
     try:
-        sql = str(ibis.to_sql(placeholder))
+        provider = placeholder._find_backend(use_default=True)
+        compiler = getattr(provider, "compiler", None)
+        if compiler is None:
+            return {}
+        out = compiler.to_sqlglot(placeholder.unbind())
     except Exception:
         return {}
-    return {node: max(1, sql.count(name)) for node, name in sentinels.items()}
+
+    counts = Counter()
+    for query in out if isinstance(out, list) else [out]:
+        for table in query.find_all(sg.exp.Table):
+            counts[table.name] += 1
+    return {node: max(1, counts[name]) for node, name in sentinels.items()}
 
 
 @tracer.start_as_current_span("register_and_transform_remote_tables")

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -651,11 +651,16 @@ def register_and_transform_remote_tables(
     def replacer(node, kwargs):
         if isinstance(node, RemoteTable):
             remote_expr = node.remote_expr
-            schema = remote_expr.as_table().schema().to_pyarrow()
+            # Cache the reader's own (physical) schema, not the logical
+            # ``as_table().schema()``. The two can diverge -- e.g. a dropped
+            # ``row_number`` still rides along in the stream -- and StreamCache
+            # exports the declared schema over the Arrow C stream FFI, where a
+            # batch with extra children aborts the process
+            # (``fields.len() == num_children``). The reader already carries the
+            # true schema; column coercion is the consumer's job
+            # (``read_record_batches`` -> ``_select_and_cast``).
             cache = StreamCache(
-                pa.RecordBatchReader.from_batches(
-                    schema, remote_expr.to_pyarrow_batches()
-                ),
+                remote_expr.to_pyarrow_batches(),
                 max_readers=reader_counts.get(node),
             )
             caches.append(cache)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -581,6 +581,50 @@ class Read(ops.DatabaseTable):
         )
 
 
+def count_remote_table_readers(expr):
+    """Count how many times each ``RemoteTable`` is physically scanned.
+
+    The scan count is not visible in the expression graph: a single graph
+    reference can compile to several physical table scans. The asof-join with
+    tolerance lowering, for one, scans an input twice (xorq #983). Each
+    ``RemoteTable`` is rewritten to a placeholder table under a freshly
+    generated, unique name, the placeholder expression is compiled to SQL, and
+    that name's occurrences are counted — giving the exact per-table scan count
+    whatever lowering the backend compiler applies. The fresh name (rather than
+    the possibly short or shared user-supplied one) keeps the substring count
+    unambiguous.
+
+    The counts become each ``StreamCache``'s ``max_readers``, bounding memory:
+    batches are evicted once all readers advance past them. Each count is
+    floored at 1 — a bare ``RemoteTable`` is still scanned once, and
+    ``max_readers=0`` would forbid the reader that is in fact created.
+
+    Returns an empty mapping when the SQL cannot be produced (e.g. a non-SQL
+    backend); the caller then builds an unbounded cache — safe, but without
+    eviction.
+    """
+    op = expr.op()
+    sentinels = {}
+
+    def replacer(node, kwargs):
+        if isinstance(node, RemoteTable):
+            name = gen_name()
+            sentinels[node] = name
+            return ops.DatabaseTable(name=name, schema=node.schema, source=node.source)
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        return node
+
+    placeholder = op.replace(replacer).to_expr()
+    if not sentinels:
+        return {}
+    try:
+        sql = str(ibis.to_sql(placeholder))
+    except Exception:
+        return {}
+    return {node: max(1, sql.count(name)) for node, name in sentinels.items()}
+
+
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
     expr: Expr, **kwargs: Any
@@ -589,6 +633,7 @@ def register_and_transform_remote_tables(
     caches = []
 
     op = expr.op()
+    reader_counts = count_remote_table_readers(expr)
 
     def replacer(node, kwargs):
         if isinstance(node, RemoteTable):
@@ -597,7 +642,8 @@ def register_and_transform_remote_tables(
             cache = StreamCache(
                 pa.RecordBatchReader.from_batches(
                     schema, remote_expr.to_pyarrow_batches()
-                )
+                ),
+                max_readers=reader_counts.get(node),
             )
             caches.append(cache)
             table_name = gen_name()

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
 import functools
-import itertools
 import operator
 import warnings
-from collections import defaultdict
-from itertools import tee
-from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable
 
 import pyarrow as pa
 import toolz
+from batchcorder import StreamCache
+from opentelemetry import trace
 
 from xorq.backends.xorq_datafusion import connect as xo_connect
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.otel_utils import get_current_span, tracer
+from xorq.common.utils.otel_utils import tracer
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
     instrument_reader,
@@ -25,10 +23,9 @@ from xorq.vendor.ibis.common.collections import (
     FrozenDict,
     FrozenOrderedDict,
 )
-from xorq.vendor.ibis.common.graph import Graph
 from xorq.vendor.ibis.expr import operations as ops
 from xorq.vendor.ibis.expr.format import fmt, render_schema
-from xorq.vendor.ibis.expr.operations import Node, Relation
+from xorq.vendor.ibis.expr.operations import Node
 from xorq.writes import DrainingIterator, WriteThrough
 
 
@@ -42,31 +39,6 @@ def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
     while isinstance(node, CachedNode):
         node = node.parent.op()
     return node
-
-
-# https://stackoverflow.com/questions/6703594/is-the-result-of-itertools-tee-thread-safe-python
-class SafeTee(object):
-    """tee object wrapped to make it thread-safe"""
-
-    def __init__(self, teeobj, lock):
-        self.teeobj = teeobj
-        self.lock = lock
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        with self.lock:
-            return next(self.teeobj)
-
-    def __copy__(self):
-        return SafeTee(self.teeobj.__copy__(), self.lock)
-
-    @classmethod
-    def tee(cls, iterable, n=2):
-        """tuple of n independent thread-safe iterators"""
-        lock = Lock()
-        return tuple(cls(teeobj, lock) for teeobj in tee(iterable, n))
 
 
 def recursive_update(obj, replacements):
@@ -609,82 +581,48 @@ class Read(ops.DatabaseTable):
         )
 
 
-_count = itertools.count()
-
-
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
     expr: Expr, **kwargs: Any
 ) -> tuple[Expr, dict]:
     created = {}
+    caches = []
 
     op = expr.op()
-    graph, _ = Graph.from_bfs(op).toposort()
-    counts = defaultdict(int)
-    for node in graph:
-        if isinstance(node, RemoteTable):
-            counts[node] += 1
-
-        if isinstance(node, Relation):
-            for arg in node.__args__:
-                if isinstance(arg, RemoteTable):
-                    counts[arg] += 1
-
-    if counts:
-        get_current_span().add_event(
-            "remote_table.replace", {"counts.values": tuple(counts.values())}
-        )
-    batches_table = {}
-    for arg, count in counts.items():
-        ex = arg.remote_expr
-        batches = ex.to_pyarrow_batches()
-        schema = ex.as_table().schema().to_pyarrow()
-        replicas = SafeTee.tee(batches, count)
-        batches_table[arg] = (schema, list(replicas))
-
-    def mark_remote_table(node):
-        schema, batchess = batches_table[node]
-        name = f"{node.name}_cu{next(_count)}_t{len(batchess)}"
-        reader = pa.RecordBatchReader.from_batches(schema, batchess.pop())
-        result = node.source.read_record_batches(
-            reader,
-            table_name=name,
-            **kwargs,
-        )
-        created[name] = node.source
-        return result.op()
 
     def replacer(node, kwargs):
         if isinstance(node, RemoteTable):
-            result = mark_remote_table(node)
-            batches_table[result] = batches_table.pop(node)
-            node = result
-        else:
-            kwargs = kwargs or {}
-            if isinstance(node, Relation):
-                updated = {}
-                for _k, v in list(kwargs.items()):
-                    try:
-                        if v in batches_table:
-                            updated[v] = mark_remote_table(v)
+            remote_expr = node.remote_expr
+            schema = remote_expr.as_table().schema().to_pyarrow()
+            cache = StreamCache(
+                pa.RecordBatchReader.from_batches(
+                    schema, remote_expr.to_pyarrow_batches()
+                )
+            )
+            caches.append(cache)
+            table_name = gen_name()
+            result = node.source.read_record_batches(cache, table_name=table_name)
+            created[table_name] = node.source
+            return result.op()
 
-                    except TypeError:  # v may not be hashable
-                        continue
-
-                if len(updated) > 0:
-                    kwargs = {
-                        k: recursive_update(v, updated) for k, v in kwargs.items()
-                    }
-
-            if kwargs:
-                node = node.__recreate__(kwargs)
+        if kwargs:
+            node = node.__recreate__(kwargs)
 
         return node
 
-    # op.replace, not replace_nodes: replacer has side effects that must not
-    # fire inside opaque sub-exprs (handled lazily during UDF execution).
-    expr = op.replace(replacer).to_expr()
-    return expr, created
+    # Intentionally op.replace, not replace_nodes: replacer has side effects
+    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr)
+    try:
+        expr = op.replace(replacer).to_expr()
+    except Exception:
+        for cache in caches:
+            cache.close()
+        raise
+    if caches:
+        trace.get_current_span().add_event(
+            "remote_table.replace", {"remote_table.count": len(caches)}
+        )
+    return expr, created, caches
 
 
 # Backends whose single, non-re-entrant connection deadlocks the streaming tee
@@ -810,5 +748,9 @@ def prepare_create_table_from_expr(con, expr, **kwargs):
 
     if (expr_backend := expr._find_backend()) != con:
         raise ValueError(f"expr backend must be {con}, is {expr_backend}")
-    (table, _, _) = _transform_expr(expr, **kwargs)
-    return table
+    (table, _created, _drains, _caches) = _transform_expr(expr, **kwargs)
+    try:
+        return table
+    finally:
+        for cache in _caches:
+            cache.close()

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import functools
+import weakref
+from collections import Counter
+from typing import Any, Callable, NamedTuple
+
+import pyarrow as pa
+from batchcorder import StreamCache
+from opentelemetry import trace
+
+from xorq.common.utils.logging_utils import get_logger
+from xorq.common.utils.otel_utils import tracer
+from xorq.expr.relations import RemoteTable, gen_name
+from xorq.vendor.ibis import Expr
+from xorq.vendor.ibis.backends import BaseBackend
+from xorq.vendor.ibis.expr import operations as ops
+from xorq.writes import DrainingIterator
+
+
+logger = get_logger(__name__)
+
+
+def count_remote_table_readers(expr: Expr) -> dict[RemoteTable, int]:
+    """Count how many times each ``RemoteTable`` is physically scanned.
+
+    The scan count is not visible in the expression graph: a single graph
+    reference can compile to several physical table scans. The asof-join with
+    tolerance lowering, for one, scans an input twice (xorq #983). Each
+    ``RemoteTable`` is rewritten to a placeholder table under a freshly
+    generated, unique name, the placeholder expression is compiled to a sqlglot
+    AST, and the ``Table`` nodes bearing that name are counted — giving the
+    exact per-table scan count whatever lowering the backend compiler applies.
+    Counting ``Table`` AST nodes (rather than substrings of the rendered SQL)
+    ignores column references, aliases, and string literals, so even a short or
+    shared user-supplied table name cannot inflate the count.
+
+    The counts become each ``StreamCache``'s ``max_readers``, bounding memory:
+    batches are evicted once all readers advance past them. Each count is
+    floored at 1 — a bare ``RemoteTable`` is still scanned once, and
+    ``max_readers=0`` would forbid the reader that is in fact created.
+
+    Returns an empty mapping when no SQL AST can be produced (e.g. a non-SQL
+    backend); the caller then builds an unbounded cache — safe, but without
+    eviction.
+    """
+    import sqlglot as sg  # noqa: PLC0415
+
+    op = expr.op()
+    sentinels = {}
+
+    def replacer(node, kwargs):
+        if isinstance(node, RemoteTable):
+            name = gen_name()
+            sentinels[node] = name
+            return ops.DatabaseTable(name=name, schema=node.schema, source=node.source)
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        return node
+
+    placeholder = op.replace(replacer).to_expr()
+    if not sentinels:
+        return {}
+    try:
+        provider = placeholder._find_backend(
+            use_default=True
+        )  # xorq-style: disable=protected-access
+        compiler = getattr(provider, "compiler", None)
+        if compiler is None:
+            return {}
+        out = compiler.to_sqlglot(placeholder.unbind())
+    except Exception:
+        return {}
+
+    counts = Counter()
+    for query in out if isinstance(out, list) else [out]:
+        for table in query.find_all(sg.exp.Table):
+            counts[table.name] += 1
+    return {node: max(1, counts[name]) for node, name in sentinels.items()}
+
+
+def drop_placeholder(con: BaseBackend, table_name: str) -> None:
+    """Best-effort drop of a placeholder registered by ``read_record_batches``.
+
+    duckdb registers the StreamCache as a VIEW, so ``drop_table`` always
+    raises a kind-mismatch there (``force=True`` does not suppress it) and
+    ``drop_view`` is the real path; pandas raises KeyError on a missing
+    table even with ``force=True``, hence the inner suppression --
+    ``force=True`` alone cannot make this idempotent across backends.
+    """
+    try:
+        con.drop_table(table_name, force=True)
+    except Exception:
+        try:
+            con.drop_view(table_name, force=True)
+        except Exception:
+            logger.debug(
+                "drop_placeholder: neither drop_table nor drop_view succeeded",
+                table_name=table_name,
+                backend=con.name,
+                exc_info=True,
+            )
+
+
+class _ScopeEntry(NamedTuple):
+    kind: str
+    label: str
+    cleanup: Callable[[], None]
+
+    def safe_cleanup(self) -> None:
+        try:
+            self.cleanup()
+        except Exception:
+            logger.warning(
+                "scope cleanup failed",
+                kind=self.kind,
+                label=self.label,
+                exc_info=True,
+            )
+
+
+class RemoteTableScope:
+    """Owns resources materialized while replacing RemoteTable nodes.
+
+    Each ``adopt_*`` method appends to a typed list.  ``close`` tears down
+    in dependency order (tables -> caches -> readers), LIFO within each
+    category, and is idempotent.
+
+    Not thread-safe: all adopt/close calls must happen on a single thread.
+    """
+
+    def __init__(self) -> None:
+        self._readers: list[_ScopeEntry] = []
+        self._caches: list[_ScopeEntry] = []
+        self._tables: list[_ScopeEntry] = []
+        self._drains: list[DrainingIterator] = []
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def table_count(self) -> int:
+        return len(self._tables)
+
+    @property
+    def table_names(self) -> list[str]:
+        return [e.label for e in self._tables]
+
+    @property
+    def reader_count(self) -> int:
+        return len(self._readers)
+
+    @property
+    def cache_count(self) -> int:
+        return len(self._caches)
+
+    @property
+    def drain_count(self) -> int:
+        return len(self._drains)
+
+    def adopt_reader(self, reader: pa.RecordBatchReader) -> pa.RecordBatchReader:
+        self._readers.append(_ScopeEntry("reader", type(reader).__name__, reader.close))
+        return reader
+
+    def adopt_cache(self, cache: StreamCache) -> StreamCache:
+        self._caches.append(_ScopeEntry("cache", type(cache).__name__, cache.close))
+        return cache
+
+    def adopt_table(self, con: BaseBackend, table_name: str) -> str:
+        self._tables.append(
+            _ScopeEntry(
+                "table",
+                table_name,
+                functools.partial(drop_placeholder, con, table_name),
+            )
+        )
+        return table_name
+
+    def adopt_drain(self, drain: DrainingIterator) -> DrainingIterator:
+        self._drains.append(drain)
+        return drain
+
+    def _drain_step(self) -> None:
+        # Close-then-join in two passes (not LIFO _ScopeEntry cleanup): the
+        # write-through drains feed the placeholder tables, so every writer
+        # must finish consuming its stream before any table is dropped.
+        # Close all first so the writers stop pulling, then join to surface
+        # errors and ensure the side-effect writes have landed.
+        for drain in self._drains:
+            try:
+                drain.close()
+            except Exception:
+                logger.warning("scope drain close failed", exc_info=True)
+        for drain in self._drains:
+            try:
+                drain.join()
+            except Exception:
+                logger.warning("scope drain join failed", exc_info=True)
+        self._drains = []
+
+    def close(self) -> None:
+        """Release everything the scope owns; idempotent, never raises."""
+        if self._closed:
+            return
+        self._closed = True
+        self._drain_step()
+        for entry in reversed(self._tables):
+            entry.safe_cleanup()
+        for entry in reversed(self._caches):
+            entry.safe_cleanup()
+        for entry in reversed(self._readers):
+            entry.safe_cleanup()
+
+    def __enter__(self) -> RemoteTableScope:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def bind_scope_to_reader(
+    scope: RemoteTableScope,
+    reader: pa.RecordBatchReader,
+) -> pa.RecordBatchReader:
+    """Tie scope cleanup to reader exhaustion; consumes the scope.
+
+    Cleanup must stay deferred on the streaming path: duckdb/datafusion
+    scan the placeholder when the result reader is drained, and dropping
+    the duckdb view mid-drain silently truncates results.  The wrapping
+    generator's ``finally`` fires on full drain; the ``weakref.finalize``
+    backstop covers readers abandoned before the first read (a
+    never-started generator never runs its ``finally``).  Note that on
+    pyarrow 21 ``reader.close()`` alone does not finalize the wrapped
+    generator -- cleanup then fires when the last reference drops.
+    """
+
+    def gen():
+        try:
+            yield from reader
+        finally:
+            scope.close()
+
+    g = gen()
+    out = pa.RecordBatchReader.from_batches(reader.schema, g)
+
+    def _cleanup() -> None:
+        g.close()
+        scope.close()
+
+    weakref.finalize(out, _cleanup)
+    return out
+
+
+@tracer.start_as_current_span("register_and_transform_remote_tables")
+def register_and_transform_remote_tables(
+    expr: Expr, **kwargs: Any
+) -> tuple[Expr, RemoteTableScope]:
+    scope = RemoteTableScope()
+    # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
+    # outer ``**kwargs``; capture the through-kwargs here so they reach
+    # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
+    read_kwargs = kwargs
+
+    op = expr.op()
+    reader_counts = count_remote_table_readers(expr)
+
+    def replacer(node, kwargs):
+        if isinstance(node, RemoteTable):
+            remote_expr = node.remote_expr
+            # Cache the reader's own (physical) schema, not the logical
+            # ``as_table().schema()``. The two can diverge -- e.g. a dropped
+            # ``row_number`` still rides along in the stream -- and StreamCache
+            # exports the declared schema over the Arrow C stream FFI, where a
+            # batch with extra children aborts the process
+            # (``fields.len() == num_children``). The reader already carries the
+            # true schema; column coercion is the consumer's job
+            # (``read_record_batches`` -> ``_select_and_cast``).
+            reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+            cache = scope.adopt_cache(
+                StreamCache(
+                    reader,
+                    max_readers=reader_counts.get(node),
+                )
+            )
+            # adopt before registering: a partial failure inside
+            # read_record_batches (register, then raise) can't strand the
+            # placeholder, and drop_placeholder is a no-op if it never
+            # registered
+            table_name = scope.adopt_table(node.source, gen_name())
+            result = node.source.read_record_batches(
+                cache, table_name=table_name, **read_kwargs
+            )
+            return result.op()
+
+        if kwargs:
+            node = node.__recreate__(kwargs)
+
+        return node
+
+    # Intentionally op.replace, not replace_nodes: mark_remote_table has side effects
+    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr)
+    try:
+        expr = op.replace(replacer).to_expr()
+    except Exception:
+        scope.close()
+        raise
+    if scope.table_count:
+        trace.get_current_span().add_event(
+            "remote_table.replace", {"remote_table.count": scope.table_count}
+        )
+    return expr, scope
+
+
+def prepare_create_table_from_expr(
+    con: BaseBackend, expr: Expr, **kwargs: Any
+) -> tuple[Expr, RemoteTableScope]:
+    """Transform ``expr`` for eager-ingest backends and return the scope.
+
+    The caller owns the returned scope and must close it after the
+    transformed expr has been consumed (e.g. after CTAS execution).
+    Only safe for backends whose ``read_record_batches`` eagerly ingests
+    the stream synchronously (Snowflake, Postgres via ADBC).
+    """
+    from xorq.expr.api import _transform_expr  # noqa: PLC0415
+
+    expr_backend = expr._find_backend()  # xorq-style: disable=protected-access
+    if expr_backend != con:
+        raise ValueError(f"expr backend must be {con}, is {expr_backend}")
+    return _transform_expr(expr, **kwargs)

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 from batchcorder import StreamCache
 from opentelemetry import trace
 
+from xorq.common.compat import raise_collected_errors
 from xorq.common.utils.logging_utils import get_logger
 from xorq.common.utils.otel_utils import tracer
 from xorq.expr.relations import RemoteTable, gen_name
@@ -190,36 +191,56 @@ class RemoteTableScope:
         self._drains.append(drain)
         return drain
 
-    def _drain_step(self) -> None:
+    def _drain_step(self) -> list[BaseException]:
         # Close-then-join in two passes (not LIFO _ScopeEntry cleanup): the
         # write-through drains feed the placeholder tables, so every writer
         # must finish consuming its stream before any table is dropped.
         # Close all first so the writers stop pulling, then join to surface
-        # errors and ensure the side-effect writes have landed.
+        # errors and ensure the side-effect writes have landed. Returns the
+        # collected failures; the caller decides whether to raise (consumer
+        # finished successfully) or log (teardown after failure/abandon).
+        errors: list[BaseException] = []
         for drain in self._drains:
             try:
                 drain.close()
-            except Exception:
-                logger.warning("scope drain close failed", exc_info=True)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
         for drain in self._drains:
             try:
                 drain.join()
-            except Exception:
-                logger.warning("scope drain join failed", exc_info=True)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
         self._drains = []
+        return errors
 
-    def close(self) -> None:
-        """Release everything the scope owns; idempotent, never raises."""
+    def close(self, *, raise_drain_errors: bool = False) -> None:
+        """Release everything the scope owns; idempotent.
+
+        Drain (write-through) failures are correctness signals: a failed join
+        means a tee/WAP write never landed. They are surfaced by raising only
+        when ``raise_drain_errors`` is set -- the caller passes it once the
+        result has been consumed successfully (eager execute, or the result
+        reader fully drained). On the teardown-after-failure and finalizer/GC
+        paths raising is unsafe (it masks the real error or fires during
+        interpreter shutdown), so they are logged instead. Table/cache/reader
+        teardown is best-effort either way: a failure there only leaks a
+        resource, never corrupts a result, so it is always swallowed-and-logged.
+        """
         if self._closed:
             return
         self._closed = True
-        self._drain_step()
+        drain_errors = self._drain_step()
         for entry in reversed(self._tables):
             entry.safe_cleanup()
         for entry in reversed(self._caches):
             entry.safe_cleanup()
         for entry in reversed(self._readers):
             entry.safe_cleanup()
+        if raise_drain_errors:
+            raise_collected_errors("tee drain failures", drain_errors)
+        else:
+            for exc in drain_errors:
+                logger.warning("scope drain cleanup failed", exc_info=exc)
 
     def __enter__(self) -> RemoteTableScope:
         return self
@@ -248,6 +269,11 @@ def bind_scope_to_reader(
         try:
             yield from reader
         finally:
+            # Deferred path: close runs inside this generator's teardown (or
+            # the weakref.finalize backstop), where raising is unsafe -- a
+            # drain join here also races the write-through generator still in
+            # the reader chain. Always swallow-and-log; the eager call sites
+            # (remote_table_scope) surface drain failures instead.
             scope.close()
 
     g = gen()

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -277,18 +277,23 @@ def register_and_transform_remote_tables(
     def replacer(node, kwargs):
         if isinstance(node, RemoteTable):
             remote_expr = node.remote_expr
-            # Cache the reader's own (physical) schema, not the logical
-            # ``as_table().schema()``. The two can diverge -- e.g. a dropped
-            # ``row_number`` still rides along in the stream -- and StreamCache
-            # exports the declared schema over the Arrow C stream FFI, where a
-            # batch with extra children aborts the process
-            # (``fields.len() == num_children``). The reader already carries the
-            # true schema; column coercion is the consumer's job
-            # (``read_record_batches`` -> ``_select_and_cast``).
-            reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+            # Cast batches to the logical schema before entering
+            # StreamCache. The raw reader may carry extra physical columns
+            # (e.g. row_number) or mismatched types (large_utf8 vs utf8);
+            # StreamCache replays through the C Data Interface using the
+            # declared schema, so uncasted data silently corrupts reads.
+            raw_reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+            logical_schema = node.schema.to_pyarrow()
+            casting_reader = pa.RecordBatchReader.from_batches(
+                logical_schema,
+                (
+                    batch.select(logical_schema.names).cast(logical_schema)
+                    for batch in raw_reader
+                ),
+            )
             cache = scope.adopt_cache(
                 StreamCache(
-                    reader,
+                    casting_reader,
                     max_readers=reader_counts.get(node),
                 )
             )
@@ -298,7 +303,7 @@ def register_and_transform_remote_tables(
             # registered
             table_name = scope.adopt_table(node.source, gen_name())
             result = node.source.read_record_batches(
-                cache, table_name=table_name, **read_kwargs
+                cache, table_name=table_name, schema=logical_schema, **read_kwargs
             )
             return result.op()
 

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -22,6 +22,25 @@ from xorq.writes import DrainingIterator
 logger = get_logger(__name__)
 
 
+def project_and_cast_reader(
+    reader: pa.RecordBatchReader, logical_schema: pa.Schema
+) -> pa.RecordBatchReader:
+    """Project to the logical columns and cast types, before any StreamCache.
+
+    A raw remote reader may carry extra physical columns (e.g. row_number) or
+    mismatched types (large_utf8 vs utf8). The cache must hold exactly the
+    logical columns: ``StreamCache`` replays through the C Data Interface using
+    the declared schema (so uncasted data silently corrupts reads), and the
+    backend casting wrapper (``StreamCache.cast``) only retypes -- it cannot
+    drop columns. Projecting here, before the cache, keeps that single
+    invariant and lets every backend register the cache with a type-only cast.
+    """
+    return pa.RecordBatchReader.from_batches(
+        logical_schema,
+        (batch.select(logical_schema.names).cast(logical_schema) for batch in reader),
+    )
+
+
 def count_remote_table_readers(expr: Expr) -> dict[RemoteTable, int]:
     """Best-effort count of how many times each ``RemoteTable`` is scanned.
 
@@ -303,20 +322,9 @@ def register_and_transform_remote_tables(
     def replacer(node, kwargs):
         if isinstance(node, RemoteTable):
             remote_expr = node.remote_expr
-            # Cast batches to the logical schema before entering
-            # StreamCache. The raw reader may carry extra physical columns
-            # (e.g. row_number) or mismatched types (large_utf8 vs utf8);
-            # StreamCache replays through the C Data Interface using the
-            # declared schema, so uncasted data silently corrupts reads.
             raw_reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
             logical_schema = node.schema.to_pyarrow()
-            casting_reader = pa.RecordBatchReader.from_batches(
-                logical_schema,
-                (
-                    batch.select(logical_schema.names).cast(logical_schema)
-                    for batch in raw_reader
-                ),
-            )
+            casting_reader = project_and_cast_reader(raw_reader, logical_schema)
             cache = scope.adopt_cache(
                 StreamCache(
                     casting_reader,

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -336,8 +336,12 @@ def register_and_transform_remote_tables(
             # placeholder, and drop_placeholder is a no-op if it never
             # registered
             table_name = scope.adopt_table(node.source, gen_name())
+            # No ``schema=`` is passed: ``project_and_cast_reader`` already cast
+            # the stream to ``logical_schema`` before the cache, so the cache
+            # already declares it. Backends that genuinely use a schema
+            # (xorq_datafusion, pyiceberg) default to the source's own schema.
             result = node.source.read_record_batches(
-                cache, table_name=table_name, schema=logical_schema, **read_kwargs
+                cache, table_name=table_name, **read_kwargs
             )
             return result.op()
 

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -154,13 +154,20 @@ class _ScopeEntry(NamedTuple):
 
 
 class RemoteTableScope:
-    """Owns resources materialized while replacing RemoteTable nodes.
+    """Owns resources materialized while replacing ``RemoteTable`` nodes:
+    upstream readers, ``StreamCache``s, placeholder tables, and write-through
+    drains (folded in from tee transforms).
 
-    Each ``adopt_*`` method appends to a typed list.  ``close`` tears down
-    in dependency order (tables -> caches -> readers), LIFO within each
-    category, and is idempotent.
+    ``close()`` is idempotent and tears down in dependency order: drains first
+    (close-all, then join-all -- they feed the tables), then tables, caches, and
+    readers, LIFO within each. Table/cache/reader failures are logged (they only
+    leak a resource); drain-join failures are raised only with
+    ``raise_drain_errors=True`` (set once the result is consumed), else logged.
 
-    Not thread-safe: all adopt/close calls must happen on a single thread.
+    ``adopt_*`` must run on the construction thread. ``close()`` may fire from a
+    drain worker or a ``weakref.finalize`` GC thread on the streaming path; the
+    ``_closed`` guard keeps that safe. Concurrent ``close()`` is not supported,
+    but the paths are serialized so it does not arise.
     """
 
     def __init__(self) -> None:

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -22,27 +22,35 @@ logger = get_logger(__name__)
 
 
 def count_remote_table_readers(expr: Expr) -> dict[RemoteTable, int]:
-    """Count how many times each ``RemoteTable`` is physically scanned.
+    """Best-effort count of how many times each ``RemoteTable`` is scanned.
 
     The scan count is not visible in the expression graph: a single graph
-    reference can compile to several physical table scans. The asof-join with
-    tolerance lowering, for one, scans an input twice (xorq #983). Each
-    ``RemoteTable`` is rewritten to a placeholder table under a freshly
-    generated, unique name, the placeholder expression is compiled to a sqlglot
-    AST, and the ``Table`` nodes bearing that name are counted — giving the
-    exact per-table scan count whatever lowering the backend compiler applies.
-    Counting ``Table`` AST nodes (rather than substrings of the rendered SQL)
-    ignores column references, aliases, and string literals, so even a short or
-    shared user-supplied table name cannot inflate the count.
+    reference can compile to several physical table scans (e.g. a self-join over
+    one ``RemoteTable``). Each ``RemoteTable`` is rewritten to a placeholder
+    table under a freshly generated, unique name, the placeholder expression is
+    compiled to a sqlglot AST, and the ``Table`` nodes bearing that name are
+    counted. Counting ``Table`` AST nodes (rather than substrings of the
+    rendered SQL) ignores column references, aliases, and string literals, so
+    even a short or shared user-supplied table name cannot inflate the count.
 
-    The counts become each ``StreamCache``'s ``max_readers``, bounding memory:
-    batches are evicted once all readers advance past them. Each count is
-    floored at 1 — a bare ``RemoteTable`` is still scanned once, and
-    ``max_readers=0`` would forbid the reader that is in fact created.
+    This is a *lower bound*, not the exact physical scan count: it sees only the
+    scans the compiled SQL spells out, and cannot see re-scans the backend's
+    optimiser introduces below the SQL layer. The known gap is a
+    ``PARTITION BY``-only aggregate window on DuckDB, lowered to a ``GROUP BY``
+    self-join that scans its input twice while the AST shows one ``Table`` node.
+
+    The counts become each ``StreamCache``'s ``max_readers``, which both bounds
+    memory (batches are evicted once all readers advance past them) and is a
+    hard cap (a reader beyond it raises ``ValueError``). Because it is a hard
+    cap, an undercount is a correctness bug for the shapes it misses, not just a
+    missed optimisation. Each count is floored at 1 — a bare ``RemoteTable`` is
+    still scanned once, and ``max_readers=0`` would forbid the reader that is in
+    fact created.
 
     Returns an empty mapping when no SQL AST can be produced (e.g. a non-SQL
-    backend); the caller then builds an unbounded cache — safe, but without
-    eviction.
+    backend); the caller then builds an unbounded cache — always safe, just
+    without eviction. Omitting the count is safe; deriving one too low is not.
+    See ADR-0013 ("Counting accuracy").
     """
     import sqlglot as sg  # noqa: PLC0415
 

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -34,7 +34,13 @@ def project_and_cast_reader(
     backend casting wrapper (``StreamCache.cast``) only retypes -- it cannot
     drop columns. Projecting here, before the cache, keeps that single
     invariant and lets every backend register the cache with a type-only cast.
+
+    When the reader already declares the logical schema (the common case --
+    ~95% of remote scans), the per-batch select+cast is a no-op, so the reader
+    is returned unwrapped to avoid a redundant Python-level batch pass.
     """
+    if reader.schema.equals(logical_schema):
+        return reader
     return pa.RecordBatchReader.from_batches(
         logical_schema,
         (batch.select(logical_schema.names).cast(logical_schema) for batch in reader),

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -1,10 +1,21 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pyarrow as pa
 import pytest
 
 import xorq.api as xo
 import xorq.expr.relations as relations
 import xorq.vendor.ibis as ibis
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.expr.relations import CachedNode, FlightUDXF, HashingTag, Tag, flight_serve
+from xorq.expr.relations import (
+    CachedNode,
+    FlightUDXF,
+    HashingTag,
+    Tag,
+    count_remote_table_readers,
+    flight_serve,
+)
 from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
 
@@ -239,3 +250,77 @@ def test_flight_serve_returns_serve_unbound_result(monkeypatch):
 
     result = flight_serve(xo.memtable({"a": [1]}))
     assert result is expected
+
+
+# -- count_remote_table_readers ----------------------------------------------
+
+
+@pytest.fixture
+def remote_table():
+    src = xo.connect()
+    t = src.register(pa.table({"a": [1, 2, 3], "k": [1, 1, 2]}), "tt")
+    return t.into_backend(xo.connect(), "rt")
+
+
+def _only_count(expr):
+    counts = count_remote_table_readers(expr)
+    assert len(counts) == 1
+    return next(iter(counts.values()))
+
+
+def test_count_bare_remote_table_floored_at_one(remote_table):
+    # one scan, but must never be 0 (max_readers=0 forbids the reader created)
+    assert _only_count(remote_table) == 1
+
+
+def test_count_single_scan(remote_table):
+    expr = remote_table.filter(remote_table.a > 1)
+    assert _only_count(expr) == 1
+
+
+def test_count_many_fields_one_scan(remote_table):
+    # many column refs over one table resolve within a single scan
+    expr = remote_table.select(s=remote_table.a + remote_table.k)
+    assert _only_count(expr) == 1
+
+
+def test_count_self_join_is_two(remote_table):
+    expr = remote_table.join(remote_table.view(), "k")
+    assert _only_count(expr) == 2
+
+
+def test_count_asof_tolerance_double_scan():
+    # the #983 case: tolerance lowering scans the left input twice, right once.
+    # graph-level counting sees one ref each; only the compiled SQL reveals it.
+    ddb = xo.duckdb.connect()
+    sdf = pd.DataFrame(
+        {"site": ["a", "b"], "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)]}
+    )
+    edf = pd.DataFrame(
+        {
+            "site": ["a", "b"],
+            "ev": ["x", "y"],
+            "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+        }
+    )
+    left = xo.memtable(sdf).into_backend(ddb)
+    right = xo.memtable(edf).into_backend(ddb)
+    expr = left.asof_join(
+        right, on="ts", predicates="site", tolerance=timedelta(seconds=1)
+    ).drop("ts_right")
+
+    counts = count_remote_table_readers(expr)
+    assert sorted(counts.values()) == [1, 2]
+
+
+def test_count_unbindable_returns_empty(monkeypatch):
+    # SQL failure -> empty mapping -> caller builds unbounded cache (safe)
+    src = xo.connect()
+    t = src.register(pa.table({"a": [1, 2, 3]}), "tt")
+    expr = t.into_backend(xo.connect(), "rt")
+
+    def boom(*a, **k):
+        raise RuntimeError("no sql")
+
+    monkeypatch.setattr(relations.ibis, "to_sql", boom)
+    assert count_remote_table_readers(expr) == {}

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -18,7 +18,10 @@ from xorq.expr.relations import (
     Tag,
     flight_serve,
 )
-from xorq.expr.remote_table_exec import count_remote_table_readers
+from xorq.expr.remote_table_exec import (
+    count_remote_table_readers,
+    project_and_cast_reader,
+)
 from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
 from xorq.vendor.ibis.expr.types.relations import Table
@@ -384,3 +387,16 @@ def test_count_compile_failure_returns_empty(monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr(type(target.compiler), "to_sqlglot", boom)
     assert count_remote_table_readers(expr) == {}
+
+
+def test_project_and_cast_reader_drops_extra_and_retypes() -> None:
+    # extra physical column 'rn' dropped; 'a' retyped int64 -> int32
+    batch = pa.record_batch(
+        {"a": pa.array([1, 2], pa.int64()), "rn": pa.array([0, 1], pa.int64())}
+    )
+    raw = pa.RecordBatchReader.from_batches(batch.schema, [batch])
+    logical_schema = pa.schema([("a", pa.int32())])
+    out = project_and_cast_reader(raw, logical_schema)
+    table = out.read_all()
+    assert table.schema == logical_schema
+    assert table.column("a").to_pylist() == [1, 2]

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -289,6 +289,61 @@ def test_count_self_join_is_two(remote_table):
     assert _only_count(expr) == 2
 
 
+def test_count_window_is_one(remote_table):
+    expr = remote_table.mutate(rn=remote_table.a.cumsum())
+    assert _only_count(expr) == 1
+
+
+def test_count_group_by_is_one(remote_table):
+    expr = remote_table.group_by("k").agg(s=remote_table.a.sum())
+    assert _only_count(expr) == 1
+
+
+def test_count_union_all_three(remote_table):
+    r = remote_table
+    expr = (
+        r.filter(r.a < 2)
+        .union(r.filter(r.a > 2), distinct=False)
+        .union(r.filter(r.k == 2), distinct=False)
+    )
+    assert _only_count(expr) == 3
+
+
+def test_count_join_plus_scalar_subquery(remote_table):
+    # referenced in a scalar subquery and both sides of a self-join: 3 scans
+    r = remote_table
+    expr = r.mutate(mx=r.a.max().as_scalar()).join(r.view(), "k")
+    assert _only_count(expr) == 3
+
+
+def test_count_non_sql_backend_returns_empty():
+    # a non-SQL backend can't produce SQL -> empty mapping -> unbounded cache
+    pandas_con = xo.pandas.connect()
+    expr = xo.memtable({"a": [1, 2, 3]}).into_backend(pandas_con, "rt")
+    assert count_remote_table_readers(expr) == {}
+
+
+def test_count_name_collision_is_exact():
+    # two distinct RemoteTables sharing one user-supplied name are still counted
+    # independently: fresh sentinel names per table prevent any over-count
+    target = xo.connect()
+    a = xo.memtable({"id": [1, 2, 3], "v": [10, 20, 30]}).into_backend(target, "t")
+    b = xo.memtable({"id": [1, 2, 3], "v": [40, 50, 60]}).into_backend(target, "t")
+    counts = count_remote_table_readers(a.join(b, "id"))
+    assert len(counts) == 2
+    assert sorted(counts.values()) == [1, 1]
+
+
+def test_count_deferred_read_fanout(tmp_path):
+    # a deferred Read (read_parquet) behind into_backend, counted across scans
+    path = tmp_path / "data.parquet"
+    pd.DataFrame({"id": [1, 2, 3, 4], "k": ["a", "a", "b", "b"]}).to_parquet(path)
+    read = xo.deferred_read_parquet(path, xo.connect(), table_name="dr")
+    rt = read.into_backend(xo.connect(), "rt")
+    assert _only_count(rt.filter(rt.id > 1)) == 1
+    assert _only_count(rt.join(rt.view(), "k")) == 2
+
+
 def test_count_asof_tolerance_double_scan():
     # the #983 case: tolerance lowering scans the left input twice, right once.
     # graph-level counting sees one ref each; only the compiled SQL reveals it.
@@ -313,14 +368,15 @@ def test_count_asof_tolerance_double_scan():
     assert sorted(counts.values()) == [1, 2]
 
 
-def test_count_unbindable_returns_empty(monkeypatch):
-    # SQL failure -> empty mapping -> caller builds unbounded cache (safe)
+def test_count_compile_failure_returns_empty(monkeypatch):
+    # to_sqlglot failure -> empty mapping -> caller builds unbounded cache (safe)
     src = xo.connect()
     t = src.register(pa.table({"a": [1, 2, 3]}), "tt")
-    expr = t.into_backend(xo.connect(), "rt")
+    target = xo.connect()
+    expr = t.into_backend(target, "rt")
 
     def boom(*a, **k):
         raise RuntimeError("no sql")
 
-    monkeypatch.setattr(relations.ibis, "to_sql", boom)
+    monkeypatch.setattr(type(target.compiler), "to_sqlglot", boom)
     assert count_remote_table_readers(expr) == {}

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -351,9 +351,11 @@ def test_count_deferred_read_fanout(tmp_path: pathlib.Path) -> None:
     assert _only_count(rt.join(rt.view(), "k")) == 2
 
 
-def test_count_asof_tolerance_double_scan() -> None:
-    # the #983 case: tolerance lowering scans the left input twice, right once.
-    # graph-level counting sees one ref each; only the compiled SQL reveals it.
+def test_count_asof_tolerance_single_scan() -> None:
+    # #983/#2086: the tolerance lowering is now a null-out projection over a
+    # single ASOF LEFT JOIN, so each input is scanned exactly once. The old
+    # filter+re-join lowering referenced the left source twice (count [1, 2]),
+    # which broke one-shot readers; this guards against that regressing.
     ddb = xo.duckdb.connect()
     sdf = pd.DataFrame(
         {"site": ["a", "b"], "ts": [datetime(2024, 1, 1), datetime(2024, 1, 2)]}
@@ -372,7 +374,7 @@ def test_count_asof_tolerance_double_scan() -> None:
     ).drop("ts_right")
 
     counts = count_remote_table_readers(expr)
-    assert sorted(counts.values()) == [1, 2]
+    assert sorted(counts.values()) == [1, 1]
 
 
 def test_count_compile_failure_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/python/xorq/expr/tests/test_relations.py
+++ b/python/xorq/expr/tests/test_relations.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import pathlib
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -13,11 +16,12 @@ from xorq.expr.relations import (
     FlightUDXF,
     HashingTag,
     Tag,
-    count_remote_table_readers,
     flight_serve,
 )
+from xorq.expr.remote_table_exec import count_remote_table_readers
 from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr.types.core import ExprMetadata
+from xorq.vendor.ibis.expr.types.relations import Table
 
 
 @pytest.mark.parametrize(
@@ -256,50 +260,50 @@ def test_flight_serve_returns_serve_unbound_result(monkeypatch):
 
 
 @pytest.fixture
-def remote_table():
+def remote_table() -> Table:
     src = xo.connect()
     t = src.register(pa.table({"a": [1, 2, 3], "k": [1, 1, 2]}), "tt")
     return t.into_backend(xo.connect(), "rt")
 
 
-def _only_count(expr):
+def _only_count(expr: Table) -> int:
     counts = count_remote_table_readers(expr)
     assert len(counts) == 1
     return next(iter(counts.values()))
 
 
-def test_count_bare_remote_table_floored_at_one(remote_table):
+def test_count_bare_remote_table_floored_at_one(remote_table: Table) -> None:
     # one scan, but must never be 0 (max_readers=0 forbids the reader created)
     assert _only_count(remote_table) == 1
 
 
-def test_count_single_scan(remote_table):
+def test_count_single_scan(remote_table: Table) -> None:
     expr = remote_table.filter(remote_table.a > 1)
     assert _only_count(expr) == 1
 
 
-def test_count_many_fields_one_scan(remote_table):
+def test_count_many_fields_one_scan(remote_table: Table) -> None:
     # many column refs over one table resolve within a single scan
     expr = remote_table.select(s=remote_table.a + remote_table.k)
     assert _only_count(expr) == 1
 
 
-def test_count_self_join_is_two(remote_table):
+def test_count_self_join_is_two(remote_table: Table) -> None:
     expr = remote_table.join(remote_table.view(), "k")
     assert _only_count(expr) == 2
 
 
-def test_count_window_is_one(remote_table):
+def test_count_window_is_one(remote_table: Table) -> None:
     expr = remote_table.mutate(rn=remote_table.a.cumsum())
     assert _only_count(expr) == 1
 
 
-def test_count_group_by_is_one(remote_table):
+def test_count_group_by_is_one(remote_table: Table) -> None:
     expr = remote_table.group_by("k").agg(s=remote_table.a.sum())
     assert _only_count(expr) == 1
 
 
-def test_count_union_all_three(remote_table):
+def test_count_union_all_three(remote_table: Table) -> None:
     r = remote_table
     expr = (
         r.filter(r.a < 2)
@@ -309,21 +313,21 @@ def test_count_union_all_three(remote_table):
     assert _only_count(expr) == 3
 
 
-def test_count_join_plus_scalar_subquery(remote_table):
+def test_count_join_plus_scalar_subquery(remote_table: Table) -> None:
     # referenced in a scalar subquery and both sides of a self-join: 3 scans
     r = remote_table
     expr = r.mutate(mx=r.a.max().as_scalar()).join(r.view(), "k")
     assert _only_count(expr) == 3
 
 
-def test_count_non_sql_backend_returns_empty():
+def test_count_non_sql_backend_returns_empty() -> None:
     # a non-SQL backend can't produce SQL -> empty mapping -> unbounded cache
     pandas_con = xo.pandas.connect()
     expr = xo.memtable({"a": [1, 2, 3]}).into_backend(pandas_con, "rt")
     assert count_remote_table_readers(expr) == {}
 
 
-def test_count_name_collision_is_exact():
+def test_count_name_collision_is_exact() -> None:
     # two distinct RemoteTables sharing one user-supplied name are still counted
     # independently: fresh sentinel names per table prevent any over-count
     target = xo.connect()
@@ -334,7 +338,7 @@ def test_count_name_collision_is_exact():
     assert sorted(counts.values()) == [1, 1]
 
 
-def test_count_deferred_read_fanout(tmp_path):
+def test_count_deferred_read_fanout(tmp_path: pathlib.Path) -> None:
     # a deferred Read (read_parquet) behind into_backend, counted across scans
     path = tmp_path / "data.parquet"
     pd.DataFrame({"id": [1, 2, 3, 4], "k": ["a", "a", "b", "b"]}).to_parquet(path)
@@ -344,7 +348,7 @@ def test_count_deferred_read_fanout(tmp_path):
     assert _only_count(rt.join(rt.view(), "k")) == 2
 
 
-def test_count_asof_tolerance_double_scan():
+def test_count_asof_tolerance_double_scan() -> None:
     # the #983 case: tolerance lowering scans the left input twice, right once.
     # graph-level counting sees one ref each; only the compiled SQL reveals it.
     ddb = xo.duckdb.connect()
@@ -368,7 +372,7 @@ def test_count_asof_tolerance_double_scan():
     assert sorted(counts.values()) == [1, 2]
 
 
-def test_count_compile_failure_returns_empty(monkeypatch):
+def test_count_compile_failure_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     # to_sqlglot failure -> empty mapping -> caller builds unbounded cache (safe)
     src = xo.connect()
     t = src.register(pa.table({"a": [1, 2, 3]}), "tt")

--- a/python/xorq/expr/tests/test_stream_cache_contract.py
+++ b/python/xorq/expr/tests/test_stream_cache_contract.py
@@ -1,0 +1,80 @@
+"""Contract tests for the batchcorder ``StreamCache`` primitive xorq relies on.
+
+``register_and_transform_remote_tables`` builds one ``StreamCache`` per
+RemoteTable and passes ``max_readers`` from ``count_remote_table_readers``.
+Three properties of that primitive are load-bearing for the fan-out fix and
+are pinned here directly (rather than only through a backend):
+
+1. Lazy, bounded ingestion -- the upstream stream is pulled on demand, not
+   fully materialized up front (this is the whole reason StreamCache was
+   chosen over pre-ingesting into a ``pa.Table``; see ADR-0013).
+2. Replay from zero -- every reader up to ``max_readers`` replays the full
+   stream independently, which is what makes a self-join over a one-shot
+   remote reader work.
+3. Hard cap -- the ``max_readers + 1``-th reader raises ``ValueError``. This
+   is why an under-count is a correctness bug, not a memory miss (see the
+   duckdb partition-window regression test).
+
+True memory eviction (batches freed once all readers pass) is batchcorder's
+own concern and is not observable through its public API, so it is not
+asserted here.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from batchcorder import StreamCache, StreamCacheReader
+
+
+SCHEMA = pa.schema([("x", pa.int64())])
+
+
+def _stream(n: int) -> pa.RecordBatchReader:
+    def gen():
+        for i in range(n):
+            yield pa.record_batch({"x": [i]})
+
+    return pa.RecordBatchReader.from_batches(SCHEMA, gen())
+
+
+def _drain(reader: StreamCacheReader) -> list[int]:
+    return [batch.column("x")[0].as_py() for batch in reader]
+
+
+def test_ingestion_is_lazy_and_bounded() -> None:
+    cache = StreamCache(_stream(50), max_readers=1)
+    reader = iter(cache.reader())
+    consumed = [next(reader) for _ in range(3)]
+    assert len(consumed) == 3
+    # only the demanded prefix was pulled from upstream; the rest is untouched
+    assert cache.ingested_count == 3
+    assert not cache.upstream_exhausted
+
+
+def test_each_reader_replays_full_stream_from_zero() -> None:
+    cache = StreamCache(_stream(5), max_readers=2)
+    first = _drain(cache.reader())
+    second = _drain(cache.reader())
+    assert first == [0, 1, 2, 3, 4]
+    # the second reader sees the whole stream from the start, not the remainder
+    assert second == first
+    assert cache.upstream_exhausted
+
+
+def test_reader_beyond_max_readers_raises() -> None:
+    cache = StreamCache(_stream(5), max_readers=2)
+    _drain(cache.reader())
+    _drain(cache.reader())
+    # the 3rd reader exceeds the cap -- the failure that an undercounted
+    # max_readers turns into a crash mid-query
+    with pytest.raises(ValueError, match="Maximum number of readers"):
+        _drain(cache.reader())
+
+
+def test_unbounded_cache_allows_arbitrary_readers() -> None:
+    # max_readers=None is the non-SQL / compile-failure fallback: no cap, no
+    # eviction, always safe.
+    cache = StreamCache(_stream(3), max_readers=None)
+    for _ in range(5):
+        assert _drain(cache.reader()) == [0, 1, 2]

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -1,127 +1,168 @@
-"""Lifecycle regression tests for ``TransformScope``.
+"""Lifecycle regression tests for ``RemoteTableScope``.
 
 Every resource materialized while transforming an expr -- upstream readers,
-StreamCaches, registered placeholder tables -- is owned by a TransformScope
+StreamCaches, registered placeholder tables -- is owned by a RemoteTableScope
 so cleanup survives planning failures, cleanup-chain aborts and abandoned
 result readers.
 """
 
-import functools
+from __future__ import annotations
+
 import gc
+from collections.abc import Callable
 
 import pandas as pd
 import pyarrow as pa
 import pytest
 
 import xorq.api as xo
-import xorq.expr.relations as relations
+import xorq.expr.remote_table_exec as remote_table_exec
+import xorq.vendor.ibis.expr.types as ir
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.expr.api import get_plans, to_pyarrow_batches
-from xorq.expr.relations import (
-    TransformScope,
+from xorq.expr.remote_table_exec import (
+    RemoteTableScope,
+    bind_scope_to_reader,
+    drop_placeholder,
     prepare_create_table_from_expr,
     register_and_transform_remote_tables,
 )
 from xorq.tests.util import assert_frame_equal
+from xorq.vendor.ibis.backends import BaseBackend
 
 
 pytest.importorskip("duckdb")
 
 
 @pytest.fixture
-def recording_caches(monkeypatch):
+def recording_caches(monkeypatch: pytest.MonkeyPatch) -> list:
     instances = []
 
-    class RecordingStreamCache(relations.StreamCache):
-        def __init__(self, *args, **kwargs):
+    class RecordingStreamCache(remote_table_exec.StreamCache):
+        def __init__(self, *args: object, **kwargs: object) -> None:
             super().__init__(*args, **kwargs)
             self.close_count = 0
             instances.append(self)
 
-        def close(self):
+        def close(self) -> None:
             self.close_count += 1
             super().close()
 
-    monkeypatch.setattr(relations, "StreamCache", RecordingStreamCache)
+    monkeypatch.setattr(remote_table_exec, "StreamCache", RecordingStreamCache)
     return instances
 
 
-def make_remote_expr(target):
+def make_remote_expr(target: BaseBackend) -> ir.Table:
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
     rt = xo.memtable(df).into_backend(target, "rt_tbl")
     return rt.filter(rt.a > 1)
 
 
-def assert_all_closed_once(caches):
+def assert_all_closed_once(caches: list) -> None:
     assert caches and all(cache.close_count == 1 for cache in caches)
 
 
-def test_scope_close_is_idempotent():
-    events = []
-    scope = TransformScope()
-    scope.adopt("one", functools.partial(events.append, "one"))
+class _FakeCloseable:
+    def __init__(self, events: list[str], label: str) -> None:
+        self._events = events
+        self._label = label
+
+    def close(self) -> None:
+        self._events.append(self._label)
+
+
+def test_scope_close_is_idempotent() -> None:
+    events: list[str] = []
+    scope = RemoteTableScope()
+    scope.adopt_cache(_FakeCloseable(events, "one"))
     scope.close()
     scope.close()
     assert scope.closed
     assert events == ["one"]
 
 
-def test_scope_close_is_lifo():
-    events = []
-    scope = TransformScope()
-    for label in ("first", "second", "third"):
-        scope.adopt(label, functools.partial(events.append, label))
+def test_scope_close_is_lifo_within_category() -> None:
+    events: list[str] = []
+    scope = RemoteTableScope()
+    scope.adopt_reader(_FakeCloseable(events, "r1"))
+    scope.adopt_reader(_FakeCloseable(events, "r2"))
+    scope.adopt_cache(_FakeCloseable(events, "c1"))
+    scope.adopt_cache(_FakeCloseable(events, "c2"))
     scope.close()
-    assert events == ["third", "second", "first"]
+    # caches reversed, then readers reversed (tables -> caches -> readers)
+    assert events == ["c2", "c1", "r2", "r1"]
 
 
-def test_scope_failing_cleanup_does_not_skip_others():
-    events = []
-    scope = TransformScope()
-
-    def boom():
-        events.append("boom")
-        raise RuntimeError("cleanup failed")
-
-    scope.adopt("inner", functools.partial(events.append, "inner"))
-    scope.adopt("boom", boom)
-    scope.adopt("outer", functools.partial(events.append, "outer"))
+def test_scope_close_tables_before_caches_before_readers() -> None:
+    target = xo.duckdb.connect()
+    events: list[str] = []
+    scope = RemoteTableScope()
+    scope.adopt_reader(_FakeCloseable(events, "reader"))
+    scope.adopt_cache(_FakeCloseable(events, "cache"))
+    schema = pa.schema([("a", pa.int64())])
+    reader = pa.RecordBatchReader.from_batches(
+        schema, iter([pa.RecordBatch.from_pydict({"a": [1]})])
+    )
+    target.read_record_batches(reader, table_name="ph")
+    scope.adopt_table(target, "ph")
     scope.close()
-    assert events == ["outer", "boom", "inner"]
+    assert events[0] == "cache"
+    assert events[1] == "reader"
+    assert "ph" not in target.list_tables()
 
 
-def test_scope_context_manager_closes():
-    events = []
-    with TransformScope() as scope:
-        scope.adopt("one", functools.partial(events.append, "one"))
+def test_scope_failing_cleanup_does_not_skip_others() -> None:
+    events: list[str] = []
+    scope = RemoteTableScope()
+
+    class BoomCache:
+        def close(self) -> None:
+            events.append("boom")
+            raise RuntimeError("cleanup failed")
+
+    scope.adopt_reader(_FakeCloseable(events, "reader"))
+    scope.adopt_cache(BoomCache())
+    scope.adopt_cache(_FakeCloseable(events, "good_cache"))
+    scope.close()
+    # good_cache (LIFO), boom, then reader
+    assert events == ["good_cache", "boom", "reader"]
+
+
+def test_scope_context_manager_closes() -> None:
+    events: list[str] = []
+    with RemoteTableScope() as scope:
+        scope.adopt_cache(_FakeCloseable(events, "one"))
     assert scope.closed
     assert events == ["one"]
 
 
-def test_scope_close_can_leave_tables():
-    events = []
-    scope = TransformScope()
-    scope.adopt("cache", functools.partial(events.append, "cache"))
-    scope.adopt("tbl", functools.partial(events.append, "drop"), "table")
-    scope.close(drop_tables=False)
+def test_scope_close_drops_all_entries() -> None:
+    events: list[str] = []
+    scope = RemoteTableScope()
+    scope.adopt_cache(_FakeCloseable(events, "cache"))
+    scope.adopt_reader(_FakeCloseable(events, "reader"))
+    scope.close()
     assert scope.closed
-    assert events == ["cache"]
+    # caches before readers in teardown order
+    assert events == ["cache", "reader"]
 
 
-def test_drop_placeholder_handles_views_and_missing_names():
+def test_drop_placeholder_handles_views_and_missing_names() -> None:
     con = xo.duckdb.connect()
     table = pa.table({"a": [1]})
     reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches())
     # duckdb registers record batch readers as a VIEW
     con.read_record_batches(reader, table_name="ph")
     assert "ph" in con.list_tables()
-    relations.drop_placeholder(con, "ph")
+    drop_placeholder(con, "ph")
     assert "ph" not in con.list_tables()
     # missing name: must not raise
-    relations.drop_placeholder(con, "ph")
+    drop_placeholder(con, "ph")
 
 
-def test_planning_failure_releases_resources(recording_caches, monkeypatch):
+def test_planning_failure_releases_resources(
+    recording_caches: list, monkeypatch: pytest.MonkeyPatch
+) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
 
@@ -135,7 +176,7 @@ def test_planning_failure_releases_resources(recording_caches, monkeypatch):
     assert target.list_tables() == []
 
 
-def test_natural_planning_failure_releases_resources(recording_caches):
+def test_natural_planning_failure_releases_resources(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
     rt = xo.memtable(df).into_backend(target, "rt_tbl")
@@ -146,7 +187,7 @@ def test_natural_planning_failure_releases_resources(recording_caches):
     assert target.list_tables() == []
 
 
-def test_deferred_read_failure_releases_resources(recording_caches):
+def test_deferred_read_failure_releases_resources(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     df = pd.DataFrame({"a": [1, 2, 3]})
     rt = xo.memtable(df).into_backend(target, "rt_tbl")
@@ -162,7 +203,9 @@ def test_deferred_read_failure_releases_resources(recording_caches):
     assert target.list_tables() == []
 
 
-def test_failing_drop_does_not_skip_cache_close(recording_caches, monkeypatch):
+def test_failing_drop_does_not_skip_cache_close(
+    recording_caches: list, monkeypatch: pytest.MonkeyPatch
+) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     reader = to_pyarrow_batches(expr)
@@ -176,7 +219,7 @@ def test_failing_drop_does_not_skip_cache_close(recording_caches, monkeypatch):
     assert_all_closed_once(recording_caches)
 
 
-def test_get_plans_drops_placeholders(recording_caches):
+def test_get_plans_drops_placeholders(recording_caches: list) -> None:
     con = xo.connect()
     df = pd.DataFrame({"a": [1, 2, 3]})
     expr = xo.memtable(df).into_backend(con, "rt_tbl")
@@ -186,7 +229,7 @@ def test_get_plans_drops_placeholders(recording_caches):
     assert con.list_tables() == []
 
 
-def test_table_sql_failure_does_not_leak(recording_caches):
+def test_table_sql_failure_does_not_leak(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     with pytest.raises(Exception, match="rt_tbl does not exist"):
@@ -195,19 +238,19 @@ def test_table_sql_failure_does_not_leak(recording_caches):
     assert target.list_tables() == []
 
 
-def test_prepare_create_table_keeps_placeholders(recording_caches):
-    # the sole caller (snowflake create_table) runs CTAS against the
-    # placeholder after prepare returns: tables must stay registered while
-    # the caches are closed
+def test_prepare_create_table_returns_scope(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
-    table = prepare_create_table_from_expr(target, expr)
+    (table, scope) = prepare_create_table_from_expr(target, expr)
     assert table is not None
-    assert_all_closed_once(recording_caches)
+    assert not scope.closed
     assert target.list_tables() != []
+    scope.close()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
 
 
-def test_stream_full_drain_closes_once(recording_caches):
+def test_stream_full_drain_closes_once(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     reader = to_pyarrow_batches(expr)
@@ -222,7 +265,7 @@ def test_stream_full_drain_closes_once(recording_caches):
     assert cache.close_count == 1
 
 
-def test_stream_abandoned_reader_gc_closes(recording_caches):
+def test_stream_abandoned_reader_gc_closes(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     reader = to_pyarrow_batches(expr)
@@ -236,7 +279,7 @@ def test_stream_abandoned_reader_gc_closes(recording_caches):
     assert target.list_tables() == []
 
 
-def test_stream_explicit_close_then_release(recording_caches):
+def test_stream_explicit_close_then_release(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     reader = to_pyarrow_batches(expr)
@@ -250,7 +293,7 @@ def test_stream_explicit_close_then_release(recording_caches):
     assert target.list_tables() == []
 
 
-def test_stream_early_termination_then_close(recording_caches):
+def test_stream_early_termination_then_close(recording_caches: list) -> None:
     target = xo.duckdb.connect()
     df = pd.DataFrame({"a": range(1000)})
     rt = xo.memtable(df).into_backend(target, "rt_tbl")
@@ -267,10 +310,12 @@ def test_stream_early_termination_then_close(recording_caches):
 
 @pytest.mark.parametrize(
     "connect",
-    [xo.duckdb.connect, xo.connect],
-    ids=["duckdb", "xorq"],
+    [
+        pytest.param(xo.duckdb.connect, id="duckdb"),
+        pytest.param(xo.connect, id="xorq"),
+    ],
 )
-def test_into_backend_executes_correctly(connect):
+def test_into_backend_executes_correctly(connect: Callable[[], BaseBackend]) -> None:
     target = connect()
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
     rt = xo.memtable(df).into_backend(target, "rt_tbl")
@@ -283,10 +328,14 @@ def test_into_backend_executes_correctly(connect):
 
 @pytest.mark.parametrize(
     "connect",
-    [xo.duckdb.connect, xo.connect],
-    ids=["duckdb", "xorq"],
+    [
+        pytest.param(xo.duckdb.connect, id="duckdb"),
+        pytest.param(xo.connect, id="xorq"),
+    ],
 )
-def test_into_backend_fanout_executes_correctly(connect):
+def test_into_backend_fanout_executes_correctly(
+    connect: Callable[[], BaseBackend],
+) -> None:
     target = connect()
     df = pd.DataFrame({"id": [1, 2], "v": [10, 20]})
     rt = xo.memtable(df).into_backend(target, "rt_tbl")
@@ -296,59 +345,50 @@ def test_into_backend_fanout_executes_correctly(connect):
     assert target.list_tables() == []
 
 
-def test_bind_closes_at_drain_not_gc():
-    # the generator finally in bind() must fire AT exhaustion, not at GC:
-    # drain the bound reader directly while still holding a strong reference
-    # to it (the public path can mask the distinction -- the otel wrapper
-    # drops its reference at drain, letting the finalize backstop fire at the
-    # same moment under refcounting)
-    closed = []
-    scope = TransformScope()
-    scope.adopt("marker", functools.partial(closed.append, True))
+def test_bind_closes_at_drain_not_gc() -> None:
+    closed: list[str] = []
+    scope = RemoteTableScope()
+    scope.adopt_cache(_FakeCloseable(closed, "drain"))
     schema = pa.schema([("a", pa.int64())])
     inner = pa.RecordBatchReader.from_batches(
         schema, iter([pa.RecordBatch.from_pydict({"a": [1, 2]})])
     )
-    bound = scope.bind(inner)
+    bound = bind_scope_to_reader(scope, inner)
     bound.read_all()
-    assert closed == [True], "bind must close at exhaustion, not at reader GC"
+    assert closed == ["drain"], "bind must close at exhaustion, not at reader GC"
     del bound
 
 
-def test_scope_close_closes_adopted_readers():
+def test_scope_close_closes_adopted_readers() -> None:
     class StubReader:
         closed = False
 
-        def close(self):
+        def close(self) -> None:
             self.closed = True
 
-    scope = TransformScope()
+    scope = RemoteTableScope()
     stub = scope.adopt_reader(StubReader())
     scope.close()
     assert stub.closed
 
 
-def test_replacer_adopts_reader_cache_and_table():
-    # ownership contract: one (reader, cache, table) triple per RemoteTable,
-    # adopted in acquisition order so close() runs table -> cache -> reader
+def test_replacer_adopts_reader_cache_and_table() -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     _, scope = register_and_transform_remote_tables(expr.op().to_expr())
     try:
-        labels = [(kind, label) for kind, label, _ in scope._entries]
-        assert labels == [
-            ("resource", "reader"),
-            ("resource", "cache"),
-            ("table", next(iter(scope.created))),
-        ]
+        assert scope.reader_count == 1
+        assert scope.cache_count == 1
+        assert scope.table_count == 1
+        assert scope.table_names
     finally:
         scope.close()
     assert target.list_tables() == []
 
 
 def test_partial_read_record_batches_failure_drops_placeholder(
-    recording_caches, monkeypatch
-):
+    recording_caches: list, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # register-then-raise inside read_record_batches: the pre-adopted
     # placeholder must still be dropped
     target = xo.duckdb.connect()

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -1,0 +1,365 @@
+"""Lifecycle regression tests for ``TransformScope``.
+
+Every resource materialized while transforming an expr -- upstream readers,
+StreamCaches, registered placeholder tables -- is owned by a TransformScope
+so cleanup survives planning failures, cleanup-chain aborts and abandoned
+result readers.
+"""
+
+import functools
+import gc
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+import xorq.api as xo
+import xorq.expr.relations as relations
+from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.expr.api import get_plans, to_pyarrow_batches
+from xorq.expr.relations import (
+    TransformScope,
+    prepare_create_table_from_expr,
+    register_and_transform_remote_tables,
+)
+from xorq.tests.util import assert_frame_equal
+
+
+pytest.importorskip("duckdb")
+
+
+@pytest.fixture
+def recording_caches(monkeypatch):
+    instances = []
+
+    class RecordingStreamCache(relations.StreamCache):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.close_count = 0
+            instances.append(self)
+
+        def close(self):
+            self.close_count += 1
+            super().close()
+
+    monkeypatch.setattr(relations, "StreamCache", RecordingStreamCache)
+    return instances
+
+
+def make_remote_expr(target):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    return rt.filter(rt.a > 1)
+
+
+def assert_all_closed_once(caches):
+    assert caches and all(cache.close_count == 1 for cache in caches)
+
+
+def test_scope_close_is_idempotent():
+    events = []
+    scope = TransformScope()
+    scope.adopt("one", functools.partial(events.append, "one"))
+    scope.close()
+    scope.close()
+    assert scope.closed
+    assert events == ["one"]
+
+
+def test_scope_close_is_lifo():
+    events = []
+    scope = TransformScope()
+    for label in ("first", "second", "third"):
+        scope.adopt(label, functools.partial(events.append, label))
+    scope.close()
+    assert events == ["third", "second", "first"]
+
+
+def test_scope_failing_cleanup_does_not_skip_others():
+    events = []
+    scope = TransformScope()
+
+    def boom():
+        events.append("boom")
+        raise RuntimeError("cleanup failed")
+
+    scope.adopt("inner", functools.partial(events.append, "inner"))
+    scope.adopt("boom", boom)
+    scope.adopt("outer", functools.partial(events.append, "outer"))
+    scope.close()
+    assert events == ["outer", "boom", "inner"]
+
+
+def test_scope_context_manager_closes():
+    events = []
+    with TransformScope() as scope:
+        scope.adopt("one", functools.partial(events.append, "one"))
+    assert scope.closed
+    assert events == ["one"]
+
+
+def test_scope_close_can_leave_tables():
+    events = []
+    scope = TransformScope()
+    scope.adopt("cache", functools.partial(events.append, "cache"))
+    scope.adopt("tbl", functools.partial(events.append, "drop"), "table")
+    scope.close(drop_tables=False)
+    assert scope.closed
+    assert events == ["cache"]
+
+
+def test_drop_placeholder_handles_views_and_missing_names():
+    con = xo.duckdb.connect()
+    table = pa.table({"a": [1]})
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches())
+    # duckdb registers record batch readers as a VIEW
+    con.read_record_batches(reader, table_name="ph")
+    assert "ph" in con.list_tables()
+    relations.drop_placeholder(con, "ph")
+    assert "ph" not in con.list_tables()
+    # missing name: must not raise
+    relations.drop_placeholder(con, "ph")
+
+
+def test_planning_failure_releases_resources(recording_caches, monkeypatch):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("planning failed")
+
+    monkeypatch.setattr(type(target), "to_pyarrow_batches", boom)
+    with pytest.raises(RuntimeError, match="planning failed"):
+        to_pyarrow_batches(expr)
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_natural_planning_failure_releases_resources(recording_caches):
+    target = xo.duckdb.connect()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    expr = rt.mutate(c=rt.b.cast("int64"))
+    with pytest.raises(Exception, match="(?i)convert"):
+        expr.execute()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_deferred_read_failure_releases_resources(recording_caches):
+    target = xo.duckdb.connect()
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    missing = deferred_read_parquet(
+        "/nonexistent/missing.parquet",
+        con=target,
+        schema=xo.schema({"a": "int64"}),
+    )
+    expr = rt.union(missing)
+    with pytest.raises(ValueError, match="At least one path is required"):
+        expr.execute()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_failing_drop_does_not_skip_cache_close(recording_caches, monkeypatch):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+
+    def boom(self, name, *args, **kwargs):
+        raise RuntimeError("drop failed")
+
+    monkeypatch.setattr(type(target), "drop_table", boom)
+    monkeypatch.setattr(type(target), "drop_view", boom)
+    reader.read_all()
+    assert_all_closed_once(recording_caches)
+
+
+def test_get_plans_drops_placeholders(recording_caches):
+    con = xo.connect()
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    expr = xo.memtable(df).into_backend(con, "rt_tbl")
+    plans = get_plans(expr)
+    assert plans
+    assert_all_closed_once(recording_caches)
+    assert con.list_tables() == []
+
+
+def test_table_sql_failure_does_not_leak(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    with pytest.raises(Exception, match="rt_tbl does not exist"):
+        expr.sql("SELECT * FROM rt_tbl")
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_prepare_create_table_keeps_placeholders(recording_caches):
+    # the sole caller (snowflake create_table) runs CTAS against the
+    # placeholder after prepare returns: tables must stay registered while
+    # the caches are closed
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    table = prepare_create_table_from_expr(target, expr)
+    assert table is not None
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() != []
+
+
+def test_stream_full_drain_closes_once(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+    table = reader.read_all()
+    assert table.num_rows == 2
+    (cache,) = recording_caches
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+    # releasing the drained reader is a no-op (idempotent close)
+    del reader
+    gc.collect()
+    assert cache.close_count == 1
+
+
+def test_stream_abandoned_reader_gc_closes(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+    (cache,) = recording_caches
+    assert cache.close_count == 0
+    assert target.list_tables() != []
+    # never read a single batch: the weakref.finalize backstop must fire
+    del reader
+    gc.collect()
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+
+
+def test_stream_explicit_close_then_release(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+    # pyarrow does not finalize wrapped generators on close(); cleanup
+    # fires when the last reference drops
+    reader.close()
+    del reader
+    gc.collect()
+    (cache,) = recording_caches
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+
+
+def test_stream_early_termination_then_close(recording_caches):
+    target = xo.duckdb.connect()
+    df = pd.DataFrame({"a": range(1000)})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    reader = to_pyarrow_batches(rt.limit(1))
+    batch = reader.read_next_batch()
+    assert len(batch) == 1
+    reader.close()
+    del reader
+    gc.collect()
+    (cache,) = recording_caches
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+
+
+@pytest.mark.parametrize(
+    "connect",
+    [xo.duckdb.connect, xo.connect],
+    ids=["duckdb", "xorq"],
+)
+def test_into_backend_executes_correctly(connect):
+    target = connect()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    expr = rt.filter(rt.a > 1).select("a", "b")
+    result = expr.execute().reset_index(drop=True)
+    expected = df[df.a > 1].reset_index(drop=True)
+    assert_frame_equal(result, expected)
+    assert target.list_tables() == []
+
+
+@pytest.mark.parametrize(
+    "connect",
+    [xo.duckdb.connect, xo.connect],
+    ids=["duckdb", "xorq"],
+)
+def test_into_backend_fanout_executes_correctly(connect):
+    target = connect()
+    df = pd.DataFrame({"id": [1, 2], "v": [10, 20]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    expr = rt.join(rt, "id")
+    result = expr.execute()
+    assert len(result) == 2
+    assert target.list_tables() == []
+
+
+def test_bind_closes_at_drain_not_gc():
+    # the generator finally in bind() must fire AT exhaustion, not at GC:
+    # drain the bound reader directly while still holding a strong reference
+    # to it (the public path can mask the distinction -- the otel wrapper
+    # drops its reference at drain, letting the finalize backstop fire at the
+    # same moment under refcounting)
+    closed = []
+    scope = TransformScope()
+    scope.adopt("marker", functools.partial(closed.append, True))
+    schema = pa.schema([("a", pa.int64())])
+    inner = pa.RecordBatchReader.from_batches(
+        schema, iter([pa.RecordBatch.from_pydict({"a": [1, 2]})])
+    )
+    bound = scope.bind(inner)
+    bound.read_all()
+    assert closed == [True], "bind must close at exhaustion, not at reader GC"
+    del bound
+
+
+def test_scope_close_closes_adopted_readers():
+    class StubReader:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    scope = TransformScope()
+    stub = scope.adopt_reader(StubReader())
+    scope.close()
+    assert stub.closed
+
+
+def test_replacer_adopts_reader_cache_and_table():
+    # ownership contract: one (reader, cache, table) triple per RemoteTable,
+    # adopted in acquisition order so close() runs table -> cache -> reader
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    _, scope = register_and_transform_remote_tables(expr.op().to_expr())
+    try:
+        labels = [(kind, label) for kind, label, _ in scope._entries]
+        assert labels == [
+            ("resource", "reader"),
+            ("resource", "cache"),
+            ("table", next(iter(scope.created))),
+        ]
+    finally:
+        scope.close()
+    assert target.list_tables() == []
+
+
+def test_partial_read_record_batches_failure_drops_placeholder(
+    recording_caches, monkeypatch
+):
+    # register-then-raise inside read_record_batches: the pre-adopted
+    # placeholder must still be dropped
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+
+    def register_then_boom(self, source, table_name=None):
+        self.con.register(table_name, source)
+        raise RuntimeError("partial registration failure")
+
+    monkeypatch.setattr(type(target), "read_record_batches", register_then_boom)
+    with pytest.raises(RuntimeError, match="partial registration failure"):
+        expr.execute()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -394,7 +394,7 @@ def test_partial_read_record_batches_failure_drops_placeholder(
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
 
-    def register_then_boom(self, source, table_name=None):
+    def register_then_boom(self, source, table_name=None, schema=None, **kwargs):
         self.con.register(table_name, source)
         raise RuntimeError("partial registration failure")
 

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -128,6 +128,46 @@ def test_scope_failing_cleanup_does_not_skip_others() -> None:
     assert events == ["good_cache", "boom", "reader"]
 
 
+class _FakeDrain:
+    def __init__(self, *, join_error: BaseException | None = None) -> None:
+        self.closed = False
+        self.joined = False
+        self._join_error = join_error
+
+    def close(self) -> None:
+        self.closed = True
+
+    def join(self) -> None:
+        self.joined = True
+        if self._join_error is not None:
+            raise self._join_error
+
+
+def test_scope_close_raises_drain_errors_when_requested() -> None:
+    events: list[str] = []
+    scope = RemoteTableScope()
+    drain = scope.adopt_drain(_FakeDrain(join_error=RuntimeError("drain boom")))
+    scope.adopt_cache(_FakeCloseable(events, "cache"))
+    with pytest.raises(RuntimeError, match="drain boom"):
+        scope.close(raise_drain_errors=True)
+    assert drain.closed and drain.joined
+    # teardown still runs before the drain error is surfaced
+    assert events == ["cache"]
+    assert scope.closed
+
+
+def test_scope_close_swallows_drain_errors_by_default() -> None:
+    events: list[str] = []
+    scope = RemoteTableScope()
+    drain = scope.adopt_drain(_FakeDrain(join_error=RuntimeError("drain boom")))
+    scope.adopt_cache(_FakeCloseable(events, "cache"))
+    # default close() logs drain failures instead of raising (deferred path)
+    scope.close()
+    assert drain.closed and drain.joined
+    assert events == ["cache"]
+    assert scope.closed
+
+
 def test_scope_context_manager_closes() -> None:
     events: list[str] = []
     with RemoteTableScope() as scope:

--- a/python/xorq/flight/backend.py
+++ b/python/xorq/flight/backend.py
@@ -168,12 +168,7 @@ class Backend(SQLBackend):
         self,
         source: pa.Table | pa.RecordBatchReader | StreamCache,
         table_name: str | None = None,
-        schema: pa.Schema | None = None,
-        **kwargs: Any,
     ) -> ir.Table:
-        # ``schema`` is accepted-and-ignored: the stream is already projected and
-        # cast to the logical schema upstream, before the StreamCache, in
-        # register_and_transform_remote_tables.
         table_name = table_name or gen_name("read_record_batches")
         self.con.upload_batches(table_name, source)
         return self.table(table_name)

--- a/python/xorq/flight/backend.py
+++ b/python/xorq/flight/backend.py
@@ -127,7 +127,7 @@ class Backend(SQLBackend):
             self.con.upload_table(table_name, source)
         elif isinstance(source, pd.DataFrame):
             self.con.upload_batches(
-                table_name, pa.RecordBatchReader.from_stream(source)
+                table_name, pa.Table.from_pandas(source).to_reader()
             )
         elif isinstance(source, pa.RecordBatchReader):
             self.con.upload_batches(table_name, source)

--- a/python/xorq/flight/backend.py
+++ b/python/xorq/flight/backend.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 import pyarrow as pa
 import toolz
+from batchcorder import StreamCache
 
 from xorq.common.utils.rbr_utils import (
     make_filtered_reader,
@@ -163,7 +164,16 @@ class Backend(SQLBackend):
 
         return self.read_record_batches(source, table_name=table_name)
 
-    def read_record_batches(self, source, table_name=None):
+    def read_record_batches(
+        self,
+        source: pa.Table | pa.RecordBatchReader | StreamCache,
+        table_name: str | None = None,
+        schema: pa.Schema | None = None,
+        **kwargs: Any,
+    ) -> ir.Table:
+        # ``schema`` is accepted-and-ignored: the stream is already projected and
+        # cast to the logical schema upstream, before the StreamCache, in
+        # register_and_transform_remote_tables.
         table_name = table_name or gen_name("read_record_batches")
         self.con.upload_batches(table_name, source)
         return self.table(table_name)

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -257,14 +257,15 @@ def test_into_backend_duckdb(pg):
         .select(player_id="playerID", year_id="yearID_right")
     )
 
-    expr, created = register_and_transform_remote_tables(expr)
+    expr, created, _caches = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     res = ddb.con.sql(query).df()
 
-    assert query.count("ls_batting") == 2
+    assert len(created) == 1
+    registered_name = next(iter(created))
+    assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
-    assert len(created) == 3
 
 
 @pytest.mark.postgres
@@ -273,14 +274,15 @@ def test_into_backend_duckdb_expr(pg):
     t = pg.table("batting").into_backend(ddb, "ls_batting")
     expr = t.join(t, "playerID").limit(15).select(_.playerID * 2)
 
-    expr, created = register_and_transform_remote_tables(expr)
+    expr, created, _caches = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     res = ddb.con.sql(query).df()
 
-    assert query.count("ls_batting") == 2
+    assert len(created) == 1
+    registered_name = next(iter(created))
+    assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
-    assert len(created) == 3
 
 
 @pytest.mark.trino
@@ -288,14 +290,14 @@ def test_into_backend_duckdb_trino(trino_table):
     db_con = xo.duckdb.connect()
     expr = trino_table.head(10_000).into_backend(db_con).pipe(make_merged)
 
-    expr, created = register_and_transform_remote_tables(expr)
+    expr, created, _caches = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     df = db_con.con.sql(query).df()  # to bypass execute hotfix
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(created) == 3
+    assert len(created) == 1
 
 
 @pytest.mark.trino
@@ -310,13 +312,13 @@ def test_multiple_into_backend_duckdb_xorq(trino_table):
         .into_backend(ls_con)[lambda t: t.orderstatus == "F"]
     )
 
-    expr, created = register_and_transform_remote_tables(expr)
+    expr, created, _caches = register_and_transform_remote_tables(expr)
 
     df = expr.execute()
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(created) == 2
+    assert len(created) == 1
 
 
 @pytest.mark.trino

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import operator
 import random
@@ -11,13 +13,15 @@ import pytest
 from pytest import param
 
 import xorq.api as xo
+import xorq.vendor.ibis.expr.types as ir
 from xorq.caching import ParquetCache, SourceCache
 from xorq.common.exceptions import XorqError
-from xorq.expr.relations import register_and_transform_remote_tables
+from xorq.expr.remote_table_exec import register_and_transform_remote_tables
 from xorq.loader import load_backend
 from xorq.tests.util import assert_frame_equal, check_eq
 from xorq.vendor import ibis
 from xorq.vendor.ibis import _
+from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr.types.relations import CACHED_NODE_NAME_PLACEHOLDER
 
 
@@ -258,31 +262,29 @@ def test_into_backend_duckdb(pg):
     )
 
     expr, scope = register_and_transform_remote_tables(expr)
-    query = ibis.to_sql(expr, dialect="duckdb")
+    with scope:
+        query = ibis.to_sql(expr, dialect="duckdb")
+        res = ddb.con.sql(query).df()
 
-    res = ddb.con.sql(query).df()
-    scope.close()
-
-    assert len(scope.created) == 1
-    registered_name = next(iter(scope.created))
+    assert scope.table_count == 1
+    registered_name = scope.table_names[0]
     assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
 
 
 @pytest.mark.postgres
-def test_into_backend_duckdb_expr(pg):
+def test_into_backend_duckdb_expr(pg: BaseBackend) -> None:
     ddb = xo.duckdb.connect()
     t = pg.table("batting").into_backend(ddb, "ls_batting")
     expr = t.join(t, "playerID").limit(15).select(_.playerID * 2)
 
     expr, scope = register_and_transform_remote_tables(expr)
-    query = ibis.to_sql(expr, dialect="duckdb")
+    with scope:
+        query = ibis.to_sql(expr, dialect="duckdb")
+        res = ddb.con.sql(query).df()
 
-    res = ddb.con.sql(query).df()
-    scope.close()
-
-    assert len(scope.created) == 1
-    registered_name = next(iter(scope.created))
+    assert scope.table_count == 1
+    registered_name = scope.table_names[0]
     assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
 
@@ -293,18 +295,17 @@ def test_into_backend_duckdb_trino(trino_table):
     expr = trino_table.head(10_000).into_backend(db_con).pipe(make_merged)
 
     expr, scope = register_and_transform_remote_tables(expr)
-    query = ibis.to_sql(expr, dialect="duckdb")
-
-    df = db_con.con.sql(query).df()  # to bypass execute hotfix
-    scope.close()
+    with scope:
+        query = ibis.to_sql(expr, dialect="duckdb")
+        df = db_con.con.sql(query).df()  # to bypass execute hotfix
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(scope.created) == 1
+    assert scope.table_count == 1
 
 
 @pytest.mark.trino
-def test_multiple_into_backend_duckdb_xorq(trino_table):
+def test_multiple_into_backend_duckdb_xorq(trino_table: ir.Table) -> None:
     db_con = xo.duckdb.connect()
     ls_con = xo.connect()
 
@@ -316,13 +317,12 @@ def test_multiple_into_backend_duckdb_xorq(trino_table):
     )
 
     expr, scope = register_and_transform_remote_tables(expr)
-
-    df = expr.execute()
-    scope.close()
+    with scope:
+        df = expr.execute()
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(scope.created) == 1
+    assert scope.table_count == 1
 
 
 @pytest.mark.trino

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -257,13 +257,14 @@ def test_into_backend_duckdb(pg):
         .select(player_id="playerID", year_id="yearID_right")
     )
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     res = ddb.con.sql(query).df()
+    scope.close()
 
-    assert len(created) == 1
-    registered_name = next(iter(created))
+    assert len(scope.created) == 1
+    registered_name = next(iter(scope.created))
     assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
 
@@ -274,13 +275,14 @@ def test_into_backend_duckdb_expr(pg):
     t = pg.table("batting").into_backend(ddb, "ls_batting")
     expr = t.join(t, "playerID").limit(15).select(_.playerID * 2)
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     res = ddb.con.sql(query).df()
+    scope.close()
 
-    assert len(created) == 1
-    registered_name = next(iter(created))
+    assert len(scope.created) == 1
+    registered_name = next(iter(scope.created))
     assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
 
@@ -290,14 +292,15 @@ def test_into_backend_duckdb_trino(trino_table):
     db_con = xo.duckdb.connect()
     expr = trino_table.head(10_000).into_backend(db_con).pipe(make_merged)
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     df = db_con.con.sql(query).df()  # to bypass execute hotfix
+    scope.close()
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(created) == 1
+    assert len(scope.created) == 1
 
 
 @pytest.mark.trino
@@ -312,13 +315,14 @@ def test_multiple_into_backend_duckdb_xorq(trino_table):
         .into_backend(ls_con)[lambda t: t.orderstatus == "F"]
     )
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
 
     df = expr.execute()
+    scope.close()
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(created) == 1
+    assert len(scope.created) == 1
 
 
 @pytest.mark.trino

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -18,9 +18,6 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.common.utils.node_utils import compute_expr_hash
 from xorq.common.utils.provenance_utils import get_expr_hash
 from xorq.expr.api import (
-    _close_and_join_drains,
-    _drop_created_tables,
-    _run_cleanup,
     get_plans,
 )
 from xorq.expr.relations import (
@@ -679,123 +676,6 @@ def test_sql_view_does_not_write_or_leak(tmp_path: Path) -> None:
     assert _placeholder_tables(con) == before, "tee pass-through table leaked"
     # The view is still usable and the tee is transparent to it.
     assert view.execute()["a"].tolist() == TABLE["a"]
-
-
-def test_drop_created_tables_drops_all_and_raises(tmp_path: Path) -> None:
-    """_drop_created_tables must attempt every table even when one fails its
-    drop entirely, and surface the failure rather than swallowing it."""
-
-    class _FakeCon:
-        def __init__(self, *, fail_both: bool = False) -> None:
-            self.fail_both = fail_both
-            self.dropped: list[str] = []
-
-        def drop_table(self, name: str, force: bool = False) -> None:
-            if self.fail_both:
-                raise ValueError(f"drop_table {name}")
-            self.dropped.append(name)
-
-        def drop_view(self, name: str) -> None:
-            if self.fail_both:
-                raise ValueError(f"drop_view {name}")
-            self.dropped.append(name)
-
-    good_a, bad, good_b = _FakeCon(), _FakeCon(fail_both=True), _FakeCon()
-    created = {"a": good_a, "bad": bad, "b": good_b}
-
-    with pytest.raises(ValueError, match="drop_view bad"):
-        _drop_created_tables(created)
-
-    # the failing table in the middle did not strand the others
-    assert good_a.dropped == ["a"]
-    assert good_b.dropped == ["b"]
-
-
-def test_run_cleanup_joins_drains_before_dropping_tables() -> None:
-    """_run_cleanup must join every drain before dropping any table, so the
-    backend reader the drain consumes stays valid until the write completes."""
-    log: list[tuple[str, str]] = []
-
-    class _RecordingDrain:
-        def __init__(self, name: str) -> None:
-            self.name = name
-
-        def close(self) -> None:
-            log.append(("close", self.name))
-
-        def join(self) -> None:
-            log.append(("join", self.name))
-
-    class _RecordingCon:
-        def drop_table(self, name: str, force: bool = False) -> None:
-            log.append(("drop", name))
-
-    _run_cleanup(
-        [_RecordingDrain("d0"), _RecordingDrain("d1")], {"t0": _RecordingCon()}
-    )
-
-    join_idx = [i for i, (action, _) in enumerate(log) if action == "join"]
-    drop_idx = [i for i, (action, _) in enumerate(log) if action == "drop"]
-    assert join_idx and drop_idx
-    assert max(join_idx) < min(drop_idx), f"drop ran before a join: {log}"
-
-
-def test_run_cleanup_drops_tables_even_if_drain_fails() -> None:
-    """A drain failure must not strand the created tables, and the drain error
-    must still surface rather than being swallowed by the drop step."""
-    dropped: list[str] = []
-
-    class _FailingDrain:
-        def close(self) -> None:
-            pass
-
-        def join(self) -> None:
-            raise ValueError("drain boom")
-
-    class _RecordingCon:
-        def drop_table(self, name: str, force: bool = False) -> None:
-            dropped.append(name)
-
-    with pytest.raises(ValueError, match="drain boom"):
-        _run_cleanup([_FailingDrain()], {"t0": _RecordingCon()})
-
-    assert dropped == ["t0"], "table was not dropped after the drain failed"
-
-
-def test_close_and_join_drains_closes_all_when_one_close_fails() -> None:
-    # A close() failure on one drain (e.g. thread start fails under resource
-    # exhaustion) must not skip closing the rest, nor skip the join loop that
-    # reaps already-started drain threads. The close error is collected, not
-    # raised mid-loop.
-    log: list[tuple[str, str]] = []
-
-    class _RecordingDrain:
-        def __init__(self, name: str, fail_close: bool = False) -> None:
-            self.name = name
-            self.fail_close = fail_close
-
-        def close(self) -> None:
-            log.append(("close", self.name))
-            if self.fail_close:
-                raise RuntimeError(f"close boom {self.name}")
-
-        def join(self, timeout: float | None = None) -> None:
-            log.append(("join", self.name))
-
-    drains = [
-        _RecordingDrain("d0", fail_close=True),
-        _RecordingDrain("d1"),
-    ]
-
-    with pytest.raises(BaseException) as excinfo:  # noqa: PT011
-        _close_and_join_drains(drains)
-
-    assert ("close", "d0") in log and ("close", "d1") in log, (
-        f"a close() failure skipped a later close(): {log}"
-    )
-    assert ("join", "d1") in log, f"join loop did not run after a close failure: {log}"
-    messages = [str(e) for e in _flatten_exceptions(excinfo.value)]
-    assert any("close boom d0" in m for m in messages)
 
 
 def test_to_pyarrow_batches_full_consumption_cleans_up(tmp_path: Path) -> None:
@@ -1493,44 +1373,6 @@ def test_draining_iterator_join_surfaces_error() -> None:
     it.close()
     with pytest.raises(RuntimeError, match="simulated writer failure"):
         it.join(timeout=5)
-
-
-def _flatten_exceptions(exc: BaseException) -> list[BaseException]:
-    out = [exc]
-    for sub in getattr(exc, "exceptions", ()):  # BaseExceptionGroup (3.11+)
-        out.extend(_flatten_exceptions(sub))
-    if exc.__cause__ is not None:  # chained fallback (3.10)
-        out.extend(_flatten_exceptions(exc.__cause__))
-    return out
-
-
-def test_run_cleanup_aggregates_drain_and_drop_failures() -> None:
-    # Both cleanup steps run even when the first raises: a drain-join failure and
-    # a table-drop failure must surface together as a group, neither hiding the
-    # other (this is what the execute / to_pyarrow_batches paths rely on).
-    class _FailingDrain:
-        def close(self) -> None: ...
-
-        def join(self, timeout: float | None = None) -> None:
-            raise RuntimeError("drain join boom")
-
-    class _FailingCon:
-        def drop_table(self, name: str, force: bool = False) -> None:
-            raise RuntimeError("drop_table boom")
-
-        def drop_view(self, name: str) -> None:
-            raise RuntimeError("drop_view boom")
-
-    raised: BaseException | None = None
-    try:
-        _run_cleanup([_FailingDrain()], {"leaked_tbl": _FailingCon()})
-    except BaseException as exc:  # noqa: BLE001
-        raised = exc
-
-    assert raised is not None, "cleanup must surface the failures"
-    messages = [str(e) for e in _flatten_exceptions(raised)]
-    assert any("drain join boom" in m for m in messages)
-    assert any("drop_view boom" in m for m in messages)
 
 
 def test_draining_iterator_join_before_close_raises() -> None:

--- a/python/xorq/tests/util.py
+++ b/python/xorq/tests/util.py
@@ -49,3 +49,9 @@ def assert_frame_equal(
 
 def default_series_rename(series: pd.Series, name: str = "tmp") -> pd.Series:
     return series.rename(name)
+
+
+def reader_counts(expr: Any) -> list[int]:
+    from xorq.expr.remote_table_exec import count_remote_table_readers  # noqa: PLC0415
+
+    return sorted(count_remote_table_readers(expr).values())

--- a/python/xorq/vendor/ibis/expr/types/relations.py
+++ b/python/xorq/vendor/ibis/expr/types/relations.py
@@ -3302,17 +3302,17 @@ class Table(Expr, _FixedTextJupyterMixin):
             name = util.gen_name("sql_query")
             expr = self
 
-        from xorq.expr.api import _remove_tee_nodes, transformed
+        from xorq.expr.api import _remove_tee_nodes, remote_table_scope
 
         # Strip tee nodes first: defining a SQL view is a non-executing path, so
         # it must not register a pass-through table or fire the side-effect
         # write. Tee is schema-preserving, so the view schema is unaffected.
         # full close (placeholder drops included) on exit: only the schema
-        # probe runs while the scope is open. The returned SQLStringView
+        # probe runs while the scope is open.  The returned SQLStringView
         # embeds the transformed child, but executing it over RemoteTables
         # already fails at alias-name resolution before the released
         # resources could matter; closing here at least stops the leak.
-        with transformed(_remove_tee_nodes(expr)) as expr:
+        with remote_table_scope(_remove_tee_nodes(expr)) as expr:
             schema = backend._get_sql_string_view_schema(
                 name=name, table=expr, query=query
             )

--- a/python/xorq/vendor/ibis/expr/types/relations.py
+++ b/python/xorq/vendor/ibis/expr/types/relations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import itertools
 import operator
 import os
@@ -3303,16 +3302,17 @@ class Table(Expr, _FixedTextJupyterMixin):
             name = util.gen_name("sql_query")
             expr = self
 
-        from xorq.expr.api import _remove_tee_nodes, _transform_expr
+        from xorq.expr.api import _remove_tee_nodes, transformed
 
         # Strip tee nodes first: defining a SQL view is a non-executing path, so
         # it must not register a pass-through table or fire the side-effect
         # write. Tee is schema-preserving, so the view schema is unaffected.
-        (expr, _, _, _caches) = _transform_expr(_remove_tee_nodes(expr))
-
-        with contextlib.ExitStack() as stack:
-            for cache in _caches:
-                stack.enter_context(contextlib.closing(cache))
+        # full close (placeholder drops included) on exit: only the schema
+        # probe runs while the scope is open. The returned SQLStringView
+        # embeds the transformed child, but executing it over RemoteTables
+        # already fails at alias-name resolution before the released
+        # resources could matter; closing here at least stops the leak.
+        with transformed(_remove_tee_nodes(expr)) as expr:
             schema = backend._get_sql_string_view_schema(
                 name=name, table=expr, query=query
             )

--- a/python/xorq/vendor/ibis/expr/types/relations.py
+++ b/python/xorq/vendor/ibis/expr/types/relations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import itertools
 import operator
 import os
@@ -3307,11 +3308,16 @@ class Table(Expr, _FixedTextJupyterMixin):
         # Strip tee nodes first: defining a SQL view is a non-executing path, so
         # it must not register a pass-through table or fire the side-effect
         # write. Tee is schema-preserving, so the view schema is unaffected.
-        (expr, _, _) = _transform_expr(_remove_tee_nodes(expr))
+        (expr, _, _, _caches) = _transform_expr(_remove_tee_nodes(expr))
 
-        schema = backend._get_sql_string_view_schema(name=name, table=expr, query=query)
-        node = ops.SQLStringView(child=expr.op(), query=query, schema=schema)
-        return node.to_expr()
+        with contextlib.ExitStack() as stack:
+            for cache in _caches:
+                stack.enter_context(contextlib.closing(cache))
+            schema = backend._get_sql_string_view_schema(
+                name=name, table=expr, query=query
+            )
+            node = ops.SQLStringView(child=expr.op(), query=query, schema=schema)
+            return node.to_expr()
 
     def to_pandas(self, **kwargs) -> pd.DataFrame:
         """Convert a table expression to a pandas DataFrame.

--- a/uv.lock
+++ b/uv.lock
@@ -6260,7 +6260,7 @@ requires-dist = [
     { name = "adbc-driver-sqlite", marker = "extra == 'sqlite'", specifier = ">=1.4.0" },
     { name = "atpublic", specifier = ">=5.1" },
     { name = "attrs", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=24.1.0" },
-    { name = "batchcorder", specifier = ">=0.1.2" },
+    { name = "batchcorder", specifier = "==0.1.3" },
     { name = "boring-semantic-layer", marker = "extra == 'bsl'", specifier = ">=0.3.13" },
     { name = "cityhash", marker = "extra == 'sqlite'", specifier = ">=0.4.7,<1" },
     { name = "click", specifier = ">=8.0" },
@@ -6312,7 +6312,7 @@ requires-dist = [
     { name = "uv", specifier = ">=0.7.20" },
     { name = "xgboost", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'examples'", specifier = ">=1.6.1" },
     { name = "xorq-dasher", specifier = ">=0.1.1" },
-    { name = "xorq-datafusion", specifier = "==0.2.8" },
+    { name = "xorq-datafusion", specifier = "==0.2.9" },
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
 ]
@@ -6377,20 +6377,20 @@ wheels = [
 
 [[package]]
 name = "xorq-datafusion"
-version = "0.2.8"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/3b/e38b8eb7d9909273318ac61b47d19995bfb897b0c56987bc004086ae9535/xorq_datafusion-0.2.8.tar.gz", hash = "sha256:531ad0c0fb2fc8e547a11d6716d6739b8df352edec0dfa9e409f703cbae36693", size = 20660983, upload-time = "2026-05-27T17:13:23.97Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/f4/43d1e410fba403778a0dc8e092478ab34031b8b885b49bda0ec3da4e7beb/xorq_datafusion-0.2.9.tar.gz", hash = "sha256:77e47ef4614544eb6ffc75629b2940da0a446ddf7afece7354b9a40232e35304", size = 20660299, upload-time = "2026-06-09T09:02:36.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/f1/313d2a5f5d4bcf113140a45e5b6ca73c48c50922b77d80baa72626735f04/xorq_datafusion-0.2.8-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:42aaa81e86a4b2a4ba5959b2182d6db8860c8dbfb2c2ae8519621f1f89d706c5", size = 33167786, upload-time = "2026-05-27T17:13:02.786Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d3/881818cbd733520510b1c223d3a83da07892ff04964eb91902b5aa8475de/xorq_datafusion-0.2.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:4dbce3eb86532377ef966603169046b6acc5c428acd653641766fcf2294b894b", size = 30784360, upload-time = "2026-05-27T17:13:05.496Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4d/0810fea1926d89e6c83673304ecae86c611c9232ab2d41d151a13813a606/xorq_datafusion-0.2.8-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05ffa26fa8400f4a43fe8c3dc5a902d71478dd23cffd3d663ba313c1aa1583c6", size = 37223942, upload-time = "2026-05-27T17:13:08.292Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d5/dba5911784dfe51adcde0cabd283e51d3bd81159148ce1c593e3557c0317/xorq_datafusion-0.2.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8a8aeb997da35d063c07adca9c8f46aee003284d3a026a1029551d6036332af", size = 34616947, upload-time = "2026-05-27T17:13:11.181Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/41/add87c4ae0db13449c2261c7613e181d57fb9d48c13d3c4f01a985b6d30e/xorq_datafusion-0.2.8-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a62b5d4f2c08057f2ea11f580fafb8c8f1fe5b6efc86fa869447252b71cc8a75", size = 31989743, upload-time = "2026-05-27T17:13:14.191Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/45/bfe393e630bca11604ef41f4234624fda408edc6e6038093b6bd9f7a06b4/xorq_datafusion-0.2.8-cp38-abi3-win32.whl", hash = "sha256:18038b116c68b0ee346359eea325596126aa32085435ee37fb46092d4ba74985", size = 32918250, upload-time = "2026-05-27T17:13:16.582Z" },
-    { url = "https://files.pythonhosted.org/packages/91/45/a88db36693345213b28c50c8a20043e87f74c2dc54040a24b122c02b691e/xorq_datafusion-0.2.8-cp38-abi3-win_amd64.whl", hash = "sha256:16166167a59aedda7fa330bbca1af5729db8fd999c991ed1a283165cf852fb4a", size = 36648477, upload-time = "2026-05-27T17:13:21.675Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8d/d3fbcc1fc0789fc788390c36f9fddb37ac633bda1043501e617c7ff1c4a7/xorq_datafusion-0.2.9-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:206b10ee317b69644d4abd6a7c4e7ff14803bc0f0604fcd337ae5023dfac6514", size = 33154027, upload-time = "2026-06-09T09:02:09.078Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/37/c27add86a1569d1f8fdec1061e98d158b1f212c528e9291656d08aa5c2e0/xorq_datafusion-0.2.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:21446b86ed7039f719f81ae9bffc6210af6fd1cb23acc42b176782924ed48592", size = 30779807, upload-time = "2026-06-09T09:02:13.136Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/647dfd72d02f607581619b811c7b387aaaa4e15c4affddc28d784d0b995e/xorq_datafusion-0.2.9-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:480bc8747791f7dca0aacc980d23e8a70f330d33ee7d5d64e07b517b23fb5507", size = 37197416, upload-time = "2026-06-09T09:02:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/be/f7451c3cfb8d410e78b7e7ba26413425d1bd4cf91ea2a80e5a15f8398f31/xorq_datafusion-0.2.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d825533bbac509df0477e641ca0c8f8627c8116a222ff42209ad264df4becd87", size = 34614882, upload-time = "2026-06-09T09:02:19.682Z" },
+    { url = "https://files.pythonhosted.org/packages/48/bc/ecc669bf5524ec4f75a7f744f2b7c40b614ad4a8cad9af5b344dd2f54e28/xorq_datafusion-0.2.9-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48e7a904e8a1fb1d2cfb43d8a3553300ab1aa73842d54c6e03de6bc805dce946", size = 31996314, upload-time = "2026-06-09T09:02:22.555Z" },
+    { url = "https://files.pythonhosted.org/packages/48/fa/d8c71cb7bb92e0972a11dcaab79c0505b647d6353ab0b8e71b422138e48a/xorq_datafusion-0.2.9-cp38-abi3-win32.whl", hash = "sha256:7fe780e5678359a6b5a587cd9875d16e46a066cc5c1a633d8a92de50c4a83c51", size = 32922674, upload-time = "2026-06-09T09:02:25.983Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e6/c50fab0701210aae471c65fed581466af3754069e2ac1011338dac59411d/xorq_datafusion-0.2.9-cp38-abi3-win_amd64.whl", hash = "sha256:ab5657ff9506d19da53eb732228461600bdc101c84b69e0ad20b7e2ebdf6ae1b", size = 36658028, upload-time = "2026-06-09T09:02:33.132Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -420,6 +420,23 @@ wheels = [
 ]
 
 [[package]]
+name = "batchcorder"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/4d/ef6ee4f348b31736c34dc81c327052a61e77f31fe1bf862ccb28364d4410/batchcorder-0.1.3.tar.gz", hash = "sha256:bd74b90c83d146bf1bbf4582c1e7e04b312fe17df8bf1b034c0ba90532bf2b14", size = 245435, upload-time = "2026-06-08T11:34:40.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8b/f13bb954e848b868e8a3bfa9116bfa7cbf541e665c3575852815757e5fe6/batchcorder-0.1.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8971845bb2b92e318d19d39b373e13b40c1fa98b0eeed37b8aee63a59ce7c975", size = 1184642, upload-time = "2026-06-08T11:34:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a5/ecafe8a525d507d2b49ee612da2cf119832674cb535318f2092d033935cc/batchcorder-0.1.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:024f07f8daa8f5fe00eb577abd8e80baecb5a74374579df68194ac3eff77ea29", size = 1135124, upload-time = "2026-06-08T11:34:31.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e1/5049542d85de2ec3753655e11224a9fa0422eb135228670886d5eb9ab339/batchcorder-0.1.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:703d2ac6e1409e4c199ad71042600b4e27a658847883fe173dbfd65e7a5fff49", size = 1405786, upload-time = "2026-06-08T11:34:33.393Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/4f/e92d207da271016428f2dbb4bae1d23e5d6ffb2f4120131ef69d8bbdda7c/batchcorder-0.1.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:24a3825c707149851bc2271a93a3873842bb282f1fc031c41a022c38ed8c857a", size = 1342325, upload-time = "2026-06-08T11:34:35.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/66e46d2a6e82e074abd03b49d53ff6b55acd2c2b634733beea86aa2a8d4d/batchcorder-0.1.3-cp310-abi3-win32.whl", hash = "sha256:47c5a1846f9e28cc6d1d6ec802525d64244e9df7f6a2f396b9ece8ee66b690f3", size = 891880, upload-time = "2026-06-08T11:34:37.34Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ae/36b740b070a756d31ada6d46636918fab3aa0f89b809ccdde32a773ae2c9/batchcorder-0.1.3-cp310-abi3-win_amd64.whl", hash = "sha256:90c8a5155020213bcda2e5a9d533a429aee04cde4ec5cd032da932b8341d83f2", size = 1009069, upload-time = "2026-06-08T11:34:38.921Z" },
+]
+
+[[package]]
 name = "beartype"
 version = "0.22.9"
 source = { registry = "https://pypi.org/simple" }
@@ -6091,6 +6108,7 @@ source = { editable = "." }
 dependencies = [
     { name = "atpublic" },
     { name = "attrs" },
+    { name = "batchcorder" },
     { name = "click" },
     { name = "cloudpickle" },
     { name = "cryptography" },
@@ -6242,6 +6260,7 @@ requires-dist = [
     { name = "adbc-driver-sqlite", marker = "extra == 'sqlite'", specifier = ">=1.4.0" },
     { name = "atpublic", specifier = ">=5.1" },
     { name = "attrs", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=24.1.0" },
+    { name = "batchcorder", specifier = ">=0.1.2" },
     { name = "boring-semantic-layer", marker = "extra == 'bsl'", specifier = ">=0.3.13" },
     { name = "cityhash", marker = "extra == 'sqlite'", specifier = ">=0.4.7,<1" },
     { name = "click", specifier = ">=8.0" },
@@ -6251,8 +6270,8 @@ requires-dist = [
     { name = "databricks-sql-connector", marker = "extra == 'databricks'", specifier = ">=3.0.0" },
     { name = "datafusion", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'datafusion'", specifier = ">=0.6,<49" },
     { name = "duckdb", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'examples'", specifier = ">=0.10.3,<2" },
-    { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.1.3" },
-    { name = "duckdb", marker = "extra == 'gizmosql'", specifier = ">=1.1.3" },
+    { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.5" },
+    { name = "duckdb", marker = "extra == 'gizmosql'", specifier = ">=1.5" },
     { name = "filelock", specifier = ">=3.13" },
     { name = "geoarrow-types", marker = "extra == 'geospatial'", specifier = ">=0.2,<1" },
     { name = "git-annex", marker = "extra == 'annex'", specifier = ">=10.20250220" },
@@ -6293,7 +6312,7 @@ requires-dist = [
     { name = "uv", specifier = ">=0.7.20" },
     { name = "xgboost", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'examples'", specifier = ">=1.6.1" },
     { name = "xorq-dasher", specifier = ">=0.1.1" },
-    { name = "xorq-datafusion", specifier = "==0.2.7" },
+    { name = "xorq-datafusion", specifier = "==0.2.8" },
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
 ]
@@ -6306,7 +6325,7 @@ dev = [
     { name = "blackdoc", specifier = "==0.4.6" },
     { name = "codespell", extras = ["hard-encoding-detection", "toml"], specifier = "==2.4.2" },
     { name = "datafusion", specifier = ">=43.1.0" },
-    { name = "duckdb", specifier = ">=1.1.3" },
+    { name = "duckdb", specifier = ">=1.5" },
     { name = "git-cliff", specifier = ">=2.2.1,<3.0.0" },
     { name = "ipython", specifier = ">=8.19.0,<9.11.0" },
     { name = "matplotlib", specifier = ">=3.8.0" },
@@ -6358,20 +6377,20 @@ wheels = [
 
 [[package]]
 name = "xorq-datafusion"
-version = "0.2.7"
+version = "0.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/d01aaf4b6f6940f8709321d356ca29490280a0bce85b90f4247b13256725/xorq_datafusion-0.2.7.tar.gz", hash = "sha256:be1dbdbef6ea513df1aae189fe5fa6e54a8e8556dc824a74a888473b4c1929cb", size = 20639907, upload-time = "2026-05-14T11:00:22.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/3b/e38b8eb7d9909273318ac61b47d19995bfb897b0c56987bc004086ae9535/xorq_datafusion-0.2.8.tar.gz", hash = "sha256:531ad0c0fb2fc8e547a11d6716d6739b8df352edec0dfa9e409f703cbae36693", size = 20660983, upload-time = "2026-05-27T17:13:23.97Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/84/e514a0e1d63197817de49da5d940136060e57447396c69748ebae210c291/xorq_datafusion-0.2.7-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5152aabfc7452ef5e7f7469d7ed835cb6d478696745ce98eccac1abf9cb04112", size = 48099334, upload-time = "2026-05-14T10:59:48.596Z" },
-    { url = "https://files.pythonhosted.org/packages/51/98/5f8a1555af37c4a814c69231015ac08dea4ade4e8b250509bb65cdc56ae3/xorq_datafusion-0.2.7-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:3874fc7e0186e53dcce7fe5390a71be97c8c386f5044063cb96327a64d6a9112", size = 45730841, upload-time = "2026-05-14T10:59:54.741Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/f9/8137598bf67c40ea0b75d39adfe8a3b6824440a56e9bc201f3d26992c355/xorq_datafusion-0.2.7-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:225b612874ee2da79c2a7d80ec4e7040baaf6db0f1fa364dc79b16b320fb17c0", size = 58486501, upload-time = "2026-05-14T10:59:59.092Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/23/2fa5c4eb26d3755cf34df95aeb79af76647e04159c88897232a561b46fdd/xorq_datafusion-0.2.7-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fec22bd24018410152fc5f8582033e86046f0f31e581aaa2f29103d3dacb35ef", size = 51751418, upload-time = "2026-05-14T11:00:04.567Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/4c/1309100ba3e21be388d8dec28c4560481447cada4f409da1ea0863b7bd70/xorq_datafusion-0.2.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b1177c5dcd9ea3b519d2c9d2db16296740463f2302319dda88983a9204463a32", size = 49958539, upload-time = "2026-05-14T11:00:09.619Z" },
-    { url = "https://files.pythonhosted.org/packages/08/6a/5dcf6d9db0d7b94afc9851f309c505b9edd4c4c571c11efd301a4dad12cc/xorq_datafusion-0.2.7-cp38-abi3-win32.whl", hash = "sha256:36193827af0c134b14dcf6229ffe9d064e8e8a94888373e6ecaf4c47a5ef6587", size = 40319107, upload-time = "2026-05-14T11:00:14.359Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/35/e820dba4c884f3eb6aaec6a8a53b94db0a4a7d9ec1b2cc4bbfde45df26fd/xorq_datafusion-0.2.7-cp38-abi3-win_amd64.whl", hash = "sha256:b018b51dc8d1a4c9336cb3a477885fe5224e376b8ba83a2fa191c43dde90e6fe", size = 44687714, upload-time = "2026-05-14T11:00:18.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f1/313d2a5f5d4bcf113140a45e5b6ca73c48c50922b77d80baa72626735f04/xorq_datafusion-0.2.8-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:42aaa81e86a4b2a4ba5959b2182d6db8860c8dbfb2c2ae8519621f1f89d706c5", size = 33167786, upload-time = "2026-05-27T17:13:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d3/881818cbd733520510b1c223d3a83da07892ff04964eb91902b5aa8475de/xorq_datafusion-0.2.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:4dbce3eb86532377ef966603169046b6acc5c428acd653641766fcf2294b894b", size = 30784360, upload-time = "2026-05-27T17:13:05.496Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4d/0810fea1926d89e6c83673304ecae86c611c9232ab2d41d151a13813a606/xorq_datafusion-0.2.8-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05ffa26fa8400f4a43fe8c3dc5a902d71478dd23cffd3d663ba313c1aa1583c6", size = 37223942, upload-time = "2026-05-27T17:13:08.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d5/dba5911784dfe51adcde0cabd283e51d3bd81159148ce1c593e3557c0317/xorq_datafusion-0.2.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8a8aeb997da35d063c07adca9c8f46aee003284d3a026a1029551d6036332af", size = 34616947, upload-time = "2026-05-27T17:13:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/41/add87c4ae0db13449c2261c7613e181d57fb9d48c13d3c4f01a985b6d30e/xorq_datafusion-0.2.8-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a62b5d4f2c08057f2ea11f580fafb8c8f1fe5b6efc86fa869447252b71cc8a75", size = 31989743, upload-time = "2026-05-27T17:13:14.191Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/45/bfe393e630bca11604ef41f4234624fda408edc6e6038093b6bd9f7a06b4/xorq_datafusion-0.2.8-cp38-abi3-win32.whl", hash = "sha256:18038b116c68b0ee346359eea325596126aa32085435ee37fb46092d4ba74985", size = 32918250, upload-time = "2026-05-27T17:13:16.582Z" },
+    { url = "https://files.pythonhosted.org/packages/91/45/a88db36693345213b28c50c8a20043e87f74c2dc54040a24b122c02b691e/xorq_datafusion-0.2.8-cp38-abi3-win_amd64.whl", hash = "sha256:16166167a59aedda7fa330bbca1af5729db8fd999c991ed1a283165cf852fb4a", size = 36648477, upload-time = "2026-05-27T17:13:21.675Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix #983: asof_join with tolerance and self-join returned empty results
because SafeTee exhausted a one-shot Arrow iterator on re-scan.

StreamCache (batchcorder 0.1.3) wraps any Arrow stream in a replayable
Rust-backed cache. DuckDB/DataFusion acquire independent StreamCacheReader
handles per scan — thread-safe concurrent reads. Only memory mode is used;
batches live in a Rust Arc<Vec<RecordBatch>>. Disk spill is not configured
and not enabled.

## Bounded memory via `max_readers`

Each StreamCache is constructed with `max_readers` = a per-RemoteTable scan
count, so batches are evicted once all readers advance past them (instead of
retaining the whole stream). batchcorder enforces `max_readers` as a hard
cap: an under-count crashes (`ValueError: Maximum number of readers reached`
when the backend creates reader N+1), an over-count silently disables
eviction. Omitting it (passing `None`) leaves the cache unbounded — always
safe, no eviction.

The scan count is **not** visible in the expression graph: a single graph
reference can compile to several physical scans (e.g. a self-join, the
canonical multi-scan shape). `count_remote_table_readers` therefore rewrites
each RemoteTable to a placeholder under a fresh unique name, compiles the
expression to a sqlglot AST, and counts `Table` nodes bearing that name —
robust across compiler lowering and immune to inflation from column refs,
aliases, or string literals. Counts are floored at 1 (a bare RemoteTable is
still scanned once; `max_readers=0` would forbid the reader that is in fact
created); on SQL-compile failure (e.g. a non-SQL backend) the mapping is
empty and the cache is left unbounded.

The count is a best-effort **lower bound**, not an exact scan count: it sees
only the scans the compiled SQL spells out, not re-scans the backend's
optimiser introduces below the SQL layer. Known gap: a DuckDB `PARTITION BY`-
only aggregate window lowers to a `GROUP BY` self-join that scans its input
twice while the AST counts one — an under-count that currently raises. See
the ADR ("Counting accuracy") for the tradeoff.

DuckDB scans the cache directly, so the count drives eviction and an
under-count crashes. DataFusion reads the outer cache once (`from_stream`)
and re-wraps it into an inner cache it scans per reference, so an over-count
on the outer cache there merely disables eviction (never crashes).

## Core changes

- **remote_table_exec.py** (new): `register_and_transform_remote_tables`,
  `count_remote_table_readers`, `RemoteTableScope`, `bind_scope_to_reader`,
  and `prepare_create_table_from_expr` — moved out of relations.py. The
  replacer creates one StreamCache per RemoteTable node with `max_readers`
  from `count_remote_table_readers`, and returns `(expr, scope)` where the
  `RemoteTableScope` owns every materialized resource (upstream readers,
  StreamCaches, placeholder tables, tee drains) behind one idempotent
  `close()` that tears down in dependency order.
- **relations.py**: SafeTee, the old graph-walk
  `register_and_transform_remote_tables`, and `prepare_create_table_from_expr`
  removed (relocated to remote_table_exec.py). RemoteTable caches its
  reader's physical schema for the StreamCache.
- **api.py**: `_transform_expr` returns `(expr, scope)`. Eager call sites
  (`_pandas_execute`, `get_plans`, caching/storage) use the new
  `remote_table_scope` context manager, which closes the scope on exit and
  raises tee/WAP drain failures only on the success path. The streaming
  `to_pyarrow_batches` path uses `bind_scope_to_reader`, which defers
  `scope.close()` to the result reader's generator `finally` (with a
  `weakref.finalize` backstop for readers abandoned before first read) —
  replacing the removed `rbr_wrapper`/`_run_cleanup` helpers.

## Backend `read_record_batches` plumbing

- **logical schema**: `read_record_batches` takes the logical schema and
  projects/casts the physical reader down to it, dropping extra physical
  columns. `project_and_cast_reader` short-circuits when the schema already
  matches. Redundant schema args were removed where the reader carries it.
- **xorq_datafusion**: registers `StreamCache` via `StreamCache.cast` (a
  replayable casting view over the same buffer) so DataFusion reads purely
  from Rust — prevents the GIL/Mutex deadlock fixed upstream in
  xorq-datafusion ef86e2b (Python::attach moved to spawn_blocking). Uses
  `CastingStreamCache` so fan-out scans still evict; `read_record_batches`
  collapsed into a single match with a shared `_casting_reader` helper and
  rollback hoisted across all source types. Bumps xorq-datafusion 0.2.7 →
  0.2.9.
- **postgres**: adds a `to_pyarrow_batches` override on the xorq Backend;
  uses PgADBC for the ADBC primary path + psycopg fallback for session-local
  temp tables, logging the swallowed ADBC connection failure before falling
  back. Plugs an ADBC leak and restores remote-table kwargs. (The vendored
  postgres backend is not touched.)
- **gizmosql**: materializes empty `StreamCache` streams and emits a
  zero-row batch so an empty stream still ingests over Flight SQL.
- **sqlite / pandas / pyiceberg**: handle `StreamCache` input in
  `read_record_batches` (shared `coerce_to_arrow_table` helper).
- **snowflake**: pass keypair as a PEM string for adbc>=1.11 compat; drop
  snowflake from `_ADBC_BACKENDS` `mode="replace"`; restore `create_table`
  permissiveness for non-Expr objects.
- **flight**: use `to_reader` instead of the pyarrow-14-only `from_stream`.

## Tests

- expr/tests/test_relations.py: unit tests for `count_remote_table_readers`
  (bare=1, single scan=1, many fields=1, self-join=2, asof double-scan=[1,2],
  unbindable → empty mapping)
- expr/tests/test_transform_scope.py + test_stream_cache_contract.py:
  RemoteTableScope lifecycle and StreamCache reader contract
- backends/duckdb/tests/test_into_backend.py and
  backends/xorq_datafusion/tests/test_into_backend.py: into_backend fan-out
  edge cases — bare, filter, self-join, two scalar subqueries, 3-way union,
  two distinct tables, empty-table fan-out, nested chain, asof double-scan
- backends/duckdb/tests/test_asof_join.py: assert single-scan tolerance
  lowering after #2086; pin the max_readers under-count crash for the
  partition-by window
- backends/xorq_datafusion/tests/test_stream_cache_deadlock.py: subprocess
  regression test for the two-scan GIL/Mutex deadlock; plus reentrancy and
  register coverage
- backends/{gizmosql,postgres,sqlite,pandas,snowflake} tests: backend
  read_record_batches / into_backend / to_pyarrow_batches coverage

Decision recorded in docs/adr/0013-batchcorder-stream-cache-for-remote-
table-fan-out.md. Covers: root cause, SafeTee failure modes, StreamCache
resource lifecycle (RemoteTableScope; explicit close at all executing call
sites), memory-only tradeoffs, the max_readers counting-accuracy gap, and
alternatives considered (tee, pre-ingest to pa.Table).

Closes #983
