### PR TITLE
feat(cli): accept zip files in `xorq run` and `xorq uv run`

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -24,7 +24,7 @@ from xorq.init_templates import InitTemplates
 
 @contextlib.contextmanager
 def maybe_unzip(path):
-    if str(path).endswith(".zip"):
+    if str(path).lower().endswith(".zip"):
         from xorq.catalog.zip_utils import extract_build_zip_context  # noqa: PLC0415
 
         with extract_build_zip_context(path) as build_dir:

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import os
 import pdb
@@ -19,6 +20,17 @@ from xorq.cli_options import (
     unbind_options,
 )
 from xorq.init_templates import InitTemplates
+
+
+@contextlib.contextmanager
+def maybe_unzip(path):
+    if str(path).endswith(".zip"):
+        from xorq.catalog.zip_utils import extract_build_zip_context  # noqa: PLC0415
+
+        with extract_build_zip_context(path) as build_dir:
+            yield str(build_dir)
+    else:
+        yield path
 
 
 def _lazy_span(name):
@@ -920,14 +932,15 @@ def uv_run(build_path, cache_dir, output_path, output_format, limit, raw_params)
       # Stream JSON to stdout
       xorq uv run builds/7061dd65ff3c -f json -o -
     """
-    uv_run_command(
-        build_path,
-        cache_dir,
-        output_path,
-        output_format,
-        limit=limit,
-        raw_params=raw_params,
-    )
+    with maybe_unzip(build_path) as p:
+        uv_run_command(
+            p,
+            cache_dir,
+            output_path,
+            output_format,
+            limit=limit,
+            raw_params=raw_params,
+        )
 
 
 @uv_group.command("run-cached")
@@ -1141,7 +1154,8 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
       # Sample 100 rows with a parameter override
       xorq run builds/f02d28198715 --limit 100 -p threshold=0.5 -o sample.parquet
     """
-    run_command(build_path, output_path, output_format, cache_dir, limit, raw_params)
+    with maybe_unzip(build_path) as p:
+        run_command(p, output_path, output_format, cache_dir, limit, raw_params)
 
 
 @cli.command("run-cached")

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -1,3 +1,4 @@
+import collections.abc
 import contextlib
 import datetime
 import os
@@ -23,7 +24,7 @@ from xorq.init_templates import InitTemplates
 
 
 @contextlib.contextmanager
-def maybe_unzip(path):
+def maybe_unzip(path: str) -> collections.abc.Generator[str, None, None]:
     if str(path).lower().endswith(".zip"):
         from xorq.catalog.zip_utils import extract_build_zip_context  # noqa: PLC0415
 

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -1665,14 +1665,14 @@ def test_serve_options_decorator():
     assert "port=8080" in result.output
 
 
-def test_maybe_unzip_non_zip_passthrough(tmp_path):
+def test_maybe_unzip_non_zip_passthrough(tmp_path: Path) -> None:
     build_dir = tmp_path / "my_build"
     build_dir.mkdir()
     with maybe_unzip(str(build_dir)) as p:
         assert p == str(build_dir)
 
 
-def test_maybe_unzip_valid_zip(tmp_path):
+def test_maybe_unzip_valid_zip(tmp_path: Path) -> None:
     build_dir = tmp_path / "my_build"
     build_dir.mkdir()
     (build_dir / "file.txt").write_text("hello")
@@ -1685,7 +1685,7 @@ def test_maybe_unzip_valid_zip(tmp_path):
         assert (Path(p) / "file.txt").read_text() == "hello"
 
 
-def test_maybe_unzip_case_insensitive_extension(tmp_path):
+def test_maybe_unzip_case_insensitive_extension(tmp_path: Path) -> None:
     build_dir = tmp_path / "my_build"
     build_dir.mkdir()
     (build_dir / "file.txt").write_text("hello")
@@ -1697,14 +1697,14 @@ def test_maybe_unzip_case_insensitive_extension(tmp_path):
         assert (Path(p) / "file.txt").read_text() == "hello"
 
 
-def test_maybe_unzip_nonexistent_zip_raises(tmp_path):
+def test_maybe_unzip_nonexistent_zip_raises(tmp_path: Path) -> None:
     zip_path = tmp_path / "does_not_exist.zip"
     with pytest.raises(FileNotFoundError):
         with maybe_unzip(str(zip_path)) as _:
             pass
 
 
-def test_maybe_unzip_invalid_zip_raises(tmp_path):
+def test_maybe_unzip_invalid_zip_raises(tmp_path: Path) -> None:
     zip_path = tmp_path / "bad.zip"
     zip_path.write_text("this is not a zip")
     with pytest.raises(zipfile.BadZipFile):

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess as _subprocess
 import sys
 import uuid
+import zipfile
 from itertools import chain
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -26,6 +27,7 @@ from xorq.cli import (
     arbitrate_output_format,
     build_command,
     cli,
+    maybe_unzip,
     run_command,
 )
 from xorq.cli_constants import OutputFormats
@@ -1661,3 +1663,50 @@ def test_serve_options_decorator():
     assert result.exit_code == 0
     assert "host=0.0.0.0" in result.output
     assert "port=8080" in result.output
+
+
+def test_maybe_unzip_non_zip_passthrough(tmp_path):
+    build_dir = tmp_path / "my_build"
+    build_dir.mkdir()
+    with maybe_unzip(str(build_dir)) as p:
+        assert p == str(build_dir)
+
+
+def test_maybe_unzip_valid_zip(tmp_path):
+    build_dir = tmp_path / "my_build"
+    build_dir.mkdir()
+    (build_dir / "file.txt").write_text("hello")
+    zip_path = tmp_path / "archive.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(build_dir / "file.txt", "my_build/file.txt")
+    with maybe_unzip(str(zip_path)) as p:
+        assert p != str(zip_path)
+        assert Path(p).is_dir()
+        assert (Path(p) / "file.txt").read_text() == "hello"
+
+
+def test_maybe_unzip_case_insensitive_extension(tmp_path):
+    build_dir = tmp_path / "my_build"
+    build_dir.mkdir()
+    (build_dir / "file.txt").write_text("hello")
+    zip_path = tmp_path / "archive.ZIP"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(build_dir / "file.txt", "my_build/file.txt")
+    with maybe_unzip(str(zip_path)) as p:
+        assert Path(p).is_dir()
+        assert (Path(p) / "file.txt").read_text() == "hello"
+
+
+def test_maybe_unzip_nonexistent_zip_raises(tmp_path):
+    zip_path = tmp_path / "does_not_exist.zip"
+    with pytest.raises(FileNotFoundError):
+        with maybe_unzip(str(zip_path)) as _:
+            pass
+
+
+def test_maybe_unzip_invalid_zip_raises(tmp_path):
+    zip_path = tmp_path / "bad.zip"
+    zip_path.write_text("this is not a zip")
+    with pytest.raises(zipfile.BadZipFile):
+        with maybe_unzip(str(zip_path)) as _:
+            pass


### PR DESCRIPTION
## Summary
- `xorq run` and `xorq uv run` now accept a `.zip` build archive as the build path argument
- Reuses the existing `extract_build_zip_context` from `xorq.catalog.zip_utils`, which validates the archive has exactly one top-level directory and the required members
- Extraction goes to a temp dir that is cleaned up automatically after the run completes

## Test plan
- [x] `xorq run <build_dir>` still works as before (no regression)
- [x] `xorq run <build.zip>` extracts and runs successfully
- [x] `xorq uv run <build.zip>` extracts and runs successfully
- [ ] Invalid zip (missing required members) raises a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)