### PR TITLE
fix(relations): cast batches to declared schema before building RecordBatchReader

### DIFF
--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -585,8 +585,10 @@ _count = itertools.count()
 
 
 @tracer.start_as_current_span("register_and_transform_remote_tables")
-def register_and_transform_remote_tables(expr, **kwargs):
-    created = {}
+def register_and_transform_remote_tables(
+    expr: Expr, **kwargs: Any
+) -> tuple[Expr, dict[str, Any]]:
+    created: dict[str, Any] = {}
 
     op = expr.op()
     graph, _ = Graph.from_bfs(op).toposort()
@@ -604,7 +606,7 @@ def register_and_transform_remote_tables(expr, **kwargs):
         trace.get_current_span().add_event(
             "remote_table.replace", {"counts.values": tuple(counts.values())}
         )
-    batches_table = {}
+    batches_table: dict[Node, tuple[pa.Schema, list[SafeTee]]] = {}
     for arg, count in counts.items():
         ex = arg.remote_expr
         batches = ex.to_pyarrow_batches()
@@ -612,10 +614,12 @@ def register_and_transform_remote_tables(expr, **kwargs):
         replicas = SafeTee.tee(batches, count)
         batches_table[arg] = (schema, list(replicas))
 
-    def mark_remote_table(node):
+    def mark_remote_table(node: Node) -> Node:
+        schema: pa.Schema
+        batchess: list[SafeTee]
         schema, batchess = batches_table[node]
-        name = f"{node.name}_cu{next(_count)}_t{len(batchess)}"
-        reader = pa.RecordBatchReader.from_batches(
+        name: str = f"{node.name}_cu{next(_count)}_t{len(batchess)}"
+        reader: pa.RecordBatchReader = pa.RecordBatchReader.from_batches(
             schema,
             (batch.select(schema.names).cast(schema) for batch in batchess.pop()),
         )

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -2,7 +2,9 @@ import functools
 import itertools
 import operator
 from collections import defaultdict
-from typing import Any, Callable
+from collections.abc import Callable, Iterator
+from threading import Lock
+from typing import Any
 
 import pyarrow as pa
 import toolz
@@ -26,7 +28,7 @@ from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node, Relation
 
 
-def replace_cache_table(node, kwargs):
+def replace_cache_table(node: Node, kwargs: dict[str, Any]) -> Node:
     if kwargs:
         node = node.__recreate__(kwargs)
 
@@ -43,31 +45,33 @@ def replace_cache_table(node, kwargs):
 class SafeTee(object):
     """tee object wrapped to make it thread-safe"""
 
-    def __init__(self, teeobj, lock):
+    teeobj: Iterator[Any]
+    lock: Lock
+
+    def __init__(self, teeobj: Iterator[Any], lock: Lock) -> None:
         self.teeobj = teeobj
         self.lock = lock
 
-    def __iter__(self):
+    def __iter__(self) -> "SafeTee":
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         with self.lock:
             return next(self.teeobj)
 
-    def __copy__(self):
+    def __copy__(self) -> "SafeTee":
         return SafeTee(self.teeobj.__copy__(), self.lock)
 
     @classmethod
-    def tee(cls, iterable, n=2):
+    def tee(cls, iterable: Iterator[Any], n: int = 2) -> tuple["SafeTee", ...]:
         """tuple of n independent thread-safe iterators"""
         from itertools import tee  # noqa: PLC0415
-        from threading import Lock  # noqa: PLC0415
 
         lock = Lock()
         return tuple(cls(teeobj, lock) for teeobj in tee(iterable, n))
 
 
-def recursive_update(obj, replacements):
+def recursive_update(obj: Any, replacements: dict[Node, Any]) -> Any:
     if isinstance(obj, Node):
         if obj in replacements:
             return replacements[obj]
@@ -89,8 +93,8 @@ def recursive_update(obj, replacements):
         return obj
 
 
-def replace_source_factory(source: Any):
-    def replace_source(node, _, **kwargs):
+def replace_source_factory(source: Any) -> Callable[[Node, Any], Node]:
+    def replace_source(node: Node, _: Any, **kwargs: Any) -> Node:
         if "source" in kwargs:
             kwargs["source"] = source
         return node.__recreate__(kwargs)
@@ -105,7 +109,7 @@ class Tag(ops.Relation):
     values = FrozenDict()
 
     @property
-    def tag(self):
+    def tag(self) -> str | None:
         return self.metadata.get("tag")
 
     def __dasher_tokenize__(self):
@@ -155,7 +159,7 @@ class RemoteTable(DatabaseTableView):
     remote_expr: Expr
 
     @classmethod
-    def from_expr(cls, con, expr, name=None):
+    def from_expr(cls, con: Any, expr: Expr, name: str | None = None) -> "RemoteTable":
         name = name or gen_name()
         return cls(
             name=name,
@@ -165,7 +169,7 @@ class RemoteTable(DatabaseTableView):
         )
 
 
-def into_backend(expr, con, name=None):
+def into_backend(expr: Expr, con: Any, name: str | None = None) -> Expr:
     return RemoteTable.from_expr(con=con, expr=expr, name=name).to_expr()
 
 
@@ -177,7 +181,7 @@ class FlightExpr(DatabaseTableView):
     do_instrument_reader: bool = False
 
     @classmethod
-    def validate_schema(cls, input_expr, unbound_expr):
+    def validate_schema(cls, input_expr: Expr, unbound_expr: Expr) -> None:
         from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
 
         (dt, *rest) = walk_nodes(ops.UnboundTable, unbound_expr)
@@ -191,12 +195,12 @@ class FlightExpr(DatabaseTableView):
     @classmethod
     def from_exprs(
         cls,
-        input_expr,
-        unbound_expr,
-        make_server=None,
-        make_connection=None,
-        name=None,
-        **kwargs,
+        input_expr: Expr,
+        unbound_expr: Expr,
+        make_server: Callable | None = None,
+        make_connection: Callable | None = None,
+        name: str | None = None,
+        **kwargs: Any,
     ):
         from xorq.flight import FlightServer  # noqa: PLC0415
 
@@ -217,7 +221,7 @@ class FlightExpr(DatabaseTableView):
             **kwargs,
         )
 
