### PR TITLE
ci: update GitHub Actions to node24 runtime

### DIFF
--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download test data
         run: just download-data
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-docs-deploy.yml
+++ b/.github/workflows/ci-docs-deploy.yml
@@ -24,13 +24,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: cache ibis test data
         id: cache-test-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ci/ibis-testing-data
           key: ibis-testing-data-${{ hashFiles('justfile') }}
@@ -39,7 +39,7 @@ jobs:
         if: steps.cache-test-data.outputs.cache-hit != 'true'
         run: just download-data
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: cache quarto
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/quarto
           key: quarto-1.8.24

--- a/.github/workflows/ci-docs-preview.yml
+++ b/.github/workflows/ci-docs-preview.yml
@@ -13,17 +13,16 @@ jobs:
       cancel-in-progress: true
     if: github.event.label.name == 'docs-preview'
     steps:
-      - uses: actions/create-github-app-token@v2.2.2
+      - uses: actions/create-github-app-token@v3.2.0
         id: generate_token
         with:
           app-id: ${{ secrets.DOCS_BOT_APP_ID }}
           private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
 
       - name: reset label
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: docs-preview
-          github_token: ${{ steps.generate_token.outputs.token }}
+        run: gh issue edit ${{ github.event.pull_request.number }} --remove-label "docs-preview"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: checkout
         uses: actions/checkout@v6
@@ -31,13 +30,13 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: cache ibis test data
         id: cache-test-data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ci/ibis-testing-data
           key: ibis-testing-data-${{ hashFiles('justfile') }}
@@ -46,7 +45,7 @@ jobs:
         if: steps.cache-test-data.outputs.cache-hit != 'true'
         run: just download-data
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -60,7 +59,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: cache quarto
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/quarto
           key: quarto-1.8.24
@@ -81,9 +80,9 @@ jobs:
           POSTGRES_PORT: 5432
           POSTGRES_DATABASE: ibis_testing
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: install netlify cli
         run: npm install -g netlify-cli
@@ -101,7 +100,7 @@ jobs:
 
       - name: create preview link comment
         if: success()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ steps.generate_token.outputs.token }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-downstream-bsl.yml
+++ b/.github/workflows/ci-downstream-bsl.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ inputs.bsl-ref || env.BSL_REF }}
           path: _bsl
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -42,9 +42,9 @@ jobs:
           enable-cache: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: _bsl/docs/web/package-lock.json
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -37,7 +37,7 @@ jobs:
           path: "python src"
           ignore_words_file: .codespell.ignore-words
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-pre-release.yml
+++ b/.github/workflows/ci-pre-release.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: install uv

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: install uv

--- a/.github/workflows/ci-test-catalog.yml
+++ b/.github/workflows/ci-test-catalog.yml
@@ -51,7 +51,7 @@ jobs:
           git config --global user.name "CI"
           git config --global user.email "ci@xorq.dev"
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -65,7 +65,7 @@ jobs:
           sudo apt-get update -qq -y
           sudo apt-get install -qq -y ${{ join(matrix.backend.sys-deps, ' ') }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-test-databricks.yml
+++ b/.github/workflows/ci-test-databricks.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-test-examples.yml
+++ b/.github/workflows/ci-test-examples.yml
@@ -31,14 +31,14 @@ jobs:
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download test data
         run: just download-data
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-test-gcs.yml
+++ b/.github/workflows/ci-test-gcs.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,7 +43,7 @@ jobs:
           enable-cache: true
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 

--- a/.github/workflows/ci-test-ibis-compatibility.yml
+++ b/.github/workflows/ci-test-ibis-compatibility.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-test-install.yaml
+++ b/.github/workflows/ci-test-install.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-test-s3.yml
+++ b/.github/workflows/ci-test-s3.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-test-slow.yml
+++ b/.github/workflows/ci-test-slow.yml
@@ -36,14 +36,14 @@ jobs:
             python-version: "3.12"
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download test data
         run: just download-data
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci-test-snowflake.yml
+++ b/.github/workflows/ci-test-snowflake.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -90,7 +90,7 @@ jobs:
           git config --global user.name "CI"
           git config --global user.email "ci@xorq.dev"
 
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -105,7 +105,7 @@ jobs:
       - name: download test data
         run: just download-data
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -120,11 +120,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: ${{ matrix.backend.services }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build postgres image with GHA layer cache
         if: ${{ contains(matrix.backend.services, 'postgres') }}
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         with:
           files: compose.yaml
           targets: postgres

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write  # to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
Bumps all node20/node12 actions before June 16 2026 deprecation deadline:
- actions/cache v4→v5
- actions/setup-python v5→v6
- actions/setup-node v4→v6 (node-version 20→24)
- actions/create-github-app-token v2.2.2→v3.2.0
- docker/setup-buildx-action v3→v4
- docker/bake-action v6→v7
- google-github-actions/auth v2→v3
- peter-evans/create-or-update-comment v4→v5
- release-drafter/release-drafter v6→v7
- extractions/setup-just v3→v4
- replace actions-ecosystem/action-remove-labels@v1 (node12) with gh CLI