### PR TITLE
fix: install per-call dasher memos in normalization_context

### DIFF
--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -92,7 +92,6 @@ class ModificationTimeStrategy(CacheStrategy):
 
 @frozen
 class SnapshotStrategy(CacheStrategy):
-    @with_caches
     def calc_key(self, expr: ir.Expr):
         with self.normalization_context(expr) as local:
             replaced = self._replace_remote_table(expr, local)
@@ -100,6 +99,7 @@ class SnapshotStrategy(CacheStrategy):
             return self.key_prefix + "-".join(("snapshot", tokenized))
 
     @contextlib.contextmanager
+    @with_caches  # must be inner so memos span the full with-block
     def normalization_context(self, expr):
         """Yield a snapshot-flavored Hasher; callers tokenize through it.
 
@@ -109,8 +109,8 @@ class SnapshotStrategy(CacheStrategy):
         installed in ``_current_hasher`` so transitive tokenize calls inside
         the opaque-placeholder replacer (``_parent_token``) propagate the
         snapshot-flavored rules instead of falling back to the data-sensitive
-        global HASHER.  A per-call DT memo is installed alongside so repeated
-        visits of the same DT under deeply nested into_backend chains
+        global HASHER.  Per-call memos are installed alongside so repeated
+        visits of the same nodes under deeply nested into_backend chains
         normalize once.
         """
         from xorq.common.utils.dasher import _current_hasher  # noqa: PLC0415

--- a/python/xorq/common/utils/dasher/__init__.py
+++ b/python/xorq/common/utils/dasher/__init__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import contextvars
 import functools
+import inspect
 import operator
 from typing import TYPE_CHECKING
 
@@ -177,16 +178,50 @@ def _reset_per_call_memos(tokens):
 def with_caches(fn):
     """Wrap a callable so a single invocation installs+tears down the dasher
     per-call memos.  Use at user-facing entry points (``tokenize``,
-    ``SnapshotStrategy.calc_key``) so all rule invocations within the call
-    share the same memos."""
+    ``SnapshotStrategy.calc_key``, ``normalization_context``) so all rule
+    invocations within the call share the same memos.
 
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        tokens = _install_per_call_memos()
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            _reset_per_call_memos(tokens)
+    Works on regular functions, coroutines, generator functions, and async
+    generator functions: for generators the memos stay alive across ``yield``,
+    so ``@contextlib.contextmanager`` / ``@contextlib.asynccontextmanager``
+    can be stacked on top and the caller's ``with`` block sees the memos."""
+    if inspect.isasyncgenfunction(fn):
+
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            tokens = _install_per_call_memos()
+            try:
+                async for item in fn(*args, **kwargs):
+                    yield item
+            finally:
+                _reset_per_call_memos(tokens)
+    elif inspect.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def wrapper(*args, **kwargs):
+            tokens = _install_per_call_memos()
+            try:
+                return await fn(*args, **kwargs)
+            finally:
+                _reset_per_call_memos(tokens)
+    elif inspect.isgeneratorfunction(fn):
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            tokens = _install_per_call_memos()
+            try:
+                yield from fn(*args, **kwargs)
+            finally:
+                _reset_per_call_memos(tokens)
+    else:
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            tokens = _install_per_call_memos()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _reset_per_call_memos(tokens)
 
     return wrapper
 

--- a/python/xorq/common/utils/tests/test_caching_utils.py
+++ b/python/xorq/common/utils/tests/test_caching_utils.py
@@ -1,10 +1,17 @@
+import asyncio
 from pathlib import Path
 
 import pytest
 
+import xorq.api as xo
 from xorq.caching.strategy import SnapshotStrategy, snapshot_normalize_read
 from xorq.common.utils.caching_utils import get_xorq_cache_dir
-from xorq.common.utils.dasher._relations import _normalize_read_xorq
+from xorq.common.utils.dasher import with_caches
+from xorq.common.utils.dasher._opaque import (
+    _expr_normalize_memo,
+    _parent_token_memo,
+)
+from xorq.common.utils.dasher._relations import _dt_normalize_memo, _normalize_read_xorq
 from xorq.common.utils.tests._test_helpers import FakeRead
 
 
@@ -89,3 +96,86 @@ def test_normalize_read_xorq_single_path(tmp_path):
 
     result = _normalize_read_xorq(read)
     assert result[0] == "xorq.Read"
