### PR TITLE
feat(catalog): add --no-sync option to compose for parity with add

### DIFF
--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1154,6 +1154,7 @@ def _compose_via_reinvoke(ctx, catalog, entries):
 
 @cli.command("compose")
 @click.argument("entries", nargs=-1, shell_complete=_complete_entry_or_alias_names)
+@sync_option
 @code_option
 @click.option(
     "-a",
@@ -1194,6 +1195,7 @@ def _compose_via_reinvoke(ctx, catalog, entries):
 def compose(
     ctx,
     entries,
+    sync,
     code,
     alias,
     cache_dir,
@@ -1257,7 +1259,7 @@ def compose(
             aliases = (alias,) if alias else ()
             alias_existed = alias and catalog.catalog_yaml.contains_alias(alias)
             entry_existed = catalog.contains(entry_name)
-            catalog.add(build_path, aliases=aliases, exist_ok=True)
+            catalog.add(build_path, sync=sync, aliases=aliases, exist_ok=True)
             label = alias or entry_name
             if entry_existed:
                 if alias and not alias_existed:

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -886,7 +886,50 @@ def test_catalog_compose_reinvokes_via_uv(
     assert captured["merge_bundle"] is not None
     assert len(captured["merge_bundle"].wheel_paths) > 0
     assert captured["add_build_path"] == pre_built
+    assert captured["add_sync"] is True
     assert captured["add_aliases"] == ("outer-alias",)
+
+
+def test_catalog_compose_no_sync(
+    catalog_with_source_and_transform, monkeypatch, tmp_path
+):
+    """--no-sync must propagate sync=False to catalog.add."""
+    pre_built = tmp_path / "fake-build"
+    pre_built.mkdir()
+    (pre_built / DumpFiles.expr).write_text("# placeholder\n")
+    (pre_built / DumpFiles.requirements).write_text("")
+
+    captured = {}
+
+    def _write_build_path(*args, **kwargs):
+        idx = args.index("--emit-build-path-to")
+        Path(args[idx + 1]).write_text(str(pre_built))
+
+    monkeypatch.setattr(
+        "xorq.ibis_yaml.packager.uv_tool_run",
+        _fake_uv_tool_run(captured, side_effect=_write_build_path),
+    )
+    monkeypatch.setattr(cli_mod, "_compose_expr", _must_not_call("_compose_expr"))
+
+    def spy_stage(bundle, build_path):
+        captured["merge_build_path"] = build_path
+        captured["merge_bundle"] = bundle
+
+    def spy_add(self, build_path, sync=True, aliases=(), exist_ok=False):
+        captured["add_sync"] = sync
+        return MagicMock(name="catalog_entry")
+
+    monkeypatch.setattr(cli_mod, "_stage_bundle_into_build", spy_stage)
+    monkeypatch.setattr(Catalog, "add", spy_add)
+
+    catalog_path, _, _ = catalog_with_source_and_transform
+    bare = CliRunner()
+    result = bare.invoke(
+        cli,
+        ["--path", catalog_path, "compose", "--no-sync", "src", "trn"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["add_sync"] is False
 
 
 def test_catalog_compose_dry_run_relays_inner_stdout(

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -857,8 +857,9 @@ def test_catalog_compose_reinvokes_via_uv(
         captured["merge_build_path"] = build_path
         captured["merge_bundle"] = bundle
 
-    def spy_add(self, build_path, aliases=(), exist_ok=False):
+    def spy_add(self, build_path, sync=True, aliases=(), exist_ok=False):
         captured["add_build_path"] = build_path
+        captured["add_sync"] = sync
         captured["add_aliases"] = aliases
         return MagicMock(name="catalog_entry")
 


### PR DESCRIPTION
Plumb the shared sync_option into `xorq catalog compose` and forward it to the final `catalog.add`, so composed entries can be cataloged without triggering a git-annex sync, matching `xorq catalog add`.