### PR TITLE
fix(dasher): drop Alias wrapper on NamedScalarParameter placeholder

### DIFF
--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -231,6 +231,8 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
             # Replace with a typed NULL so SQL compilation works without a
             # translation rule for NamedScalarParameter.  A bare Literal
             # (no .name()) is required — Project forbids Alias values.
+            # Parameter identity (label, dtype, default) is folded into the
+            # structural hash separately via _collect_param_anchors.
             return api.literal(value=None, type=node.dtype).op()
         case _:
             if _kwargs:
@@ -336,6 +338,24 @@ def _normalize_expr_xorq(expr):
     return result
 
 
+def _collect_param_anchors(op: Node) -> tuple[str, ...]:
+    """Return a stable tuple of per-parameter identity strings.
+
+    Walks the op graph for NamedScalarParameter nodes and produces a
+    content-stable anchor for each occurrence (preserving graph order).
+    These anchors are folded into the structural hash so that two
+    same-dtype parameters produce distinct tokens even though their
+    placeholders (typed NULLs) are identical in SQL.
+    """
+    import xorq.expr.operations as xops  # noqa: PLC0415
+    from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
+
+    return tuple(
+        _stable_opaque_name("param", p.label, str(p.dtype), str(p.default))
+        for p in walk_nodes(xops.NamedScalarParameter, op)
+    )
+
+
 def _decompose_expr(
     expr: Expr, op: Node
 ) -> tuple[
@@ -344,11 +364,14 @@ def _decompose_expr(
     tuple[DatabaseTable, ...],
     tuple[AggUDF | ScalarUDF, ...],
     tuple[InMemoryTable, ...],
+    tuple[str, ...],
 ]:
     """Split an expression into structural SQL, data leaves, and UDFs.
 
-    Returns ``(sql, reads, dts, udfs, mems)`` where *reads*/*dts*/*mems* are
-    the data-carrying leaf ops and *udfs* are structural code-identity ops.
+    Returns ``(sql, reads, dts, udfs, mems, param_anchors)`` where
+    *reads*/*dts*/*mems* are the data-carrying leaf ops, *udfs* are
+    structural code-identity ops, and *param_anchors* are stable identity
+    strings for each NamedScalarParameter in graph order.
     """
     from xorq.common.utils.graph_utils import replace_nodes, walk_nodes  # noqa: PLC0415
     from xorq.expr.api import get_compiler, to_sql  # noqa: PLC0415
@@ -360,6 +383,8 @@ def _decompose_expr(
     from xorq.vendor.ibis.expr.operations.udf import AggUDF, ScalarUDF  # noqa: PLC0415
 
     compiler = get_compiler(expr)
+    # Collect param anchors *before* replacement erases the identity.
+    param_anchors = _collect_param_anchors(op)
     # Use replace_nodes (not op.replace) so the opaque-placeholder rewrite
     # descends into Any-typed sub-expressions (RemoteTable.remote_expr,
     # CachedNode.parent, FlightExpr/UDXF.input_expr,
@@ -378,7 +403,7 @@ def _decompose_expr(
     )
     udfs = tuple(walk_nodes((AggUDF, ScalarUDF), op))
     mems = tuple(walk_nodes(InMemoryTable, op))
-    return sql, reads, dts, udfs, mems
+    return sql, reads, dts, udfs, mems, param_anchors
 
 
 def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
@@ -386,10 +411,10 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
 
     from xorq.common.utils.dasher import HASHER, _current_hasher  # noqa: PLC0415
 
-    sql, reads, dts, udfs, mems = _decompose_expr(expr, op)
+    sql, reads, dts, udfs, mems, param_anchors = _decompose_expr(expr, op)
     hasher = _current_hasher.get() or HASHER
 
-    structural_hash = hasher.tokenize("ibis.Expr.structural", sql, udfs)
+    structural_hash = hasher.tokenize("ibis.Expr.structural", sql, udfs, param_anchors)
 
     def _read_name(r):
         read_kwargs = dict(r.read_kwargs)

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -228,14 +228,10 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
                 _parent_token(node.parent),
             )
         case xops.NamedScalarParameter():
-            # Replace with a literal of the same dtype so SQL compilation
-            # works without a translation rule for NamedScalarParameter, and
-            # use a content-stable name so two builds with the same param
-            # produce identical placeholders.
-            anchor = _stable_opaque_name(
-                "param", node.label, str(node.dtype), str(node.default)
-            )
-            return api.literal(value=None, type=node.dtype).name(anchor).op()
+            # Replace with a typed NULL so SQL compilation works without a
+            # translation rule for NamedScalarParameter.  A bare Literal
+            # (no .name()) is required — Project forbids Alias values.
+            return api.literal(value=None, type=node.dtype).op()
         case _:
             if _kwargs:
                 return node.__recreate__(_kwargs)

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -414,7 +414,10 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
     sql, reads, dts, udfs, mems, param_anchors = _decompose_expr(expr, op)
     hasher = _current_hasher.get() or HASHER
 
-    structural_hash = hasher.tokenize("ibis.Expr.structural", sql, udfs, param_anchors)
+    hash_args = ("ibis.Expr.structural", sql, udfs)
+    if param_anchors:
+        hash_args += (param_anchors,)
+    structural_hash = hasher.tokenize(*hash_args)
 
     def _read_name(r):
         read_kwargs = dict(r.read_kwargs)

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -269,6 +269,29 @@ def test_bare_param_as_project_value_tokenizes():
     assert isinstance(tok, str) and len(tok) > 0
 
 
+def test_two_params_same_dtype_produce_distinct_tokens():
+    """Two NamedScalarParameters of the same dtype in one expression must not
+    collapse to the same placeholder — their tokens must differ."""
+    t = xo.memtable({"_": [0]})
+    p1 = xo.param("start", "int64")
+    p2 = xo.param("end", "int64")
+
+    tok_both = tokenize(t.select(a=p1, b=p2))
+    tok_same = tokenize(t.select(a=p1, b=p1))
+    assert tok_both != tok_same
+
+
+def test_two_params_same_dtype_in_filter_produce_distinct_tokens():
+    """Same-dtype params used in filter position must also be distinguishable."""
+    t = xo.memtable({"x": [1, 2, 3]})
+    p1 = xo.param("lo", "int64")
+    p2 = xo.param("hi", "int64")
+
+    tok_two = tokenize(t.filter(t.x > p1).filter(t.x < p2))
+    tok_one = tokenize(t.filter(t.x > p1).filter(t.x < p1))
+    assert tok_two != tok_one
+
+
 # --- _stat_or_canonical: catalog-extract path canonicalization ------------
 
 

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -259,6 +259,16 @@ def test_expr_with_named_param_tokenizes_without_raising():
     assert isinstance(tok, str) and len(tok) > 0
 
 
+def test_bare_param_as_project_value_tokenizes():
+    """Regression (#2037): a NamedScalarParameter as a direct Project column
+    value must not be wrapped in Alias — Project forbids Alias values."""
+    expr = xo.memtable({"_": [0]}).select(
+        year_months=xo.param("year_months", "string", default="2025_11,2025_12")
+    )
+    tok = tokenize(expr)
+    assert isinstance(tok, str) and len(tok) > 0
+
+
 # --- _stat_or_canonical: catalog-extract path canonicalization ------------
 
 

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -281,6 +281,18 @@ def test_two_params_same_dtype_produce_distinct_tokens():
     assert tok_both != tok_same
 
 
+def test_two_params_same_dtype_swapped_positions_produce_distinct_tokens():
+    """Swapping two same-dtype params across select positions must produce
+    a different token, even though the SQL after NULL substitution is identical."""
+    t = xo.memtable({"_": [0]})
+    p1 = xo.param("start", "int64")
+    p2 = xo.param("end", "int64")
+
+    tok_ab = tokenize(t.select(a=p1, b=p2))
+    tok_ba = tokenize(t.select(a=p2, b=p1))
+    assert tok_ab != tok_ba
+
+
 def test_two_params_same_dtype_in_filter_produce_distinct_tokens():
     """Same-dtype params used in filter position must also be distinguishable."""
     t = xo.memtable({"x": [1, 2, 3]})


### PR DESCRIPTION
## Summary
- `_xorq_opaque_to_placeholder` wrapped the `NamedScalarParameter` replacement literal in `.name(anchor)`, producing an `Alias` node. When the parameter was a bare `Project` column value, `Project.__recreate__` rejected it with `SignatureValidationError`.
- Drop the `.name()` call — the column name comes from the `Project` dict key, not the `Alias` — and return a bare `Literal`.
- Bare `Literal(None, dtype)` placeholders are identical for same-dtype params, which caused token collisions (two distinct params producing the same hash). Fix by collecting stable per-parameter identity anchors from the original op graph before replacement and folding them into the structural hash via `_collect_param_anchors`.

Closes #2037

## Test plan
- [x] Existing `test_dasher.py` param/opaque tests pass (80/80)
- [x] Repro from the issue (`tokenize()` on `memtable.select(year_months=param(...))`) now succeeds
- [x] Two same-dtype params in `select` produce distinct tokens (`test_two_params_same_dtype_produce_distinct_tokens`)
- [x] Two same-dtype params in `filter` produce distinct tokens (`test_two_params_same_dtype_in_filter_produce_distinct_tokens`)
- [x] Token output is stable across repeated calls
- [x] SQL output unchanged for previously-working cases (param in filter, param in coalesce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)