### PR TITLE
docs(concepts): add 'catalog as executable memory' explanation

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -102,6 +102,7 @@ website:
           section: "Fundamentals"
           contents:
             - concepts/understanding_xorq/why_deferred_execution.qmd
+            - concepts/understanding_xorq/catalog_as_executable_memory.qmd
             - concepts/understanding_xorq/expression_format.qmd
             - concepts/understanding_xorq/expression_types.qmd
         - id: execution-backends-section

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -1,0 +1,131 @@
+---
+title: "The catalog as executable memory"
+---
+
+Most "memory" an agent accumulates is prose: markdown notes, a `MEMORY.md`
+index, chat history. Prose memory has to be re-read and re-interpreted by
+whatever model picks it up next, and it has no way to *run*. A xorq catalog is
+the other kind of memory — **executable**. Each entry is a content-addressed
+pipeline plus the environment to run it, so a future agent or human doesn't
+re-derive the computation from a description; it executes the artifact and gets
+the same answer.
+
+This page explains what that means and why the catalog is built the way it is.
+For the hands-on version, see
+[Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd);
+for the commands, the [`catalog` CLI reference](/api_reference/cli/catalog/init.qmd).
+
+## What a memory item is
+
+In a prose memory system the unit is a snippet of text. In xorq the unit is an
+**entry**: a built [expression](/concepts/understanding_xorq/expression_types.qmd)
+together with its pinned Python environment. An entry is enough to reproduce a
+result on a machine that has never seen the code that produced it — the wheel
+and `requirements.txt` travel with it (see
+[Environments and uv](/concepts/understanding_xorq/environments_and_uv.qmd)).
+
+You reason about an entry the way you reason about a matrix — by its invariants,
+not its entries:
+
+- **Schema** — what columns it produces, and of what type.
+- **Lineage** — which sources and transforms it depends on.
+- **Content hash** — a deterministic fingerprint of the computation. Same
+  pipeline, same hash; change a filter and the hash changes.
+- **Deterministic execution** — the pinned environment makes "run it again"
+  return the same bytes.
+
+These are knowable *before* execution. An agent can decide whether an entry is
+the one it needs by reading metadata, without running anything.
+
+## Why a git repo, not a service
+
+A xorq catalog is a git repository of build artifacts on the filesystem —
+nothing more. There is no server to call and no API to learn. That choice is
+deliberate:
+
+- **Discovery is file operations.** Metadata lives in `metadata/*.yaml` sidecars
+  next to the zipped entries. Listing, filtering, and lookup-by-alias or by-hash
+  are `ls`, `grep`, and `git` — tools every agent already has. An agent that
+  clones the repo can find everything without learning anything new.
+- **History is the audit log.** Every catalog operation is a commit. `git log`
+  and `git reflog` tell you exactly when an entry was added, aliased, or
+  removed, and by whom — provenance you get for free from git rather than
+  building separately.
+- **Sharing is `git push` / `git clone`.** Collaboration is the pull-request
+  workflow teams already run. A teammate clones the catalog, adds an entry on a
+  branch, opens a PR; merging it is an ordinary merge. A catalog supports at most
+  one git remote ([ADR-0011](/adr/0011-catalog-single-git-remote.md)), which
+  keeps "where is the source of truth" unambiguous. Large files are handled by
+  git-annex rather than bloating the repo.
+
+The catalog is portable for the same reason any git repo is: it is just files.
+
+## What is on disk
+
+After `catalog init` the repo holds a single manifest:
+
+```yaml
+# catalog.yaml
+entries: []
+aliases: []
+```
+
+`catalog add` packages a build directory — the manifest (`expr.yaml` plus
+`*_metadata.json`) and the uv-pinned environment — into an entry and records it.
+A populated catalog looks like:
+
+```
+git-catalogs/penguins
+├── aliases
+│   └── penguins-agg.zip -> ../entries/fa2122f6a9e9.zip
+├── entries
+│   └── fa2122f6a9e9.zip
+├── metadata
+│   └── fa2122f6a9e9.zip.metadata.yaml
+└── catalog.yaml
+```
+
+Entries are zipped builds named by their content hash. Aliases are symlinks
+pointing at an entry — a human-readable name (`penguins-agg`) for a hash
+(`fa2122f6a9e9`). Metadata sidecars are plain YAML, which is what makes
+discovery a `grep`:
+
+```bash
+# Entries that emit an 'avg_bill_length' column
+grep -l 'avg_bill_length' git-catalogs/penguins/metadata/*.yaml
+
+# Entries running on DataFusion
+grep -l 'xorq_datafusion' git-catalogs/penguins/metadata/*.yaml
+```
+
+## Why content-addressing matters
+
+Entries are named by a hash of the computation, not by a timestamp or a
+user-chosen filename. Two consequences fall out of that:
+
+1. **Reuse is automatic.** Building the same pipeline twice produces the same
+   hash, so the second build is a no-op — the entry already exists. There is no
+   "did someone already compute this?" question to answer by hand.
+2. **Identity is honest.** If two entries have the same hash they *are* the same
+   computation; if the hashes differ, something in the graph or its inputs
+   changed. The name can't lie about what the artifact does, the way a filename
+   like `final_v2_fixed.py` can.
+
+Aliases sit on top of this: they give a stable name to "whatever the current
+best version is" while the underlying hash moves as the pipeline evolves. The
+hash is identity; the alias is intent.
+
+## The shape of the idea
+
+A prose note says *what someone once did*. A catalog entry *is the thing*, ready
+to run, with its schema, lineage, and environment attached. That is the
+difference between memory you have to trust and memory you can execute — and
+it's why the catalog, not a pile of scripts, is where xorq keeps what an agent
+learns.
+
+## See also
+
+- [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd) — the publish / clone / pull loop, hands-on
+- [`catalog` CLI reference](/api_reference/cli/catalog/init.qmd) — every catalog subcommand
+- [Expression types](/concepts/understanding_xorq/expression_types.qmd) — what gets stored in an entry
+- [Environments and uv](/concepts/understanding_xorq/environments_and_uv.qmd) — how the pinned runtime travels with an entry

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -2,18 +2,18 @@
 title: "The catalog as executable memory"
 ---
 
