### PR TITLE
fix(datafusion): harden read_record_batches and tighten types

### DIFF
--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -696,7 +696,13 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
-        self.con.register_record_batch_reader(table_ident, source.cast(source.schema))
+        schema = source.schema
+        self.con.register_record_batch_reader(
+            table_ident,
+            pa.RecordBatchReader.from_batches(
+                schema, (batch.select(schema.names).cast(schema) for batch in source)
+            ),
+        )
         return self.table(table_name)
 
     def execute(self, expr: ir.Expr, **kwargs: Any):

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import contextlib
 import functools
 import inspect
+import itertools
 import typing
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -692,15 +693,81 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
         return self.register(delta_table.to_pyarrow_dataset(), table_name=table_name)
 
-    def read_record_batches(self, source, table_name=None):
+    def read_record_batches(
+        self,
+        source: pa.Table | pa.RecordBatchReader | Iterable[pa.RecordBatch],
+        table_name: str | None = None,
+    ) -> ir.Table:
+        """Register Arrow data as a table in the current database.
+
+        Each batch is cast to the declared schema before being handed to
+        DataFusion. This prevents silent data corruption when physical Arrow
+        types differ from the declared schema (e.g. ``large_utf8`` batches
+        with a ``utf8`` schema), which would otherwise cause DataFusion to
+        misread 64-bit offsets as 32-bit across the C Data Interface boundary.
+
+        Parameters
+        ----------
+        source
+            The Arrow data to register. Accepts:
+
+            - ``pa.Table`` — converted to batches via ``to_batches()``.
+            - ``pa.RecordBatchReader`` — consumed directly; schema taken from
+              the reader.
+            - Any ``Iterable[pa.RecordBatch]`` (list, tuple, generator) —
+              schema inferred from the first batch.
+        table_name
+            Name for the registered table. Defaults to a sequentially
+            generated name.
+
+        Returns
+        -------
+        ir.Table
+            The just-registered table.
+
+        Raises
+        ------
+        ValueError
+            If ``source`` is an iterable that yields no batches.
+
+        Examples
+        --------
+        From a ``pa.Table``:
+
+        >>> import pyarrow as pa
+        >>> import xorq.api as xo
+        >>> t = xo.connect().read_record_batches(pa.table({"a": [1, 2, 3]}))
+
+        From a list of ``pa.RecordBatch``:
+
+        >>> batches = [pa.record_batch({"a": [1, 2]}), pa.record_batch({"a": [3]})]
+        >>> t = xo.connect().read_record_batches(batches)
+
+        """
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
-        schema = source.schema
+        schema: pa.Schema
+        batches: Iterable[pa.RecordBatch]
+        match source:
+            case pa.Table():
+                schema = source.schema
+                batches = source.to_batches()
+            case pa.RecordBatchReader():
+                schema = source.schema
+                batches = source
+            case _:
+                it = iter(source)
+                try:
+                    first = next(it)
+                except StopIteration:
+                    raise ValueError("source contains no record batches") from None
+                schema = first.schema
+                batches = itertools.chain([first], it)
         self.con.register_record_batch_reader(
             table_ident,
             pa.RecordBatchReader.from_batches(
-                schema, (batch.select(schema.names).cast(schema) for batch in source)
+                schema, (batch.select(schema.names).cast(schema) for batch in batches)
             ),
         )
         return self.table(table_name)

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -734,9 +734,11 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
         Raises
         ------
+        TypeError
+            If ``source`` is not a ``pa.Table``, ``pa.RecordBatchReader``, or iterable.
         ValueError
-            If ``source`` is an iterable or ``pa.Table`` that yields no batches,
-            or if a batch is missing columns required by the declared schema.
+            If ``source`` has no rows, or if a batch is missing columns required
+            by the declared schema.
             Cast errors from type incompatibilities are deferred: they surface
             during ``.execute()``, not at this call site, because batches are
             cast lazily as DataFusion consumes the reader.
@@ -758,23 +760,31 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
+        if not isinstance(source, (pa.Table, pa.RecordBatchReader)) and not hasattr(
+            source, "__iter__"
+        ):
+            raise TypeError(f"unsupported source type: {type(source).__name__}")
         schema: pa.Schema
         batches: Iterable[pa.RecordBatch]
         match source:
             case pa.Table():
                 if source.num_rows == 0:
