### PR TITLE
docs(tutorials): add get-started-with-xorq-init tutorial

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -66,6 +66,7 @@ website:
         - id: core-tutorials-section
           section: "Core tutorials"
           contents:
+            - href: tutorials/core_tutorials/get-started-with-xorq-init.qmd
             - href: tutorials/core_tutorials/build_a_semantic_catalog.qmd
             - href: tutorials/core_tutorials/working_with_the_catalog.qmd
         - id: ml-tutorials-section

--- a/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
+++ b/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
@@ -154,4 +154,5 @@ xorq uv run "$BUILD" --format csv -o /dev/stdout 2>/dev/null | head -6
 
 - [Why deferred execution?](/concepts/understanding_xorq/why_deferred_execution.qmd)
 - [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd)
-- [`xorq build` reference](/api_reference/cli/build.qmd)
+- [`xorq uv build` reference](/api_reference/cli/uv-build.qmd)
+- [`xorq uv run` reference](/api_reference/cli/uv-run.qmd)

--- a/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
+++ b/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
@@ -1,0 +1,157 @@
+---
+title: "Get started with xorq init"
+description: "Scaffold a baseball analytics pipeline in minutes with xorq init, deferred_read_csv, and xorq build"
+icon: "box-seam"
+headline: "Scaffold a pipeline in one command"
+---
+
+Scaffold a xorq project, load Moneyball CSVs, build a top-batters leaderboard. Pure xorq, no ibis import, no shell tricks.
+
+## Prerequisites
+
+[uv](https://docs.astral.sh/uv/):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+## Scaffold
+
+xorq requires Python 3.13. Make sure uv has it, then scaffold and sync against it explicitly:
+
+```bash
+uv python install 3.13
+uvx -p3.13 xorq@latest init --path moneyball
+cd moneyball
+uv sync -p3.13
+source .venv/bin/activate
+```
+
+`uvx` bootstraps xorq once; from here on the `xorq` on your PATH comes from the project's pinned `.venv`.
+
+::: {.callout-note}
+###  Use uvx, not a permanent install
+We prefer `uvx xorq@latest ...` for global xorq commands vs other methods because you're guaranteed to get the latest version of xorq.  Once you have created the xorq project we recommend you activate the uv environment and use the xorq in the venv from there on so that the `xorq` you invoke with is the same as the `xorq` in the pyproject.
+:::
+
+List what was created (including dotfiles):
+
+```bash
+ls -1A
+```
+
+A complete locked project: `pyproject.toml`, `uv.lock`, an exported `requirements.txt`, a `src/` package, and a starter `expr.py`. The `with-uvenv` script and `.envrc` are helpers xorq uses internally --- you don't need to invoke them.
+
+## Get the data
+
+```bash
+curl -fL -o Batting.csv https://raw.githubusercontent.com/xorq-labs/baseballdatabank/master/core/Batting.csv
+curl -fL -o People.csv https://raw.githubusercontent.com/xorq-labs/baseballdatabank/master/core/People.csv
+```
+
+## Write the expression
+
+Replace `expr.py` with:
+
+```python
+# expr.py
+import xorq.api as xo
+
+# in-process backend; no server, no config
+con = xo.connect()
+
+# register CSVs as typed expressions, no read until build time
+batting = xo.deferred_read_csv(con=con, path="Batting.csv", table_name="Batting")
+people  = xo.deferred_read_csv(con=con, path="People.csv",  table_name="People")
+
+# attach player bio columns to each player-season row
+batting = batting.join(
+    people["playerID", "nameFirst", "nameLast", "bats", "throws", "birthYear"],
+    "playerID",
+)
+
+# HBP and SF are null in older seasons, coalesce so arithmetic doesn't null-poison
+batting = batting.mutate(
+    HBP=batting.HBP.fill_null(0),
+    SF=batting.SF.fill_null(0),
+)
+
+# on-base percentage: (H + BB + HBP) / (AB + BB + HBP + SF)
+batting = batting.mutate(
+    OBP=(batting.H + batting.BB + batting.HBP)
+        / (batting.AB.cast("float64") + batting.BB + batting.HBP + batting.SF)
+)
+
+# modern era, AL/NL only, real hitters (>=100 AB so batting avg is meaningful)
+batting = batting.filter(
+    batting.lgID.isin(["AL", "NL"]),
+    batting.yearID > 1965,
+    batting.AB >= 100,
+)
+
+# batting average per player-season
+ranked = batting.mutate(batting_avg=batting.H / batting.AB.cast("float64"))
+
+# rank within each (league, year) by batting_avg, descending
+win    = xo.window(group_by=["lgID", "yearID"], order_by=xo.desc("batting_avg"))
+ranked = ranked.mutate(rank=xo.row_number().over(win) + 1)
+
+# top 10 per league-year; `expr` is what `xorq build` compiles
+expr = ranked.filter(ranked.rank <= 10).drop("rank")
+```
+
+`xo.deferred_read_csv` registers each CSV against any backend with automatic schema inference --- nothing is read until execution. Each binding is a typed xorq expression you can join, filter, and aggregate without writing pandas. `expr` is a description of the computation; `xorq uv build` compiles it.
+
+## Build and run
+
+```bash
+BUILD=$(xorq uv build expr.py -e expr --builds-dir builds | tail -1)
+echo "$BUILD"
+```
+
+You'll see something like `builds/f22643d56d2c` --- the hash is derived from the expression graph and your lock file, so yours will differ.
+
+```bash
+xorq uv run "$BUILD" --output-path top_batters.parquet
+```
+
+Each build is self-contained:
+
+```bash
+ls "$BUILD"
+```
+
+`expr.yaml` is the serialized graph; `requirements.txt` is pinned from your lock. Hand the directory to anyone with `xorq` and `xorq uv run` reproduces the result.
+
+If `expr.py` changes its build changes. Edit `expr.py` and run `xorq uv build` again --- bump the year filter from 1965 to 1970:
+
+```bash
+xorq uv build expr.py -e expr --builds-dir builds
+```
+
+You'll get a new directory next to the old one:
+
+```bash
+ls -1 builds
+```
+
+Nothing is overwritten. Re-running `xorq uv build` with no changes returns the same hash, no new directory.
+
+## Inspect
+
+```bash
+xorq uv run "$BUILD" --format csv -o /dev/stdout 2>/dev/null | head -6
+```
+
+## What you used
+
+- `xo.deferred_read_csv` --- lazy CSV registration, schema inferred at build time
+- `.join`, `.mutate`, `.filter` --- expression construction, nothing executes
+- `xo.window` / `xo.row_number` / `xo.desc` --- windowing, all on the `xo` namespace
+- `xorq uv build` / `xorq uv run` --- compile to `builds/<hash>/`, then execute in the project's locked env
+
+## Next
+
+- [Why deferred execution?](/concepts/understanding_xorq/why_deferred_execution.qmd)
+- [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd)
+- [`xorq build` reference](/api_reference/cli/build.qmd)

--- a/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
+++ b/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
@@ -64,10 +64,12 @@ con = xo.connect()
 batting = xo.deferred_read_csv(con=con, path="Batting.csv", table_name="Batting")
 people  = xo.deferred_read_csv(con=con, path="People.csv",  table_name="People")
 
-# attach player bio columns to each player-season row
+# attach player bio columns to each player-season row;
+# inner (the default) drops batting rows with no matching player in People
 batting = batting.join(
     people["playerID", "nameFirst", "nameLast", "bats", "throws", "birthYear"],
     "playerID",
+    how="inner",
 )
 
 # HBP and SF are null in older seasons, coalesce so arithmetic doesn't null-poison
@@ -76,17 +78,18 @@ batting = batting.mutate(
     SF=batting.SF.fill_null(0),
 )
 
-# on-base percentage: (H + BB + HBP) / (AB + BB + HBP + SF)
-batting = batting.mutate(
-    OBP=(batting.H + batting.BB + batting.HBP)
-        / (batting.AB.cast("float64") + batting.BB + batting.HBP + batting.SF)
-)
-
 # modern era, AL/NL only, real hitters (>=100 AB so batting avg is meaningful)
 batting = batting.filter(
     batting.lgID.isin(["AL", "NL"]),
     batting.yearID > 1965,
     batting.AB >= 100,
+)
+
+# on-base percentage: (H + BB + HBP) / (AB + BB + HBP + SF) --- computed after
+# the AB >= 100 filter so the denominator is never zero
+batting = batting.mutate(
+    OBP=(batting.H + batting.BB + batting.HBP)
+        / (batting.AB.cast("float64") + batting.BB + batting.HBP + batting.SF)
 )
 
 # batting average per player-season

--- a/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
+++ b/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
@@ -1,11 +1,11 @@
 ---
-title: "Get started with Xorq init"
-description: "Scaffold a baseball analytics pipeline in minutes using Xorq's init, deferred_read_csv, and build commands"
+title: "Get started with Xorq"
+description: "Scaffold a baseball analytics pipeline in minutes using init, deferred_read_csv, and build commands"
 icon: "box-seam"
 headline: "Scaffold a pipeline in one command"
 ---
 
-Scaffold a Xorq project, load Moneyball CSVs, build a top-batters leaderboard. Pure Xorq, no ibis import, no shell tricks.
+Scaffold a Xorq project, load Moneyball CSVs, build a top-batters leaderboard.
 
 ## Prerequisites
 
@@ -103,7 +103,7 @@ ranked = ranked.mutate(rank=xo.row_number().over(win) + 1)
 expr = ranked.filter(ranked.rank <= 10).drop("rank")
 ```
 
-`xo.deferred_read_csv` registers each CSV against any backend with automatic schema inference --- it reads nothing until execution. Each binding is a typed Xorq expression you can join, filter, and aggregate without writing pandas. `expr` describes the computation. `xorq uv build` compiles it.
+`xo.deferred_read_csv` registers each CSV against any backend, sampling the file to infer its schema at build time --- the bulk read stays deferred until execution. Each binding is a typed Xorq expression you can join, filter, and aggregate without writing pandas. `expr` describes the computation. `xorq uv build` compiles it.
 
 ## Build and run
 
@@ -112,7 +112,7 @@ BUILD=$(xorq uv build expr.py -e expr --builds-dir builds | tail -1)
 echo "$BUILD"
 ```
 
-You'll see something like `builds/f22643d56d2c` --- Xorq derives the hash from the expression graph and your lock file, so yours differs.
+You'll see something like `builds/f22643d56d2c` --- Xorq derives the hash from the expression graph, so yours may differ.
 
 ```bash
 xorq uv run "$BUILD" --output-path top_batters.parquet

--- a/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
+++ b/docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd
@@ -1,11 +1,11 @@
 ---
-title: "Get started with xorq init"
-description: "Scaffold a baseball analytics pipeline in minutes with xorq init, deferred_read_csv, and xorq build"
+title: "Get started with Xorq init"
+description: "Scaffold a baseball analytics pipeline in minutes using Xorq's init, deferred_read_csv, and build commands"
 icon: "box-seam"
 headline: "Scaffold a pipeline in one command"
 ---
 
-Scaffold a xorq project, load Moneyball CSVs, build a top-batters leaderboard. Pure xorq, no ibis import, no shell tricks.
+Scaffold a Xorq project, load Moneyball CSVs, build a top-batters leaderboard. Pure Xorq, no ibis import, no shell tricks.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ## Scaffold
 
-xorq requires Python 3.13. Make sure uv has it, then scaffold and sync against it explicitly:
+Xorq supports Python 3.10 through 3.13. This tutorial pins 3.13 so uv scaffolds and syncs against one explicit interpreter:
 
 ```bash
 uv python install 3.13
@@ -27,20 +27,20 @@ uv sync -p3.13
 source .venv/bin/activate
 ```
 
-`uvx` bootstraps xorq once; from here on the `xorq` on your PATH comes from the project's pinned `.venv`.
+`uvx` bootstraps Xorq once. From here on, the `xorq` on your PATH comes from the project's pinned `.venv`.
 
 ::: {.callout-note}
 ###  Use uvx, not a permanent install
-We prefer `uvx xorq@latest ...` for global xorq commands vs other methods because you're guaranteed to get the latest version of xorq.  Once you have created the xorq project we recommend you activate the uv environment and use the xorq in the venv from there on so that the `xorq` you invoke with is the same as the `xorq` in the pyproject.
+Prefer `uvx xorq@latest ...` for global Xorq commands over other install methods --- it guarantees the latest version. After creating the Xorq project, activate the uv environment and use the `xorq` in the venv from then on, so the `xorq` you invoke matches the `xorq` pinned in the pyproject.
 :::
 
-List what was created (including dotfiles):
+List everything the scaffold created, including dotfiles:
 
 ```bash
 ls -1A
 ```
 
-A complete locked project: `pyproject.toml`, `uv.lock`, an exported `requirements.txt`, a `src/` package, and a starter `expr.py`. The `with-uvenv` script and `.envrc` are helpers xorq uses internally --- you don't need to invoke them.
+A complete locked project: `pyproject.toml`, `uv.lock`, an exported `requirements.txt`, a `src/` package, and a starter `expr.py`. The `with-uvenv` script and `.envrc` are helpers Xorq uses internally --- you don't need to invoke them.
 
 ## Get the data
 
@@ -100,7 +100,7 @@ ranked = ranked.mutate(rank=xo.row_number().over(win) + 1)
 expr = ranked.filter(ranked.rank <= 10).drop("rank")
 ```
 
-`xo.deferred_read_csv` registers each CSV against any backend with automatic schema inference --- nothing is read until execution. Each binding is a typed xorq expression you can join, filter, and aggregate without writing pandas. `expr` is a description of the computation; `xorq uv build` compiles it.
+`xo.deferred_read_csv` registers each CSV against any backend with automatic schema inference --- it reads nothing until execution. Each binding is a typed Xorq expression you can join, filter, and aggregate without writing pandas. `expr` describes the computation. `xorq uv build` compiles it.
 
 ## Build and run
 
@@ -109,7 +109,7 @@ BUILD=$(xorq uv build expr.py -e expr --builds-dir builds | tail -1)
 echo "$BUILD"
 ```
 
-You'll see something like `builds/f22643d56d2c` --- the hash is derived from the expression graph and your lock file, so yours will differ.
+You'll see something like `builds/f22643d56d2c` --- Xorq derives the hash from the expression graph and your lock file, so yours differs.
 
 ```bash
 xorq uv run "$BUILD" --output-path top_batters.parquet
@@ -121,7 +121,7 @@ Each build is self-contained:
 ls "$BUILD"
 ```
 
-`expr.yaml` is the serialized graph; `requirements.txt` is pinned from your lock. Hand the directory to anyone with `xorq` and `xorq uv run` reproduces the result.
+`expr.yaml` is the serialized graph. `requirements.txt` pins the dependencies from your lock. Hand the directory to anyone with `xorq` and `xorq uv run` reproduces the result.
 
 If `expr.py` changes its build changes. Edit `expr.py` and run `xorq uv build` again --- bump the year filter from 1965 to 1970:
 


### PR DESCRIPTION
Adds a no-cloud getting-started tutorial: scaffold a project with `xorq init`, load Moneyball CSVs with `deferred_read_csv`, and build a top-batters leaderboard with `xorq uv build` / `xorq uv run`. In-process datafusion backend, no server, no `ibis` import.

## Changes
- New tutorial: `docs/tutorials/core_tutorials/get-started-with-xorq-init.qmd`
- Registered first in the **Core tutorials** sidebar (`docs/_quarto.yml`)

## Verified end-to-end (against xorq 0.3.28)
- `uvx xorq@latest init --path moneyball` scaffolds the project (`expr.py` at repo root)
- `uv sync` resolves a xorq with the `xorq uv build` / `xorq uv run` subcommands
- CSV source URLs return 200; every referenced column (`HBP`, `SF`, `H`, `BB`, `AB`, `lgID`, `yearID`, `playerID`, `nameFirst/Last`, `bats`, `throws`, `birthYear`) exists
- `xorq uv build` → `builds/<hash>/`; rebuild with no change = same hash, edit = new dir, nothing overwritten
- `xorq uv run` produces **1120 rows, 0 NaN/Inf**, sensible OBP/AVG (e.g. Frank Thomas 1997, .456 OBP)

## Review fixes folded in
- **Python requirement corrected** — supports 3.10–3.13 (was "requires 3.13")
- **Next links** point to the `uv build` / `uv run` reference pages, matching the commands the tutorial uses (was plain `build`)
- **OBP computed after the `AB >= 100` filter** so the denominator is never zero; ~18k zero-AB rows previously produced NaN/Inf intermediates (build hash unchanged — output identical)
- **Explicit `how="inner"`** on the People join, with a note that unmatched batting rows drop
- **Vale clean** — root `.vale.ini` maps `qmd`→`md` so fenced/inline code isn't linted as prose

## Notes
- The `pyproject.toml` / `uv.lock` / `CHANGELOG.md` diffs are the **0.3.28 release commit** that sits in this branch's base but isn't in `main` yet; they drop out of the diff once `main` includes the release.

Part of the Diataxis docs effort — #2023 (Phase 0a: #2024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
