### PR TITLE
docs(tutorials): drive working_with_the_catalog from the CLI

### DIFF
--- a/.github/workflows/ci-docs-lint.yml
+++ b/.github/workflows/ci-docs-lint.yml
@@ -33,8 +33,15 @@ jobs:
 
       - name: Install Python doc dependencies
         # Include the project itself (not --only-group) so quartodoc can import
-        # `xorq` to build the API reference; --no-default-groups skips dev/test.
-        run: uv sync --no-default-groups --group docs
+        # `xorq` to build the API reference; --no-default-groups skips dev. The
+        # test group provides pytest for the CLI-contract step below.
+        run: uv sync --no-default-groups --group docs --group test
+
+      - name: CLI contract (docs reference real commands)
+        # Sybil parses every `xorq ...` invocation from the docs' bash fences
+        # and asserts each subcommand + flag resolves against the live click
+        # tree. Catches renamed/removed/typo'd CLI references. See docs/conftest.py.
+        run: uv run --no-sync pytest docs/ -q
 
       - name: Generate CLI reference
         # The CLI pages are generated from Click docstrings and gitignored;

--- a/docs/cli_contract.py
+++ b/docs/cli_contract.py
@@ -1,0 +1,128 @@
+"""Static contract check: every ``xorq ...`` command referenced in the docs
+must resolve against the real click command tree.
+
+This is the doc-side counterpart to the ``*.snippets.py`` smoke test. The
+smoke test proves the tutorial *runs*; this proves the tutorial *talks about
+commands that exist* — so a renamed flag or removed subcommand breaks the docs
+in CI instead of silently rotting. It does not execute anything, so it is
+immune to the placeholders (``<you>``, ``$BUILD_A``, ``~/work``), GitHub steps,
+and tabset duplicates that make the prose non-executable.
+
+Pure functions, no Sybil/pytest import — ``docs/conftest.py`` wires these into
+Sybil, and they're directly callable for unit testing.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+
+# A command-position token that doesn't look like this is treated as a
+# placeholder/metavar (e.g. ``<command>``, ``COMMAND``, ``$VAR``) and stops
+# validation of that invocation rather than being flagged as a typo.
+_COMMAND_NAME = re.compile(r"^[a-z][a-z0-9-]+$")
+
+# Options click adds implicitly or that are universally safe to reference.
+_ALWAYS_VALID_OPTS = frozenset({"--help", "-h", "--version"})
+
+# A simple command runs until one of these shell operators.
+_INVOCATION = re.compile(r"(?:(?<=\s)|(?<=\()|^)xorq\s+([^|&;)\n]+)")
+
+_root = None
+
+
+def iter_xorq_invocations(block_text):
+    """Yield the token list (after ``xorq``) for each ``xorq`` invocation in a
+    bash code block. Strips a leading ``uv run`` and digs inside ``$(...)``;
+    non-``xorq`` lines (git, gh, uv add, mkdir, ...) and comments are skipped.
+    """
+    invocations = []
+    for raw_line in block_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        for match in _INVOCATION.finditer(line):
+            tail = match.group(1).strip()
+            if not tail:
+                continue
+            try:
+                tokens = shlex.split(tail, comments=True)
+            except ValueError:
+                tokens = tail.split()
+            if tokens:
+                invocations.append(tokens)
+    return invocations
+
+
+def _get_root():
+    global _root
+    if _root is None:
+        from xorq.cli import _load_catalog_cli, cli  # noqa: PLC0415
+
+        _load_catalog_cli()  # registers the lazily-loaded `catalog` subgroup
+        _root = cli
+    return _root
+
+
+def _option_names(node):
+    names = set(_ALWAYS_VALID_OPTS)
+    for param in node.params:
+        for opt in list(param.opts) + list(param.secondary_opts):
+            if opt.startswith("-"):
+                names.add(opt)
+    return names
+
+
+def _takes_value(node, opt):
+    for param in node.params:
+        if opt in param.opts or opt in param.secondary_opts:
+            return not getattr(param, "is_flag", False) and not getattr(
+                param, "count", False
+            )
+    return False
+
+
+def validate_invocation(tokens):
+    """Walk the click tree for one ``xorq`` invocation; raise AssertionError on
+    an unknown subcommand or option. Placeholders and positional arguments are
+    ignored.
+    """
+    import click  # noqa: PLC0415
+
+    node = _get_root()
+    path = ["xorq"]
+    i, n = 0, len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok == "--":
+            i += 1
+            continue
+        if tok.startswith("-"):
+            name = tok.split("=", 1)[0]
+            valid = _option_names(node)
+            assert name in valid, (
+                f"`{' '.join(path)}` has no option {name!r} "
+                f"(valid: {', '.join(sorted(valid))})"
+            )
+            if "=" not in tok and _takes_value(node, name):
+                i += 1  # skip the option's value token
+            i += 1
+            continue
+        if isinstance(node, click.Group):
+            sub = node.commands.get(tok)
+            if sub is not None:
+                node = sub
+                path.append(tok)
+                i += 1
+                continue
+            if _COMMAND_NAME.match(tok):
+                raise AssertionError(
+                    f"`{' '.join(path)}` has no subcommand {tok!r} "
+                    f"(valid: {', '.join(sorted(node.commands))})"
+                )
+            # Placeholder / metavar (e.g. <command>, COMMAND, $VAR): can't
+            # validate further — stop here rather than false-flag it.
+            return
+        # Leaf command: remaining non-option tokens are positional args.
+        i += 1

--- a/docs/cli_contract.py
+++ b/docs/cli_contract.py
@@ -32,14 +32,33 @@ _INVOCATION = re.compile(r"(?:(?<=\s)|(?<=\()|^)xorq\s+([^|&;)\n]+)")
 _root = None
 
 
+def _logical_lines(block_text):
+    """Yield logical lines, joining shell ``\\`` continuations into one. Without
+    this, options on a continuation line (which doesn't start with ``xorq``) are
+    silently skipped — see ``serve-unbound.qmd``'s multi-line invocation.
+    """
+    buf = ""
+    for raw_line in block_text.splitlines():
+        stripped = raw_line.rstrip()
+        if stripped.endswith("\\"):
+            buf += stripped[:-1] + " "
+        else:
+            yield buf + raw_line
+            buf = ""
+    if buf:
+        yield buf
+
+
 def iter_xorq_invocations(block_text):
     """Yield the token list (after ``xorq``) for each ``xorq`` invocation in a
     bash code block. Strips a leading ``uv run`` and digs inside ``$(...)``;
     non-``xorq`` lines (git, gh, uv add, mkdir, ...) and comments are skipped.
+    Shell ``\\`` line continuations are joined first so options on the second
+    line are validated too.
     """
     invocations = []
-    for raw_line in block_text.splitlines():
-        line = raw_line.strip()
+    for logical_line in _logical_lines(block_text):
+        line = logical_line.strip()
         if not line or line.startswith("#"):
             continue
         for match in _INVOCATION.finditer(line):
@@ -58,9 +77,12 @@ def iter_xorq_invocations(block_text):
 def _get_root():
     global _root
     if _root is None:
-        from xorq.cli import _load_catalog_cli, cli  # noqa: PLC0415
+        from xorq.cli import cli  # noqa: PLC0415
 
-        _load_catalog_cli()  # registers the lazily-loaded `catalog` subgroup
+        # `cli` is a PdbGroup that lazily registers the `catalog` subgroup on
+        # first lookup. Going through the public get_command avoids depending on
+        # the private `_load_catalog_cli` helper.
+        cli.get_command(None, "catalog")
         _root = cli
     return _root
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,29 @@
+"""Sybil wiring for the docs CLI-contract check (see cli_contract.py).
+
+The sybil import is guarded so environments without sybil installed (e.g. the
+core test matrix) simply collect nothing from ``docs/`` instead of erroring at
+import time.
+"""
+
+import os
+import sys
+
+
+sys.path.insert(0, os.path.dirname(__file__))  # make cli_contract importable
+
+try:
+    from cli_contract import iter_xorq_invocations, validate_invocation
+    from sybil import Sybil
+    from sybil.parsers.markdown import CodeBlockParser
+except ImportError:
+    pass
+else:
+
+    def _evaluate(example):
+        for tokens in iter_xorq_invocations(example.parsed):
+            validate_invocation(tokens)
+
+    pytest_collect_file = Sybil(
+        parsers=[CodeBlockParser(language="bash", evaluator=_evaluate)],
+        patterns=["*.qmd"],
+    ).pytest()

--- a/docs/getting_started/quickstart.qmd
+++ b/docs/getting_started/quickstart.qmd
@@ -234,7 +234,7 @@ Run the server with your build hash:
 xorq serve-unbound builds/$BUILD_HASH \
   --host localhost \
   --port 8001 \
-  --to_unbind_hash d9cebcfbeeadc40f4a39814357716481
+  --to-unbind-hash d9cebcfbeeadc40f4a39814357716481
 ```
 
 ### Windows (PowerShell)
@@ -242,12 +242,12 @@ xorq serve-unbound builds/$BUILD_HASH \
 xorq serve-unbound builds/$env:BUILD_HASH `
   --host localhost `
   --port 8001 `
-  --to_unbind_hash d9cebcfbeeadc40f4a39814357716481
+  --to-unbind-hash d9cebcfbeeadc40f4a39814357716481
 ```
 
 ### Windows (CMD)
 ```cmd
-xorq serve-unbound builds/%BUILD_HASH% --host localhost --port 8001 --to_unbind_hash d9cebcfbeeadc40f4a39814357716481
+xorq serve-unbound builds/%BUILD_HASH% --host localhost --port 8001 --to-unbind-hash d9cebcfbeeadc40f4a39814357716481
 ```
 
 :::

--- a/docs/test_cli_contract.py
+++ b/docs/test_cli_contract.py
@@ -1,0 +1,106 @@
+"""Unit tests for the docs CLI-contract checker (see cli_contract.py).
+
+These exercise the pure parsing/validation functions directly, covering the
+edge cases the Sybil ``.qmd`` sweep does not pin down on its own: line
+continuations, ``=``-attached option values, the ``--`` separator, placeholder
+metavars, and the unknown-subcommand / unknown-option failure paths.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+sys.path.insert(0, os.path.dirname(__file__))  # make cli_contract importable
+
+from cli_contract import iter_xorq_invocations, validate_invocation  # noqa: E402
+
+
+pytestmark = pytest.mark.library
+
+
+class TestIterXorqInvocations:
+    def test_plain(self):
+        assert iter_xorq_invocations("xorq catalog init") == [["catalog", "init"]]
+
+    def test_strips_uv_run(self):
+        # `uv run` is shell, not a xorq token — the regex matches at `xorq`.
+        assert iter_xorq_invocations("uv run xorq catalog list-aliases") == [
+            ["catalog", "list-aliases"]
+        ]
+
+    def test_skips_comments_and_blanks(self):
+        text = "# a comment\n\nxorq build foo.py\n"
+        assert iter_xorq_invocations(text) == [["build", "foo.py"]]
+
+    def test_skips_non_xorq_lines(self):
+        text = "git push -u origin main\nmkdir -p ~/work\nxorq catalog push"
+        assert iter_xorq_invocations(text) == [["catalog", "push"]]
+
+    def test_digs_inside_command_substitution(self):
+        text = "BUILD_A=$(uv run xorq uv build flights_model.py -e expr | tail -1)"
+        assert iter_xorq_invocations(text) == [
+            ["uv", "build", "flights_model.py", "-e", "expr"]
+        ]
+
+    def test_joins_line_continuation(self):
+        # The Medium finding: options on the continuation line must be seen.
+        text = (
+            "xorq serve-unbound builds/7061dd65ff3c --host 0.0.0.0 --port 8001 \\\n"
+            "  --cache-dir cache --to-unbind-hash b2370a29c19df8e1e639c63252dacd0e"
+        )
+        assert iter_xorq_invocations(text) == [
+            [
+                "serve-unbound",
+                "builds/7061dd65ff3c",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8001",
+                "--cache-dir",
+                "cache",
+                "--to-unbind-hash",
+                "b2370a29c19df8e1e639c63252dacd0e",
+            ]
+        ]
+
+
+class TestValidateInvocation:
+    def test_known_subcommand_ok(self):
+        validate_invocation(["catalog", "init"])
+
+    def test_unknown_subcommand_raises(self):
+        with pytest.raises(AssertionError, match="no subcommand 'frobnicate'"):
+            validate_invocation(["frobnicate"])
+
+    def test_unknown_option_raises(self):
+        with pytest.raises(AssertionError, match="no option"):
+            validate_invocation(["catalog", "--definitely-not-a-flag"])
+
+    def test_equals_attached_option_value(self):
+        # `--name=foo` must split on `=` so the option resolves and the value
+        # isn't treated as a stray token.
+        validate_invocation(["catalog", "--name=foo", "init"])
+
+    def test_double_dash_separator_ignored(self):
+        validate_invocation(["catalog", "--", "init"])
+
+    def test_placeholder_metavar_stops_validation(self):
+        # A non-command-looking token (`<command>`, `COMMAND`, `$VAR`) is a
+        # metavar; validation stops rather than false-flagging it.
+        validate_invocation(["<command>"])
+        validate_invocation(["$VAR"])
+        validate_invocation(["COMMAND", "--whatever"])
+
+    def test_continuation_then_validate_catches_underscore_regression(self):
+        # End-to-end: the parsed continuation tokens flow into validation, so a
+        # future `--to_unbind_hash` regression on line 2 would now be caught.
+        (tokens,) = iter_xorq_invocations(
+            "xorq serve-unbound builds/abc --host 0.0.0.0 \\\n"
+            "  --to_unbind_hash deadbeef"
+        )
+        with pytest.raises(AssertionError, match="no option '--to_unbind_hash'"):
+            validate_invocation(tokens)

--- a/docs/tutorials/core_tutorials/working_with_the_catalog.qmd
+++ b/docs/tutorials/core_tutorials/working_with_the_catalog.qmd
@@ -301,7 +301,7 @@ That commits a new entry on the `add-aa-only-model` branch in your clone—`--no
 
 ::: {.callout-note}
 ### `--no-sync`
-Passing `--no-sync` skips the git-annex sync after the add—it commits to the working branch but doesn't reach out to the remote. You'll push the branch yourself in the next step, after reviewing the diff.
+By default `xorq catalog add` pulls then pushes the catalog's git remote after committing; `--no-sync` skips that, leaving the new commit purely local. The default is harmless when no remote is configured yet (User A's first `add` earlier had nothing to pull or push), but User B's clone *does* have an `origin`—so `--no-sync` is what keeps the entry on the local feature branch until you push it yourself in the next step, after reviewing the diff.
 :::
 
 Push the feature branch and open the PR:
@@ -310,8 +310,9 @@ Push the feature branch and open the PR:
 
 ### GitHub
 ```bash
-git -C ~/work/flights-catalog-userb log --oneline -3      # confirm: "add: <hash> (aliases flights-aa-only)"
-git -C ~/work/flights-catalog-userb push -u origin add-aa-only-model
+cd ~/work/flights-catalog-userb
+git log --oneline -3      # confirm: "add: <hash> (aliases flights-aa-only)"
+git push -u origin add-aa-only-model
 gh pr create --title "Add AA-only flights model" --body "Adds an AA-filtered view of the flights model under alias flights-aa-only."
 ```
 

--- a/docs/tutorials/core_tutorials/working_with_the_catalog.qmd
+++ b/docs/tutorials/core_tutorials/working_with_the_catalog.qmd
@@ -7,13 +7,18 @@ headline: "A catalog is just a git repo"
 
 In [Build a semantic catalog](build_a_semantic_catalog.qmd) you tagged a BSL flights model and dropped it into a local catalog. That catalog is a regular git repository—every entry, alias, and revision is a git commit. The moment you push it to a remote, anyone with access can clone it, query the model, propose changes, and run the model against their own backend.
 
-This tutorial walks you through the collaboration loop end-to-end. You'll play both sides:
+This tutorial walks you through the collaboration loop end-to-end, driven from the `xorq` command line (`xorq uv build`, `xorq catalog ...`) rather than the Python API. You'll play both sides:
 
 - **User A** publishes the catalog to GitHub.
 - **User B** clones it, recovers the model, and proposes a new entry via pull request.
 - **User A** reviews, merges, and pulls the changes back.
 
 You'll also see how to swap the connection profile at recovery time, so a downstream user can run the cataloged expression against their own backend without modifying the entry.
+
+::: {.callout-note}
+### Why the command line here
+The foundation tutorial cataloged the model with the Python API (`catalog.add(expr)`). This tutorial does the same job from the shell: `xorq uv build` packages a script into a build artifact, and `xorq catalog add <build-dir>` files that artifact into the catalog. The build artifact carries a dependency-pinned wheel of your project, so the command-line flow is what you'd reach for in CI or a Makefile—no Python entry point to maintain. The two Python-only steps that remain (recovering the BSL model, swapping the profile) are called out where they appear.
+:::
 
 ## Prerequisites
 
@@ -29,32 +34,18 @@ You need:
 
 ::: {.callout-note}
 ### A catalog is a git repo
-Xorq's catalog stores entries as files in a git repository: `catalog.yaml` is the index, `aliases/` holds alias pointers, `entries/` holds the entry zips themselves, and `metadata/` holds a sidecar yaml per entry. Every `catalog.add(...)` is one git commit. That means GitHub's permission model, branch protection rules, and pull requests Just Work—there's no separate object store, no extra service to provision.
+Xorq's catalog stores entries as files in a git repository: `catalog.yaml` is the index, `aliases/` holds alias pointers, `entries/` holds the entry zips themselves, and `metadata/` holds a sidecar yaml per entry. Every `xorq catalog add` is one git commit. That means GitHub's permission model, branch protection rules, and pull requests Just Work—there's no separate object store, no extra service to provision.
 :::
 
-## Publish the catalog to GitHub (User A)
+## Build the model into an artifact (User A)
 
-::: {.callout-tip}
-### Follow along without GitHub
-You don't need a GitHub account to work through this tutorial—a local bare git repo behaves the same way for `clone`/`push`/`pull`. Each remote-using step below has a **Local bare repo** tab next to the GitHub one; pick one and stay on it.
-:::
-
-Recreate the catalog at a stable path (`~/work/flights-catalog-usera`) so the rest of the tutorial has somewhere persistent to point at, then re-add the flights model the same way the foundation tutorial did. Save the snippet below as `publish_catalog.py` in User A's `~/flights-tutorial/` project directory and run it with `uv run python publish_catalog.py` from there:
+The command line catalogs *build artifacts*, not live Python objects, so the first step is to produce one. Save the model definition below as `flights_model.py` in User A's `~/flights-tutorial/` project. It's the same model as the foundation tutorial, trimmed to just the definition and a final `to_tagged(...)` assignment to `expr`, the variable `xorq uv build` looks for:
 
 ```python
-# publish_catalog.py
-from pathlib import Path
-
+# flights_model.py
 from boring_semantic_layer import to_semantic_table, to_tagged
 import xorq.api as xo
-from xorq.catalog.catalog import Catalog
 
-catalog_dir = Path("~/work/flights-catalog-usera").expanduser()
-catalog_dir.parent.mkdir(parents=True, exist_ok=True)    # <1>
-
-catalog = Catalog.from_repo_path(catalog_dir, init=True)
-
-# Same memtable + semantic model as the foundation tutorial
 flights = xo.memtable(
     {
         "origin":      ["JFK", "LAX", "ORD", "JFK", "LAX", "ORD", "JFK", "LAX"],
@@ -78,30 +69,61 @@ flights_model = (
         total_distance=lambda t: t.distance.sum(),
     )
 )
-flights_model_expr = to_tagged(flights_model)
-catalog.add(flights_model_expr, aliases=("flights-model",), sync=False)
+expr = to_tagged(flights_model)
 ```
-1. `Catalog.from_repo_path(..., init=True)` creates the leaf directory but not its parent, so make sure `~/work/` exists first.
+
+Build it from inside the project directory. `-e expr` names the variable to build; `xorq uv build` resolves the project root by searching upward for `pyproject.toml`, so the cwd matters:
+
+```bash
+cd ~/flights-tutorial
+uv run xorq uv build flights_model.py -e expr
+# prints the build directory, e.g. builds/a1b2c3d4e5f6
+```
+
+The command prints the build directory it created (under `builds/`) as the last line—you'll pass that path to `catalog add` next. To capture it in a shell variable instead of copying by hand:
+
+```bash
+BUILD_A=$(cd ~/flights-tutorial && uv run xorq uv build flights_model.py -e expr | tail -1)
+```
 
 ::: {.callout-note}
-### Expect wheel-build output on `catalog.add(...)`
-Each `catalog.add(...)` packages your project as a wheel and stores it inside the entry, so the cataloged expression keeps a frozen record of the dependencies it was built against. You'll see `Building wheel...`, `running egg_info`, and `Successfully built ...whl` in the output, plus a `UserWarning` about local filesystem paths from the inline `memtable`—both are expected and not errors.
+### Expect wheel-build output on `xorq uv build`
+`xorq uv build` packages your project as a wheel and stores it inside the build artifact, so the cataloged expression keeps a frozen record of the dependencies it was built against. You'll see `Building wheel...`, `running egg_info`, and `Successfully built ...whl` in the output, plus a `UserWarning` about local filesystem paths from the inline `memtable`—both are expected and not errors. If OTel console export pollutes stdout and breaks the `tail -1` capture, pass `--emit-build-path-to build_path.txt` and read the path from that file.
 :::
 
-Wire up a remote. The first push needs `-u` to set upstream tracking:
+## Publish the catalog to GitHub (User A)
+
+::: {.callout-tip}
+### Follow along without GitHub
+You don't need a GitHub account to work through this tutorial—a local bare git repo behaves the same way for `clone`/`push`/`pull`. Each remote-using step below has a **Local bare repo** tab next to the GitHub one; pick one and stay on it.
+:::
+
+Initialize the catalog at a stable path (`~/work/flights-catalog-usera`) so the rest of the tutorial has somewhere persistent to point at, then add the build artifact under the `flights-model` alias. `init` creates the catalog's leaf directory but not its parent, so make sure `~/work/` exists first:
+
+```bash
+mkdir -p ~/work
+cd ~/flights-tutorial
+uv run xorq catalog --path ~/work/flights-catalog-usera init
+uv run xorq catalog --path ~/work/flights-catalog-usera add "$BUILD_A" -a flights-model
+uv run xorq catalog --path ~/work/flights-catalog-usera list-aliases
+# flights-model
+```
+
+(`--path` is a group option, so it comes *before* the subcommand. If you didn't capture `$BUILD_A`, substitute the `builds/<hash>` path the build step printed.)
+
+Wire up a remote and push. `xorq catalog set-remote` adds the git remote; the first push still needs raw `git push -u` to set upstream tracking, which `xorq catalog push` doesn't do:
 
 ::: {.panel-tabset}
 
 ### GitHub
-Create an empty repository on GitHub (web UI: "New repository" → leave empty), then run these in the catalog directory:
+Create an empty repository on GitHub (web UI: "New repository" → leave empty), then point the catalog at it and push:
 
 ```bash
-cd ~/work/flights-catalog-usera
-git remote add origin https://github.com/<you>/flights-catalog.git
-git push -u origin main
+uv run xorq catalog --path ~/work/flights-catalog-usera set-remote https://github.com/<you>/flights-catalog.git
+git -C ~/work/flights-catalog-usera push -u origin main
 ```
 
-Or, equivalently, with the `gh` command-line tool from inside the catalog directory—`--source=.` means "create the repo from this working directory," so the `cd` matters:
+Or, equivalently, with the `gh` command-line tool from inside the catalog directory—`--source=.` means "create the repo from this working directory," so the `cd` matters. `gh` adds the `origin` remote and pushes for you, so you don't need `set-remote`:
 
 ```bash
 cd ~/work/flights-catalog-usera
@@ -115,26 +137,19 @@ Initialize a local bare repo to act as the "remote"—same git semantics, no Git
 git init --bare ~/work/flights-catalog-remote.git
 ```
 
-Then, in the catalog directory (note: this is `~/work/flights-catalog-usera`, **not** the bare repo you just created):
+Then point the catalog at it and push:
 
 ```bash
-cd ~/work/flights-catalog-usera
-git remote add origin "file://$HOME/work/flights-catalog-remote.git"
-git push -u origin main
+uv run xorq catalog --path ~/work/flights-catalog-usera set-remote "file://$HOME/work/flights-catalog-remote.git"
+git -C ~/work/flights-catalog-usera push -u origin main
 ```
 
 :::
 
-That first push has to use raw git: `catalog.push()` doesn't add remotes or set upstream tracking, so there's nothing for it to push to until `git remote add` + `git push -u` have run once. Every subsequent publish can use `catalog.push()`, which runs `git push` against every remote configured on the repo. Either append it to the bottom of `publish_catalog.py` (where `catalog` is already in scope), or run it as its own one-off—save the snippet below as `push_catalog.py` in User A's `~/flights-tutorial/` project and run `uv run python push_catalog.py` from there:
+Every subsequent publish can use `xorq catalog push`, which runs `git push` against the configured remote:
 
-```python
-# push_catalog.py
-from pathlib import Path
-
-from xorq.catalog.catalog import Catalog
-
-catalog = Catalog.from_repo_path(Path("~/work/flights-catalog-usera").expanduser(), init=False)
-catalog.push()
+```bash
+uv run xorq catalog --path ~/work/flights-catalog-usera push
 ```
 
 Verify the remote sees what you expect:
@@ -146,7 +161,7 @@ Verify the remote sees what you expect:
 gh repo view --web   # opens the repo on GitHub
 ```
 
-You should see `catalog.yaml` (the index) at the top level, plus `aliases/`, `entries/`, and `metadata/` directories. Click into `aliases/` and you'll see `flights-model.zip`—the alias from the foundation tutorial.
+You should see `catalog.yaml` (the index) at the top level, plus `aliases/`, `entries/`, and `metadata/` directories. Click into `aliases/` and you'll see `flights-model.zip`—the alias you just added.
 
 ### Local bare repo
 A bare repo has no working tree to `ls`, so list its files at `main` directly:
@@ -170,76 +185,42 @@ uv add "xorq[bsl,duckdb,sqlite]"
 printf '\n[tool.setuptools]\npy-modules = []\n' >> pyproject.toml
 ```
 
-This is the same setup the foundation tutorial walked you through for User A, just under a different directory name. From here on, every User B script runs with `uv run python <script>.py` from inside `~/flights-tutorial-userb/`. The `uv run` command picks up that project's `.venv` automatically, so you never have to deactivate User A's venv to run User B's code.
+This is the same setup the foundation tutorial walked you through for User A, just under a different directory name. From here on, every User B command runs with `uv run xorq ...` from inside `~/flights-tutorial-userb/`. The `uv run` command picks up that project's `.venv` automatically, so you never have to deactivate User A's venv to run User B's code.
 
 ::: {.callout-tip}
 ### Two projects, no venv switching
-With User A's `flights-tutorial/` and User B's `flights-tutorial-userb/`, you have two `.venv`s on disk. `uv run python script.py` looks at the `pyproject.toml` of the directory you're in and uses *that* venv—so as long as you `cd` into the right project before each command, the right venv is used. No `source`, no `deactivate`.
+With User A's `flights-tutorial/` and User B's `flights-tutorial-userb/`, you have two `.venv`s on disk. `uv run xorq ...` looks at the `pyproject.toml` of the directory you're in and uses *that* venv—so as long as you `cd` into the right project before each command, the right venv is used. No `source`, no `deactivate`.
 :::
 
 ## Clone the catalog (User B)
 
-User B clones the catalog with one call:
+User B clones the catalog with one command:
 
 ::: {.panel-tabset}
 
 ### GitHub
-Save the snippet below as `clone_catalog.py` in `~/flights-tutorial-userb/` and run `uv run python clone_catalog.py` from there:
-
-```python
-# clone_catalog.py
-from pathlib import Path
-
-from xorq.catalog.catalog import Catalog
-
-catalog = Catalog.clone_from(
-    "https://github.com/<you>/flights-catalog.git",
-    Path("~/work/flights-catalog-userb").expanduser(),
-)
-
-print("Aliases:", catalog.list_aliases())
-# ['flights-model']
-```
-
-The same thing is available from the command line—pick one or the other; running both fails on the second clone because the directory already exists:
-
 ```bash
+cd ~/flights-tutorial-userb
 uv run xorq catalog clone https://github.com/<you>/flights-catalog.git --path ~/work/flights-catalog-userb
 uv run xorq catalog --path ~/work/flights-catalog-userb list-aliases
+# flights-model
 ```
 
 ### Local bare repo
-Save the snippet below as `clone_catalog.py` in `~/flights-tutorial-userb/` and run `uv run python clone_catalog.py` from there:
-
-```python
-# clone_catalog.py
-from pathlib import Path
-
-from xorq.catalog.catalog import Catalog
-
-catalog = Catalog.clone_from(
-    f"file://{Path('~/work/flights-catalog-remote.git').expanduser()}",
-    Path("~/work/flights-catalog-userb").expanduser(),
-)
-
-print("Aliases:", catalog.list_aliases())
-# ['flights-model']
-```
-
-The same thing is available from the command line—pick one or the other; running both fails on the second clone because the directory already exists:
-
 ```bash
+cd ~/flights-tutorial-userb
 uv run xorq catalog clone "file://$HOME/work/flights-catalog-remote.git" --path ~/work/flights-catalog-userb
 uv run xorq catalog --path ~/work/flights-catalog-userb list-aliases
+# flights-model
 ```
 
 :::
 
-User B never saw User A's Python file, never saw the original `to_semantic_table(...)` call. All they have is a git clone—and that's enough.
+User B never saw User A's `flights_model.py`, never saw the original `to_semantic_table(...)` call. All they have is a git clone—and that's enough.
 
 ## Recover and query the model (User B)
 
-Recover the model the same way the foundation tutorial did. Because the catalog is plain git, the entry contents arrived during `clone_from`, so `from_tagged` can read them immediately. Save the snippet below as `recover_model.py` in `~/flights-tutorial-userb/` and run it with `uv run python recover_model.py`:
+Recovering the BSL `SemanticModel` so you can call `.query(...)` is a Python step. `from_tagged` rebuilds the semantic layer from the cataloged expression. Because the catalog is plain git, the entry contents arrived during `clone`, so `from_tagged` can read them immediately. Save the snippet below as `recover_model.py` in `~/flights-tutorial-userb/` and run it with `uv run python recover_model.py`:
 
 ```python
 # recover_model.py
@@ -261,28 +242,22 @@ print(
 )
 ```
 
-The recovered `SemanticModel` has the same dimensions and measures User A defined. The data User A used (the inline `xo.memtable(...)` from the foundation tutorial) is serialized inside the entry, so the query runs locally—no shared filesystem, no out-of-band data transfer.
+The recovered `SemanticModel` has the same dimensions and measures User A defined. The data User A used (the inline `xo.memtable(...)`) is serialized inside the entry, so the query runs locally—no shared filesystem, no out-of-band data transfer.
 
 ## Propose a change via pull request (User B)
 
 User B wants to publish a refined view: same model, but filtered to American Airlines only. Because the catalog is a git repo, they branch, commit, push, and open a PR—exactly like any other code change.
 
 ```bash
-cd ~/work/flights-catalog-userb
-git checkout -b add-aa-only-model
+git -C ~/work/flights-catalog-userb checkout -b add-aa-only-model
 ```
 
-Build the new entry in Python. User B has the same flights data as User A—it's the inline `memtable` from the foundation tutorial—so they reconstruct it the same way. Save the snippet below as `add_aa_model.py` in `~/flights-tutorial-userb/`:
+Build the new entry the same way User A built the first one. User B has the same flights data—it's the inline `memtable`—so they reconstruct it in a script. Save the snippet below as `aa_flights_model.py` in `~/flights-tutorial-userb/`:
 
 ```python
-# add_aa_model.py
-from pathlib import Path
-
+# aa_flights_model.py
 from boring_semantic_layer import to_semantic_table, to_tagged
 import xorq.api as xo
-from xorq.catalog.catalog import Catalog
-
-catalog = Catalog.from_repo_path(Path("~/work/flights-catalog-userb").expanduser(), init=False)
 
 flights = xo.memtable(
     {
@@ -308,42 +283,44 @@ aa_model = (
         avg_dep_delay=lambda t: t.dep_delay.mean(),
     )
 )
-
-aa_model_expr = to_tagged(aa_model)
-catalog.add(aa_model_expr, aliases=("flights-aa-only",), sync=False)
+expr = to_tagged(aa_model)
 ```
 
-Run it from User B's project—`uv run` puts you in that project's venv, and `catalog.add(...)` finds `~/flights-tutorial-userb/pyproject.toml` from cwd to build the dependency-pinning wheel:
+Build it from User B's project, then add it under a new alias with `--no-sync`:
 
 ```bash
 cd ~/flights-tutorial-userb
-uv run python add_aa_model.py
+BUILD_B=$(uv run xorq uv build aa_flights_model.py -e expr | tail -1)
+uv run xorq catalog --path ~/work/flights-catalog-userb add "$BUILD_B" -a flights-aa-only --no-sync
+uv run xorq catalog --path ~/work/flights-catalog-userb list-aliases
+# flights-aa-only
+# flights-model
 ```
 
-That commits a new entry on the `add-aa-only-model` branch in your clone—`sync=False` deliberately keeps it local so you can review and push the branch yourself in the next step.
+That commits a new entry on the `add-aa-only-model` branch in your clone—`--no-sync` deliberately keeps it local so you can review and push the branch yourself in the next step.
 
 ::: {.callout-note}
-### `sync=False`
-Passing `sync=False` keeps the add local—it commits to the working branch but doesn't push to the remote. You'll push the branch yourself in the next step, after reviewing the diff.
+### `--no-sync`
+Passing `--no-sync` skips the git-annex sync after the add—it commits to the working branch but doesn't reach out to the remote. You'll push the branch yourself in the next step, after reviewing the diff.
 :::
 
-Push the feature branch and open the PR. Run these from User B's catalog directory (`~/work/flights-catalog-userb`):
+Push the feature branch and open the PR:
 
 ::: {.panel-tabset}
 
 ### GitHub
 ```bash
-git log --oneline -3                    # confirm: "add: <hash> (aliases flights-aa-only)"
-git push -u origin add-aa-only-model
+git -C ~/work/flights-catalog-userb log --oneline -3      # confirm: "add: <hash> (aliases flights-aa-only)"
+git -C ~/work/flights-catalog-userb push -u origin add-aa-only-model
 gh pr create --title "Add AA-only flights model" --body "Adds an AA-filtered view of the flights model under alias flights-aa-only."
 ```
 
-User A reviews the PR on GitHub. Because each `catalog.add(...)` is a single commit, the diff is small and readable: a new alias under `aliases/`, a new entry under `entries/`, a new sidecar under `metadata/`, and an update to `catalog.yaml`.
+User A reviews the PR on GitHub. Because each `xorq catalog add` is a single commit, the diff is small and readable: a new alias under `aliases/`, a new entry under `entries/`, a new sidecar under `metadata/`, and an update to `catalog.yaml`.
 
 ### Local bare repo
 ```bash
-git log --oneline -3                    # confirm: "add: <hash> (aliases flights-aa-only)"
-git push -u origin add-aa-only-model
+git -C ~/work/flights-catalog-userb log --oneline -3      # confirm: "add: <hash> (aliases flights-aa-only)"
+git -C ~/work/flights-catalog-userb push -u origin add-aa-only-model
 ```
 
 There's no PR—User A reviews the change as a regular fetched branch (see the next section). The diff is the same: a new alias under `aliases/`, a new entry under `entries/`, a new sidecar under `metadata/`, and an update to `catalog.yaml`.
@@ -372,31 +349,26 @@ git push origin main
 
 :::
 
-Once main has moved on the remote, User A pulls. `catalog.pull()` runs `git pull` against every git remote, fast-forwarding the local main. Save the snippet below as `pull_catalog.py` in User A's `~/flights-tutorial/` project and run it with `uv run python pull_catalog.py` from there:
+Once main has moved on the remote, User A pulls. `xorq catalog pull` runs `git pull` against the configured remote, fast-forwarding the local main:
 
-```python
-# pull_catalog.py
-from pathlib import Path
-
-from xorq.catalog.catalog import Catalog
-
-catalog_a = Catalog.from_repo_path(Path("~/work/flights-catalog-usera").expanduser(), init=False)
-catalog_a.pull()
-
-print("Aliases now:", catalog_a.list_aliases())
-# ['flights-model', 'flights-aa-only']
+```bash
+cd ~/flights-tutorial
+uv run xorq catalog --path ~/work/flights-catalog-usera pull
+uv run xorq catalog --path ~/work/flights-catalog-usera list-aliases
+# flights-aa-only
+# flights-model
 ```
 
 ::: {.callout-note}
-### On the local-bare-repo path, `pull()` is effectively a no-op
-You merged in your local clone and pushed up—your local `main` is already at the merged tip, so there's nothing for `pull()` to fast-forward. The script is still worth running because it's the same one-liner User A would use after a teammate clicked "Merge pull request" on GitHub; here it just confirms the new alias is visible.
+### On the local-bare-repo path, `pull` is effectively a no-op
+You merged in your local clone and pushed up—your local `main` is already at the merged tip, so there's nothing for `pull` to fast-forward. The command is still worth running because it's the same one-liner User A would use after a teammate clicked "Merge pull request" on GitHub; here it just confirms the new alias is visible.
 :::
 
 The same alias is now visible everywhere the catalog is cloned. Anyone with access can recover and query `flights-aa-only` exactly the way they recover `flights-model`.
 
 ## Swap the profile at recovery time
 
-The catalog stores expressions, not connections. When User A built the entry they used the default Xorq backend (a `xorq_datafusion` session); when User B recovers it, they may want to execute against a different profile—perhaps a SQLite database they've configured locally, a Postgres instance with extra resources, or a Snowflake warehouse.
+The catalog stores expressions, not connections. When User A built the entry they used the default Xorq backend (a `xorq_datafusion` session); when User B recovers it, they may want to execute against a different profile—perhaps a SQLite database they've configured locally, a Postgres instance with extra resources, or a Snowflake warehouse. Rebinding to a connection is a Python step.
 
 A **profile** in Xorq is a named connection configuration: `con_name` plus connection kwargs, serialized to disk. Save one with `Profile.from_con(con).save(alias=...)`, load it with `Profile.load(...)`.
 
@@ -450,10 +422,11 @@ The `Executing against backend: sqlite` line is the proof—User A cataloged the
 
 ## What you learned
 
-- A Xorq catalog is a git repository: every `catalog.add(...)` is one commit, and the diff is small enough to review on GitHub.
-- Sharing the catalog is `catalog.push()` (after a one-time `git remote add origin` + `git push -u origin main`); cloning uses `Catalog.clone_from(...)`.
+- A Xorq catalog is a git repository: every `xorq catalog add` is one commit, and the diff is small enough to review on GitHub.
+- `xorq uv build <script> -e expr` packages a model script into a dependency-pinned build artifact; `xorq catalog add <build-dir> -a <alias>` files it into the catalog.
+- Sharing the catalog is `xorq catalog push` (after a one-time `xorq catalog set-remote` + `git push -u origin main`); cloning uses `xorq catalog clone <url> --path ...`.
 - Collaboration uses the GitHub workflow you already know: branch, commit, push, open a PR. The reviewer sees alias and entry files in the diff; merging makes the new alias available everywhere the catalog is cloned.
-- `from_tagged(flights_entry.expr)` recovers the BSL model on the consumer side—the same call as in the foundation tutorial, regardless of where the entry came from.
+- `from_tagged(flights_entry.expr)` recovers the BSL model on the consumer side—a Python step, the same call as in the foundation tutorial, regardless of where the entry came from.
 - `catalog.load(name, con=...)` rebinds a cataloged expression to a different connection at recovery time. Combined with named `Profile`s, downstream users can pick their own execution backend—SQLite, Postgres, anything Xorq supports—without modifying the entry.
 
 ## Next steps

--- a/docs/tutorials/core_tutorials/working_with_the_catalog.snippets.py
+++ b/docs/tutorials/core_tutorials/working_with_the_catalog.snippets.py
@@ -1,11 +1,12 @@
 """Code samples adapted from docs/tutorials/core_tutorials/working_with_the_catalog.qmd.
 
 The tutorial drives the publish / clone / pull loop from the ``xorq`` CLI
-(`xorq uv build`, `xorq uv run`, `xorq catalog ...`) rather than the Python
-API. This smoke test mirrors that flow: each shell snippet in the tutorial
-becomes a ``subprocess.run([...])`` call here. Python only re-appears where
-the tutorial uses it — recovering the BSL ``SemanticModel`` via
-``from_tagged`` and rebinding the entry to a SQLite profile.
+(`xorq uv build`, `xorq catalog ...`) rather than the Python API. This smoke
+test mirrors that flow: each CLI step in the tutorial becomes a
+``subprocess.run([...])`` call here. Python only re-appears where the tutorial
+uses it — recovering the BSL ``SemanticModel`` via ``from_tagged`` and
+rebinding the entry to a SQLite profile. The GitHub-only steps (the PR UI,
+``gh``) have no runnable equivalent and are left to the prose.
 
 Without a real GitHub remote we stand in a local *bare* git repository to
 play the role of the GitHub-hosted origin: User A pushes to the bare repo,
@@ -148,7 +149,7 @@ def _latest_build(builds_dir):
 try:
     # %% --- Define and build the model (User A)
     (_USER_A_PROJ / "flights_model.py").write_text(_FLIGHTS_MODEL_PY)
-    _run(
+    _stdout_a = _run(
         [
             _XORQ,
             "uv",
@@ -162,6 +163,13 @@ try:
         cwd=_USER_A_PROJ,
     )
     _build_a = _latest_build(_USER_A_PROJ / "builds")
+    # The tutorial recovers the build dir via `... | tail -1`, so the last
+    # stdout line must be that path. Assert it here, not just the mtime sort,
+    # so the documented contract breaks the test if stdout gets polluted.
+    _last_a = _stdout_a.strip().splitlines()[-1]
+    assert (_USER_A_PROJ / _last_a).resolve() == _build_a.resolve(), (
+        f"last stdout line {_last_a!r} != build dir {_build_a}"
+    )
 
     # %% --- Initialize catalog and add the entry (User A)
     _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "init"])
@@ -189,6 +197,9 @@ try:
         [_XORQ, "catalog", "--path", str(_CATALOG_A), "set-remote", str(_BARE)],
     )
     _run(["git", "push", "-u", "origin", "main"], cwd=_CATALOG_A)
+    # `git push -u` already transferred everything, so this exercises command +
+    # remote resolution + exit status, not a delta. Transfer-with-a-delta is
+    # covered by User B's `git push` of the feature branch and User A's `pull`.
     _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "push"])
 
     # %% --- Clone the catalog (User B)
@@ -228,7 +239,7 @@ try:
     # %% --- Propose a change (User B): branch, build, add with --no-sync
     _run(["git", "checkout", "-b", "add-aa-only-model"], cwd=_CATALOG_B)
     (_USER_B_PROJ / "aa_flights_model.py").write_text(_AA_FLIGHTS_MODEL_PY)
-    _run(
+    _stdout_b = _run(
         [
             _XORQ,
             "uv",
@@ -242,6 +253,10 @@ try:
         cwd=_USER_B_PROJ,
     )
     _build_b = _latest_build(_USER_B_PROJ / "builds")
+    _last_b = _stdout_b.strip().splitlines()[-1]
+    assert (_USER_B_PROJ / _last_b).resolve() == _build_b.resolve(), (
+        f"last stdout line {_last_b!r} != build dir {_build_b}"
+    )
     _run(
         [
             _XORQ,

--- a/docs/tutorials/core_tutorials/working_with_the_catalog.snippets.py
+++ b/docs/tutorials/core_tutorials/working_with_the_catalog.snippets.py
@@ -1,36 +1,48 @@
 """Code samples adapted from docs/tutorials/core_tutorials/working_with_the_catalog.qmd.
 
-The tutorial walks through pushing a catalog to GitHub and a teammate cloning
-it back over the network. Without a real GitHub remote, the smoke test stands
-in a local *bare* git repository to play the role of the GitHub-hosted origin:
-User A pushes to the bare repo, User B clones from it, User B pushes a feature
-branch back to it, and "merging the PR" becomes fast-forwarding ``main`` on
-the bare repo. End state is identical to a real merge — User A pulls and sees
-the new alias — so the API surface exercised here matches what a reader doing
-the live GitHub workflow would hit.
+The tutorial drives the publish / clone / pull loop from the ``xorq`` CLI
+(`xorq uv build`, `xorq uv run`, `xorq catalog ...`) rather than the Python
+API. This smoke test mirrors that flow: each shell snippet in the tutorial
+becomes a ``subprocess.run([...])`` call here. Python only re-appears where
+the tutorial uses it — recovering the BSL ``SemanticModel`` via
+``from_tagged`` and rebinding the entry to a SQLite profile.
 
-What's still *not* exercised: the GitHub UI itself (branch protection, PR
-reviews, merge button). The prose covers those; the smoke test only verifies
-the xorq APIs that bracket the human-in-the-loop step.
+Without a real GitHub remote we stand in a local *bare* git repository to
+play the role of the GitHub-hosted origin: User A pushes to the bare repo,
+User B clones from it, User B pushes a feature branch back, and "merging
+the PR" becomes fast-forwarding ``main`` on the bare repo. End state is
+identical to a real merge — User A pulls and sees the new alias.
 """
 
 # %% --- test fixture: stand in for `uv init && uv add "xorq[bsl,duckdb,sqlite]"`
 import os as _os
 import shutil as _shutil
 import subprocess as _subprocess
+import sys as _sys
 import tempfile as _tempfile
 from pathlib import Path as _Path
 
-_workdir = _Path(_tempfile.mkdtemp(prefix="xorq-catalog-tutorial-"))
-(_workdir / "pyproject.toml").write_text(
-    '[project]\nname = "flights-tutorial"\nversion = "0.0.0"\n'
-    'dependencies = ["xorq[bsl,duckdb,sqlite]"]\n'
-    "[tool.setuptools]\npackages = []\n"
-)
-(_workdir / "requirements.txt").write_text("xorq[bsl,duckdb,sqlite]\n")
-_os.chdir(_workdir)
 
-# Stand-in for the GitHub-hosted origin: a bare repo both users push to.
+_workdir = _Path(_tempfile.mkdtemp(prefix="xorq-catalog-tutorial-"))
+
+# Two project dirs, mirroring `~/flights-tutorial` (User A) and
+# `~/flights-tutorial-userb` (User B). Each gets its own pyproject.toml so
+# `xorq uv build` can resolve the project root from the script path.
+_USER_A_PROJ = _workdir / "flights-tutorial"
+_USER_B_PROJ = _workdir / "flights-tutorial-userb"
+for _proj in (_USER_A_PROJ, _USER_B_PROJ):
+    _proj.mkdir(parents=True, exist_ok=True)
+    (_proj / "pyproject.toml").write_text(
+        '[project]\nname = "flights-tutorial"\nversion = "0.0.0"\n'
+        'dependencies = ["xorq[bsl,duckdb,sqlite]"]\n'
+        "[tool.setuptools]\npackages = []\n"
+    )
+    # `xorq uv build` needs a requirements.txt or uv.lock to pin the project's
+    # deps inside the produced wheel. The tutorial reader gets one via
+    # `uv add ...`; the smoke test ships a hand-written requirements.txt for
+    # the same effect without touching the network.
+    (_proj / "requirements.txt").write_text("xorq[bsl,duckdb,sqlite]\n")
+
 _BARE = _workdir / "remote.git"
 _subprocess.run(
     ["git", "init", "--bare", "-b", "main", _BARE],
@@ -38,70 +50,170 @@ _subprocess.run(
     capture_output=True,
 )
 
-_USER_A = _workdir / "userA" / "flights-catalog"
-_USER_B = _workdir / "userB" / "flights-catalog"
-_USER_A.parent.mkdir(parents=True, exist_ok=True)
+_CATALOG_A = _workdir / "user_a" / "flights-catalog"
+_CATALOG_B = _workdir / "user_b" / "flights-catalog"
+_CATALOG_A.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _run(cmd, cwd=None, env=None):
+    """Run a CLI command, fail loudly on non-zero, return stdout."""
+    result = _subprocess.run(
+        cmd, cwd=cwd, env=env, capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {cmd}\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+    return result.stdout
+
+
+# Path to the `xorq` CLI installed alongside the running interpreter.
+_XORQ = str(_Path(_sys.executable).parent / "xorq")
+assert _Path(_XORQ).exists(), f"xorq CLI not found at {_XORQ}"
+
+
+_FLIGHTS_MODEL_PY = """\
+from boring_semantic_layer import to_semantic_table, to_tagged
+import xorq.api as xo
+
+flights = xo.memtable(
+    {
+        "origin":      ["JFK", "LAX", "ORD", "JFK", "LAX", "ORD", "JFK", "LAX"],
+        "destination": ["LAX", "ORD", "JFK", "ORD", "JFK", "LAX", "LAX", "JFK"],
+        "carrier":     ["AA",  "UA",  "AA",  "UA",  "AA",  "UA",  "AA",  "UA"],
+        "dep_delay":   [10.0, -5.0,  30.0,  15.0, -2.0,  45.0,   5.0,  20.0],
+        "distance":    [2475, 1745,   740,  1300, 2475,  1745,  2475,  2475],
+    },
+    name="flights",
+)
+flights_model = (
+    to_semantic_table(flights)
+    .with_dimensions(
+        origin=lambda t: t.origin,
+        destination=lambda t: t.destination,
+        carrier=lambda t: t.carrier,
+    )
+    .with_measures(
+        flight_count=lambda t: t.count(),
+        avg_dep_delay=lambda t: t.dep_delay.mean(),
+        total_distance=lambda t: t.distance.sum(),
+    )
+)
+expr = to_tagged(flights_model)
+"""
+
+_AA_FLIGHTS_MODEL_PY = """\
+from boring_semantic_layer import to_semantic_table, to_tagged
+import xorq.api as xo
+
+flights = xo.memtable(
+    {
+        "origin":      ["JFK", "LAX", "ORD", "JFK", "LAX", "ORD", "JFK", "LAX"],
+        "destination": ["LAX", "ORD", "JFK", "ORD", "JFK", "LAX", "LAX", "JFK"],
+        "carrier":     ["AA",  "UA",  "AA",  "UA",  "AA",  "UA",  "AA",  "UA"],
+        "dep_delay":   [10.0, -5.0,  30.0,  15.0, -2.0,  45.0,   5.0,  20.0],
+        "distance":    [2475, 1745,   740,  1300, 2475,  1745,  2475,  2475],
+    },
+    name="flights",
+)
+aa_flights = flights.filter(flights.carrier == "AA")
+aa_model = (
+    to_semantic_table(aa_flights)
+    .with_dimensions(
+        origin=lambda t: t.origin,
+        destination=lambda t: t.destination,
+    )
+    .with_measures(
+        flight_count=lambda t: t.count(),
+        avg_dep_delay=lambda t: t.dep_delay.mean(),
+    )
+)
+expr = to_tagged(aa_model)
+"""
 # --- end fixture ---
 
 
+def _latest_build(builds_dir):
+    builds = sorted(
+        (p for p in builds_dir.iterdir() if p.is_dir()),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    assert builds, f"no build dirs in {builds_dir}"
+    return builds[0]
+
+
 try:
-    # %% --- Publish the catalog (User A)
-    import xorq.api as xo
-    from boring_semantic_layer import to_semantic_table, to_tagged
-    from xorq.catalog.catalog import Catalog
+    # %% --- Define and build the model (User A)
+    (_USER_A_PROJ / "flights_model.py").write_text(_FLIGHTS_MODEL_PY)
+    _run(
+        [
+            _XORQ,
+            "uv",
+            "build",
+            "flights_model.py",
+            "-e",
+            "expr",
+            "--builds-dir",
+            "builds",
+        ],
+        cwd=_USER_A_PROJ,
+    )
+    _build_a = _latest_build(_USER_A_PROJ / "builds")
 
-    catalog = Catalog.from_repo_path(_USER_A, init=True)
+    # %% --- Initialize catalog and add the entry (User A)
+    _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "init"])
+    _run(
+        [
+            _XORQ,
+            "catalog",
+            "--path",
+            str(_CATALOG_A),
+            "add",
+            str(_build_a),
+            "-a",
+            "flights-model",
+        ]
+    )
+    _aliases_a = (
+        _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "list-aliases"])
+        .strip()
+        .splitlines()
+    )
+    assert _aliases_a == ["flights-model"], _aliases_a
 
-    flights = xo.memtable(
-        {
-            "origin": ["JFK", "LAX", "ORD", "JFK", "LAX", "ORD", "JFK", "LAX"],
-            "destination": ["LAX", "ORD", "JFK", "ORD", "JFK", "LAX", "LAX", "JFK"],
-            "carrier": ["AA", "UA", "AA", "UA", "AA", "UA", "AA", "UA"],
-            "dep_delay": [10.0, -5.0, 30.0, 15.0, -2.0, 45.0, 5.0, 20.0],
-            "distance": [2475, 1745, 740, 1300, 2475, 1745, 2475, 2475],
-        },
-        name="flights",
+    # %% --- Wire up the (bare) remote and push (User A)
+    _run(
+        [_XORQ, "catalog", "--path", str(_CATALOG_A), "set-remote", str(_BARE)],
     )
-    flights_model = (
-        to_semantic_table(flights)
-        .with_dimensions(
-            origin=lambda t: t.origin,
-            destination=lambda t: t.destination,
-            carrier=lambda t: t.carrier,
-        )
-        .with_measures(
-            flight_count=lambda t: t.count(),
-            avg_dep_delay=lambda t: t.dep_delay.mean(),
-            total_distance=lambda t: t.distance.sum(),
-        )
-    )
-    flights_model_expr = to_tagged(flights_model)
-    catalog.add(flights_model_expr, aliases=("flights-model",), sync=False)
-
-    # Tutorial: `gh repo create` + `git remote add origin <url>` + `git push -u origin main`.
-    # Smoke test: point origin at the local bare repo and push.
-    _subprocess.run(
-        ["git", "remote", "add", "origin", _BARE],
-        cwd=_USER_A,
-        check=True,
-        capture_output=True,
-    )
-    _subprocess.run(
-        ["git", "push", "-u", "origin", "main"],
-        cwd=_USER_A,
-        check=True,
-        capture_output=True,
-    )
+    _run(["git", "push", "-u", "origin", "main"], cwd=_CATALOG_A)
+    _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "push"])
 
     # %% --- Clone the catalog (User B)
-    catalog_b = Catalog.clone_from(_BARE, _USER_B)
+    _run(
+        [
+            _XORQ,
+            "catalog",
+            "clone",
+            str(_BARE),
+            "--path",
+            str(_CATALOG_B),
+        ]
+    )
+    _aliases_b = (
+        _run([_XORQ, "catalog", "--path", str(_CATALOG_B), "list-aliases"])
+        .strip()
+        .splitlines()
+    )
+    assert _aliases_b == ["flights-model"], _aliases_b
 
-    print("Aliases:", catalog_b.list_aliases())
-    assert catalog_b.list_aliases() == ["flights-model"]
-
-    # %% --- Recover and query the model (User B)
+    # %% --- Recover and query the model (User B) — Python-only step
     from boring_semantic_layer import from_tagged
+    from xorq.catalog.catalog import Catalog
 
+    catalog_b = Catalog.from_repo_path(_CATALOG_B, init=False)
     flights_entry = catalog_b.get_catalog_entry("flights-model", maybe_alias=True)
     flights_model_b = from_tagged(flights_entry.expr)
     assert type(flights_model_b).__name__ == "SemanticModel"
@@ -113,70 +225,69 @@ try:
     ).order_by("origin")
     print(by_origin.execute())
 
-    # %% --- Propose a change (User B)
-    # Tutorial: branch + catalog.add + git push branch + gh pr create.
-    _subprocess.run(
-        ["git", "checkout", "-b", "add-aa-only-model"],
-        cwd=_USER_B,
-        check=True,
-        capture_output=True,
+    # %% --- Propose a change (User B): branch, build, add with --no-sync
+    _run(["git", "checkout", "-b", "add-aa-only-model"], cwd=_CATALOG_B)
+    (_USER_B_PROJ / "aa_flights_model.py").write_text(_AA_FLIGHTS_MODEL_PY)
+    _run(
+        [
+            _XORQ,
+            "uv",
+            "build",
+            "aa_flights_model.py",
+            "-e",
+            "expr",
+            "--builds-dir",
+            "builds",
+        ],
+        cwd=_USER_B_PROJ,
     )
+    _build_b = _latest_build(_USER_B_PROJ / "builds")
+    _run(
+        [
+            _XORQ,
+            "catalog",
+            "--path",
+            str(_CATALOG_B),
+            "add",
+            str(_build_b),
+            "-a",
+            "flights-aa-only",
+            "--no-sync",
+        ]
+    )
+    _aliases_b_after = set(
+        _run([_XORQ, "catalog", "--path", str(_CATALOG_B), "list-aliases"])
+        .strip()
+        .splitlines()
+    )
+    assert _aliases_b_after == {"flights-model", "flights-aa-only"}, _aliases_b_after
 
-    # User B reconstructs the same flights memtable they got from the foundation tutorial.
-    flights_b = xo.memtable(
-        {
-            "origin": ["JFK", "LAX", "ORD", "JFK", "LAX", "ORD", "JFK", "LAX"],
-            "destination": ["LAX", "ORD", "JFK", "ORD", "JFK", "LAX", "LAX", "JFK"],
-            "carrier": ["AA", "UA", "AA", "UA", "AA", "UA", "AA", "UA"],
-            "dep_delay": [10.0, -5.0, 30.0, 15.0, -2.0, 45.0, 5.0, 20.0],
-            "distance": [2475, 1745, 740, 1300, 2475, 1745, 2475, 2475],
-        },
-        name="flights",
-    )
-    aa_flights = flights_b.filter(flights_b.carrier == "AA")
-    aa_model = (
-        to_semantic_table(aa_flights)
-        .with_dimensions(
-            origin=lambda t: t.origin,
-            destination=lambda t: t.destination,
-        )
-        .with_measures(
-            flight_count=lambda t: t.count(),
-            avg_dep_delay=lambda t: t.dep_delay.mean(),
-        )
-    )
-    aa_model_expr = to_tagged(aa_model)
-    catalog_b.add(aa_model_expr, aliases=("flights-aa-only",), sync=False)
-    assert set(catalog_b.list_aliases()) == {"flights-model", "flights-aa-only"}
+    _run(["git", "push", "-u", "origin", "add-aa-only-model"], cwd=_CATALOG_B)
 
-    _subprocess.run(
-        ["git", "push", "-u", "origin", "add-aa-only-model"],
-        cwd=_USER_B,
-        check=True,
-        capture_output=True,
-    )
-
-    # %% --- Merge the PR (the prose says: User A clicks Merge on GitHub).
-    # Equivalent on the bare repo: fast-forward main to the feature branch.
-    _subprocess.run(
+    # %% --- "Merge the PR" — tutorial prose: User A clicks Merge on GitHub.
+    # On the bare repo, equivalent to fast-forwarding main to the feature branch.
+    _run(
         ["git", "update-ref", "refs/heads/main", "refs/heads/add-aa-only-model"],
         cwd=_BARE,
-        check=True,
-        capture_output=True,
     )
 
     # %% --- Pull the merged change (User A)
-    catalog_a = Catalog.from_repo_path(_USER_A, init=False)
-    catalog_a.pull()
-    print("User A aliases after pull:", catalog_a.list_aliases())
-    assert set(catalog_a.list_aliases()) == {"flights-model", "flights-aa-only"}
+    _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "pull"])
+    _aliases_a_after = set(
+        _run([_XORQ, "catalog", "--path", str(_CATALOG_A), "list-aliases"])
+        .strip()
+        .splitlines()
+    )
+    assert _aliases_a_after == {"flights-model", "flights-aa-only"}, _aliases_a_after
 
-    # %% --- Swap the profile at recovery time
+    # %% --- Swap the profile at recovery time — Python-only step
+    import xorq.api as xo
     from xorq.vendor.ibis.backends.profiles import Profile
 
     sqlite_con = xo.sqlite.connect()
     Profile.from_con(sqlite_con).save(alias="local_dev_sqlite", clobber=True)
 
+    catalog_a = Catalog.from_repo_path(_CATALOG_A, init=False)
     profile = Profile.load("local_dev_sqlite")
     expr = catalog_a.load("flights-model", con=profile.get_con())
 

--- a/docs/tutorials/core_tutorials/your_first_build.qmd
+++ b/docs/tutorials/core_tutorials/your_first_build.qmd
@@ -315,7 +315,7 @@ Added build 050dac72b4d8 as entry ce9fe1e5-0004-4087-b668-f67dfbdea6ba revision 
 Now you can reference this build by name instead of hash. List catalog entries:
 
 ```bash
-xorq catalog ls
+xorq catalog list
 ```
 
 **Output:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ docs = [
     "ibis-framework>=10.5.0",
     "pymarkdownlnt>=0.9.37",
     "python-frontmatter>=1.1.0",
+    "sybil>=6",
 ]
 
 [project.entry-points."xorq.backends"]

--- a/uv.lock
+++ b/uv.lock
@@ -5634,6 +5634,32 @@ wheels = [
 ]
 
 [[package]]
+name = "sybil"
+version = "9.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/46/bae21847b8d761ddd6ede1811d32818342dbd482c32a2a5805c28d9b2f18/sybil-9.3.0.tar.gz", hash = "sha256:847d1d17b8a857c4bb3f8471b4a57b8affa939a60fbf507e70aa72ad79097c05", size = 89078, upload-time = "2025-12-02T09:29:09.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/08/cd3cf2a82570748cfb3142e795044197deff81ad3b70a0b9a9c22331e70a/sybil-9.3.0-py3-none-any.whl", hash = "sha256:0b108b980ab9fac774953042b07fcb5858aa19a38404d0cb42c30c93423ac0c1", size = 39286, upload-time = "2025-12-02T09:29:08.417Z" },
+]
+
+[[package]]
+name = "sybil"
+version = "10.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/2b/5ee5ef413b87f215c03cd08462dc341903b86707e517e20715823c984893/sybil-10.0.1.tar.gz", hash = "sha256:319eed013ebe848f8c57ce79c1ed526e506d952c778693979bc509513ae72a68", size = 80120, upload-time = "2026-03-26T08:56:30.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/f3/4f2a8069d212a33bccc88be13b5bdad61f810054f6c21c6da3aa25fb38d0/sybil-10.0.1-py3-none-any.whl", hash = "sha256:0030d8583d5ce97969397d303db1f17054f61b23f18469c0ac61f9f42735571c", size = 40316, upload-time = "2026-03-26T08:56:29.502Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6190,6 +6216,8 @@ docs = [
     { name = "pymarkdownlnt" },
     { name = "python-frontmatter" },
     { name = "quartodoc" },
+    { name = "sybil", version = "9.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sybil", version = "10.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 test = [
     { name = "coverage", extra = ["toml"] },
@@ -6300,6 +6328,7 @@ docs = [
     { name = "pymarkdownlnt", specifier = ">=0.9.37" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "quartodoc", specifier = ">=0.7.2,<0.11.2" },
+    { name = "sybil", specifier = ">=6" },
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = "==7.13.4" },


### PR DESCRIPTION
Rewrites the `working_with_the_catalog` tutorial to drive the catalog
collaboration loop (publish / clone / PR / pull) from the `xorq` CLI rather
than the Python API, and brings the prose in line with the verified
`.snippets.py` companion.

## What changed

- **`working_with_the_catalog.qmd`** — prose converted to the CLI flow:
  - new "Build the model into an artifact" step (`xorq uv build -e expr`)
  - `xorq catalog init / add / list-aliases / set-remote / push / pull / clone`
    replace `Catalog.from_repo_path`, `catalog.add(expr)`, `Catalog.clone_from`,
    etc.; GitHub vs local-bare-repo tabs preserved
  - wheel-build callout moved to `xorq uv build` (where it happens);
    `sync=False` → `--no-sync`
  - the two genuinely-Python steps (BSL recovery via `from_tagged`, profile
    swap via `Profile` / `catalog.load`) kept and flagged as such
  - "What you learned" updated to CLI verbs
- **`working_with_the_catalog.snippets.py`** — smoke test drives the same CLI
  flow via `subprocess`, so test and prose now agree.

## Why CLI (Diataxis rationale)

This is a **tutorial** — learning-oriented, so the steps must be reproducible
and trustworthy. Two reasons to drive it from the CLI:

- **Fills a coverage hole, no duplication.** The foundation tutorial
  (`build_a_semantic_catalog`) already teaches the Python API. Re-teaching the
  same surface here would be redundant; the CLI is the surface that otherwise
  has no tutorial.
- **Matches who does this work.** The collaboration loop is shell/CI/teammate
  territory (publish, clone, open a PR, pull) — the CLI is the interface
  operators actually use and the form you'd drop in a Makefile or CI step.

## On testing

Driving from the CLI is *harder* to smoke-test than the Python API
(subprocess, stdout build-path capture, exit codes) — but it tests **more**:
the installed `xorq` binary, entry-point wiring, arg parsing, and flags
(`-e`, `--no-sync`, `set-remote`). A pure-Python test can pass while
`xorq catalog add` is broken; the CLI test exercises the full stack the reader
runs. The extra brittleness mirrors the friction a reader hits — useful signal,
not pure cost.

## Verification

- `.snippets.py` runs end-to-end (publish / clone / branch / merge / pull)
  clean against `xorq 0.3.27`
- `vale` 0/0/0, `pymarkdown` clean, `quarto render` succeeds

## Follow-up (not in this PR)

The smoke test runs `.snippets.py`, not the `.qmd` fences — so prose↔snippet
drift isn't caught automatically (it's what let the docs go stale here). A
lightweight doc→CLI contract test (introspect the click app, assert every
`xorq ...` invocation referenced in docs resolves to a real command + flags)
would close that gap. Tracked separately.

Part of the Diataxis docs effort — #2023 (Phase 0a: #2024).