-                    raise ValueError("source contains no record batches")
+                    raise ValueError("source has no rows")
                 schema = source.schema
                 batches = source.to_batches()
             case pa.RecordBatchReader():
                 schema = source.schema
-                batches = source
+                try:
+                    first = source.read_next_batch()
+                except StopIteration:
+                    raise ValueError("source has no rows") from None
+                batches = itertools.chain([first], source)
             case _:
                 it = iter(source)
                 try:
                     first = next(it)
                 except StopIteration:
-                    raise ValueError("source contains no record batches") from None
+                    raise ValueError("source has no rows") from None
                 schema = first.schema
                 batches = itertools.chain([first], it)
         self.con.register_record_batch_reader(

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -737,8 +737,8 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         TypeError
             If ``source`` is not a ``pa.Table``, ``pa.RecordBatchReader``, or iterable.
         ValueError
-            If ``source`` has no rows, or if a batch is missing columns required
-            by the declared schema.
+            If ``source`` is an iterable with no rows (schema cannot be inferred),
+            or if a batch is missing columns required by the declared schema.
             Cast errors from type incompatibilities are deferred: they surface
             during ``.execute()``, not at this call site, because batches are
             cast lazily as DataFusion consumes the reader.
@@ -768,8 +768,6 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         batches: Iterable[pa.RecordBatch]
         match source:
             case pa.Table():
-                if source.num_rows == 0:
-                    raise ValueError("source has no rows")
                 schema = source.schema
                 batches = source.to_batches()
             case pa.RecordBatchReader():
@@ -777,8 +775,9 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 try:
                     first = source.read_next_batch()
                 except StopIteration:
-                    raise ValueError("source has no rows") from None
-                batches = itertools.chain([first], source)
+                    batches = iter([])
+                else:
+                    batches = itertools.chain([first], source)
             case _:
                 it = iter(source)
                 try:

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -57,6 +57,13 @@ from xorq.vendor.ibis.formats.pyarrow import PyArrowType
 from xorq.vendor.ibis.util import gen_name, normalize_filename, normalize_filenames
 
 
+def _select_and_cast(batch, schema):
+    missing = set(schema.names) - set(batch.schema.names)
+    if missing:
+        raise ValueError(f"batch missing columns required by schema: {sorted(missing)}")
+    return batch.select(schema.names).cast(schema)
+
+
 def _compile_pyarrow_udwf(udwf_node):
     def make_datafusion_udwf(
         input_types,
@@ -728,7 +735,11 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         Raises
         ------
         ValueError
-            If ``source`` is an iterable that yields no batches.
+            If ``source`` is an iterable or ``pa.Table`` that yields no batches,
+            or if a batch is missing columns required by the declared schema.
+            Cast errors from type incompatibilities are deferred: they surface
+            during ``.execute()``, not at this call site, because batches are
+            cast lazily as DataFusion consumes the reader.
 
         Examples
         --------
@@ -751,6 +762,8 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         batches: Iterable[pa.RecordBatch]
         match source:
             case pa.Table():
+                if source.num_rows == 0:
+                    raise ValueError("source contains no record batches")
                 schema = source.schema
                 batches = source.to_batches()
             case pa.RecordBatchReader():
@@ -767,7 +780,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         self.con.register_record_batch_reader(
             table_ident,
             pa.RecordBatchReader.from_batches(
-                schema, (batch.select(schema.names).cast(schema) for batch in batches)
+                schema, (_select_and_cast(batch, schema) for batch in batches)
             ),
         )
         return self.table(table_name)

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -58,12 +58,9 @@ from xorq.vendor.ibis.util import gen_name, normalize_filename, normalize_filena
 
 
 def _select_and_cast(batch: pa.RecordBatch, schema: pa.Schema) -> pa.RecordBatch:
-    missing = set(schema.names) - set(batch.schema.names)
-    if missing:
-        raise ValueError(f"batch missing columns required by schema: {sorted(missing)}")
-    extra = set(batch.schema.names) - set(schema.names)
-    if extra:
-        raise ValueError(f"batch has columns not in schema: {sorted(extra)}")
+    mismatch = set(schema.names).symmetric_difference(batch.schema.names)
+    if mismatch:
+        raise ValueError(f"batch schema mismatch: {sorted(mismatch)}")
     return batch.select(schema.names).cast(schema)
 
 

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import itertools
 import typing
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -57,14 +57,17 @@ from xorq.vendor.ibis.formats.pyarrow import PyArrowType
 from xorq.vendor.ibis.util import gen_name, normalize_filename, normalize_filenames
 
 
-def _select_and_cast(batch, schema):
+def _select_and_cast(batch: pa.RecordBatch, schema: pa.Schema) -> pa.RecordBatch:
     missing = set(schema.names) - set(batch.schema.names)
     if missing:
         raise ValueError(f"batch missing columns required by schema: {sorted(missing)}")
+    extra = set(batch.schema.names) - set(schema.names)
+    if extra:
+        raise ValueError(f"batch has columns not in schema: {sorted(extra)}")
     return batch.select(schema.names).cast(schema)
 
 
-def _compile_pyarrow_udwf(udwf_node):
+def _compile_pyarrow_udwf(udwf_node) -> WindowUDF:
     def make_datafusion_udwf(
         input_types,
         return_type,
@@ -170,7 +173,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
     compiler = compiler
 
     @staticmethod
-    def _translate_sort(exprs: list[ir.Expr]):
+    def _translate_sort(exprs: list[ir.Expr]) -> list[Expr]:
         result = []
         for expr in exprs:
             if not isinstance(node := expr.op(), ops.SortKey):
@@ -184,7 +187,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         return result
 
     @property
-    def version(self):
+    def version(self) -> str:
         return xorq.__version__
 
     def do_connect(self, config: SessionConfig | None = None) -> None:
@@ -215,7 +218,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         pass
 
     @contextlib.contextmanager
-    def _safe_raw_sql(self, sql: sge.Statement) -> Any:
+    def _safe_raw_sql(self, sql: sge.Statement) -> Iterator[list[pa.RecordBatch]]:
         yield self.raw_sql(sql).collect()
 
     def _get_schema_using_query(self, query: str) -> sch.Schema:
@@ -249,7 +252,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             }
         )
 
-    def _register_builtin_udfs(self):
+    def _register_builtin_udfs(self) -> None:
         from xorq.backends.xorq_datafusion import udfs  # noqa: PLC0415
 
         for name, func in inspect.getmembers(
@@ -339,7 +342,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             name=udf_node.__func_name__,
         )
 
-    def raw_sql(self, query: str | sge.Expression) -> Any:
+    def raw_sql(self, query: str | sge.Expression) -> DataFrame:
         """Execute a SQL string `query` against the database."""
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.dialect, pretty=True)
@@ -542,7 +545,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         raw_sql = backend.compile(source.as_table(), **kwargs)
         return backend.con.sql(raw_sql)
 
