### PR TITLE
fix(codecov): wait for all CI jobs before posting status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 coverage:
+  notify:
+    wait_for_ci: true
   status:
     project:
       default:


### PR DESCRIPTION
## Summary
- Adds `notify.wait_for_ci: true` to `codecov.yml` so codecov delays its project/patch status checks until GitHub reports all CI jobs as finished
- Eliminates phantom coverage drops caused by incomplete uploads (e.g. the -8.99% false alarm on #2007)

Closes #2046

## Test plan
- [ ] Merge and observe that codecov status checks no longer appear until all CI jobs complete
- [ ] Verify coverage deltas are stable and reflect actual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)