### PR TITLE
build: enable DTZ ruff rules for timezone safety

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,10 +233,18 @@ extend-select = [
     "C4",     # flake8-comprehensions: unnecessary list/dict/set comprehensions
     "FURB",   # refurb: modernize Python code
     "PLC0415",  # import-outside-toplevel: imports must be at module level
+    "DTZ",      # flake8-datetimez: enforce timezone-aware datetime usage
+    "PLW1514",  # unspecified-encoding: require explicit encoding= in open() (needs preview)
 ]
 ignore = [
     "B018",  # useless-expression: side-effect property access is intentional
     "B905",  # zip-without-explicit-strict: not enforced project-wide
+    # TODO: fix existing DTZ violations and remove these ignores
+    "DTZ001",   # call-datetime-without-tzinfo (22 existing violations)
+    "DTZ002",   # call-datetime-today (1 existing violation)
+    "DTZ005",   # call-datetime-now-without-tzinfo (10 existing violations)
+    "DTZ006",   # call-datetime-fromtimestamp (3 existing violations)
+    "DTZ011",   # call-date-today (4 existing violations)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ extend-select = [
     "FURB",   # refurb: modernize Python code
     "PLC0415",  # import-outside-toplevel: imports must be at module level
     "DTZ",      # flake8-datetimez: enforce timezone-aware datetime usage
-    "PLW1514",  # unspecified-encoding: require explicit encoding= in open() (needs preview)
+    # TODO: add PLW1514 (unspecified-encoding) when it graduates from ruff preview
 ]
 ignore = [
     "B018",  # useless-expression: side-effect property access is intentional


### PR DESCRIPTION
## Summary
- Enable `DTZ` rules to catch naive datetime usage (`datetime.now()` without `tz=`, `datetime.utcnow()`, etc.)
- Temporarily ignore 5 DTZ sub-rules with 40 existing violations so CI stays green; new datetime code with other DTZ patterns is caught immediately
- `PLW1514` (unspecified-encoding) deferred as a TODO — it requires ruff preview mode, which isn't practical to enable project-wide (~17k additional violations)

## Existing violations (suppressed via `ignore`)
| Rule | Description | Count |
|------|-------------|-------|
| DTZ001 | `datetime()` without `tzinfo` | 22 |
| DTZ005 | `datetime.now()` without `tz=` | 10 |
| DTZ011 | `date.today()` | 4 |
| DTZ006 | `datetime.fromtimestamp()` without `tz=` | 3 |
| DTZ002 | `datetime.today()` | 1 |

## Test plan
- [ ] CI passes with new rules enabled
- [ ] Follow-up PRs to fix existing DTZ violations and remove ignores
- [ ] PLW1514 to be added when it graduates from ruff preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)