### PR TITLE
deps: bump xorq-style to ~=0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ dev = [
     "trino==0.336.0",
     "pip>=24.3.1",
     "vendoring>=1.2.0",
-    "xorq-style~=0.1.2",
+    "xorq-style~=0.1.3",
     "pyopenssl>=24.3.0",
     "duckdb>=1.1.3",
     "datafusion>=43.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -6088,7 +6088,7 @@ dev = [
     { name = "trino", specifier = "==0.336.0" },
     { name = "vendoring", specifier = ">=1.2.0" },
     { name = "xgboost", specifier = ">=1.6.1" },
-    { name = "xorq-style", specifier = "~=0.1.2" },
+    { name = "xorq-style", specifier = "~=0.1.3" },
 ]
 docs = [
     { name = "griffe", specifier = "<2.0" },
@@ -6174,15 +6174,15 @@ wheels = [
 
 [[package]]
 name = "xorq-style"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/42/9fd69c8b245d95a9c5e8f582e66311b72ccbe05a6f380967101614cd4826/xorq_style-0.1.2.tar.gz", hash = "sha256:4290c022c18bd6399785624e3a0d4bd8ecc3c618a2ebe049f2faff596f7d5fe7", size = 57853, upload-time = "2026-05-25T20:05:28.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/16/3499ce4e93f9ac0d4486cd3336330ef7587eb57eb58f1437304b1fa6ef09/xorq_style-0.1.3.tar.gz", hash = "sha256:a79ccbdf87c2352b059f66826e1001c57e8236bed6819a4cefecb54cdf6176b9", size = 58474, upload-time = "2026-05-28T13:33:32.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/38/b0cd1b2d73444226a11e6c8deb54aa649a3fb979216170f2ab3b83354584/xorq_style-0.1.2-py3-none-any.whl", hash = "sha256:bc197a1d514cf902bb9b0424094cdd3e078200d8d6221606f5e928b3968e95ae", size = 8797, upload-time = "2026-05-25T20:05:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/78/8e/38357d8afb5f237eb4df53e0d533b87c69f67a131959aac6640d2d87161b/xorq_style-0.1.3-py3-none-any.whl", hash = "sha256:aa3fb32a76ea3ca2092544d402c500c3711f201d7df35d5b706bf1aba2224dba", size = 8799, upload-time = "2026-05-28T13:33:31.301Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `xorq-style` from `~=0.1.2` to `~=0.1.3` to pick up the bugfix release

## Test plan
- [x] CI passes with updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)