### PR TITLE
style: cosmetic cleanups split out from dasher migration

### DIFF
--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -114,7 +114,7 @@ def read_csv_rbr(*args, schema=None, chunksize=DEFAULT_CHUNKSIZE, dtype=None, **
     import pandas as pd  # noqa: PLC0415
 
     if dtype is not None:
-        raise Exception("pass `dtype` as pyarrow `schema`")
+        raise TypeError("pass `dtype` as pyarrow `schema`")
     if chunksize is None:
         raise ValueError("chunksize must not be `None`")
     if schema is not None:
@@ -198,7 +198,7 @@ def deferred_read_csv(
     """
 
     infer_schema = kwargs.pop("infer_schema", infer_csv_schema_pandas)
-    deferred_read_csv.method_name = method_name = "read_csv"
+    method_name = "read_csv"
 
     if con is None:
         con = default_backend()
@@ -271,7 +271,7 @@ def deferred_read_parquet(
          An expression representing the deferred read operation.
     """
 
-    deferred_read_parquet.method_name = method_name = "read_parquet"
+    method_name = "read_parquet"
     if con is None:
         con = default_backend()
     method = getattr(con, method_name)

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -42,7 +42,7 @@ def _git_is_present(cwd=None):
 
 
 def get_git_state(hash_diffs):
-    (commit, diff, diff_cached) = (
+    commit, diff, diff_cached = (
         subprocess.check_output(lst).decode().strip()
         for lst in (
             ["git", "rev-parse", "HEAD"],
@@ -85,7 +85,7 @@ def get_log_path(log_path=default_log_path):
     try:
         log_path.parent.mkdir(exist_ok=True, parents=True)
     except Exception:
-        (_, log_path) = tempfile.mkstemp(suffix=".log", prefix="xorq-")
+        _, log_path = tempfile.mkstemp(suffix=".log", prefix="xorq-")
     return log_path
 
 
@@ -110,8 +110,9 @@ if _log_level_str != "OFF":
     log_level = getattr(logging, _log_level_str)
     _xorq_logger = logging.getLogger("xorq")
     _xorq_logger.setLevel(log_level)
+    _MAX_LOG_BYTES = 50 * 2**20
     _rfh = logging.handlers.RotatingFileHandler(
-        log_path, maxBytes=50 * 2**20, backupCount=3
+        log_path, maxBytes=_MAX_LOG_BYTES, backupCount=3
     )
     _rfh.setFormatter(
         structlog.stdlib.ProcessorFormatter(

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -114,13 +114,16 @@ class SQL(Config):
 
 
 class Pins(Config):
-    """SQL-related options.
+    """Pin board configuration options.
 
     Attributes
     ----------
-    dialect : str
-        Dialect to use for printing SQL when the backend cannot be determined.
-
+    protocol : str
+        Storage protocol for the pin board (e.g. ``"gcs"``).
+    path : str
+        Root path for the pin board.
+    storage_options : dict
+        Backend-specific storage options passed to the pin board.
     """
 
     protocol: str = "gcs"

--- a/python/xorq/expr/ml/structer.py
+++ b/python/xorq/expr/ml/structer.py
@@ -75,7 +75,6 @@ class KVEncoder:
         if hasattr(result, "toarray"):
             result = result.toarray()
 
-        # Force float64 to match return_type and ensure PyArrow compatibility
         return pd.Series(KVEncoder._make_kv_tuple(names, row) for row in result)
 
     @staticmethod


### PR DESCRIPTION
## Summary

- Replace bare `Exception` with `TypeError` in `read_csv_rbr`
- Remove unnecessary attribute assignments on `deferred_read_csv` / `deferred_read_parquet`
- Fix docstring for `Pins` config class
- Minor style cleanups: remove redundant parentheses, extract magic number to named constant, drop stale comment

> **Depends on** #1951 (`integrate-xorq-dasher`)

## Test plan

- [ ] Existing tests pass — no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)