### PR TITLE
feat(catalog): add __main__ guard to catalog CLI

### DIFF
--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -2115,3 +2115,7 @@ def serve_unbound(
     # Span covers startup only; server.wait() runs outside to avoid a never-exported span.
     logger.info(f"Serving entry {entry!r} on {flight_url.to_location()}")
     server.wait()
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- Add `if __name__ == "__main__":` block to `python/xorq/catalog/cli.py` so the catalog CLI can be invoked via `python -m xorq.catalog.cli`

## Test plan
- [x] Run `python -m xorq.catalog.cli --help` and verify it prints usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)