-    def _register_path(self, path: str, table_name: str, **kwargs) -> ir.Table:
+    def _register_path(self, path: str, table_name: str, **kwargs: Any) -> ir.Table:
         if path.startswith(("parquet://", "parq://")) or path.endswith(
             ("parq", "parquet")
         ):
@@ -557,7 +560,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         self,
         source: ir.Table,
         table_name: str | None = None,
-    ):
+    ) -> ir.Table:
         table_name = table_name or gen_name("register_table_provider")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
@@ -772,12 +775,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 batches = source.to_batches()
             case pa.RecordBatchReader():
                 schema = source.schema
-                try:
-                    first = source.read_next_batch()
-                except StopIteration:
-                    batches = iter([])
-                else:
-                    batches = itertools.chain([first], source)
+                batches = source
             case _:
                 it = iter(source)
                 try:
@@ -820,7 +818,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         *,
         chunk_size: int = 1_000_000,
         **kwargs: Any,
-    ):
+    ) -> pa.ipc.RecordBatchReader:
         self._register_udfs(expr)
         self._register_in_memory_tables(expr)
         table_expr = expr.as_table()
@@ -856,7 +854,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         database: str | None = None,
         temp: bool = False,
         overwrite: bool = False,
-    ):
+    ) -> ir.Table:
         """Create a table in Datafusion.
 
         Parameters
@@ -964,15 +962,15 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 for batch in batch_reader:
                     writer.write_batch(batch)
 
-    def _extract_catalog(self, query):
+    def _extract_catalog(self, query: str) -> dict[str, ir.Table]:
         tables = parse_one(query).find_all(exp.Table)
         return {table.name: self.table(table.name) for table in tables}
 
-    def register_udwf(self, func: WindowUDF):
+    def register_udwf(self, func: WindowUDF) -> None:
         self.con.register_udwf(func)
 
 
-def connect(config: SessionConfig | None = None):
+def connect(config: SessionConfig | None = None) -> Backend:
     con = Backend()
     con.do_connect(config)
     return con

--- a/python/xorq/backends/xorq_datafusion/__init__.py
+++ b/python/xorq/backends/xorq_datafusion/__init__.py
@@ -760,8 +760,8 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name = table_name or gen_name("read_record_batches")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
         self.con.deregister_table(table_ident)
-        if not isinstance(source, (pa.Table, pa.RecordBatchReader)) and not hasattr(
-            source, "__iter__"
+        if not isinstance(source, (pa.Table, pa.RecordBatchReader)) and (
+            isinstance(source, (str, bytes)) or not hasattr(source, "__iter__")
         ):
             raise TypeError(f"unsupported source type: {type(source).__name__}")
         schema: pa.Schema

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -61,6 +61,79 @@ def test_read_record_batches_type_mismatch():
     assert t.execute()["x"].tolist() == ["hello", "world"]
 
 
+def test_read_record_batches_from_table():
+    con = xo.connect()
+    t = con.read_record_batches(pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+    result = t.execute()
+    assert result["a"].tolist() == [1, 2, 3]
+    assert result["b"].tolist() == ["x", "y", "z"]
+
+
+def test_read_record_batches_from_list():
+    con = xo.connect()
+    batches = [
+        pa.record_batch({"a": [1, 2], "b": ["x", "y"]}),
+        pa.record_batch({"a": [3], "b": ["z"]}),
+    ]
+    t = con.read_record_batches(batches)
+    result = t.execute()
+    assert result["a"].tolist() == [1, 2, 3]
+    assert result["b"].tolist() == ["x", "y", "z"]
+
+
+def test_read_record_batches_from_tuple():
+    con = xo.connect()
+    batches = (
+        pa.record_batch({"n": [10, 20]}),
+        pa.record_batch({"n": [30]}),
+    )
+    t = con.read_record_batches(batches)
+    assert t.execute()["n"].tolist() == [10, 20, 30]
+
+
+def test_read_record_batches_from_generator():
+    con = xo.connect()
+
+    def gen():
+        yield pa.record_batch({"v": [1.0, 2.0]})
+        yield pa.record_batch({"v": [3.0]})
+
+    t = con.read_record_batches(gen())
+    assert t.execute()["v"].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_read_record_batches_empty_raises():
+    con = xo.connect()
+    with pytest.raises(ValueError, match="no record batches"):
+        con.read_record_batches([])
+
+
+def test_read_record_batches_empty_generator_raises():
+    con = xo.connect()
+
+    def empty():
+        return
+        yield  # noqa: B901
+
+    with pytest.raises(ValueError, match="no record batches"):
+        con.read_record_batches(empty())
+
+
+def test_read_record_batches_wrong_type_raises():
+    con = xo.connect()
+    with pytest.raises((TypeError, AttributeError)):
+        con.read_record_batches("not_a_source")
+
+
+def test_read_record_batches_schema_mismatch_raises():
+    # Passing batches with incompatible schema (field missing) should raise at cast time.
+    con = xo.connect()
+    first = pa.record_batch({"a": [1, 2], "b": [3, 4]})
+    second = pa.record_batch({"a": [5]})  # missing column "b"
+    with pytest.raises(ValueError, match="does not exist in schema"):
+        con.read_record_batches([first, second]).execute()
+
+
 def test_register_unbound_expr_raises():
     con = xo.connect()
     t = xo.table({"a": "int64"}, name="unbound")

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -47,11 +47,6 @@ def test_read_record_batches_type_mismatch():
     lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])
     assert lying_reader.schema.field("x").type == pa.utf8()
 
-    # Naive registration (bypassing read_record_batches) silently corrupts:
-    con.con.register_record_batch_reader("naive_table", lying_reader)
-    naive_result = con.table("naive_table").execute()["x"].tolist()
-    assert naive_result != ["hello", "world"], "naive registration should corrupt data"
-
     # read_record_batches casts each batch before crossing the C boundary:
     fresh_reader = pa.RecordBatchReader.from_batches(
         utf8_schema,
@@ -108,6 +103,12 @@ def test_read_record_batches_empty_raises():
         con.read_record_batches([])
 
 
+def test_read_record_batches_empty_table_raises():
+    con = xo.connect()
+    with pytest.raises(ValueError, match="no record batches"):
+        con.read_record_batches(pa.table({"a": pa.array([], type=pa.int64())}))
+
+
 def test_read_record_batches_empty_generator_raises():
     con = xo.connect()
 
@@ -121,7 +122,7 @@ def test_read_record_batches_empty_generator_raises():
 
 def test_read_record_batches_wrong_type_raises():
     con = xo.connect()
-    with pytest.raises((TypeError, AttributeError)):
+    with pytest.raises(AttributeError, match="schema"):
         con.read_record_batches("not_a_source")
 
 
@@ -130,7 +131,7 @@ def test_read_record_batches_schema_mismatch_raises():
     con = xo.connect()
     first = pa.record_batch({"a": [1, 2], "b": [3, 4]})
     second = pa.record_batch({"a": [5]})  # missing column "b"
-    with pytest.raises(ValueError, match="does not exist in schema"):
+    with pytest.raises(ValueError, match="batch missing columns required by schema"):
         con.read_record_batches([first, second]).execute()
 
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -143,6 +143,15 @@ def test_read_record_batches_schema_mismatch_raises():
         con.read_record_batches([first, second]).execute()
 
 
+def test_read_record_batches_extra_columns_raises():
+    # Schema inferred from first batch; second batch has extra column → error at cast time.
+    con = xo.connect()
+    first = pa.record_batch({"a": [1, 2], "b": [3, 4]})
+    second = pa.record_batch({"a": [5], "b": [6], "extra": [7]})
+    with pytest.raises(ValueError, match="batch has columns not in schema"):
+        con.read_record_batches([first, second]).execute()
+
+
 def test_register_unbound_expr_raises():
     con = xo.connect()
     t = xo.table({"a": "int64"}, name="unbound")

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -29,6 +29,38 @@ def test_register_table_provider():
     assert t.get_name() in con.list_tables()
 
 
+def test_read_record_batches_type_mismatch():
+    # register_and_transform_remote_tables builds a RecordBatchReader with
+    # schema from ex.as_table().schema().to_pyarrow() (ibis-declared, e.g.
+    # utf8 for VARCHAR) but batches from ex.to_pyarrow_batches() which may
+    # emit a different physical type (e.g. large_utf8 for DuckDB VARCHAR).
+    # Passing this "lying reader" directly to DataFusion via C Data Interface
+    # silently corrupts data: the utf8 offset buffer is 32-bit but large_utf8
+    # data uses 64-bit offsets, so DataFusion misreads row boundaries.
+    # read_record_batches must cast each batch to the declared schema before
+    # handing the reader to DataFusion.
+    con = xo.connect()
+    utf8_schema = pa.schema([("x", pa.utf8())])
+    batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
+    # RecordBatchReader.from_batches does not validate batch types against the
+    # declared schema, reproducing the lying reader from production code paths.
+    lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])
+    assert lying_reader.schema.field("x").type == pa.utf8()
+
+    # Naive registration (bypassing read_record_batches) silently corrupts:
+    con.con.register_record_batch_reader("naive_table", lying_reader)
+    naive_result = con.table("naive_table").execute()["x"].tolist()
+    assert naive_result != ["hello", "world"], "naive registration should corrupt data"
+
+    # read_record_batches casts each batch before crossing the C boundary:
+    fresh_reader = pa.RecordBatchReader.from_batches(
+        utf8_schema,
+        [pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})],
+    )
+    t = con.read_record_batches(fresh_reader)
+    assert t.execute()["x"].tolist() == ["hello", "world"]
+
+
 def test_register_unbound_expr_raises():
     con = xo.connect()
     t = xo.table({"a": "int64"}, name="unbound")

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -48,11 +48,7 @@ def test_read_record_batches_type_mismatch():
     assert lying_reader.schema.field("x").type == pa.utf8()
 
     # read_record_batches casts each batch before crossing the C boundary:
-    fresh_reader = pa.RecordBatchReader.from_batches(
-        utf8_schema,
-        [pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})],
-    )
-    t = con.read_record_batches(fresh_reader)
+    t = con.read_record_batches(lying_reader)
     assert t.execute()["x"].tolist() == ["hello", "world"]
 
 
@@ -132,6 +128,12 @@ def test_read_record_batches_wrong_type_raises():
     con = xo.connect()
     with pytest.raises(TypeError, match="unsupported source type"):
         con.read_record_batches(42)
+
+
+def test_read_record_batches_string_raises():
+    con = xo.connect()
+    with pytest.raises(TypeError, match="unsupported source type"):
+        con.read_record_batches("not_a_path")
 
 
 def test_read_record_batches_schema_mismatch_raises():

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -103,10 +103,10 @@ def test_read_record_batches_empty_raises():
         con.read_record_batches([])
 
 
-def test_read_record_batches_empty_table_raises():
+def test_read_record_batches_empty_table_returns_empty():
     con = xo.connect()
-    with pytest.raises(ValueError, match="no rows"):
-        con.read_record_batches(pa.table({"a": pa.array([], type=pa.int64())}))
+    t = con.read_record_batches(pa.table({"a": pa.array([], type=pa.int64())}))
+    assert t.execute().empty
 
 
 def test_read_record_batches_empty_generator_raises():
@@ -120,12 +120,12 @@ def test_read_record_batches_empty_generator_raises():
         con.read_record_batches(empty())
 
 
-def test_read_record_batches_empty_reader_raises():
+def test_read_record_batches_empty_reader_returns_empty():
     con = xo.connect()
     schema = pa.schema([("a", pa.int64())])
     reader = pa.RecordBatchReader.from_batches(schema, [])
-    with pytest.raises(ValueError, match="no rows"):
-        con.read_record_batches(reader)
+    t = con.read_record_batches(reader)
+    assert t.execute().empty
 
 
 def test_read_record_batches_wrong_type_raises():

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -99,13 +99,13 @@ def test_read_record_batches_from_generator():
 
 def test_read_record_batches_empty_raises():
     con = xo.connect()
-    with pytest.raises(ValueError, match="no record batches"):
+    with pytest.raises(ValueError, match="no rows"):
         con.read_record_batches([])
 
 
 def test_read_record_batches_empty_table_raises():
     con = xo.connect()
-    with pytest.raises(ValueError, match="no record batches"):
+    with pytest.raises(ValueError, match="no rows"):
         con.read_record_batches(pa.table({"a": pa.array([], type=pa.int64())}))
 
 
@@ -116,14 +116,22 @@ def test_read_record_batches_empty_generator_raises():
         return
         yield  # noqa: B901
 
-    with pytest.raises(ValueError, match="no record batches"):
+    with pytest.raises(ValueError, match="no rows"):
         con.read_record_batches(empty())
+
+
+def test_read_record_batches_empty_reader_raises():
+    con = xo.connect()
+    schema = pa.schema([("a", pa.int64())])
+    reader = pa.RecordBatchReader.from_batches(schema, [])
+    with pytest.raises(ValueError, match="no rows"):
+        con.read_record_batches(reader)
 
 
 def test_read_record_batches_wrong_type_raises():
     con = xo.connect()
-    with pytest.raises(AttributeError, match="schema"):
-        con.read_record_batches("not_a_source")
+    with pytest.raises(TypeError, match="unsupported source type"):
+        con.read_record_batches(42)
 
 
 def test_read_record_batches_schema_mismatch_raises():

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -139,7 +139,7 @@ def test_read_record_batches_schema_mismatch_raises():
     con = xo.connect()
     first = pa.record_batch({"a": [1, 2], "b": [3, 4]})
     second = pa.record_batch({"a": [5]})  # missing column "b"
-    with pytest.raises(ValueError, match="batch missing columns required by schema"):
+    with pytest.raises(ValueError, match="batch schema mismatch"):
         con.read_record_batches([first, second]).execute()
 
 
@@ -148,7 +148,7 @@ def test_read_record_batches_extra_columns_raises():
     con = xo.connect()
     first = pa.record_batch({"a": [1, 2], "b": [3, 4]})
     second = pa.record_batch({"a": [5], "b": [6], "extra": [7]})
-    with pytest.raises(ValueError, match="batch has columns not in schema"):
+    with pytest.raises(ValueError, match="batch schema mismatch"):
         con.read_record_batches([first, second]).execute()
 
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_udf.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_udf.py
@@ -9,7 +9,9 @@ import toolz
 import xorq.api as xo
 import xorq.expr.datatypes as dt
 from xorq.api import make_pandas_expr_udf, make_pandas_udf, udf
+from xorq.common.utils import classproperty
 from xorq.expr.ml.enums import ResponseMethod
+from xorq.expr.pyaggregator import PyAggregator, make_struct_type
 from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis import _
 from xorq.vendor.ibis import literal as L
@@ -28,6 +30,33 @@ def my_mean(arr: dt.float64) -> dt.float64:
 @udf.agg.pyarrow
 def add_mean(a: dt.float64, b: dt.float64) -> dt.float64:
     return pc.mean(pc.add(a, b))
+
+
+def test_pyarrow_udaf_empty_input():
+    # Regression: PyAggregator.pystate() called pa.concat_arrays([]) when
+    # _states is empty (zero rows fed to UDAF), raising ArrowInvalid.
+    # Verify it returns an empty struct array instead of crashing.
+    class _TestAgg(PyAggregator):
+        @classproperty
+        def struct_type(cls):
+            return make_struct_type(["x"], [pa.float64()])
+
+        def py_evaluate(self):
+            return pc.mean(self.pystate().field("x"))
+
+        @classproperty
+        def return_type(cls):
+            return pa.float64()
+
+        @classproperty
+        def name(cls):
+            return "_test_agg"
+
+    agg = _TestAgg()
+    assert agg._states == []
+    result = agg.pystate()
+    assert isinstance(result, pa.StructArray)
+    assert len(result) == 0
 
 
 return_type = pa.struct(

--- a/python/xorq/expr/pyaggregator.py
+++ b/python/xorq/expr/pyaggregator.py
@@ -29,6 +29,8 @@ class PyAggregator(Accumulator, ABC):
         self._states = []
 
     def pystate(self):
+        if not self._states:
+            return pa.array([], type=self.struct_type)
         return pa.concat_arrays(map(pickle.loads, self._states))
 
     def state(self):

--- a/python/xorq/tests/test_cli_arrow.py
+++ b/python/xorq/tests/test_cli_arrow.py
@@ -14,7 +14,7 @@ def test_to_pyarrow_stream():
     """Test writing Arrow IPC stream to a buffer."""
     # Create test data
     table = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
-    expr = xo.connect().read_record_batches(table.to_reader())
+    expr = xo.connect().read_record_batches(table)
     # Write to buffer
     buf = io.BytesIO()
     xo.to_pyarrow_stream(expr, sink=buf)

--- a/python/xorq/tests/test_cli_arrow.py
+++ b/python/xorq/tests/test_cli_arrow.py
@@ -14,7 +14,7 @@ def test_to_pyarrow_stream():
     """Test writing Arrow IPC stream to a buffer."""
     # Create test data
     table = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
-    expr = xo.connect().read_record_batches(table)
+    expr = xo.connect().read_record_batches(table.to_reader())
     # Write to buffer
     buf = io.BytesIO()
     xo.to_pyarrow_stream(expr, sink=buf)


### PR DESCRIPTION
`read_record_batches` previously accepted only a `pa.RecordBatchReader`
and called `.cast(source.schema)` directly — no type dispatch, no schema
validation, no support for tables or iterables.

Changes:
- Accept `pa.Table`, `pa.RecordBatchReader`, and any `Iterable[pa.RecordBatch]`
- Cast each batch through `_select_and_cast` before crossing the C Data
  Interface boundary — prevents silent corruption when physical types
  (e.g. large_utf8) differ from declared schema types
- Raise `ValueError` on schema mismatch (missing or extra columns) via
  symmetric_difference check
- Remove unnecessary `read_next_batch()` peek in RecordBatchReader branch;
  pa.RecordBatchReader is directly iterable
- Handle empty pa.Table and empty RecordBatchReader without error
- Raise `ValueError` on empty generic iterable (schema cannot be inferred)
- Add precise return/param types throughout Backend and module-level helpers