### PR TITLE
chore: remove unused 24MB parquet file to speed up clones

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -125,7 +125,6 @@ Most examples define a top-level `expr` variable and can be conveniently run wit
 | File | Description |
 |------|-------------|
 | `data/iris.csv` | Classic Iris classification dataset |
-| `data/data.rownum.parquet` | Lending Club dataset with row numbering for ML examples |
 
 
 ### Examples that require API keys


### PR DESCRIPTION
## Summary
- Removes `examples/data/data.rownum.parquet` (24 MB Lending Club dataset) which is not referenced by any code — examples now load this data via the pins system
- Shrinks `--depth 1` clones from ~23 MB to ~4 MB (estimated ~5x speedup)
- Updates `examples/README.md` to remove the stale entry

## Test plan
- [x] CI passes — no code references this file
- [x] Grep confirms zero imports/reads of this path across all `.py`, `.yaml`, `.toml`, `.json`, `.ipynb` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)