### PR TITLE
feat(catalog): serve-unbound command and uv run-cached test

### DIFF
--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1709,57 +1709,60 @@ def serve_unbound(
     from xorq.cli import _apply_cli_params, _get_cache_dir  # noqa: PLC0415
     from xorq.common.utils.logging_utils import get_print_logger  # noqa: PLC0415
     from xorq.common.utils.node_utils import expr_to_unbound  # noqa: PLC0415
+    from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
 
     logger = get_print_logger()
     cache_dir = _get_cache_dir(cache_dir)
 
-    with click_context_catalog(ctx):
-        catalog = ctx.obj.make_catalog(init=False)
-        catalog_entry = _get_catalog_entry(catalog, entry)
+    with tracer.start_as_current_span("catalog.serve_unbound") as span:
+        span.set_attributes({"entry": entry, "has_code": code is not None})
+        with click_context_catalog(ctx):
+            catalog = ctx.obj.make_catalog(init=False)
+            catalog_entry = _get_catalog_entry(catalog, entry)
 
-        if not catalog_entry.is_content_local:
-            catalog_entry.fetch()
+            if not catalog_entry.is_content_local:
+                catalog_entry.fetch()
 
-        expr = catalog_entry.load_expr(cache_dir=cache_dir)
+            expr = catalog_entry.load_expr(cache_dir=cache_dir)
 
-        if code is not None:
-            from xorq.catalog.bind import _eval_code  # noqa: PLC0415
+            if code is not None:
+                from xorq.catalog.bind import _eval_code  # noqa: PLC0415
 
-            expr = _eval_code(code, expr)
+                expr = _eval_code(code, expr)
 
-        rename_map = (
-            _parse_rename_params(raw_rename_params) if raw_rename_params else {}
-        )
-        if entry in rename_map:
-            from xorq.common.utils.graph_utils import rename_params  # noqa: PLC0415
-
-            expr = rename_params(expr, rename_map[entry])
-
-        expr = _apply_cli_params(expr, raw_params)
-
-        if fuse:
-            expr = expr.ls.fused
-
-        try:
-            from xorq.flight.metrics import setup_console_metrics  # noqa: PLC0415
-
-            setup_console_metrics(prometheus_port=prometheus_port)
-        except ImportError:
-            logger.warning(
-                "Metrics support requires 'opentelemetry-sdk' and console exporter"
+            rename_map = (
+                _parse_rename_params(raw_rename_params) if raw_rename_params else None
             )
+            if rename_map and entry in rename_map:
+                from xorq.common.utils.graph_utils import rename_params  # noqa: PLC0415
 
-        unbound_expr = expr_to_unbound(
-            expr,
-            hash=to_unbind_hash,
-            tag=to_unbind_tag,
-            typs=typ,
-            strategy=SnapshotStrategy(),
-        )
-        flight_url = xorq.flight.FlightUrl(host=host, port=port)
-        make_server = partial(xorq.flight.FlightServer, flight_url=flight_url)
-        server, _ = xorq.expr.relations.flight_serve_unbound(
-            unbound_expr, make_server=make_server
-        )
-        logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
-        server.wait()
+                expr = rename_params(expr, rename_map[entry])
+
+            expr = _apply_cli_params(expr, raw_params)
+
+            if fuse:
+                expr = expr.ls.fused
+
+            try:
+                from xorq.flight.metrics import setup_console_metrics  # noqa: PLC0415
+
+                setup_console_metrics(prometheus_port=prometheus_port)
+            except ImportError:
+                logger.warning(
+                    "Metrics support requires 'opentelemetry-sdk' and console exporter"
+                )
+
+            unbound_expr = expr_to_unbound(
+                expr,
+                hash=to_unbind_hash,
+                tag=to_unbind_tag,
+                typs=typ,
+                strategy=SnapshotStrategy(),
+            )
+            flight_url = xorq.flight.FlightUrl(host=host, port=port)
+            make_server = partial(xorq.flight.FlightServer, flight_url=flight_url)
+            server, _ = xorq.expr.relations.flight_serve_unbound(
+                unbound_expr, make_server=make_server
+            )
+            logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
+            server.wait()

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1768,5 +1768,6 @@ def serve_unbound(
                 "server_started", {"flight_url": str(flight_url.to_location())}
             )
 
+    # Span covers startup only; server.wait() runs outside to avoid a never-exported span.
     logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
     server.wait()

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -25,7 +25,9 @@ from xorq.cli_options import (
     output_options,
     params_option,
     rename_params_option,
+    serve_options,
     sync_option,
+    unbind_options,
 )
 
 
@@ -1671,3 +1673,93 @@ def run_cached(
                     expr_transform=_wrap_cache,
                     cache_dir=resolved_cache_dir,
                 )
+
+
+@cli.command("serve-unbound")
+@click.argument("entry", shell_complete=_complete_entry_or_alias_names)
+@unbind_options
+@serve_options
+@code_option
+@fuse_option
+@rename_params_option
+@params_option
+@cache_dir_option
+@click.pass_context
+def serve_unbound(
+    ctx,
+    entry,
+    to_unbind_hash,
+    to_unbind_tag,
+    typ,
+    host,
+    port,
+    prometheus_port,
+    code,
+    fuse,
+    raw_rename_params,
+    raw_params,
+    cache_dir,
+):
+    """Resolve a catalog entry, unbind a node, and serve via Flight."""
+    from functools import partial  # noqa: PLC0415
+
+    import xorq.expr.relations  # noqa: PLC0415
+    import xorq.flight  # noqa: PLC0415
+    from xorq.caching.strategy import SnapshotStrategy  # noqa: PLC0415
+    from xorq.cli import _apply_cli_params, _get_cache_dir  # noqa: PLC0415
+    from xorq.common.utils.logging_utils import get_print_logger  # noqa: PLC0415
+    from xorq.common.utils.node_utils import expr_to_unbound  # noqa: PLC0415
+
+    logger = get_print_logger()
+    cache_dir = _get_cache_dir(cache_dir)
+
+    with click_context_catalog(ctx):
+        catalog = ctx.obj.make_catalog(init=False)
+        catalog_entry = _get_catalog_entry(catalog, entry)
+
+        if not catalog_entry.is_content_local:
+            catalog_entry.fetch()
+
+        expr = catalog_entry.load_expr(cache_dir=cache_dir)
+
+        if code is not None:
+            from xorq.catalog.bind import _eval_code  # noqa: PLC0415
+
+            expr = _eval_code(code, expr)
+
+        rename_map = (
+            _parse_rename_params(raw_rename_params) if raw_rename_params else {}
+        )
+        if entry in rename_map:
+            from xorq.common.utils.graph_utils import rename_params  # noqa: PLC0415
+
+            expr = rename_params(expr, rename_map[entry])
+
+        expr = _apply_cli_params(expr, raw_params)
+
+        if fuse:
+            expr = expr.ls.fused
+
+        try:
+            from xorq.flight.metrics import setup_console_metrics  # noqa: PLC0415
+
+            setup_console_metrics(prometheus_port=prometheus_port)
+        except ImportError:
+            logger.warning(
+                "Metrics support requires 'opentelemetry-sdk' and console exporter"
+            )
+
+        unbound_expr = expr_to_unbound(
+            expr,
+            hash=to_unbind_hash,
+            tag=to_unbind_tag,
+            typs=typ,
+            strategy=SnapshotStrategy(),
+        )
+        flight_url = xorq.flight.FlightUrl(host=host, port=port)
+        make_server = partial(xorq.flight.FlightServer, flight_url=flight_url)
+        server, _ = xorq.expr.relations.flight_serve_unbound(
+            unbound_expr, make_server=make_server
+        )
+        logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
+        server.wait()

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1764,5 +1764,9 @@ def serve_unbound(
             server, _ = xorq.expr.relations.flight_serve_unbound(
                 unbound_expr, make_server=make_server
             )
-            logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
-            server.wait()
+            span.add_event(
+                "server_started", {"flight_url": str(flight_url.to_location())}
+            )
+
+    logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
+    server.wait()

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -1253,14 +1253,18 @@ def test_uv_run_cached_roundtrip(tmpdir):
         ("xorq", "init", "--path", str(path), "--template", "penguins")
     )
     assert returncode == 0, stderr
+    # Template's requirements.txt may be from a different uv version, causing sync failures
     path.joinpath("requirements.txt").unlink(missing_ok=True)
 
     (returncode, stdout, stderr) = subprocess_run(
         ("xorq", "uv", "build", str(path / "expr.py")), text=True
     )
     assert returncode == 0, stderr
+    # build_command prints the build directory path as the last line of stdout
     build_path = Path(stdout.strip().split("\n")[-1])
-    assert build_path.exists()
+    assert build_path.exists(), (
+        f"build_path not found: {build_path!r} (stdout={stdout!r})"
+    )
 
     output_path = tmpdir / "cached_output.parquet"
     cache_dir = tmpdir / "cache"

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -18,6 +18,7 @@ from click.testing import CliRunner
 import xorq
 import xorq.api as xo
 from xorq.caching.strategy import SnapshotStrategy
+from xorq.catalog.cli import cli as catalog_cli
 from xorq.cli import (
     arbitrate_output_format,
     build_command,
@@ -1220,6 +1221,67 @@ def test_uv_run_unbound_help():
     ):
         assert flag in result.output, f"missing {flag}"
     assert "stdout" in result.output, "--output-path help text should mention stdout"
+
+
+def test_catalog_serve_unbound_help():
+    result = CliRunner().invoke(catalog_cli, ["serve-unbound", "--help"])
+    assert result.exit_code == 0
+    for flag in (
+        "--to_unbind_hash",
+        "--to_unbind_tag",
+        "--typ",
+        "--host",
+        "--port",
+        "--prometheus-port",
+        "--code",
+        "--fuse",
+        "--rename-params",
+        "--params",
+        "--cache-dir",
+    ):
+        assert flag in result.output, f"missing {flag}"
+
+
+@pytest.mark.slow(level=2)
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="requirements.txt issues for python3.10"
+)
+def test_uv_run_cached_roundtrip(tmpdir):
+    tmpdir = Path(tmpdir)
+    path = tmpdir / "xorq-template-penguins"
+    (returncode, _, stderr) = subprocess_run(
+        ("xorq", "init", "--path", str(path), "--template", "penguins")
+    )
+    assert returncode == 0, stderr
+    path.joinpath("requirements.txt").unlink(missing_ok=True)
+
+    (returncode, stdout, stderr) = subprocess_run(
+        ("xorq", "uv", "build", str(path / "expr.py")), text=True
+    )
+    assert returncode == 0, stderr
+    build_path = Path(stdout.strip().split("\n")[-1])
+    assert build_path.exists()
+
+    output_path = tmpdir / "cached_output.parquet"
+    cache_dir = tmpdir / "cache"
+    (returncode, _, stderr) = subprocess_run(
+        (
+            "xorq",
+            "uv",
+            "run-cached",
+            str(build_path),
+            "--cache-type",
+            "modification-time",
+            "--output-path",
+            str(output_path),
+            "--cache-dir",
+            str(cache_dir),
+        ),
+        text=True,
+    )
+    assert returncode == 0, stderr
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
 
 
 def test_batch_size_forwarded_to_pyarrow_stream(monkeypatch):


### PR DESCRIPTION
## Summary

- Add `xorq catalog serve-unbound` command (Phase 4 of CLI parity plan): resolves a catalog entry, applies compose options (`--fuse`, `--code`, `--rename-params`, `--params`), unbinds a specified node, and serves via Flight
- Add OTel tracing span (`catalog.serve_unbound`) matching the pattern used by `catalog run` and `catalog run-cached`
- Align `rename_map` sentinel to `None` (consistent with `_resolve_and_execute` and `_resolve_single_entry`)
- Add help-text test for `catalog serve-unbound`
- Add end-to-end roundtrip integration test for `xorq uv run-cached`

> **Depends on:** #1962 (merged)

## Test plan

- [x] `test_catalog_serve_unbound_help` — verifies all expected flags in `--help`
- [x] `test_uv_run_cached_roundtrip` — `xorq init` → `uv build` → `uv run-cached --cache-type modification-time` → output file exists
- [x] All existing help-text and decorator tests still pass
- [x] Ruff lint and format clean
- [ ] `uv run-unbound` roundtrip tests deferred to follow-up PR (needs unbound expression fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)