### PR TITLE
perf(dasher): replace fqn() imports with string literals

### DIFF
--- a/python/xorq/common/utils/dasher/__init__.py
+++ b/python/xorq/common/utils/dasher/__init__.py
@@ -25,10 +25,8 @@ from __future__ import annotations
 import contextvars
 import functools
 import inspect
-import operator
 from typing import TYPE_CHECKING
 
-import toolz
 from xorq_dasher import DEFAULT_HASHER, Hasher, fqn
 
 
@@ -100,50 +98,31 @@ from xorq.common.utils.dasher._relations import (  # noqa: E402, F401
 )
 
 
-def _build_extra_rules():
-    import types as _types  # noqa: PLC0415
+_EXTRA_RULES: tuple[tuple[str, object], ...] = (
+    ("functools._lru_cache_wrapper", normalize_lru_cache),
+    ("functools.partial", normalize_functools_partial),
+    ("builtins.builtin_function_or_method", normalize_builtin_callable),
+    ("builtins.slice", normalize_slice),
+    ("builtins.property", normalize_property),
+    ("toolz.functoolz.Compose", normalize_toolz_compose),
+    ("toolz.functoolz.curry", normalize_toolz_curry),
+    ("toolz.functoolz.excepts", normalize_toolz_excepts),
+    ("operator.methodcaller", normalize_methodcaller),
+    (
+        "xorq.vendor.ibis.expr.operations.relations.DatabaseTable",
+        _databasetable_dispatcher,
+    ),
+    ("xorq.expr.relations.Read", _normalize_read_xorq),
+    ("xorq.vendor.ibis.expr.types.core.Expr", _normalize_expr_xorq),
+    ("xorq.vendor.ibis.expr.schema.Schema", normalize_ibis_schema),
+    ("xorq.vendor.ibis.expr.operations.udf.ScalarUDF", _normalize_scalar_udf_xorq),
+    ("numpy.dtype", normalize_numpy_dtype),
+    ("pandas.core.series.Series", normalize_pandas_series),
+    ("pandas.core.frame.DataFrame", normalize_pandas_dataframe),
+    ("xorq.common.utils.toolz_utils.curry", normalize_toolz_curry),
+)
 
-    import numpy as np  # noqa: PLC0415
-    import pandas as pd  # noqa: PLC0415
-
-    from xorq.expr.relations import Read  # noqa: PLC0415
-    from xorq.vendor.ibis.expr.operations.relations import (  # noqa: PLC0415
-        DatabaseTable,
-        Schema,
-    )
-    from xorq.vendor.ibis.expr.operations.udf import ScalarUDF  # noqa: PLC0415
-    from xorq.vendor.ibis.expr.types import Expr  # noqa: PLC0415
-
-    rules = [
-        (fqn(functools._lru_cache_wrapper), normalize_lru_cache),
-        (fqn(functools.partial), normalize_functools_partial),
-        (fqn(_types.BuiltinFunctionType), normalize_builtin_callable),
-        (fqn(_types.BuiltinMethodType), normalize_builtin_callable),
-        (fqn(slice), normalize_slice),
-        (fqn(property), normalize_property),
-        (fqn(toolz.functoolz.Compose), normalize_toolz_compose),
-        (fqn(toolz.curry), normalize_toolz_curry),
-        (fqn(toolz.functoolz.excepts), normalize_toolz_excepts),
-        (fqn(operator.methodcaller), normalize_methodcaller),
-        (fqn(DatabaseTable), _databasetable_dispatcher),
-        (fqn(Read), _normalize_read_xorq),
-        (fqn(Expr), _normalize_expr_xorq),
-        (fqn(Schema), normalize_ibis_schema),
-        (fqn(ScalarUDF), _normalize_scalar_udf_xorq),
-        (fqn(np.dtype), normalize_numpy_dtype),
-        (fqn(pd.Series), normalize_pandas_series),
-        (fqn(pd.DataFrame), normalize_pandas_dataframe),
-    ]
-    try:
-        from xorq.common.utils.toolz_utils import curry as xo_curry  # noqa: PLC0415
-
-        rules.append((fqn(xo_curry), normalize_toolz_curry))
-    except ImportError:
-        pass
-    return tuple(rules)
-
-
-HASHER: Hasher = DEFAULT_HASHER.override(*_build_extra_rules())
+HASHER: Hasher = DEFAULT_HASHER.override(*_EXTRA_RULES)
 
 
 def _install_per_call_memos():

--- a/python/xorq/common/utils/dasher/_gap_rules.py
+++ b/python/xorq/common/utils/dasher/_gap_rules.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING
 import toolz
 from xorq_dasher.rules.functions import normalize_function
 