-Most "memory" an agent accumulates is prose: markdown notes, a `MEMORY.md`
-index, chat history. Prose memory has to be re-read and re-interpreted by
+Most "memory" an agent accumulates is prose: Markdown notes, a `MEMORY.md`
+index, chat history. Prose memory has to be reread and reinterpreted by
 whatever model picks it up next, and it has no way to *run*. A Xorq catalog is
 the other kind of memory—**executable**. Each entry is a content-addressed
 pipeline plus the environment to run it, so a future agent or human doesn't
 re-derive the computation from a description; it executes the artifact and gets
 the same answer.
 
-The same instinct drives teams to keep agent memory as markdown in a git repo
+The same instinct drives teams to keep agent memory as Markdown in a git repo
 rather than in a vector database: the files stay the source of truth, and the
 data never gets trapped behind a proprietary schema or query language. A Xorq
-catalog takes that instinct one step further. Where a markdown note still has to
+catalog takes that instinct one step further. Where a Markdown note still has to
 be read and acted on, a catalog entry can be executed directly.
 
 This page explains what that means and why the catalog is built that way.

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -85,6 +85,13 @@ anything, and a stale index can never disagree with the artifact it points to.
 
 ## What's on disk
 
+::: {.callout-important}
+A catalog uses symlinks for aliases, so it expects a POSIX filesystem that
+preserves them. On Windows, run catalog operations under
+[WSL](https://learn.microsoft.com/windows/wsl/) — a native Windows filesystem
+without symlink support will produce a broken catalog.
+:::
+
 After `catalog init` the repo holds a single manifest:
 
 ```yaml

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -4,34 +4,33 @@ title: "The catalog as executable memory"
 
 Most "memory" an agent accumulates is prose: markdown notes, a `MEMORY.md`
 index, chat history. Prose memory has to be re-read and re-interpreted by
-whatever model picks it up next, and it has no way to *run*. A xorq catalog is
-the other kind of memory — **executable**. Each entry is a content-addressed
+whatever model picks it up next, and it has no way to *run*. A Xorq catalog is
+the other kind of memory—**executable**. Each entry is a content-addressed
 pipeline plus the environment to run it, so a future agent or human doesn't
 re-derive the computation from a description; it executes the artifact and gets
 the same answer.
 
-This page explains what that means and why the catalog is built the way it is.
+This page explains what that means and why the catalog is built that way.
 For the hands-on version, see
 [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd);
-for the commands, the [`catalog` CLI reference](/api_reference/cli/catalog/init.qmd).
+for the API, the [`Catalog` reference](/reference/Catalog.qmd).
 
-## What a memory item is
+## What a memory entry is
 
-In a prose memory system the unit is a snippet of text. In xorq the unit is an
+In a prose memory system the unit is a snippet of text. In Xorq the unit is an
 **entry**: a built [expression](/concepts/understanding_xorq/expression_types.qmd)
 together with its pinned Python environment. An entry is enough to reproduce a
-result on a machine that has never seen the code that produced it — the wheel
-and `requirements.txt` travel with it (see
-[Environments and uv](/concepts/understanding_xorq/environments_and_uv.qmd)).
+result on a machine that has never seen the code that produced it—the wheel
+and `requirements.txt` travel with it.
 
-You reason about an entry the way you reason about a matrix — by its invariants,
-not its entries:
+You reason about an entry the way you reason about a matrix—by its invariants,
+not its cells:
 
-- **Schema** — what columns it produces, and of what type.
-- **Lineage** — which sources and transforms it depends on.
-- **Content hash** — a deterministic fingerprint of the computation. Same
+- **Schema**—what columns it produces, and of what type.
+- **Lineage**—which sources and transforms it depends on.
+- **Content hash**—a deterministic fingerprint of the computation. Same
   pipeline, same hash; change a filter and the hash changes.
-- **Deterministic execution** — the pinned environment makes "run it again"
+- **Deterministic execution**—the pinned environment makes "run it again"
   return the same bytes.
 
 These are knowable *before* execution. An agent can decide whether an entry is
@@ -39,28 +38,27 @@ the one it needs by reading metadata, without running anything.
 
 ## Why a git repo, not a service
 
-A xorq catalog is a git repository of build artifacts on the filesystem —
+A Xorq catalog is a git repository of build artifacts on the filesystem—
 nothing more. There is no server to call and no API to learn. That choice is
 deliberate:
 
 - **Discovery is file operations.** Metadata lives in `metadata/*.yaml` sidecars
   next to the zipped entries. Listing, filtering, and lookup-by-alias or by-hash
-  are `ls`, `grep`, and `git` — tools every agent already has. An agent that
+  are `ls`, `grep`, and `git`—tools every agent already has. An agent that
   clones the repo can find everything without learning anything new.
 - **History is the audit log.** Every catalog operation is a commit. `git log`
   and `git reflog` tell you exactly when an entry was added, aliased, or
-  removed, and by whom — provenance you get for free from git rather than
+  removed, and by whom—provenance you get for free from git rather than
   building separately.
 - **Sharing is `git push` / `git clone`.** Collaboration is the pull-request
   workflow teams already run. A teammate clones the catalog, adds an entry on a
-  branch, opens a PR; merging it is an ordinary merge. A catalog supports at most
-  one git remote ([ADR-0011](/adr/0011-catalog-single-git-remote.md)), which
-  keeps "where is the source of truth" unambiguous. Large files are handled by
-  git-annex rather than bloating the repo.
+  branch, opens a PR; the merge is ordinary. A catalog supports at most
+  one git remote, which keeps "where's the source of truth" unambiguous. Large
+  files are handled by git-annex rather than bloating the repo.
 
-The catalog is portable for the same reason any git repo is: it is just files.
+The catalog is portable for the same reason any git repo is: it's just files.
 
-## What is on disk
+## What's on disk
 
 After `catalog init` the repo holds a single manifest:
 
@@ -70,8 +68,8 @@ entries: []
 aliases: []
 ```
 
-`catalog add` packages a build directory — the manifest (`expr.yaml` plus
-`*_metadata.json`) and the uv-pinned environment — into an entry and records it.
+`catalog add` packages a build directory—the manifest (`expr.yaml` plus
+`*_metadata.json`) and the uv-pinned environment—into an entry and records it.
 A populated catalog looks like:
 
 ```
@@ -86,7 +84,7 @@ git-catalogs/penguins
 ```
 
 Entries are zipped builds named by their content hash. Aliases are symlinks
-pointing at an entry — a human-readable name (`penguins-agg`) for a hash
+pointing at an entry—a human-readable name (`penguins-agg`) for a hash
 (`fa2122f6a9e9`). Metadata sidecars are plain YAML, which is what makes
 discovery a `grep`:
 
@@ -104,7 +102,7 @@ Entries are named by a hash of the computation, not by a timestamp or a
 user-chosen filename. Two consequences fall out of that:
 
 1. **Reuse is automatic.** Building the same pipeline twice produces the same
-   hash, so the second build is a no-op — the entry already exists. There is no
+   hash, so the second build is a no-op—the entry already exists. There is no
    "did someone already compute this?" question to answer by hand.
 2. **Identity is honest.** If two entries have the same hash they *are* the same
    computation; if the hashes differ, something in the graph or its inputs
@@ -115,17 +113,16 @@ Aliases sit on top of this: they give a stable name to "whatever the current
 best version is" while the underlying hash moves as the pipeline evolves. The
 hash is identity; the alias is intent.
 
-## The shape of the idea
+## Memory you can run
 
 A prose note says *what someone once did*. A catalog entry *is the thing*, ready
-to run, with its schema, lineage, and environment attached. That is the
-difference between memory you have to trust and memory you can execute — and
-it's why the catalog, not a pile of scripts, is where xorq keeps what an agent
+to run, with its schema, lineage, and environment attached. That's the
+difference between memory you have to trust and memory you can execute—and
+it's why the catalog, not a pile of scripts, is where Xorq keeps what an agent
 learns.
 
 ## See also
 
-- [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd) — the publish / clone / pull loop, hands-on
-- [`catalog` CLI reference](/api_reference/cli/catalog/init.qmd) — every catalog subcommand
-- [Expression types](/concepts/understanding_xorq/expression_types.qmd) — what gets stored in an entry
-- [Environments and uv](/concepts/understanding_xorq/environments_and_uv.qmd) — how the pinned runtime travels with an entry
+- [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd)—the publish / clone / pull loop, hands-on
+- [`Catalog` reference](/reference/Catalog.qmd)—the catalog API
+- [Expression types](/concepts/understanding_xorq/expression_types.qmd)—what gets stored in an entry

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -35,8 +35,11 @@ not its cells:
 - **Lineage**—which sources and transforms it depends on.
 - **Content hash**—a deterministic fingerprint of the computation. Same
   pipeline, same hash; change a filter and the hash changes.
-- **Deterministic execution**—the pinned environment makes "run it again"
-  return the same bytes.
+- **Deterministic execution**—the hash fingerprints the pipeline
+  *specification*, and the pinned environment makes "run it again" reproduce the
+  same computation on the same code path. (It doesn't promise byte-identical
+  output: timestamps, aggregation order, or floating-point rounding can still
+  vary at runtime.)
 
 These are knowable *before* execution. An agent can decide whether an entry is
 the one it needs by reading metadata, without running anything.
@@ -59,7 +62,8 @@ deliberate:
   workflow teams already run. A teammate clones the catalog, adds an entry on a
   branch, opens a PR; the merge is ordinary. A catalog supports at most
   one git remote, which keeps "where's the source of truth" unambiguous. Large
-  files are handled by git-annex rather than bloating the repo.
+  files are handled by an opt-in [git-annex](https://git-annex.branchable.com/)
+  remote rather than bloating the repo.
 
 - **No vendor lock-in.** A vector-database memory store keeps your data inside a
   proprietary schema; getting it out means an export job and a migration plan.
@@ -106,7 +110,8 @@ git-catalogs/penguins
 
 Entries are zipped builds named by their content hash. Aliases are symlinks
 pointing at an entry—a human-readable name (`penguins-agg`) for a hash
-(`fa2122f6a9e9`), so a catalog expects a POSIX filesystem that preserves
+(`fa2122f6a9e9`). The symlink on disk carries the `.zip` suffix of its target
+(`penguins-agg.zip`), so a catalog expects a POSIX filesystem that preserves
 symlinks. Metadata sidecars are plain YAML, which is what makes discovery a
 `grep`:
 

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -88,8 +88,8 @@ anything, and a stale index can never disagree with the artifact it points to.
 ::: {.callout-important}
 A catalog uses symlinks for aliases, so it expects a POSIX filesystem that
 preserves them. On Windows, run catalog operations under
-[WSL](https://learn.microsoft.com/windows/wsl/) — a native Windows filesystem
-without symlink support will produce a broken catalog.
+[WSL](https://learn.microsoft.com/windows/wsl/)—a native Windows filesystem
+without symlink support produces a broken catalog.
 :::
 
 After `catalog init` the repo holds a single manifest:

--- a/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
+++ b/docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd
@@ -10,10 +10,15 @@ pipeline plus the environment to run it, so a future agent or human doesn't
 re-derive the computation from a description; it executes the artifact and gets
 the same answer.
 
+The same instinct drives teams to keep agent memory as markdown in a git repo
+rather than in a vector database: the files stay the source of truth, and the
+data never gets trapped behind a proprietary schema or query language. A Xorq
+catalog takes that instinct one step further. Where a markdown note still has to
+be read and acted on, a catalog entry can be executed directly.
+
 This page explains what that means and why the catalog is built that way.
 For the hands-on version, see
-[Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd);
-for the API, the [`Catalog` reference](/reference/Catalog.qmd).
+[Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd).
 
 ## What a memory entry is
 
@@ -56,7 +61,23 @@ deliberate:
   one git remote, which keeps "where's the source of truth" unambiguous. Large
   files are handled by git-annex rather than bloating the repo.
 
+- **No vendor lock-in.** A vector-database memory store keeps your data inside a
+  proprietary schema; getting it out means an export job and a migration plan.
+  A catalog is files, so migrating is `git clone` or an `rsync` of the
+  directory. Nothing is trapped behind an API.
+
 The catalog is portable for the same reason any git repo is: it's just files.
+
+## Indexes are derived, not the source of truth
+
+A vector store inverts the usual relationship: the index *is* the memory, and the
+original text is something you hope was preserved alongside the embeddings. A
+catalog keeps the source of truth on disk—the entries and their YAML
+metadata—and treats any richer lookup as a layer built on top. The plain-text
+sidecars already make keyword search a `grep`; nothing stops you from building a
+BM25 or vector index over the same metadata when you want fuzzy recall. Because
+those indexes are derived, you can rebuild or throw them away without losing
+anything, and a stale index can never disagree with the artifact it points to.
 
 ## What's on disk
 
@@ -85,8 +106,9 @@ git-catalogs/penguins
 
 Entries are zipped builds named by their content hash. Aliases are symlinks
 pointing at an entry—a human-readable name (`penguins-agg`) for a hash
-(`fa2122f6a9e9`). Metadata sidecars are plain YAML, which is what makes
-discovery a `grep`:
+(`fa2122f6a9e9`), so a catalog expects a POSIX filesystem that preserves
+symlinks. Metadata sidecars are plain YAML, which is what makes discovery a
+`grep`:
 
 ```bash
 # Entries that emit an 'avg_bill_length' column
@@ -103,7 +125,11 @@ user-chosen filename. Two consequences fall out of that:
 
 1. **Reuse is automatic.** Building the same pipeline twice produces the same
    hash, so the second build is a no-op—the entry already exists. There is no
-   "did someone already compute this?" question to answer by hand.
+   "did someone already compute this?" question to answer by hand. Prose and
+   vector memory have to dedupe explicitly—comparing embeddings, running
+   similarity heuristics—because two notes describing the same fact look
+   different on disk. Content-addressing makes that question disappear: identical
+   computations collapse to one entry by construction.
 2. **Identity is honest.** If two entries have the same hash they *are* the same
    computation; if the hashes differ, something in the graph or its inputs
    changed. The name can't lie about what the artifact does, the way a filename
@@ -124,5 +150,4 @@ learns.
 ## See also
 
 - [Working with the catalog](/tutorials/core_tutorials/working_with_the_catalog.qmd)—the publish / clone / pull loop, hands-on
-- [`Catalog` reference](/reference/Catalog.qmd)—the catalog API
 - [Expression types](/concepts/understanding_xorq/expression_types.qmd)—what gets stored in an entry

--- a/docs/concepts/understanding_xorq/expression_types.qmd
+++ b/docs/concepts/understanding_xorq/expression_types.qmd
@@ -16,7 +16,7 @@ Three of the kinds are **structural** --- they fall out of the shape of the expr
 | **Expr** | Bound data with transformations applied | No |
 | **UnboundExpr** | A template expression not tied to any backend | Yes |
 
-Two more are **tag-driven**—they're recognized by domain-specific tags
+Two more are **tag-driven** --- they're recognized by domain-specific tags
 that higher-level tools (the ML pipeline API, the catalog, semantic layers)
 attach to the outermost node:
 


### PR DESCRIPTION
## Summary

Adds a net-new explanation page, **"The catalog as executable memory"**, to the Concepts → Fundamentals section. It frames a Xorq catalog as a git repo of content-addressed build artifacts — *executable* memory, in contrast to prose/vector memory that has to be re-read and re-interpreted.

## Changes

- **New page** `docs/concepts/understanding_xorq/catalog_as_executable_memory.qmd` covering:
  - What a memory *entry* is (built expression + pinned environment; reasoned about by schema, lineage, content hash, deterministic execution)
  - Why a git repo, not a service (discovery via `ls`/`grep`/`git`, history as audit log, sharing via `git push`/`clone`, no vendor lock-in)
  - Indexes are derived, not the source of truth
  - What's on disk after `catalog init` / `catalog add`, grounded in a live layout
  - Why content-addressing matters (automatic reuse, honest identity; aliases as intent)
- **Nav**: registered the page in `docs/_quarto.yml` under Fundamentals, after `why_deferred_execution`
- **`expression_types.qmd`**: minor vale lint fixes (contraction + "for example" over "e.g.")

## Notes

Cross-refs and the previously-dead `environments_and_uv.qmd` link were resolved in follow-up commits on this branch.

Part of the Diataxis docs effort — #2023 (Phase 0a: #2024).