### PR TITLE
fix(cli): hyphenate unbind options and improve test quality

### DIFF
--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -81,12 +81,12 @@ def unbind_options(fn):
         help="Type of the node to unbind.",
     )(fn)
     fn = click.option(
-        "--to_unbind_tag",
+        "--to-unbind-tag",
         default=None,
         help="Tag of the node to unbind.",
     )(fn)
     fn = click.option(
-        "--to_unbind_hash",
+        "--to-unbind-hash",
         default=None,
         help="Hash of the node to unbind.",
     )(fn)

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -590,9 +590,7 @@ class _BasePackagedRunner(ABC):
         default=None,
     )
     output_path = field(validator=optional(instance_of(str)), default=None)
-    output_format = field(
-        validator=in_(OutputFormats), default=DEFAULT_OUTPUT_FORMAT
-    )
+    output_format = field(validator=in_(OutputFormats), default=DEFAULT_OUTPUT_FORMAT)
     limit = field(validator=optional(instance_of(int)), default=None)
     python_version = field(validator=_validate_python_version, default=None)
     _bundle: Bundle = field(init=False, repr=False, eq=False, default=None)
@@ -690,8 +688,8 @@ class PackagedUnboundRunner(_BasePackagedRunner):
 
     def _extra_args(self):
         return (
-            *(("--to_unbind_hash", self.to_unbind_hash) if self.to_unbind_hash else ()),
-            *(("--to_unbind_tag", self.to_unbind_tag) if self.to_unbind_tag else ()),
+            *(("--to-unbind-hash", self.to_unbind_hash) if self.to_unbind_hash else ()),
+            *(("--to-unbind-tag", self.to_unbind_tag) if self.to_unbind_tag else ()),
             *(("--typ", self.typ) if self.typ else ()),
             *(
                 ("--batch-size", str(self.batch_size))

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -976,7 +976,7 @@ def test_serve_unbound_hash(serve_hash, pipeline_https_build):
         "xorq",
         "serve-unbound",
         str(pipeline_https_build),
-        "--to_unbind_hash",
+        "--to-unbind-hash",
         serve_hash,
     ) + (("--typ", typ) if typ else ())
     with serve_process(serve_args) as (proc, peeker):
@@ -1011,7 +1011,7 @@ def test_serve_unbound_tag(serve_tag, pipeline_https_build):
         "xorq",
         "serve-unbound",
         str(pipeline_https_build),
-        "--to_unbind_tag",
+        "--to-unbind-tag",
         serve_tag,
     )
     with serve_process(serve_args) as (proc, peeker):
@@ -1036,7 +1036,7 @@ def test_serve_unbound_tag_get_exchange(pipeline_https_build, parquet_dir):
         "xorq",
         "serve-unbound",
         str(pipeline_https_build),
-        "--to_unbind_tag",
+        "--to-unbind-tag",
         serve_tag,
     )
     with serve_process(serve_args) as (proc, peeker):
@@ -1074,7 +1074,7 @@ def test_serve_unbound_tag_get_exchange_udf(fixture_dir, tmp_path):
         "xorq",
         "serve-unbound",
         str(output.getvalue().strip()),
-        "--to_unbind_tag",
+        "--to-unbind-tag",
         serve_tag,
     )
     with serve_process(serve_args) as (proc, peeker):
@@ -1128,7 +1128,7 @@ def test_serve_penguins_template(tmpdir, tmp_path):
             "xorq",
             "serve-unbound",
             str(target_dir / match.group()),
-            "--to_unbind_hash",
+            "--to-unbind-hash",
             serve_hash,
         )
         with serve_process(serve_args) as (proc, peeker):
@@ -1210,8 +1210,8 @@ def test_uv_run_unbound_help():
     result = CliRunner().invoke(cli, ["uv", "run-unbound", "--help"])
     assert result.exit_code == 0
     for flag in (
-        "--to_unbind_hash",
-        "--to_unbind_tag",
+        "--to-unbind-hash",
+        "--to-unbind-tag",
         "--typ",
         "--batch-size",
         "--instream",
@@ -1227,8 +1227,8 @@ def test_catalog_serve_unbound_help():
     result = CliRunner().invoke(catalog_cli, ["serve-unbound", "--help"])
     assert result.exit_code == 0
     for flag in (
-        "--to_unbind_hash",
-        "--to_unbind_tag",
+        "--to-unbind-hash",
+        "--to-unbind-tag",
         "--typ",
         "--host",
         "--port",
@@ -1250,7 +1250,7 @@ def test_uv_run_cached_roundtrip(tmpdir):
     tmpdir = Path(tmpdir)
     path = tmpdir / "xorq-template-penguins"
     (returncode, _, stderr) = subprocess_run(
-        ("xorq", "init", "--path", str(path), "--template", "penguins")
+        ("xorq", "init", "--path", str(path), "--template", "penguins"), text=True
     )
     assert returncode == 0, stderr
     # Template's requirements.txt may be from a different uv version, causing sync failures
@@ -1285,7 +1285,28 @@ def test_uv_run_cached_roundtrip(tmpdir):
     )
     assert returncode == 0, stderr
     assert output_path.exists()
-    assert output_path.stat().st_size > 0
+    first_size = output_path.stat().st_size
+    assert first_size > 0
+
+    output_path_2 = tmpdir / "cached_output_2.parquet"
+    (returncode, _, stderr) = subprocess_run(
+        (
+            "xorq",
+            "uv",
+            "run-cached",
+            str(build_path),
+            "--cache-type",
+            "modification-time",
+            "--output-path",
+            str(output_path_2),
+            "--cache-dir",
+            str(cache_dir),
+        ),
+        text=True,
+    )
+    assert returncode == 0, stderr
+    assert output_path_2.exists()
+    assert output_path_2.stat().st_size == first_size
 
 
 def test_batch_size_forwarded_to_pyarrow_stream(monkeypatch):
@@ -1400,7 +1421,7 @@ def test_cache_strategy_options_decorator():
 def test_unbind_options_decorator():
     cmd = _make_test_command(unbind_options)
     result = CliRunner().invoke(
-        cmd, ["--to_unbind_hash", "abc", "--to_unbind_tag", "v1", "--typ", "int"]
+        cmd, ["--to-unbind-hash", "abc", "--to-unbind-tag", "v1", "--typ", "int"]
     )
     assert result.exit_code == 0
     assert "to_unbind_hash=abc" in result.output


### PR DESCRIPTION
## Summary
- Rename `--to_unbind_hash`/`--to_unbind_tag` to `--to-unbind-hash`/`--to-unbind-tag` to match Click's hyphenated convention used by all other options (`--cache-dir`, `--prometheus-port`, `--rename-params`, etc.)
- Add `text=True` to the `subprocess_run` init call in `test_uv_run_cached_roundtrip` so assertion failures show readable strings instead of `b'...'`
- Add a second cache-hit run to `test_uv_run_cached_roundtrip` to verify the cached path produces identical output

## Test plan
- [ ] `test_uv_run_cached_roundtrip` passes (both cold and warm cache runs)
- [ ] `test_uv_run_unbound_help` passes with hyphenated flags
- [ ] `test_catalog_serve_unbound_help` passes with hyphenated flags
- [ ] `test_unbind_options_decorator` passes (Python param names unchanged)
- [ ] All `test_serve_unbound_*` tests pass with hyphenated CLI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)