-    def to_rbr(self, do_instrument_reader=None):
+    def to_rbr(self, do_instrument_reader: bool | None = None) -> pa.RecordBatchReader:
         from xorq.flight.action import AddExchangeAction  # noqa: PLC0415
         from xorq.flight.exchanger import (  # noqa: PLC0415
             UnboundExprExchanger,
@@ -254,7 +258,7 @@ class FlightExpr(DatabaseTableView):
         schema = self.schema.to_pyarrow()
         return pa.RecordBatchReader.from_batches(schema, gen)
 
-    def serve(self, make_server=None, **kwargs):
+    def serve(self, make_server: Callable | None = None, **kwargs: Any):
         return flight_serve_unbound(
             self.unbound_expr, make_server=make_server, **kwargs
         )
@@ -324,7 +328,7 @@ class FlightUDXF(DatabaseTableView):
     do_instrument_reader: bool = False
 
     @classmethod
-    def validate_schema(cls, input_expr, udxf):
+    def validate_schema(cls, input_expr: Expr, udxf: Any) -> Schema:
         if not udxf.schema_in_condition(input_expr.schema()):
             schema_in_required = getattr(udxf, "schema_in_required", None)
             raise ValueError(
@@ -338,12 +342,12 @@ class FlightUDXF(DatabaseTableView):
     @classmethod
     def from_expr(
         cls,
-        input_expr,
-        udxf,
-        make_server=None,
-        make_connection=None,
-        name=None,
-        **kwargs,
+        input_expr: Expr,
+        udxf: Any,
+        make_server: Callable | None = None,
+        make_connection: Callable | None = None,
+        name: str | None = None,
+        **kwargs: Any,
     ):
         from xorq.common.utils.tls_utils import TLSKwargs  # noqa: PLC0415
         from xorq.flight import FlightServer  # noqa: PLC0415
@@ -366,7 +370,7 @@ class FlightUDXF(DatabaseTableView):
             **kwargs,
         )
 
-    def to_rbr(self, do_instrument_reader=None):
+    def to_rbr(self, do_instrument_reader: bool | None = None) -> pa.RecordBatchReader:
         from xorq.flight.action import AddExchangeAction  # noqa: PLC0415
 
         if do_instrument_reader is None:
@@ -615,8 +619,6 @@ def register_and_transform_remote_tables(
         batches_table[arg] = (schema, list(replicas))
 
     def mark_remote_table(node: Node) -> Node:
-        schema: pa.Schema
-        batchess: list[SafeTee]
         schema, batchess = batches_table[node]
         name: str = f"{node.name}_cu{next(_count)}_t{len(batchess)}"
         reader: pa.RecordBatchReader = pa.RecordBatchReader.from_batches(
@@ -662,11 +664,11 @@ def register_and_transform_remote_tables(
     return expr, created
 
 
-def render_backend(con):
+def render_backend(con: Any) -> str:
     return f"{con.name}-{id(con)}"
 
 
-def get_cache_params(cache):
+def get_cache_params(cache: Any) -> tuple[str | None, bool | None, str]:
     from xorq.caching import (  # noqa: PLC0415
         ParquetCache,
         ParquetSnapshotCache,

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -615,7 +615,10 @@ def register_and_transform_remote_tables(expr, **kwargs):
     def mark_remote_table(node):
         schema, batchess = batches_table[node]
         name = f"{node.name}_cu{next(_count)}_t{len(batchess)}"
-        reader = pa.RecordBatchReader.from_batches(schema, batchess.pop())
+        reader = pa.RecordBatchReader.from_batches(
+            schema,
+            (batch.select(schema.names).cast(schema) for batch in batchess.pop()),
+        )
         result = node.source.read_record_batches(
             reader,
             table_name=name,

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -3,14 +3,17 @@ import operator
 import random
 from operator import methodcaller
 from pathlib import PosixPath
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import sqlglot as sg
 from pytest import param
 
 import xorq.api as xo
+from xorq.backends.xorq_datafusion import Backend
 from xorq.caching import ParquetCache, SourceCache
 from xorq.common.exceptions import XorqError
 from xorq.expr.relations import register_and_transform_remote_tables
@@ -19,6 +22,7 @@ from xorq.tests.util import assert_frame_equal, check_eq
 from xorq.vendor import ibis
 from xorq.vendor.ibis import _
 from xorq.vendor.ibis.expr.types.relations import CACHED_NODE_NAME_PLACEHOLDER
+from xorq.vendor.ibis.util import gen_name
 
 
 expected_tables = (
@@ -742,6 +746,85 @@ def test_multi_engine_cache(pg, ls_con, ls_batting, tmp_path, backend_name):
     )
 
     assert expr.execute() is not None
+
+
+def _make_large_utf8_backend(con):
+    """Return a wrapper that overrides to_pyarrow_batches to emit large_utf8.
+
+    Simulates backends (e.g. psycopg3 for Postgres TEXT columns) that emit
+    large_utf8 where ibis schema declares utf8. Used to verify that
+    register_and_transform_remote_tables casts batches before constructing
+    the RecordBatchReader, preventing silent C Data Interface corruption.
+    """
+    orig = con.__class__.to_pyarrow_batches
+
+    def large_utf8_batches(self, expr, **kwargs):
+        reader = orig(self, expr, **kwargs)
+        large_schema = pa.schema(
+            [
+                pa.field(
+                    f.name, pa.large_utf8() if pa.types.is_string(f.type) else f.type
+                )
+                for f in reader.schema
+            ]
+        )
+        return pa.RecordBatchReader.from_batches(
+            large_schema,
+            (batch.cast(large_schema) for batch in reader),
+        )
+
+    return patch.object(con.__class__, "to_pyarrow_batches", large_utf8_batches)
+
+
+def _naive_read_record_batches(self, source, table_name=None):
+    """read_record_batches without any cast — exposes lying-reader corruption."""
+    table_name = table_name or gen_name("read_record_batches")
+    table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
+    self.con.deregister_table(table_ident)
+    self.con.register_record_batch_reader(table_ident, source)
+    return self.table(table_name)
+
+
+def test_lying_reader_corrupts_datafusion_directly():
+    # Confirm the threat model at the DataFusion level: a RecordBatchReader
+    # that declares utf8 but carries large_utf8 batches silently corrupts
+    # string values when passed directly to register_record_batch_reader via
+    # the C Data Interface (64-bit offsets misread as 32-bit).
+    con = xo.connect()
+    utf8_schema = pa.schema([("x", pa.utf8())])
+    batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
+    lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])
+
+    con.con.register_record_batch_reader("lying_table", lying_reader)
+    result = con.table("lying_table").execute()["x"].tolist()
+
+    assert result != ["hello", "world"], (
+        "DataFusion should corrupt data from a lying reader — "
+        "if this assertion fails the underlying C Data Interface behaviour changed"
+    )
+
+
+def test_register_and_transform_casts_lying_reader(monkeypatch):
+    # register_and_transform_remote_tables must cast each batch to the declared
+    # schema before constructing the RecordBatchReader. Without this cast the
+    # lying reader (large_utf8 physical, utf8 declared schema) silently
+    # corrupts string values in DataFusion via the C Data Interface.
+    # This test fails when the cast is absent from
+    # register_and_transform_remote_tables (even if read_record_batches is naive).
+    duck = xo.duckdb.connect()
+    duck.create_table("src_strings", pa.table({"x": ["hello", "world"], "n": [1, 2]}))
+    t = duck.table("src_strings")
+
+    con = xo.connect()
+    monkeypatch.setattr(Backend, "read_record_batches", _naive_read_record_batches)
+
+    with _make_large_utf8_backend(duck):
+        remote = t.into_backend(con)
+        expr, _ = register_and_transform_remote_tables(remote)
+        result = expr.execute()
+
+    assert result["x"].tolist() == ["hello", "world"]
+    assert result["n"].tolist() == [1, 2]
 
 
 def test_multi_backend(parquet_dir):

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -757,6 +757,10 @@ def test_lying_reader_corrupts_datafusion_directly():
     # (test_into_backend_pyiceberg_string_preserved) validates the cast is
     # still safe to keep.
     con = xo.connect()
+    if not hasattr(con, "con") or not hasattr(con.con, "register_record_batch_reader"):
+        pytest.skip(
+            "backend internals changed: con.con.register_record_batch_reader unavailable"
+        )
     utf8_schema = pa.schema([("x", pa.utf8())])
     batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
     lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -746,7 +746,6 @@ def test_multi_engine_cache(pg, ls_con, ls_batting, tmp_path, backend_name):
 
 @pytest.mark.xfail(
     strict=True,
-    raises=AssertionError,
     reason="DataFusion corrupts large_utf8 batches declared as utf8 via C Data Interface; "
     "XPASS means upstream fixed the ABI mismatch — verify test_into_backend_pyiceberg_string_preserved still covers the cast",
 )
@@ -771,6 +770,7 @@ def test_lying_reader_corrupts_datafusion_directly():
 
 
 def test_into_backend_pyiceberg_string_preserved(tmp_path):
+    pytest.importorskip("pyiceberg")
     # PyIceberg returns large_string for string columns (physical Arrow type
     # from Parquet). ibis schema declares string/utf8. Without the cast in
     # register_and_transform_remote_tables the RecordBatchReader lies about its

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -3,17 +3,14 @@ import operator
 import random
 from operator import methodcaller
 from pathlib import PosixPath
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-import sqlglot as sg
 from pytest import param
 
 import xorq.api as xo
-from xorq.backends.xorq_datafusion import Backend
 from xorq.caching import ParquetCache, SourceCache
 from xorq.common.exceptions import XorqError
 from xorq.expr.relations import register_and_transform_remote_tables
@@ -22,7 +19,6 @@ from xorq.tests.util import assert_frame_equal, check_eq
 from xorq.vendor import ibis
 from xorq.vendor.ibis import _
 from xorq.vendor.ibis.expr.types.relations import CACHED_NODE_NAME_PLACEHOLDER
-from xorq.vendor.ibis.util import gen_name
 
 
 expected_tables = (
@@ -748,83 +744,50 @@ def test_multi_engine_cache(pg, ls_con, ls_batting, tmp_path, backend_name):
     assert expr.execute() is not None
 
 
-def _make_large_utf8_backend(con):
-    """Return a wrapper that overrides to_pyarrow_batches to emit large_utf8.
-
-    Simulates backends (e.g. psycopg3 for Postgres TEXT columns) that emit
-    large_utf8 where ibis schema declares utf8. Used to verify that
-    register_and_transform_remote_tables casts batches before constructing
-    the RecordBatchReader, preventing silent C Data Interface corruption.
-    """
-    orig = con.__class__.to_pyarrow_batches
-
-    def large_utf8_batches(self, expr, **kwargs):
-        reader = orig(self, expr, **kwargs)
-        large_schema = pa.schema(
-            [
-                pa.field(
-                    f.name, pa.large_utf8() if pa.types.is_string(f.type) else f.type
-                )
-                for f in reader.schema
-            ]
-        )
-        return pa.RecordBatchReader.from_batches(
-            large_schema,
-            (batch.cast(large_schema) for batch in reader),
-        )
-
-    return patch.object(con.__class__, "to_pyarrow_batches", large_utf8_batches)
-
-
-def _naive_read_record_batches(self, source, table_name=None):
-    """read_record_batches without any cast — exposes lying-reader corruption."""
-    table_name = table_name or gen_name("read_record_batches")
-    table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
-    self.con.deregister_table(table_ident)
-    self.con.register_record_batch_reader(table_ident, source)
-    return self.table(table_name)
-
-
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="DataFusion corrupts large_utf8 batches declared as utf8 via C Data Interface; "
+    "XPASS means upstream fixed the ABI mismatch — verify test_into_backend_pyiceberg_string_preserved still covers the cast",
+)
 def test_lying_reader_corrupts_datafusion_directly():
-    # Confirm the threat model at the DataFusion level: a RecordBatchReader
-    # that declares utf8 but carries large_utf8 batches silently corrupts
-    # string values when passed directly to register_record_batch_reader via
-    # the C Data Interface (64-bit offsets misread as 32-bit).
+    # Documents the threat model: DataFusion misreads 64-bit large_utf8 offsets
+    # as 32-bit utf8 when the declared schema says utf8 but physical batches are
+    # large_utf8. Expected to fail (corruption happens). If DataFusion fixes
+    # this, the xfail becomes XPASS and the companion functional test
+    # (test_into_backend_pyiceberg_string_preserved) validates the cast is
+    # still safe to keep.
     con = xo.connect()
     utf8_schema = pa.schema([("x", pa.utf8())])
     batch = pa.record_batch({"x": pa.array(["hello", "world"], type=pa.large_utf8())})
     lying_reader = pa.RecordBatchReader.from_batches(utf8_schema, [batch])
 
+    # con.con is the raw DataFusion SessionContext; intentionally bypass the
+    # public read_record_batches API (which casts) to probe bare DataFusion behaviour.
     con.con.register_record_batch_reader("lying_table", lying_reader)
     result = con.table("lying_table").execute()["x"].tolist()
 
-    assert result != ["hello", "world"], (
-        "DataFusion should corrupt data from a lying reader — "
-        "if this assertion fails the underlying C Data Interface behaviour changed"
+    assert result == ["hello", "world"]
+
+
+def test_into_backend_pyiceberg_string_preserved(tmp_path):
+    # PyIceberg returns large_string for string columns (physical Arrow type
+    # from Parquet). ibis schema declares string/utf8. Without the cast in
+    # register_and_transform_remote_tables the RecordBatchReader lies about its
+    # schema and DataFusion silently corrupts the values.
+    ice_con = xo.pyiceberg.connect(warehouse_path=str(tmp_path))
+    src = pa.table(
+        {"symbol": ["AAPL", "GOOGL", "MSFT"], "price": [150.0, 180.0, 420.0]}
     )
+    ice_con.create_table("quotes", src)
+    t = ice_con.table("quotes")
 
-
-def test_register_and_transform_casts_lying_reader(monkeypatch):
-    # register_and_transform_remote_tables must cast each batch to the declared
-    # schema before constructing the RecordBatchReader. Without this cast the
-    # lying reader (large_utf8 physical, utf8 declared schema) silently
-    # corrupts string values in DataFusion via the C Data Interface.
-    # This test fails when the cast is absent from
-    # register_and_transform_remote_tables (even if read_record_batches is naive).
-    duck = xo.duckdb.connect()
-    duck.create_table("src_strings", pa.table({"x": ["hello", "world"], "n": [1, 2]}))
-    t = duck.table("src_strings")
-
+    cols = ["symbol", "price"]
     con = xo.connect()
-    monkeypatch.setattr(Backend, "read_record_batches", _naive_read_record_batches)
+    result = t.into_backend(con).execute().sort_values(cols).reset_index(drop=True)
+    expected = src.to_pandas().sort_values(cols).reset_index(drop=True)
 
-    with _make_large_utf8_backend(duck):
-        remote = t.into_backend(con)
-        expr, _ = register_and_transform_remote_tables(remote)
-        result = expr.execute()
-
-    assert result["x"].tolist() == ["hello", "world"]
-    assert result["n"].tolist() == [1, 2]
+    assert_frame_equal(result, expected)
 
 
 def test_multi_backend(parquet_dir):


### PR DESCRIPTION
PyIceberg (and other backends backed by Parquet) return large_string for
string columns; ibis schema declares utf8. RecordBatchReader.from_batches
With a mismatched schema creates a "lying reader": DataFusion reads the
declared schema to determine offset width but physical buffers use 64-bit
offsets, silently corrupting string values via the C Data Interface.

Cast each batch to the declared schema before constructing the reader in
register_and_transform_remote_tables.

Tests:
- test_lying_reader_corrupts_datafusion_directly (xfail/strict) — documents
  DataFusion's raw ABI behaviour becomes XPASS if upstream fixes it
- test_into_backend_pyiceberg_string_preserved — real end-to-end regression
  using PyIceberg (no mocking); fails without the cast