### PR TITLE
fix(devcontainer): auto-resolve workspace to git root

### DIFF
--- a/dev/devcontainer
+++ b/dev/devcontainer
@@ -62,6 +62,21 @@ else
     export DEV_WORKSPACE="$(cd "$DEV_WORKSPACE" && pwd)"
 fi
 
+# Auto-resolve to git root when workspace is a subdirectory of a checkout.
+# Mounting a subdirectory as the container workspace leaves /workspaces/src
+# without a .git entry, so git (and tools like Claude Code) can't find the
+# repo and fail with "not a git repository".
+if [ -d "$DEV_WORKSPACE" ]; then
+    _git_toplevel="$(git -C "$DEV_WORKSPACE" rev-parse --show-toplevel 2>/dev/null)" || {
+        echo "error: $DEV_WORKSPACE is not inside a git repository" >&2
+        exit 1
+    }
+    if [ "$DEV_WORKSPACE" != "$_git_toplevel" ]; then
+        echo "note: resolving workspace to git root: $_git_toplevel (was: $DEV_WORKSPACE)" >&2
+        export DEV_WORKSPACE="$_git_toplevel"
+    fi
+fi
+
 # PROJECT_NAME scopes container names and shared volumes — must be consistent
 # across worktrees, so always read from the main tree's project.env.
 _main_project_env="$DEV_MAIN_TREE/.devcontainer/project/project.env"


### PR DESCRIPTION
## Summary
- Running `dev/devcontainer` from a subdirectory (not the repo root) mounted only that subdir as the container workspace, leaving `/workspaces/src` without a `.git` entry — git and Claude Code inside the container failed with "not a git repository"
- Adds a guard after workspace path resolution that detects subdirectories and auto-resolves to `git rev-parse --show-toplevel`, printing a note to stderr
- Skipped when the directory doesn't exist (only happens on `down`/`clean` paths for already-removed worktrees)

## Test plan
- [ ] Run `dev/devcontainer up` from the repo root — no change in behavior
- [ ] Run `dev/devcontainer up` from a subdirectory (e.g. `python/xorq/`) — should print `note: resolving workspace to git root: ...` and start normally
- [ ] Run `dev/devcontainer -w python/xorq up` — should also auto-resolve
- [ ] Run `dev/devcontainer down` for a non-existent worktree path — should skip the check and proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)