### PR TITLE
docs(bsl-catalog): drop unneeded duckdb extra from tutorial

### DIFF
--- a/docs/tutorials/core_tutorials/build_a_semantic_catalog.qmd
+++ b/docs/tutorials/core_tutorials/build_a_semantic_catalog.qmd
@@ -19,12 +19,12 @@ You need:
 
 ## Set up a project directory
 
-`catalog.add(...)` needs a `pyproject.toml` in the working directory (or an ancestor) so it can pin the xorq version embedded in the entry. Create a fresh project and pull in xorq with the BSL and DuckDB extras:
+`catalog.add(...)` needs a `pyproject.toml` in the working directory (or an ancestor) so it can pin the xorq version embedded in the entry. Create a fresh project and pull in xorq with the BSL extra:
 
 ```bash
 mkdir flights-tutorial && cd flights-tutorial
 uv init --bare
-uv add "xorq[bsl,duckdb]"
+uv add "xorq[bsl]"
 printf '\n[tool.setuptools]\npy-modules = []\n' >> pyproject.toml
 ```
 
@@ -49,11 +49,6 @@ source .venv/bin/activate
 ```
 
 The rest of the tutorial assumes the venv is active.
-:::
-
-::: {.callout-note}
-### Why DuckDB?
-The catalog stores the in-memory `flights` table as a parquet file alongside the entry. Reading that parquet back when you recover the model uses DuckDB by default, so it has to be installed.
 :::
 
 ::: {.callout-note}

--- a/docs/tutorials/core_tutorials/build_a_semantic_catalog.snippets.py
+++ b/docs/tutorials/core_tutorials/build_a_semantic_catalog.snippets.py
@@ -6,8 +6,8 @@ so the snippets file mirrors the reader's experience top-to-bottom; the final
 unified script in the tutorial is the same code in one piece, so we don't
 repeat it here.
 
-The tutorial tells readers to ``uv init`` and ``uv add "xorq[bsl,duckdb]"`` in
-a project directory before running the script. We mimic that here by chdir'ing
+The tutorial tells readers to ``uv init`` and ``uv add "xorq[bsl]"`` in a
+project directory before running the script. We mimic that here by chdir'ing
 into a fresh tempdir with a pyproject.toml + requirements.txt that name xorq
 as a dep — that's the same shape the wheel packager sees in the reader's
 project, just hand-written instead of resolved by ``uv lock``. Skipping the
@@ -16,7 +16,7 @@ starts to depend on a fully-resolved transitive lock, this fixture should be
 upgraded to run ``uv lock`` for real.
 """
 
-# %% --- test fixture: stand in for `uv init && uv add "xorq[bsl,duckdb]"`
+# %% --- test fixture: stand in for `uv init && uv add "xorq[bsl]"`
 import os as _os
 import shutil as _shutil
 import tempfile as _tempfile
@@ -25,10 +25,10 @@ from pathlib import Path as _Path
 _workdir = _Path(_tempfile.mkdtemp(prefix="xorq-build-tutorial-"))
 (_workdir / "pyproject.toml").write_text(
     '[project]\nname = "flights-tutorial"\nversion = "0.0.0"\n'
-    'dependencies = ["xorq[bsl,duckdb]"]\n'
+    'dependencies = ["xorq[bsl]"]\n'
     "[tool.setuptools]\npackages = []\n"
 )
-(_workdir / "requirements.txt").write_text("xorq[bsl,duckdb]\n")
+(_workdir / "requirements.txt").write_text("xorq[bsl]\n")
 _os.chdir(_workdir)
 # --- end fixture ---
 


### PR DESCRIPTION
## Summary
- The Build-a-Semantic-Catalog tutorial told readers to install `xorq[bsl,duckdb]` and included a "Why DuckDB?" callout claiming the catalog's parquet read-back path needed it. That's not (or no longer) true — the default `xorq_datafusion` backend handles the full memtable → catalog → recover → execute round-trip on its own.
- Drops the `duckdb` extra from the `uv add` line, removes the stale callout, and updates the snippets fixture's embedded `pyproject.toml`/`requirements.txt` so it matches.

## Test plan
- [x] Re-ran `docs/tutorials/core_tutorials/build_a_semantic_catalog.snippets.py` end-to-end with `duckdb` import-blocked via a `sys.meta_path` finder; output (dimensions, both queries, the deliberate-failure assertion, recover-from-fresh-handle query) matches the tutorial prose verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)