+from xorq.common.utils.inspect_utils import get_partial_arguments
+
 
 if TYPE_CHECKING:
     import numpy as np
@@ -63,8 +65,6 @@ def normalize_toolz_compose(composed: toolz.functoolz.Compose) -> tuple:
 
 
 def normalize_toolz_curry(curried: toolz.curry) -> tuple:
-    from xorq.common.utils.inspect_utils import get_partial_arguments  # noqa: PLC0415
-
     partial_arguments = get_partial_arguments(
         curried.func, *curried.args, **curried.keywords
     )

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -14,6 +14,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import xxhash
+from xorq_dasher.rules.expr import normalize_inmemorytable
 
 
 if TYPE_CHECKING:
@@ -407,8 +408,6 @@ def _decompose_expr(
 
 
 def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
-    from xorq_dasher.rules.expr import normalize_inmemorytable  # noqa: PLC0415
-
     from xorq.common.utils.dasher import HASHER, _current_hasher  # noqa: PLC0415
 
     sql, reads, dts, udfs, mems, param_anchors = _decompose_expr(expr, op)

--- a/python/xorq/common/utils/dasher/_paths.py
+++ b/python/xorq/common/utils/dasher/_paths.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 import itertools
 import pathlib
 import re
+import urllib.error
+import urllib.request
+
+import yaml12
 
 
 # Catalog-extract tempdir prefix. ``xorq.catalog.expr_utils.load_expr_from_zip``
@@ -42,9 +46,6 @@ def _normalize_path_stat(path: str, **kwargs) -> tuple:
     """Stable metadata for a path: HTTP HEAD, cloud metadata, or local stat."""
 
     if isinstance(path, str) and path.startswith(("http://", "https://")):
-        import urllib.error  # noqa: PLC0415
-        import urllib.request  # noqa: PLC0415
-
         req = urllib.request.Request(
             path, method="HEAD", headers={"User-Agent": "xorq-cache"}
         )
@@ -148,8 +149,6 @@ def _extract_datafusion_plan_paths(ep_str: str) -> tuple[str, ...]:
     :func:`_canonicalize_catalog_path` so two ``load_expr_from_zip`` calls on
     the same zip produce equal tokens (ADR-0007).
     """
-
-    import yaml12  # noqa: PLC0415
 
     file_groups_match = re.search(r"file_groups=(\{[^}]*\})", ep_str)
     if not file_groups_match:

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -13,6 +13,13 @@ import contextvars
 import pathlib
 import re
 
+from xorq_dasher.rules.expr import (
+    normalize_cached_node,
+    normalize_databasetable,
+    normalize_memory_databasetable,
+    normalize_remote_table,
+)
+
 from xorq.common.utils.dasher._gap_rules import normalize_ibis_schema
 from xorq.common.utils.dasher._opaque import _MISSING, _rename_unbound_xorq
 from xorq.common.utils.dasher._paths import (
@@ -104,9 +111,6 @@ def _normalize_duckdb_databasetable_xorq(dt):
     """
 
     import sqlglot as sg  # noqa: PLC0415
-    from xorq_dasher.rules.expr import (  # noqa: PLC0415
-        normalize_memory_databasetable,
-    )
 
     name = sg.table(dt.name, quoted=dt.source.compiler.quoted).sql(
         dialect=dt.source.name
@@ -157,10 +161,6 @@ def _normalize_datafusion_databasetable_xorq(dt):
     ``test_parquet_cache_storage``). Mirror the legacy xorq behavior: extract
     file paths from the plan and stat them.
     """
-
-    from xorq_dasher.rules.expr import (  # noqa: PLC0415
-        normalize_memory_databasetable,
-    )
 
     table = dt.source.con.table(dt.name)
     ep_str = str(table.execution_plan())
@@ -216,12 +216,6 @@ def _databasetable_dispatcher(dt):
 
 
 def _dispatch_databasetable(dt):
-    from xorq_dasher.rules.expr import (  # noqa: PLC0415
-        normalize_cached_node,
-        normalize_databasetable,
-        normalize_remote_table,
-    )
-
     from xorq.expr.relations import (  # noqa: PLC0415
         CachedNode,
         FlightExpr,

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -26,10 +26,14 @@ from __future__ import annotations
 import functools
 import operator
 import pickle
+import types
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import toolz
+from xorq_dasher import fqn
 
 import xorq.api as xo
 import xorq.common.utils.dasher as dasher
@@ -38,6 +42,7 @@ import xorq.expr.relations as rel
 from xorq.caching import ParquetCache
 from xorq.common.utils import graph_utils
 from xorq.common.utils.dasher import (
+    _EXTRA_RULES,
     HASHER,
     _canonicalize_catalog_path,
     _extract_datafusion_plan_paths,
@@ -59,8 +64,12 @@ from xorq.common.utils.dasher._opaque import (
 )
 from xorq.common.utils.defer_utils import normalize_read_path_stat
 from xorq.common.utils.tests._test_helpers import BombHasher, MockOp, Probe
+from xorq.common.utils.toolz_utils import curry as xo_curry
 from xorq.expr.udf import agg, make_pandas_expr_udf
 from xorq.vendor.ibis.expr.operations.generic import Cast
+from xorq.vendor.ibis.expr.operations.relations import DatabaseTable, Schema
+from xorq.vendor.ibis.expr.operations.udf import ScalarUDF
+from xorq.vendor.ibis.expr.types import Expr
 
 
 # --- file-change invalidation ---------------------------------------------
@@ -948,3 +957,37 @@ def test_expr_metadata_zero_slot_scalar():
     assert meta["slots"] == []
     assert isinstance(meta["structural_hash"], str)
     assert compute_expr_token(meta["structural_hash"], ()) == token
+
+
+def test_extra_rules_fqn_strings():
+    """Guard against class relocations silently breaking hardcoded FQN strings."""
+    expected = {
+        "functools._lru_cache_wrapper": functools._lru_cache_wrapper,
+        "functools.partial": functools.partial,
+        "builtins.builtin_function_or_method": types.BuiltinFunctionType,
+        "builtins.slice": slice,
+        "builtins.property": property,
+        "toolz.functoolz.Compose": toolz.functoolz.Compose,
+        "toolz.functoolz.curry": toolz.curry,
+        "toolz.functoolz.excepts": toolz.functoolz.excepts,
+        "operator.methodcaller": operator.methodcaller,
+        "xorq.vendor.ibis.expr.operations.relations.DatabaseTable": DatabaseTable,
+        "xorq.expr.relations.Read": rel.Read,
+        "xorq.vendor.ibis.expr.types.core.Expr": Expr,
+        "xorq.vendor.ibis.expr.schema.Schema": Schema,
+        "xorq.vendor.ibis.expr.operations.udf.ScalarUDF": ScalarUDF,
+        "numpy.dtype": np.dtype,
+        "pandas.core.series.Series": pd.Series,
+        "pandas.core.frame.DataFrame": pd.DataFrame,
+        "xorq.common.utils.toolz_utils.curry": xo_curry,
+    }
+    for literal, cls in expected.items():
+        assert fqn(cls) == literal, (
+            f"FQN drift: {cls!r} moved from {literal!r} to {fqn(cls)!r}; "
+            f"update the string in _EXTRA_RULES"
+        )
+
+    production_fqns = {fqn_str for fqn_str, _ in _EXTRA_RULES}
+    assert production_fqns == set(expected), (
+        f"test/production mismatch: {production_fqns.symmetric_difference(set(expected))}"
+    )


### PR DESCRIPTION
## Summary
- Replace every `fqn(SomeClass)` call with its pre-computed string literal in a module-level `_EXTRA_RULES` tuple, eliminating heavy imports of numpy, pandas, `xorq.expr.relations`, and the ibis expression/operations hierarchy
- `fqn()` just returns `f"{typ.__module__}.{typ.__qualname__}"` — the strings are static and known ahead of time
- Hoist cheap deferred imports (`xorq_dasher.rules.expr`, `xorq.common.utils.inspect_utils`, `urllib.request`, `urllib.error`, `yaml12`) to module level across `_gap_rules.py`, `_opaque.py`, `_paths.py`, and `_relations.py` — these add <1ms since they're already in `sys.modules` or trivially small
- Remove now-unused top-level `import operator` and `import toolz`, and deduplicate the `BuiltinFunctionType`/`BuiltinMethodType` entry (same type in CPython)

## Impact
`import xorq.common.utils.dasher` goes from **~2,050ms to ~75ms** (27x faster).

The previous `_build_extra_rules()` function imported `xorq.expr.relations.Read` at call time, which transitively pulled in the entire DataFusion backend, all SQL compilers/dialects (sqlglot), pandas, the full ibis expression hierarchy, and the OpenTelemetry SDK. The rules are now a module-level `_EXTRA_RULES` tuple with string-literal keys, so no heavy imports are needed.

## Test plan
- [x] `from xorq.common.utils.dasher import HASHER` succeeds
- [x] 67/68 dasher tests pass (1 pre-existing failure unrelated to this change)
- [x] Pre-commit hooks pass (ruff check + ruff format)
- [x] Import time verified with `python -X importtime`
- [x] `test_extra_rules_fqn_strings` drift guard validates every hardcoded string against `fqn(cls)` and checks set-equality with `_EXTRA_RULES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)