### PR TITLE
ci: skip tests for devcontainer-only PRs

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -23,5 +23,7 @@ jobs:
               - '!docs/**'
               - '!**/*.md'
               - '!**/*.qmd'
+              - '!.devcontainer/**'
+              - '!dev/**'
               - '!codecov.yml'
               - '!.envrc'


### PR DESCRIPTION
## Summary
- Add `.devcontainer/**` and `dev/**` to the exclusion list in `detect-changes.yml`
- PRs that only touch devcontainer/dev-tooling files will now skip test jobs, matching the existing behavior for docs-only PRs

## Test plan
- [ ] Open a PR that only touches files in `.devcontainer/` or `dev/` and verify test jobs are skipped
- [ ] Open a PR that touches both `dev/` and source code and verify test jobs still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)