### PR TITLE
refactor: centralize StrEnum compat shim and enum modules

### DIFF
--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -13,6 +13,7 @@ import toolz
 import xorq.vendor.ibis.expr.api as api
 import xorq.vendor.ibis.expr.schema as sch
 import xorq.vendor.ibis.expr.types as ir
+from xorq.backends.snowflake.enums import SnowflakeAuthenticator
 from xorq.common.utils.logging_utils import get_logger
 from xorq.expr.relations import (
     prepare_create_table_from_expr,
@@ -24,27 +25,11 @@ from xorq.vendor.ibis.expr.operations.relations import (
 )
 
 
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
-
-
 logger = get_logger(__name__)
 
 
-class SnowflakeAuthenticator(StrEnum):
-    # https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options#label-nodejs-auth-options
-    password = "none"
-    mfa = "username_password_mfa"
-    keypair = "snowflake_jwt"
-    sso = "externalbrowser"
-    # oauth = "oauth"
-    # oauth2 = "oauth_authorization_code"
-
-
 @functools.wraps(IbisSnowflakeBackend.do_connect)
-def wrapped_do_connect(self, create_object_udfs: bool = None, **kwargs: Any):
+def wrapped_do_connect(self, create_object_udfs: bool = None, **kwargs: Any) -> None:
     from xorq.common.utils.snowflake_keypair_utils import (  # noqa: PLC0415
         maybe_decrypt_private_key,
     )

--- a/python/xorq/backends/snowflake/enums.py
+++ b/python/xorq/backends/snowflake/enums.py
@@ -1,0 +1,9 @@
+from xorq.common.compat import StrEnum
+
+
+class SnowflakeAuthenticator(StrEnum):
+    # https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options#label-nodejs-auth-options
+    password = "none"
+    mfa = "username_password_mfa"
+    keypair = "snowflake_jwt"
+    sso = "externalbrowser"

--- a/python/xorq/backends/snowflake/tests/test_client.py
+++ b/python/xorq/backends/snowflake/tests/test_client.py
@@ -2,7 +2,7 @@ import pytest
 import toolz
 
 import xorq.api as xo
-from xorq.backends.snowflake import SnowflakeAuthenticator
+from xorq.backends.snowflake.enums import SnowflakeAuthenticator
 from xorq.backends.snowflake.tests.conftest import (
     inside_temp_schema,
 )

--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -1,18 +1,17 @@
-from enum import StrEnum
+from __future__ import annotations
+
 from functools import reduce
 
-from xorq.common.utils.graph_utils import replace_unbound
-from xorq.expr.relations import RemoteTable, gen_name
+from xorq.catalog.enums import CatalogTag
+from xorq.common.utils.graph_utils import replace_nodes, replace_unbound, walk_nodes
+from xorq.expr.relations import HashingTag, RemoteTable, gen_name
 from xorq.ibis_yaml.enums import ExprKind
+from xorq.vendor.ibis.expr.schema import Schema
 
 
-class CatalogTag(StrEnum):
-    SOURCE = "catalog-source"
-    TRANSFORM = "catalog-transform"
-    CODE = "catalog-code"
-
-
-def _get_transform_schema_issues(source_schema, transform_schema):
+def _get_transform_schema_issues(
+    source_schema: Schema, transform_schema: Schema
+) -> tuple[dict, dict]:
     bads = {
         col: (source_typ, transform_typ)
         for col, transform_typ in transform_schema.items()
@@ -229,9 +228,7 @@ def fuse_catalog_source(expr):
     can execute as one query.  This applies to both database-backed sources
     (DatabaseTable / DatabaseTableView) and deferred reads (Read).
     """
-    from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
     from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
-    from xorq.expr.relations import HashingTag  # noqa: PLC0415
 
     with tracer.start_as_current_span("catalog.fuse") as span:
         source_tags = tuple(
@@ -251,8 +248,6 @@ def fuse_catalog_source(expr):
             span.set_attribute("fused", False)
             span.set_attribute("reason", "not_fusable")
             return expr
-
-        from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
         catalog_tags_set = frozenset(CatalogTag)
 

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -47,8 +47,8 @@ from xorq.catalog.constants import (
     MAIN_BRANCH,
     METADATA_APPEND,
     PREFERRED_SUFFIX,
-    CatalogInfix,
 )
+from xorq.catalog.enums import CatalogInfix
 from xorq.catalog.exceptions import CatalogConfigurationError, CatalogPushError
 from xorq.catalog.expr_utils import (
     build_expr_context,
@@ -956,7 +956,7 @@ class Catalog:
         )
 
     @classmethod
-    def _resolve_default_name(cls):
+    def _resolve_default_name(cls) -> str:
         from xorq.catalog.constants import (  # noqa: PLC0415
             DEFAULT_CATALOG_CONFIG,
             DEFAULT_CATALOG_NAME,

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -29,6 +29,7 @@ from xorq.cli_options import (
     sync_option,
     unbind_options,
 )
+from xorq.ibis_yaml.enums import DumpFiles, ExprKind
 
 
 def click_handler(e):
@@ -727,8 +728,6 @@ def schema(ctx, name, as_json):
       # Machine-readable metadata
       xorq catalog schema penguins-prod --json
     """
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
-
     with click_context_catalog(ctx):
         catalog = ctx.obj.make_catalog(init=False)
         entry = _get_catalog_entry(catalog, name)
@@ -798,8 +797,6 @@ def show(ctx, name, as_json, as_raw):
         if as_json:
             click.echo(json.dumps(entry.sidecar_metadata, indent=2, default=str))
             return
-
-        from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
 
         meta = entry.metadata
         type_label = {
@@ -1048,7 +1045,6 @@ def _get_catalog_entry(catalog, name):
 def _eval_entry(catalog_entry, code, instream=None, cache_dir=None):
     """Evaluate a single catalog entry to an expression."""
     from xorq.catalog.bind import _eval_code, _make_source_expr  # noqa: PLC0415
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
 
     match catalog_entry.kind:
         case ExprKind.UnboundExpr:
@@ -1195,8 +1191,6 @@ def _assert_requirements_identical(entry_reqs):
 
 
 def _stage_bundle_into_build(bundle, build_path):
-    from xorq.ibis_yaml.enums import DumpFiles  # noqa: PLC0415
-
     for w in bundle.wheel_paths:
         dst = build_path / w.name
         if not dst.exists():
@@ -1222,7 +1216,6 @@ def _extract_wheel(zf, member, harvest_dir, seen_wheels, entry_name):
 
 
 def _harvest_entry_from_zip(zf, harvest_dir, entry_name=None, seen_wheels=None):
-    from xorq.ibis_yaml.enums import DumpFiles  # noqa: PLC0415
     from xorq.ibis_yaml.packager import (  # noqa: PLC0415
         _python_minor_from_metadata_text,
     )
@@ -1258,7 +1251,6 @@ def _harvest_entry_from_zip(zf, harvest_dir, entry_name=None, seen_wheels=None):
 @contextmanager
 def _entry_run_bundle(catalog, entries):
     from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
-    from xorq.ibis_yaml.enums import DumpFiles  # noqa: PLC0415
     from xorq.ibis_yaml.packager import JointBundle  # noqa: PLC0415
 
     if not entries:
@@ -1586,8 +1578,6 @@ def _resolve_single_entry(
     """Resolve a single catalog entry to an expression."""
     catalog_entry = _get_catalog_entry(catalog, entry)
 
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
-
     span.set_attribute("kind", str(catalog_entry.kind))
     expr = _eval_entry(catalog_entry, code, instream, cache_dir=cache_dir)
 
@@ -1819,7 +1809,6 @@ def run(
                     from xorq.catalog.zip_utils import (  # noqa: PLC0415
                         extract_build_zip_context,
                     )
-                    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
                     from xorq.ibis_yaml.packager import (  # noqa: PLC0415
                         PackagedRunner,
                     )

--- a/python/xorq/catalog/constants.py
+++ b/python/xorq/catalog/constants.py
@@ -1,16 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
-
-
-class CatalogInfix(StrEnum):
-    ALIAS = "aliases"
-    ENTRY = "entries"
-    METADATA = "metadata"
 
 
 METADATA_APPEND = ".metadata.yaml"

--- a/python/xorq/catalog/enums.py
+++ b/python/xorq/catalog/enums.py
@@ -1,0 +1,20 @@
+from xorq.common.compat import StrEnum
+
+
+class CatalogInfix(StrEnum):
+    ALIAS = "aliases"
+    ENTRY = "entries"
+    METADATA = "metadata"
+
+
+class CatalogTag(StrEnum):
+    SOURCE = "catalog-source"
+    TRANSFORM = "catalog-transform"
+    CODE = "catalog-code"
+
+
+class OnUnrebuiltBuilder(StrEnum):
+    """Policy when a builder tag has no rebuild protocol registered."""
+
+    RAISE = "raise"
+    WARN = "warn"

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -31,26 +31,15 @@ from __future__ import annotations
 import os
 import re
 import tempfile
+import warnings
 from contextlib import contextmanager, nullcontext
 from functools import cached_property, partial
-
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
 
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, optional
 
-from xorq.catalog.constants import CATALOG_YAML_NAME, CatalogInfix
-
-
-class OnUnrebuiltBuilder(StrEnum):
-    """Policy when a builder tag has no rebuild protocol registered."""
-
-    RAISE = "raise"
-    WARN = "warn"
+from xorq.catalog.constants import CATALOG_YAML_NAME
+from xorq.catalog.enums import CatalogInfix, CatalogTag, OnUnrebuiltBuilder
 
 
 @frozen
@@ -141,9 +130,6 @@ def _rebuild_subexpr(expr, *, from_catalog, to_catalog, ctx):
 
     Returns *expr* unchanged when no rebuildable tag is found.
     """
-    import warnings  # noqa: PLC0415
-
-    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
     from xorq.catalog.composer import ExprComposer  # noqa: PLC0415
     from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
     from xorq.expr.builders import (  # noqa: PLC0415

--- a/python/xorq/catalog/tests/conftest.py
+++ b/python/xorq/catalog/tests/conftest.py
@@ -20,7 +20,8 @@ from xorq.catalog.catalog import (
     Catalog,
     CatalogAlias,
 )
-from xorq.catalog.constants import MAIN_BRANCH, CatalogInfix
+from xorq.catalog.constants import MAIN_BRANCH
+from xorq.catalog.enums import CatalogInfix
 from xorq.catalog.expr_utils import build_expr_context_zip
 from xorq.catalog.replay import Replayer
 from xorq.catalog.zip_utils import with_pure_suffix

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -29,7 +29,8 @@ from xorq.catalog.catalog import (
     CatalogEntry,
     _format_push_failures,
 )
-from xorq.catalog.constants import MAIN_BRANCH, CatalogInfix
+from xorq.catalog.constants import MAIN_BRANCH
+from xorq.catalog.enums import CatalogInfix
 from xorq.catalog.exceptions import (
     CatalogConfigurationError,
     CatalogPushError,

--- a/python/xorq/catalog/tests/test_replay_rebuild.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild.py
@@ -6,16 +6,18 @@ from click.testing import CliRunner
 
 import xorq.api as xo
 from xorq.catalog.backend import GitBackend
-from xorq.catalog.bind import CatalogTag, bind
+from xorq.catalog.bind import bind
 from xorq.catalog.catalog import Catalog
 from xorq.catalog.cli import cli
 from xorq.catalog.composer import ExprComposer
+from xorq.catalog.enums import CatalogTag
 from xorq.catalog.replay import Replayer
+from xorq.catalog.tests.conftest import _replay_rebuild
 from xorq.common.utils.graph_utils import walk_nodes
-from xorq.expr.relations import HashingTag
+from xorq.expr.builders import TagHandler, register_tag_handler
+from xorq.expr.relations import HashingTag, Tag
+from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr import operations as ops
-
-from .conftest import _replay_rebuild
 
 
 @pytest.fixture
@@ -49,7 +51,6 @@ def test_rebuild_produces_consistent_target(source_catalog, target_path):
     # Execution-equivalence: every aliased entry must execute to the same data
     # in source and target. Structural checks (schema/recipe/hash) can line up
     # while a broken rebuild silently returns wrong rows.
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
 
     for alias in ("my-source", "my-transform", "bound1"):
         src_entry = catalog.get_catalog_entry(alias, maybe_alias=True)
@@ -270,11 +271,9 @@ def test_rebuild_source_transform_code_composition(source_catalog, target_path):
     assert recovered.code == "source.select('user_id')"
 
 
-def test_rebuild_preserves_outer_builder_wrapping(tmpdir, saved_registry):
-    from xorq.expr.builders import TagHandler, register_tag_handler  # noqa: PLC0415
-    from xorq.expr.relations import Tag  # noqa: PLC0415
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
-
+def test_rebuild_preserves_outer_builder_wrapping(
+    tmp_path: Path, saved_registry: None
+) -> None:
     register_tag_handler(
         TagHandler(
             tag_names=("test_rebuild_builder",),
@@ -286,7 +285,7 @@ def test_rebuild_preserves_outer_builder_wrapping(tmpdir, saved_registry):
     # transparent to dask.tokenize, so composed.tag(...) and composed hash
     # to the same entry name; if bound were pre-added, the Tag-wrapped
     # expression would collide.
-    repo = Catalog.init_repo_path(Path(tmpdir).joinpath("src"))
+    repo = Catalog.init_repo_path(tmp_path / "src")
     catalog = Catalog(backend=GitBackend(repo=repo))
     source_expr = xo.memtable({"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]})
     source_entry = catalog.add(source_expr, aliases=("my-source",))
@@ -299,9 +298,7 @@ def test_rebuild_preserves_outer_builder_wrapping(tmpdir, saved_registry):
     builder_expr = composed.tag("test_rebuild_builder")
     catalog.add(builder_expr, aliases=("builder1",))
 
-    target = _replay_rebuild(
-        catalog, Path(tmpdir).joinpath("tgt"), on_unrebuilt_builder="warn"
-    )
+    target = _replay_rebuild(catalog, tmp_path / "tgt", on_unrebuilt_builder="warn")
     new_builder = target.get_catalog_entry("builder1", maybe_alias=True)
     new_source = target.get_catalog_entry("my-source", maybe_alias=True)
     new_transform = target.get_catalog_entry("my-transform", maybe_alias=True)

--- a/python/xorq/catalog/tests/test_replay_rebuild_builders.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild_builders.py
@@ -15,14 +15,21 @@ import pytest
 
 import xorq.api as xo
 from xorq.catalog.backend import GitBackend
-from xorq.catalog.bind import CatalogTag, bind
+from xorq.catalog.bind import bind
 from xorq.catalog.catalog import Catalog
+from xorq.catalog.enums import CatalogTag
 from xorq.catalog.replay import Replayer
+from xorq.catalog.tests.conftest import _replay_rebuild
 from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.ml.enums import FittedPipelineTagKey
+from xorq.expr.ml.pipeline_lib import (
+    _FITTED_PIPELINE_REEMIT_TAGS,
+    FittedPipeline,
+    Pipeline,
+)
 from xorq.expr.relations import HashingTag
+from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr import operations as ops
-
-from .conftest import _replay_rebuild
 
 
 # -- FittedPipeline dispatch-table coverage (no catalog integration needed) --
@@ -31,34 +38,29 @@ from .conftest import _replay_rebuild
 @pytest.mark.parametrize(
     "tag_key_name, method_name",
     [
-        ("TRANSFORM", "transform"),
-        ("PREDICT", "predict"),
-        ("PREDICT_PROBA", "predict_proba"),
-        ("DECISION_FUNCTION", "decision_function"),
-        ("FEATURE_IMPORTANCES", "feature_importances"),
+        pytest.param("TRANSFORM", "transform", id="transform"),
+        pytest.param("PREDICT", "predict", id="predict"),
+        pytest.param("PREDICT_PROBA", "predict_proba", id="predict_proba"),
+        pytest.param("DECISION_FUNCTION", "decision_function", id="decision_function"),
+        pytest.param(
+            "FEATURE_IMPORTANCES", "feature_importances", id="feature_importances"
+        ),
     ],
 )
-def test_fitted_pipeline_reemit_table_coverage(tag_key_name, method_name):
+def test_fitted_pipeline_reemit_table_coverage(
+    tag_key_name: str, method_name: str
+) -> None:
     """Every reemit entry point names a real FittedPipeline method."""
     pytest.importorskip("sklearn")
-    from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
-    from xorq.expr.ml.pipeline_lib import (  # noqa: PLC0415
-        _FITTED_PIPELINE_REEMIT_TAGS,
-        FittedPipeline,
-    )
 
     tag_key = FittedPipelineTagKey[tag_key_name]
     assert tag_key in _FITTED_PIPELINE_REEMIT_TAGS
     assert callable(getattr(FittedPipeline, method_name))
 
 
-def test_fitted_pipeline_training_reserved_from_reemit():
+def test_fitted_pipeline_training_reserved_from_reemit() -> None:
     """TRAINING and ALL_STEPS are interior tags, not reemit entry points."""
     pytest.importorskip("sklearn")
-    from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
-    from xorq.expr.ml.pipeline_lib import (  # noqa: PLC0415
-        _FITTED_PIPELINE_REEMIT_TAGS,
-    )
 
     assert FittedPipelineTagKey.TRAINING not in _FITTED_PIPELINE_REEMIT_TAGS
     assert FittedPipelineTagKey.ALL_STEPS not in _FITTED_PIPELINE_REEMIT_TAGS
@@ -329,9 +331,6 @@ def test_rebuild_fitted_pipeline_roundtrip_predictions_match(tmpdir):
     from sklearn.linear_model import LinearRegression  # noqa: PLC0415
     from sklearn.pipeline import make_pipeline  # noqa: PLC0415
     from sklearn.preprocessing import StandardScaler  # noqa: PLC0415
-
-    from xorq.expr.ml.pipeline_lib import Pipeline  # noqa: PLC0415
-    from xorq.ibis_yaml.enums import ExprKind  # noqa: PLC0415
 
     train = xo.memtable(
         {

--- a/python/xorq/catalog/tests/test_three_way_list_merge.py
+++ b/python/xorq/catalog/tests/test_three_way_list_merge.py
@@ -18,10 +18,10 @@ import io
 import pytest
 
 from xorq.catalog.catalog import _parse_catalog_yaml_blob, _three_way_list_merge
-from xorq.catalog.constants import CatalogInfix
+from xorq.catalog.enums import CatalogInfix
 
 
-def test_empty_inputs():
+def test_empty_inputs() -> None:
     assert _three_way_list_merge([], [], []) == []
 
 

--- a/python/xorq/cli_constants.py
+++ b/python/xorq/cli_constants.py
@@ -1,7 +1,4 @@
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
+from xorq.common.compat import StrEnum
 
 
 class OutputFormats(StrEnum):

--- a/python/xorq/common/compat.py
+++ b/python/xorq/common/compat.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from strenum import StrEnum
+
+__all__ = ["StrEnum"]

--- a/python/xorq/common/enums.py
+++ b/python/xorq/common/enums.py
@@ -1,0 +1,16 @@
+from xorq.common.compat import StrEnum
+
+
+XORQ_METADATA_PREFIX = "xorq:"
+
+
+class RunLogFile(StrEnum):
+    LOG = "run.jsonl"
+    META = "meta.json"
+
+
+class ProvenanceField(StrEnum):
+    expr_hash = f"{XORQ_METADATA_PREFIX}expr_hash"
+    cache_strategy = f"{XORQ_METADATA_PREFIX}cache_strategy"
+    cache_storage = f"{XORQ_METADATA_PREFIX}cache_storage"
+    cache_ttl_seconds = f"{XORQ_METADATA_PREFIX}cache_ttl_seconds"

--- a/python/xorq/common/utils/logging_utils.py
+++ b/python/xorq/common/utils/logging_utils.py
@@ -11,18 +11,12 @@ import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
-from opentelemetry.trace import SpanContext, StatusCode
-
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
-
 import structlog
 from attr import field, frozen
 from attr.validators import instance_of
+from opentelemetry.trace import SpanContext, StatusCode
 
+from xorq.common.enums import RunLogFile
 from xorq.common.utils.env_utils import EnvConfigable, env_templates_dir
 
 
@@ -162,11 +156,6 @@ if _log_level_str != "OFF":
 #           meta.json          # summary written on completion
 #
 # The run ID is a UUID4, unique across all runs.
-
-
-class RunLogFile(StrEnum):
-    LOG = "run.jsonl"
-    META = "meta.json"
 
 
 def get_xorq_runs_dir() -> Path:

--- a/python/xorq/common/utils/provenance_utils.py
+++ b/python/xorq/common/utils/provenance_utils.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
-import enum
+from typing import TYPE_CHECKING
 
 import pyarrow.parquet as pq
 
-
-XORQ_METADATA_PREFIX = "xorq:"
-
-
-class ProvenanceField(enum.StrEnum):
-    expr_hash = f"{XORQ_METADATA_PREFIX}expr_hash"
-    cache_strategy = f"{XORQ_METADATA_PREFIX}cache_strategy"
-    cache_storage = f"{XORQ_METADATA_PREFIX}cache_storage"
-    cache_ttl_seconds = f"{XORQ_METADATA_PREFIX}cache_ttl_seconds"
+from xorq.common.enums import XORQ_METADATA_PREFIX, ProvenanceField
 
 
-def get_expr_hash(expr):
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr.types.core import Expr
+
+
+def get_expr_hash(expr: Expr) -> str:
     from xorq.caching.strategy import SnapshotStrategy  # noqa: PLC0415
     from xorq.ibis_yaml.compiler import canonicalize_expr  # noqa: PLC0415
     from xorq.ibis_yaml.config import config  # noqa: PLC0415

--- a/python/xorq/common/utils/snowflake_utils.py
+++ b/python/xorq/common/utils/snowflake_utils.py
@@ -13,7 +13,8 @@ from attr.validators import (
 )
 
 from xorq.backends.snowflake import Backend as SnowflakeBackend
-from xorq.backends.snowflake import SnowflakeAuthenticator, connect
+from xorq.backends.snowflake import connect
+from xorq.backends.snowflake.enums import SnowflakeAuthenticator
 from xorq.common.utils.env_utils import (
     EnvConfigable,
     env_templates_dir,

--- a/python/xorq/common/utils/tests/ibis_utils/test_backend.py
+++ b/python/xorq/common/utils/tests/ibis_utils/test_backend.py
@@ -7,7 +7,7 @@ import toolz
 from xorq.backends.datafusion import Backend as DatafusionBackend
 from xorq.backends.postgres import Backend as PostgresBackend
 from xorq.backends.snowflake import Backend as SnowflakeBackend
-from xorq.backends.snowflake import SnowflakeAuthenticator
+from xorq.backends.snowflake.enums import SnowflakeAuthenticator
 from xorq.backends.sqlite import Backend as SqliteBackend
 from xorq.common.utils.env_utils import maybe_substitute_env_var
 from xorq.common.utils.ibis_utils import (

--- a/python/xorq/common/utils/tests/test_hashing_tag.py
+++ b/python/xorq/common/utils/tests/test_hashing_tag.py
@@ -7,8 +7,8 @@ from xorq.common.utils.node_utils import (
     find_by_expr_hash,
 )
 from xorq.expr.relations import HashingTag, Tag
-from xorq.ibis_yaml.common import RefEnum, RegistryEnum
 from xorq.ibis_yaml.compiler import YamlExpressionTranslator
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.vendor import ibis
 
 

--- a/python/xorq/common/utils/tests/test_provenance_utils.py
+++ b/python/xorq/common/utils/tests/test_provenance_utils.py
@@ -8,8 +8,8 @@ import pyarrow.parquet as pq
 import xorq.api as xo
 from xorq.caching.storage import ParquetStorage, ParquetTTLStorage
 from xorq.caching.strategy import ModificationTimeStrategy, SnapshotStrategy
+from xorq.common.enums import ProvenanceField
 from xorq.common.utils.provenance_utils import (
-    ProvenanceField,
     build_provenance_metadata,
     get_expr_hash,
     inject_metadata_into_schema,

--- a/python/xorq/expr/builders/__init__.py
+++ b/python/xorq/expr/builders/__init__.py
@@ -45,6 +45,8 @@ from typing import Optional
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, is_callable, optional
 
+from xorq.expr.ml.enums import FittedPipelineTagKey
+
 
 @frozen
 class TagHandler:
@@ -242,8 +244,6 @@ def _resolve_builder_from_tag(expr):
 
 
 def _ml_pipeline_extract_metadata(tag_node):
-    from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
-
     all_steps_raw = tag_node.metadata.get(str(FittedPipelineTagKey.ALL_STEPS), ())
     dicts = tuple(dict(step_items) for step_items in all_steps_raw)
     steps = tuple(d.get("name", "unknown") for d in dicts)
@@ -266,8 +266,6 @@ def _ml_from_tag_node(tag_node):
 
 def _builtin_handlers():
     """Declare built-in handlers for ML pipeline tags."""
-    from xorq.expr.ml.enums import FittedPipelineTagKey  # noqa: PLC0415
-
     return (
         TagHandler(
             tag_names=tuple(

--- a/python/xorq/expr/ml/enums.py
+++ b/python/xorq/expr/ml/enums.py
@@ -1,7 +1,4 @@
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
+from xorq.common.compat import StrEnum
 
 
 class KVField(StrEnum):

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -25,6 +25,7 @@ from xorq.caching import (
     ParquetTTLSnapshotCache,
     SourceCache,
 )
+from xorq.catalog.enums import CatalogTag
 from xorq.common.utils.attr_utils import (
     convert_sorted_kwargs_tuple,
     validate_kwargs_tuple,
@@ -50,7 +51,7 @@ from xorq.expr.ml.fit_lib import (
 from xorq.expr.ml.structer import (
     Structer,
 )
-from xorq.expr.relations import Tag
+from xorq.expr.relations import HashingTag, Tag
 from xorq.ibis_yaml.utils import freeze
 from xorq.vendor.ibis.expr.types.core import Expr
 
@@ -1042,9 +1043,6 @@ class FittedPipeline:
         original predict/transform input is not recoverable from the
         tag subtree alone.
         """
-        from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
-        from xorq.expr.relations import HashingTag  # noqa: PLC0415
-
         tag_key = FittedPipelineTagKey(tag_node.metadata["tag"])
         if tag_key not in _FITTED_PIPELINE_REEMIT_TAGS:
             raise RuntimeError(

--- a/python/xorq/expr/ml/tests/test_structer.py
+++ b/python/xorq/expr/ml/tests/test_structer.py
@@ -4,14 +4,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
-
 import xorq.api as xo
 import xorq.expr.datatypes as dt
+from xorq.common.compat import StrEnum
 
 
 sklearn = pytest.importorskip("sklearn")

--- a/python/xorq/ibis_yaml/common.py
+++ b/python/xorq/ibis_yaml/common.py
@@ -19,27 +19,10 @@ from xorq.caching.strategy import SnapshotStrategy
 from xorq.common.utils.dasher import tokenize
 from xorq.expr.relations import HashingTag, Read, Tag
 from xorq.ibis_yaml.config import config
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.ibis_yaml.utils import freeze
 from xorq.vendor.ibis.common.collections import FrozenOrderedDict
 from xorq.vendor.ibis.expr.schema import Schema
-
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
-
-
-class RefEnum(StrEnum):
-    dtype_ref = "dtype_ref"
-    node_ref = "node_ref"
-    schema_ref = "schema_ref"
-
-
-class RegistryEnum(StrEnum):
-    dtypes = "dtypes"
-    nodes = "nodes"
-    schemas = "schemas"
 
 
 FROM_YAML_HANDLERS: dict[str, Any] = {}

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -5,7 +5,6 @@ import operator
 import pathlib
 import sys
 import warnings
-from enum import StrEnum
 from pathlib import Path
 from typing import Any, Dict
 
@@ -34,6 +33,7 @@ from xorq.caching import (
     ParquetTTLSnapshotCache,
     SnapshotStrategy,
 )
+from xorq.common.compat import StrEnum
 from xorq.common.exceptions import UnboundExpressionError
 from xorq.common.utils.caching_utils import get_xorq_cache_dir
 from xorq.common.utils.dasher import tokenize
@@ -62,15 +62,19 @@ from xorq.expr.relations import (
     Read,
 )
 from xorq.ibis_yaml.common import (
-    RefEnum,
     Registry,
-    RegistryEnum,
     TranslationContext,
     translate_from_yaml,
     translate_to_yaml,
 )
 from xorq.ibis_yaml.config import config
-from xorq.ibis_yaml.enums import DumpFiles, ExprKind, MemtableTypes
+from xorq.ibis_yaml.enums import (
+    DumpFiles,
+    ExprKind,
+    MemtableTypes,
+    RefEnum,
+    RegistryEnum,
+)
 from xorq.ibis_yaml.sql import generate_sql_plans
 from xorq.ibis_yaml.utils import freeze
 from xorq.vendor.ibis.backends.profiles import Profile

--- a/python/xorq/ibis_yaml/enums.py
+++ b/python/xorq/ibis_yaml/enums.py
@@ -1,7 +1,4 @@
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
+from xorq.common.compat import StrEnum
 
 
 class DumpFiles(StrEnum):
@@ -34,3 +31,15 @@ class ExprKind(StrEnum):
 class MemtableTypes(StrEnum):
     inmemory = "memtables"
     database_table = "database_tables"
+
+
+class RefEnum(StrEnum):
+    dtype_ref = "dtype_ref"
+    node_ref = "node_ref"
+    schema_ref = "schema_ref"
+
+
+class RegistryEnum(StrEnum):
+    dtypes = "dtypes"
+    nodes = "nodes"
+    schemas = "schemas"

--- a/python/xorq/ibis_yaml/tests/conftest.py
+++ b/python/xorq/ibis_yaml/tests/conftest.py
@@ -5,11 +5,8 @@ import pytest
 import xorq.api as xo
 import xorq.expr.datatypes as dt
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.common import (
-    RefEnum,
-    RegistryEnum,
-)
 from xorq.ibis_yaml.compiler import YamlExpressionTranslator
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.vendor.ibis import _
 from xorq.vendor.ibis.expr.operations import ExistsSubquery
 

--- a/python/xorq/ibis_yaml/tests/test_basic.py
+++ b/python/xorq/ibis_yaml/tests/test_basic.py
@@ -4,10 +4,7 @@ import decimal
 import pytest
 
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.common import (
-    RefEnum,
-    RegistryEnum,
-)
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 

--- a/python/xorq/ibis_yaml/tests/test_relations.py
+++ b/python/xorq/ibis_yaml/tests/test_relations.py
@@ -1,10 +1,11 @@
-from xorq.ibis_yaml.common import (
-    RefEnum,
-    RegistryEnum,
-)
+from __future__ import annotations
+
+import xorq.vendor.ibis.expr.types as ir
+from xorq.ibis_yaml.compiler import YamlExpressionTranslator
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 
 
-def test_filter(compiler, t):
+def test_filter(compiler: YamlExpressionTranslator, t: ir.Table) -> None:
     expr = t.filter(t.a > 0)
     yaml_dict = compiler.to_yaml(expr)
     node_ref = yaml_dict["expression"][RefEnum.node_ref]

--- a/python/xorq/ibis_yaml/tests/test_subquery.py
+++ b/python/xorq/ibis_yaml/tests/test_subquery.py
@@ -1,8 +1,7 @@
+from __future__ import annotations
+
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.ibis_yaml.common import (
-    RefEnum,
-    RegistryEnum,
-)
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 

--- a/python/xorq/ibis_yaml/tests/test_window_functions.py
+++ b/python/xorq/ibis_yaml/tests/test_window_functions.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.common import RefEnum, RegistryEnum
+import xorq.vendor.ibis.expr.types as ir
+from xorq.ibis_yaml.compiler import YamlExpressionTranslator
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 
 
-def test_window_function_roundtrip(compiler, t):
+def test_window_function_roundtrip(
+    compiler: YamlExpressionTranslator, t: ir.Table
+) -> None:
     expr = t.select(
         [
             t.c.mean()

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -30,8 +30,6 @@ from xorq.expr.relations import (
     into_backend,
 )
 from xorq.ibis_yaml.common import (
-    RefEnum,
-    RegistryEnum,
     TranslationContext,
     _translate_type,
     deserialize_callable,
@@ -39,6 +37,7 @@ from xorq.ibis_yaml.common import (
     serialize_callable,
     translate_to_yaml,
 )
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.ibis_yaml.udf import _scalar_udf_from_yaml, _scalar_udf_to_yaml  # noqa: F401
 from xorq.ibis_yaml.utils import (
     freeze,

--- a/python/xorq/ibis_yaml/udf.py
+++ b/python/xorq/ibis_yaml/udf.py
@@ -8,8 +8,6 @@ import xorq.vendor.ibis.expr.operations as ops
 import xorq.vendor.ibis.expr.rules as rlz
 from xorq.expr.relations import FlightExpr, FlightUDXF
 from xorq.ibis_yaml.common import (
-    RefEnum,
-    RegistryEnum,
     TranslationContext,
     deserialize_callable,
     register_from_yaml_handler,
@@ -17,6 +15,7 @@ from xorq.ibis_yaml.common import (
     translate_from_yaml,
     translate_to_yaml,
 )
+from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.ibis_yaml.utils import freeze
 from xorq.vendor import ibis
 from xorq.vendor.ibis.common.annotations import Argument

--- a/python/xorq/init_templates.py
+++ b/python/xorq/init_templates.py
@@ -1,10 +1,5 @@
+from xorq.common.compat import StrEnum
 from xorq.common.utils import classproperty
-
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from strenum import StrEnum
 
 
 default_branch = "main"

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -21,6 +21,7 @@ from attr.validators import (
 from public import public
 
 import xorq.vendor.ibis.expr.operations as ops
+from xorq.catalog.enums import CatalogTag
 from xorq.common.exceptions import TranslationError, XorqError
 from xorq.common.utils.func_utils import return_constant
 from xorq.ibis_yaml.enums import ExprKind
@@ -715,7 +716,6 @@ def _extract_is_source(expr):
 
 
 def _extract_catalog_tag_nodes(expr):
-    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
     from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
     from xorq.expr.relations import HashingTag  # noqa: PLC0415
 
@@ -727,8 +727,6 @@ def _extract_catalog_tag_nodes(expr):
 
 
 def _extract_sources(catalog_tag_nodes):
-    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
-
     return tuple(
         {
             "entry_name": ht.metadata.get("entry_name"),
@@ -791,7 +789,6 @@ def _extract_kind(expr):
     UnboundTable is always a leaf, never the outermost node. All other kinds
     are determined by the outermost tag/node only.
     """
-    from xorq.catalog.bind import CatalogTag  # noqa: PLC0415
     from xorq.expr.builders import extract_builder_metadata  # noqa: PLC0415
     from xorq.expr.relations import CachedNode, HashingTag, Read, Tag  # noqa: PLC0415
 


### PR DESCRIPTION
## Summary
- Introduce `xorq.common.compat.StrEnum` as the single compat shim, replacing ~10 scattered `try/except` blocks across the codebase
- Move inline enum classes to dedicated `enums.py` modules in each package (`catalog`, `common`, `backends/snowflake`, `ibis_yaml`, `expr/ml`)
- Update all consumers to import from the canonical defining module — no re-exports, every enum is imported from where it's defined
- Lift all deferred enum imports to top-level — the new leaf modules only depend on `xorq.common.compat`, so there is no circular-dependency reason to defer

## Test plan
- [x] Existing test suite passes (no import paths changed without updating consumers)
- [x] Grep for old import paths confirms zero remaining consumers of moved enums
- [x] Zero deferred imports of enum leaf modules remain in the codebase
- [x] All pre-commit hooks (ruff check, ruff format, codespell) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)