### PR TITLE
refactor: hoist deferred imports after enum extraction

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -36,6 +36,7 @@ from git import (
 )
 from git.exc import GitCommandError
 
+from xorq.catalog import constants as catalog_constants
 from xorq.catalog.annex import (
     LOCAL_ANNEX,
     Annex,
@@ -1082,19 +1083,15 @@ class Catalog:
 
     @classmethod
     def _resolve_default_name(cls) -> str:
-        from xorq.catalog.constants import (  # noqa: PLC0415
-            DEFAULT_CATALOG_CONFIG,
-            DEFAULT_CATALOG_NAME,
-        )
         from xorq.vendor.ibis.config import env_config  # noqa: PLC0415
 
         if name := env_config.XORQ_DEFAULT_CATALOG:
             return name
         try:
-            name = DEFAULT_CATALOG_CONFIG.read_text().strip()
+            name = catalog_constants.DEFAULT_CATALOG_CONFIG.read_text().strip()
         except FileNotFoundError:
-            return DEFAULT_CATALOG_NAME
-        return name or DEFAULT_CATALOG_NAME
+            return catalog_constants.DEFAULT_CATALOG_NAME
+        return name or catalog_constants.DEFAULT_CATALOG_NAME
 
     @classmethod
     def from_default(

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+import attr
 import click
 
 from xorq.catalog import constants as catalog_constants
@@ -963,8 +964,6 @@ def log(ctx: click.Context, as_json: bool) -> None:
       xorq catalog log
       xorq catalog log --json | jq '.[] | select(.type == "Add")'
     """
-    import attr  # noqa: PLC0415
-
     from xorq.catalog.replay import Replayer  # noqa: PLC0415
 
     with click_context_catalog(ctx):

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from xorq.catalog import constants as catalog_constants
 
 if TYPE_CHECKING:
     from xorq.catalog.content_store import ContentStoreConfig
@@ -330,8 +331,6 @@ def init(
             ) from err
         click.echo(f"Initialized catalog at {catalog.repo_path}")
         if remote_url:
-            from xorq.catalog.constants import DEFAULT_REMOTE  # noqa: PLC0415
-
             remote = catalog.set_remote(DEFAULT_REMOTE, remote_url)
             click.echo(f"Set remote {remote.name} -> {remote_url}")
 
@@ -560,19 +559,20 @@ def default_catalog(set_name, unset):
       xorq catalog default --unset
     """
     from xorq.catalog.catalog import Catalog  # noqa: PLC0415
-    from xorq.catalog.constants import DEFAULT_CATALOG_CONFIG  # noqa: PLC0415
     from xorq.vendor.ibis.config import env_config  # noqa: PLC0415
 
     if set_name and unset:
         raise click.UsageError("--set and --unset are mutually exclusive.")
 
     if set_name:
-        DEFAULT_CATALOG_CONFIG.parent.mkdir(parents=True, exist_ok=True)
-        DEFAULT_CATALOG_CONFIG.write_text(set_name + "\n")
+        catalog_constants.DEFAULT_CATALOG_CONFIG.parent.mkdir(
+            parents=True, exist_ok=True
+        )
+        catalog_constants.DEFAULT_CATALOG_CONFIG.write_text(set_name + "\n")
         click.echo(f"Default catalog set to {set_name!r}")
     elif unset:
         try:
-            DEFAULT_CATALOG_CONFIG.unlink()
+            catalog_constants.DEFAULT_CATALOG_CONFIG.unlink()
             click.echo("Default catalog unset (reverted to 'default')")
         except FileNotFoundError:
             click.echo("No persisted default to unset.")
@@ -580,8 +580,8 @@ def default_catalog(set_name, unset):
         name = Catalog._resolve_default_name()
         if env_config.XORQ_DEFAULT_CATALOG:
             source = "env (XORQ_DEFAULT_CATALOG)"
-        elif DEFAULT_CATALOG_CONFIG.exists():
-            source = f"config ({DEFAULT_CATALOG_CONFIG})"
+        elif catalog_constants.DEFAULT_CATALOG_CONFIG.exists():
+            source = f"config ({catalog_constants.DEFAULT_CATALOG_CONFIG})"
         else:
             source = "built-in"
         click.echo(f"{name}  (source: {source})")
@@ -700,7 +700,6 @@ def set_remote(ctx, url, name, force):
       # Replace an existing remote
       xorq catalog set-remote git@github.com:me/flights-catalog.git --force
     """
-    from xorq.catalog.constants import DEFAULT_REMOTE  # noqa: PLC0415
     from xorq.catalog.exceptions import CatalogConfigurationError  # noqa: PLC0415
 
     with click_context_catalog(ctx):
@@ -1065,7 +1064,7 @@ def replay(
         replayer.replay(target, preserve_commits=preserve_commits)
         click.echo(f"Replayed {len(replayer.ops)} operations into {target_path}")
         if remote_url:
-            from xorq.catalog.constants import (  # noqa: PLC0415
+            from xorq.catalog.constants import (
                 ANNEX_BRANCH,
                 DEFAULT_REMOTE,
                 MAIN_BRANCH,
@@ -2121,8 +2120,6 @@ def serve_unbound(
       # Bind a runtime parameter
       xorq catalog serve-unbound scorer --params threshold=0.5
     """
-    from functools import partial  # noqa: PLC0415
-
     import xorq.expr.relations  # noqa: PLC0415
     import xorq.flight  # noqa: PLC0415
     from xorq.caching.strategy import SnapshotStrategy  # noqa: PLC0415

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -20,6 +20,7 @@ import click
 
 from xorq.catalog import constants as catalog_constants
 
+
 if TYPE_CHECKING:
     from xorq.catalog.content_store import ContentStoreConfig
 
@@ -332,6 +333,8 @@ def init(
             ) from err
         click.echo(f"Initialized catalog at {catalog.repo_path}")
         if remote_url:
+            from xorq.catalog.constants import DEFAULT_REMOTE  # noqa: PLC0415
+
             remote = catalog.set_remote(DEFAULT_REMOTE, remote_url)
             click.echo(f"Set remote {remote.name} -> {remote_url}")
 
@@ -701,6 +704,7 @@ def set_remote(ctx, url, name, force):
       # Replace an existing remote
       xorq catalog set-remote git@github.com:me/flights-catalog.git --force
     """
+    from xorq.catalog.constants import DEFAULT_REMOTE  # noqa: PLC0415
     from xorq.catalog.exceptions import CatalogConfigurationError  # noqa: PLC0415
 
     with click_context_catalog(ctx):
@@ -964,6 +968,7 @@ def log(ctx: click.Context, as_json: bool) -> None:
       xorq catalog log
       xorq catalog log --json | jq '.[] | select(.type == "Add")'
     """
+
     from xorq.catalog.replay import Replayer  # noqa: PLC0415
 
     with click_context_catalog(ctx):
@@ -1063,7 +1068,7 @@ def replay(
         replayer.replay(target, preserve_commits=preserve_commits)
         click.echo(f"Replayed {len(replayer.ops)} operations into {target_path}")
         if remote_url:
-            from xorq.catalog.constants import (
+            from xorq.catalog.constants import (  # noqa: PLC0415
                 ANNEX_BRANCH,
                 DEFAULT_REMOTE,
                 MAIN_BRANCH,

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -5,6 +5,8 @@ import threading
 from collections import Counter
 from datetime import datetime
 from functools import cache, cached_property, lru_cache
+from itertools import groupby
+from operator import attrgetter
 from pathlib import Path
 from typing import Literal
 
@@ -427,9 +429,6 @@ def _get_catalog_aliases(catalog) -> tuple:
 def _build_alias_multimap(
     catalog_aliases,
 ) -> dict[str, tuple[str, ...]]:
-    from itertools import groupby  # noqa: PLC0415
-    from operator import attrgetter  # noqa: PLC0415
-
     key = attrgetter("catalog_entry.name")
     sorted_aliases = sorted(catalog_aliases, key=key)
     return {

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import Any, OrderedDict, Tuple
 
 import xorq.expr.relations as rel
@@ -6,6 +6,7 @@ import xorq.expr.udf as udf
 import xorq.vendor.ibis.expr.operations as ops
 from xorq.expr.operations import NamedScalarParameter
 from xorq.vendor.ibis import Expr
+from xorq.vendor.ibis.common.graph import Graph
 from xorq.vendor.ibis.expr.operations.core import Node
 
 
@@ -56,10 +57,6 @@ def gen_children_of(node: Node) -> Tuple[Node, ...]:
 
 
 def bfs(node):
-    from collections import deque  # noqa: PLC0415
-
-    from xorq.vendor.ibis.common.graph import Graph  # noqa: PLC0415
-
     queue = deque((to_node(node),))
     dct = {}
     while queue:
@@ -375,8 +372,6 @@ def get_ordered_unique_sources(nodes):
 
 
 def find_all_sources(expr):
-    import xorq.vendor.ibis.expr.operations as ops  # noqa: PLC0415
-
     node_types = (
         ops.DatabaseTable,
         ops.SQLQueryResult,

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import sys
+import tempfile
 from typing import TYPE_CHECKING, Any, Optional
 
 from xorq.common.utils.env_utils import (
@@ -200,8 +201,6 @@ class Pins(Config):
             pin or version, and network or filesystem failures while fetching
             from remote storage. None are caught here.
         """
-        import tempfile  # noqa: PLC0415
-
         from filelock import FileLock  # noqa: PLC0415
 
         board = board or self.get_board()

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -34,7 +34,10 @@ from xorq.expr.ml import (
 from xorq.expr.operations import _MISSING, NamedScalarParameter
 from xorq.expr.relations import (
     CachedNode,
+    FlightExpr,
+    FlightUDXF,
     HashingTag,
+    Read,
     Tag,
     register_and_transform_remote_tables,
 )
@@ -251,8 +254,6 @@ def _transform_deferred_reads(expr):
     span = get_current_span()
 
     def replace_read(node, _kwargs):
-        from xorq.expr.relations import Read  # noqa: PLC0415
-
         if isinstance(node, Read):
             read_kwargs = dict(node.read_kwargs)
             span.add_event(
@@ -329,8 +330,6 @@ def execute(expr: ir.Expr, **kwargs: Any):
 
 @tracer.start_as_current_span("_remove_tag_nodes")
 def _remove_tag_nodes(expr):
-    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
-
     def replacer(node, kwargs):
         if isinstance(node, Tag):
             while isinstance(node, Tag):
@@ -346,7 +345,6 @@ def _remove_tag_nodes(expr):
 @tracer.start_as_current_span("_remove_non_hashing_tag_nodes")
 def _remove_non_hashing_tag_nodes(expr):
     """Strip Tag nodes but preserve HashingTag nodes during hash computation."""
-    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
     def replacer(node, kwargs):
         match node:

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -415,8 +415,6 @@ def _transform_expr(expr, params=None, **kwargs):
 
 
 def _pandas_execute(con, expr: ir.Expr, **kwargs):
-    from xorq.expr.relations import FlightExpr, FlightUDXF  # noqa: PLC0415
-
     span = get_current_span()
 
     node = expr.op()
@@ -456,7 +454,6 @@ def to_pyarrow_batches(
     results
         RecordBatchReader
     """
-    from xorq.expr.relations import FlightExpr, FlightUDXF  # noqa: PLC0415
 
     span = get_current_span()
 

--- a/python/xorq/expr/builders/__init__.py
+++ b/python/xorq/expr/builders/__init__.py
@@ -45,7 +45,9 @@ from typing import Optional
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, is_callable, optional
 
+from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.ml.enums import FittedPipelineTagKey
+from xorq.expr.relations import HashingTag, Tag
 
 
 @frozen
@@ -222,9 +224,6 @@ def _resolve_builder_from_tag(expr):
 
     Raises ``ValueError`` if no handler with ``from_tag_node`` matches.
     """
-    from xorq.common.utils.graph_utils import walk_nodes  # noqa: PLC0415
-    from xorq.expr.relations import HashingTag, Tag  # noqa: PLC0415
-
     registry = _get_from_tag_node_registry()
     tag_nodes = walk_nodes((Tag, HashingTag), expr)
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -2,6 +2,8 @@ import functools
 import itertools
 import operator
 from collections import defaultdict
+from itertools import tee
+from threading import Lock
 from typing import Any, Callable
 
 import pyarrow as pa
@@ -59,9 +61,6 @@ class SafeTee(object):
     @classmethod
     def tee(cls, iterable, n=2):
         """tuple of n independent thread-safe iterators"""
-        from itertools import tee  # noqa: PLC0415
-        from threading import Lock  # noqa: PLC0415
-
         lock = Lock()
         return tuple(cls(teeobj, lock) for teeobj in tee(iterable, n))
 

--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -1,3 +1,6 @@
+import types
+
+
 try:
     import importlib.metadata as importlib_metadata
 except ModuleNotFoundError:
@@ -13,8 +16,6 @@ def load_backend(name):
     if entry_point := next(
         (ep for ep in _load_entry_points() if ep.name == name), None
     ):
-        import types  # noqa: PLC0415
-
         module = entry_point.load()
         backend = module.Backend()
         backend.register_options()


### PR DESCRIPTION
## Summary

- Removes 24 unnecessary deferred imports across 9 files, enabled by the lightweight enum/constants modules introduced in #2054 and #2053
- Three categories of hoists: dead re-imports (names already at module level), stdlib imports (always cheap), and imports from newly-lightweight internal modules
- Uses module-level reference (`catalog_constants.DEFAULT_CATALOG_CONFIG`) for monkeypatchable constants to preserve test compatibility

## Dependencies

**Stacked on #2054** (`centralize-strenum-compat`) — must be merged first. Also builds on #2053 (already merged).

## Test plan

- [x] All 9 changed modules import cleanly
- [x] `ruff check` and `ruff format` pass
- [x] `test_catalog_default.py` — 17/17 pass (validates monkeypatch compatibility)
- [x] `test_replay_rebuild.py` + `test_three_way_list_merge.py` — 42/42 pass
- [x] `test_dasher.py` + `test_hashing_tag.py` + `test_provenance_utils.py` — 99 passed, 1 xfailed
- [x] `ibis_yaml/tests/` — 103/103 pass (excluding pre-existing benchmark failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)