### PR TITLE
fix(examples): retry pins metadata fetch and enable fsspec cache

### DIFF
--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -133,7 +133,7 @@ class Pins(Config):
     protocol: str = "gcs"
     path: str = "letsql-pins"
     storage_options: dict[str, Any] = {
-        "cache_timeout": 0,
+        "cache_timeout": 300,
         "token": "anon",
     }
 

--- a/python/xorq/examples/core.py
+++ b/python/xorq/examples/core.py
@@ -1,5 +1,7 @@
 import functools
+import logging
 import pathlib
+import time
 
 from xorq.common.utils.defer_utils import (
     deferred_read_csv,
@@ -7,6 +9,8 @@ from xorq.common.utils.defer_utils import (
 )
 from xorq.config import options
 
+
+logger = logging.getLogger(__name__)
 
 whitelist = [
     "astronauts",
@@ -20,12 +24,38 @@ whitelist = [
     "hn-data-small.parquet",
 ]
 
+_PIN_META_RETRIES = 3
+_PIN_META_RETRY_DELAY = 1.0
+
+
+def _pin_meta_with_retry(board, name):
+    for attempt in range(_PIN_META_RETRIES):
+        try:
+            meta = board.pin_meta(name)
+            if meta is not None:
+                return meta
+        except Exception:
+            pass
+        if attempt < _PIN_META_RETRIES - 1:
+            delay = _PIN_META_RETRY_DELAY * (2**attempt)
+            logger.warning(
+                "pin_meta(%r) failed (attempt %d/%d), retrying in %.1fs",
+                name,
+                attempt + 1,
+                _PIN_META_RETRIES,
+                delay,
+            )
+            time.sleep(delay)
+    raise RuntimeError(
+        f"failed to fetch pin metadata for {name!r} after {_PIN_META_RETRIES} attempts"
+    )
+
 
 @functools.cache
 def get_name_to_suffix() -> dict[str, str]:
     board = options.pins.get_board()
     dct = {
-        name: pathlib.Path(board.pin_meta(name).file).suffix
+        name: pathlib.Path(_pin_meta_with_retry(board, name).file).suffix
         for name in board.pin_list()
         if name in whitelist
     }

--- a/python/xorq/examples/core.py
+++ b/python/xorq/examples/core.py
@@ -29,26 +29,35 @@ _PIN_META_RETRY_DELAY = 1.0
 
 
 def _pin_meta_with_retry(board, name):
+    last_exc = None
     for attempt in range(_PIN_META_RETRIES):
         try:
             meta = board.pin_meta(name)
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "pin_meta(%r) raised %s (attempt %d/%d)",
+                name,
+                exc,
+                attempt + 1,
+                _PIN_META_RETRIES,
+                exc_info=True,
+            )
+        else:
             if meta is not None:
                 return meta
-        except Exception:
-            pass
-        if attempt < _PIN_META_RETRIES - 1:
-            delay = _PIN_META_RETRY_DELAY * (2**attempt)
             logger.warning(
-                "pin_meta(%r) failed (attempt %d/%d), retrying in %.1fs",
+                "pin_meta(%r) returned None (attempt %d/%d)",
                 name,
                 attempt + 1,
                 _PIN_META_RETRIES,
-                delay,
             )
+        if attempt < _PIN_META_RETRIES - 1:
+            delay = _PIN_META_RETRY_DELAY * (2**attempt)
             time.sleep(delay)
     raise RuntimeError(
         f"failed to fetch pin metadata for {name!r} after {_PIN_META_RETRIES} attempts"
-    )
+    ) from last_exc
 
 
 @functools.cache

--- a/python/xorq/examples/tests/test_pin_meta_retry.py
+++ b/python/xorq/examples/tests/test_pin_meta_retry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xorq.examples.core import _pin_meta_with_retry
+
+
+def _make_board(side_effects: list) -> object:
+    calls = iter(side_effects)
+
+    class FakeBoard:
+        def pin_meta(self, name: str) -> object:
+            effect = next(calls)
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+    return FakeBoard()
+
+
+@pytest.fixture
+def mock_sleep() -> MagicMock:
+    with patch("xorq.examples.core.time.sleep") as m:
+        yield m
+
+
+def test_success_first_attempt(mock_sleep: MagicMock) -> None:
+    meta = SimpleNamespace(file="data.parquet")
+    board = _make_board([meta])
+    assert _pin_meta_with_retry(board, "test") is meta
+    mock_sleep.assert_not_called()
+
+
+def test_success_after_transient_exception(mock_sleep: MagicMock) -> None:
+    meta = SimpleNamespace(file="data.parquet")
+    board = _make_board([ConnectionError("timeout"), meta])
+    assert _pin_meta_with_retry(board, "test") is meta
+    mock_sleep.assert_called_once_with(1.0)
+
+
+def test_success_after_none_then_exception(mock_sleep: MagicMock) -> None:
+    meta = SimpleNamespace(file="data.parquet")
+    board = _make_board([None, ValueError("transient"), meta])
+    assert _pin_meta_with_retry(board, "test") is meta
+    assert mock_sleep.call_count == 2
+    mock_sleep.assert_any_call(1.0)
+    mock_sleep.assert_any_call(2.0)
+
+
+def test_all_exceptions_raises_with_cause(mock_sleep: MagicMock) -> None:
+    original = ConnectionError("network down")
+    board = _make_board([RuntimeError("a"), OSError("b"), original])
+    with pytest.raises(RuntimeError, match="after 3 attempts") as exc_info:
+        _pin_meta_with_retry(board, "test")
+    assert exc_info.value.__cause__ is original
+
+
+def test_all_none_raises_without_cause(mock_sleep: MagicMock) -> None:
+    board = _make_board([None, None, None])
+    with pytest.raises(RuntimeError, match="after 3 attempts") as exc_info:
+        _pin_meta_with_retry(board, "test")
+    assert exc_info.value.__cause__ is None
+
+
+def test_exponential_backoff_delays(mock_sleep: MagicMock) -> None:
+    board = _make_board([OSError(), OSError(), OSError()])
+    with pytest.raises(RuntimeError):
+        _pin_meta_with_retry(board, "test")
+    assert mock_sleep.call_args_list == [
+        ((1.0,),),
+        ((2.0,),),
+    ]


### PR DESCRIPTION
## Summary
- Add `_pin_meta_with_retry` to `xorq.examples.core` with exponential backoff (3 attempts), handling both exceptions and `None` returns from `board.pin_meta()`
- Log warnings with full tracebacks on transient failures; chain the root-cause exception when retries are exhausted
- Enable fsspec caching (`cache_timeout=300`) to reduce redundant remote GCS reads
- Add unit tests covering first-attempt success, transient recovery, exception chaining, `None`-return handling, and backoff timing

## Test plan
- [x] `pytest python/xorq/examples/tests/test_pin_meta_retry.py` — 6 tests pass
- [x] `test_examples[simple_example.py-expr]` passes consistently in CI
- [x] Verify pins-based examples still resolve correct file suffixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)