+
+
+# --- normalization_context installs per-call dasher memos -------------------
+
+
+def test_normalization_context_installs_per_call_memos():
+    """normalization_context must install the three per-call dasher memos
+    (_parent_token_memo, _expr_normalize_memo, _dt_normalize_memo) so
+    callers that bypass @with_caches still get memoized tokenization."""
+    assert _parent_token_memo.get() is None
+    assert _expr_normalize_memo.get() is None
+    assert _dt_normalize_memo.get() is None
+
+    t = xo.memtable({"a": [1, 2, 3]})
+    strategy = SnapshotStrategy()
+
+    with strategy.normalization_context(t) as local:
+        assert _parent_token_memo.get() is not None
+        assert _expr_normalize_memo.get() is not None
+        assert _dt_normalize_memo.get() is not None
+
+        local.tokenize(t)
+
+        assert len(_parent_token_memo.get()) > 0 or len(_expr_normalize_memo.get()) > 0
+
+    assert _parent_token_memo.get() is None
+    assert _expr_normalize_memo.get() is None
+    assert _dt_normalize_memo.get() is None
+
+
+# --- with_caches generator / coroutine support ------------------------------
+
+
+def test_with_caches_sync_generator():
+    """with_caches must keep memos alive across yield in sync generators."""
+
+    @with_caches
+    def _gen():
+        yield 42
+
+    assert _parent_token_memo.get() is None
+    items = []
+    for item in _gen():
+        assert _parent_token_memo.get() is not None
+        items.append(item)
+    assert items == [42]
+    assert _parent_token_memo.get() is None
+
+
+def test_with_caches_async_generator():
+    """with_caches must keep memos alive across yield in async generators."""
+
+    @with_caches
+    async def _async_gen():
+        yield 42
+
+    async def _run():
+        assert _parent_token_memo.get() is None
+        items = []
+        async for item in _async_gen():
+            assert _parent_token_memo.get() is not None
+            items.append(item)
+        assert items == [42]
+        assert _parent_token_memo.get() is None
+
+    asyncio.run(_run())
+
+
+def test_with_caches_coroutine():
+    """with_caches must install memos for plain async def coroutines."""
+
+    @with_caches
+    async def _coro():
+        assert _parent_token_memo.get() is not None
+        return 42
+
+    async def _run():
+        assert _parent_token_memo.get() is None
+        result = await _coro()
+        assert result == 42
+        assert _parent_token_memo.get() is None
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary

- `SnapshotStrategy.normalization_context()` sets up `_current_hasher` and `_snapshot_dt_normalize_memo` but did not install the three per-call dasher memos (`_parent_token_memo`, `_expr_normalize_memo`, `_dt_normalize_memo`)
- Without these memos, every `_parent_token` call inside the opaque-placeholder replacer recomputed full tokenization from scratch — O(N^D) instead of O(N) for N opaque nodes at depth D
- This made **catalog load+execute 25-30x slower** than direct build+execute (~33s vs ~1s for a penguins ML pipeline)
- Fix: install the memos inside `normalization_context` via `@with_caches` so every caller — `get_expr_hash`, `compute_expr_hash`, `calc_key`, and any future entry points — gets them automatically
- Extended `with_caches` to support generator functions (`yield from`), coroutines (`async def`), and async generator functions (`async for`/`yield`), so it can be stacked under `@contextlib.contextmanager` or `@contextlib.asynccontextmanager` and the memos stay alive for the caller's entire `with` block
- Removed the now-redundant `@with_caches` decorator from `calc_key` since `normalization_context` installs the same memos
- Added regression test `test_normalization_context_installs_per_call_memos` that asserts all three memos are installed inside `normalization_context`, verifies memos are populated after tokenization, and cleaned up on exit
- Added `test_with_caches_sync_generator` that verifies memos stay alive across `yield` in sync generators and are cleaned up after iteration
- Added `test_with_caches_async_generator` that verifies memos stay alive across `yield` in async generators and are cleaned up after iteration
- Added `test_with_caches_coroutine` that verifies memos are installed during plain `async def` coroutine execution and cleaned up after `await`

### Before
| Step | Time |
|------|------|
| Direct build+execute (cold) | 2.0s |
| Catalog load+execute (first) | 32.8s |
| Catalog load+execute (second) | 25.8s |

### After
| Step | Time |
|------|------|
| Direct build+execute (cold) | 1.0s |
| Catalog load+execute (first) | 1.3s |
| Catalog load+execute (second) | 0.4s |

## Test plan

- [x] All 12 `test_caching_utils` tests pass (including memo regression + sync generator + async generator + coroutine tests)
- [x] All 9 `test_provenance_utils` tests pass
- [x] All 32 `test_node_utils` + `test_hashing_tag` tests pass
- [x] All 3 `test_benchmark_dasher` benchmarks pass (no regression)
- [x] Repro script confirms 25x speedup on catalog load+execute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)