### PR TITLE
test: strict monkeypatch fixture for stale string targets

### DIFF
--- a/python/xorq/conftest.py
+++ b/python/xorq/conftest.py
@@ -1,3 +1,4 @@
+import importlib
 from pathlib import Path
 
 import numpy as np
@@ -6,6 +7,32 @@ import pytest
 
 import xorq.api as xo
 from xorq.expr.builders import _FROM_TAG_NODE_REGISTRY
+
+
+@pytest.fixture(autouse=True)
+def _strict_monkeypatch(monkeypatch):
+    """Fail fast when a string-target monkeypatch names a non-existent module attribute.
+
+    Catches the common mistake of patching ``"xorq.a.b.name"`` when ``name``
+    was imported into ``xorq.a.b`` at the top level but has since been deferred
+    — meaning the attribute no longer exists on the module and the patch would
+    silently miss.
+    """
+    _original = type(monkeypatch).setattr
+
+    def _checked_setattr(self, target, *args, **kwargs):
+        if isinstance(target, str):
+            mod_path, _, attr = target.rpartition(".")
+            if mod_path:
+                mod = importlib.import_module(mod_path)
+                if not hasattr(mod, attr):
+                    raise AttributeError(
+                        f"{attr!r} is not an attribute of {mod_path!r}; "
+                        f"patch the canonical source module instead"
+                    )
+        return _original(self, target, *args, **kwargs)
+
+    monkeypatch.setattr = _checked_setattr.__get__(monkeypatch)
 
 
 @pytest.fixture

--- a/python/xorq/tests/test_strict_monkeypatch.py
+++ b/python/xorq/tests/test_strict_monkeypatch.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_rejects_nonexistent_module_attr(monkeypatch):
+    with pytest.raises(AttributeError, match="patch the canonical source module"):
+        monkeypatch.setattr("xorq.caching.storage.DOES_NOT_EXIST", lambda: None)
+
+
+def test_allows_existing_module_attr(monkeypatch):
+    monkeypatch.setattr("os.path.sep", "/")
+
+
+def test_object_target_bypasses_check(monkeypatch):
+    import os.path  # noqa: PLC0415
+
+    monkeypatch.setattr(os.path, "sep", "/")


### PR DESCRIPTION
## Summary

- Adds an `autouse` fixture that wraps `monkeypatch.setattr` to validate string-form targets before patching
- Fails fast with a clear error when the named attribute doesn't exist on the target module — catches the silent-miss bug we hit three times when deferring imports in the caching package
- No per-test changes needed — applies globally via conftest

## Context

When a top-level import like `from xorq.common.utils.caching_utils import get_xorq_cache_dir` is deferred into a function body, any test that patches `"xorq.caching.storage.get_xorq_cache_dir"` silently patches nothing — the attribute no longer exists at module scope. pytest's own `monkeypatch.setattr` raises `AttributeError` only *after* importing the module, and the error message is confusing. This fixture catches the problem at patch time with a message that says "patch the canonical source module instead."

## Test plan

- [x] `test_strict_monkeypatch.py` — verifies rejection of nonexistent attrs, acceptance of valid ones, and passthrough of object-form targets
- [x] Existing `test_storage.py` monkeypatch tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)