### PR TITLE
feat(catalog): add CLI flags for content store configuration

### DIFF
--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -26,6 +26,8 @@ from xorq.cli_options import (
     cache_strategy_options,
     code_option,
     content_store_option,
+    cs_env_options,
+    cs_field_options,
     env_options,
     fuse_option,
     gcs_option,
@@ -248,24 +250,84 @@ def _resolve_annex_option(env_file, env_prefix, gcs):
     return None
 
 
+def _collect_cs_field_kwargs(
+    cs_bucket,
+    cs_catalog_id,
+    cs_region,
+    cs_prefix,
+    cs_host,
+    cs_port,
+    cs_protocol,
+    cs_directory,
+) -> dict:
+    """Build a kwargs dict from non-None CLI field options."""
+    mapping = {
+        "bucket": cs_bucket,
+        "catalog_id": cs_catalog_id,
+        "region": cs_region,
+        "prefix": cs_prefix,
+        "host": cs_host,
+        "port": cs_port,
+        "protocol": cs_protocol,
+        "directory": cs_directory,
+    }
+    return {k: v for k, v in mapping.items() if v is not None}
+
+
 def _resolve_content_store_option(
-    content_store_type: str | None, gcs: bool
+    content_store_type: str | None,
+    gcs: bool,
+    cs_env_file: str | None = None,
+    cs_env_prefix: str | None = None,
+    **field_kwargs,
 ) -> ContentStoreConfig | None:
     """Return a ContentStoreConfig from CLI options, or None."""
     from xorq.catalog.content_store import (  # noqa: PLC0415
         DirectoryContentStoreConfig,
         S3ContentStoreConfig,
+        content_store_config_from_env_file,
+        content_store_config_from_prefix,
     )
 
+    if cs_env_file and cs_env_prefix:
+        raise click.UsageError(
+            "--cs-env-file and --cs-env-prefix are mutually exclusive."
+        )
+
+    sources = sum(
+        x is not None for x in (content_store_type, cs_env_file, cs_env_prefix)
+    )
+    if sources > 1:
+        raise click.UsageError(
+            "--content-store, --cs-env-file, and --cs-env-prefix "
+            "are mutually exclusive."
+        )
+
+    if cs_env_file:
+        return content_store_config_from_env_file(cs_env_file, gcs=gcs, **field_kwargs)
+    if cs_env_prefix:
+        return content_store_config_from_prefix(cs_env_prefix, gcs=gcs, **field_kwargs)
+
     match content_store_type:
+        case None if field_kwargs:
+            if "bucket" in field_kwargs:
+                if gcs:
+                    return S3ContentStoreConfig.from_env_gcs(**field_kwargs)
+                return S3ContentStoreConfig.from_env(**field_kwargs)
+            if "directory" in field_kwargs:
+                return DirectoryContentStoreConfig.from_env(**field_kwargs)
+            raise click.UsageError(
+                "Content store field options (--cs-*) require --content-store, "
+                "--cs-env-file, --cs-env-prefix, or at least --cs-bucket / --cs-directory."
+            )
         case None:
             return None
         case "s3":
             if gcs:
-                return S3ContentStoreConfig.from_env_gcs()
-            return S3ContentStoreConfig.from_env()
+                return S3ContentStoreConfig.from_env_gcs(**field_kwargs)
+            return S3ContentStoreConfig.from_env(**field_kwargs)
         case "directory":
-            return DirectoryContentStoreConfig.from_env()
+            return DirectoryContentStoreConfig.from_env(**field_kwargs)
         case _:
             raise click.UsageError(
                 f"unknown content store type: {content_store_type!r}"
@@ -286,6 +348,8 @@ def _check_backend_exclusive_cli(
 @env_options
 @gcs_option
 @content_store_option
+@cs_env_options
+@cs_field_options
 @click.option(
     "--remote-url",
     default=None,
@@ -298,6 +362,16 @@ def init(
     env_prefix: str | None,
     gcs: bool,
     content_store_type: str | None,
+    cs_env_file: str | None,
+    cs_env_prefix: str | None,
+    cs_bucket: str | None,
+    cs_catalog_id: str | None,
+    cs_region: str | None,
+    cs_prefix: str | None,
+    cs_host: str | None,
+    cs_port: int | None,
+    cs_protocol: str | None,
+    cs_directory: str | None,
     remote_url: str | None,
 ) -> None:
     """Create a new catalog repository.
@@ -314,10 +388,38 @@ def init(
       xorq catalog --path ./catalogs/analytics init --remote-url git@github.com:acme/analytics-catalog.git
       # Create with an S3-backed annex remote sourced from an env file
       xorq catalog --name analytics init --env-file .env.catalog.s3
+      # Create with an S3 content store using CLI flags
+      xorq catalog --name analytics init --cs-bucket my-bucket --cs-region us-west-2
+      # Create with an S3 content store and explicit type
+      xorq catalog --name analytics init --content-store s3 --cs-bucket my-bucket
+      # Create with a content store env file
+      xorq catalog --name analytics init --cs-env-file .env.content_store.s3
+      # Create with a content store env prefix
+      xorq catalog --name analytics init --cs-env-prefix XORQ_CONTENT_STORE_S3_
+      # Create with a local directory content store
+      xorq catalog --name analytics init --cs-directory /mnt/shared/store
+      # Create with S3-compatible endpoint (MinIO)
+      xorq catalog --name analytics init --cs-bucket my-bucket --cs-host minio.local --cs-port 9000 --cs-protocol http
     """
     with click_context_catalog(ctx):
         annex = _resolve_annex_option(env_file, env_prefix, gcs)
-        content_store_config = _resolve_content_store_option(content_store_type, gcs)
+        field_kwargs = _collect_cs_field_kwargs(
+            cs_bucket,
+            cs_catalog_id,
+            cs_region,
+            cs_prefix,
+            cs_host,
+            cs_port,
+            cs_protocol,
+            cs_directory,
+        )
+        content_store_config = _resolve_content_store_option(
+            content_store_type,
+            gcs,
+            cs_env_file=cs_env_file,
+            cs_env_prefix=cs_env_prefix,
+            **field_kwargs,
+        )
         _check_backend_exclusive_cli(content_store_config, annex)
         try:
             catalog = ctx.obj.make_catalog(
@@ -990,6 +1092,8 @@ def log(ctx: click.Context, as_json: bool) -> None:
 @env_options
 @gcs_option
 @content_store_option
+@cs_env_options
+@cs_field_options
 @click.option(
     "--remote-url",
     default=None,
@@ -1018,6 +1122,16 @@ def replay(
     env_prefix,
     gcs,
     content_store_type,
+    cs_env_file,
+    cs_env_prefix,
+    cs_bucket,
+    cs_catalog_id,
+    cs_region,
+    cs_prefix,
+    cs_host,
+    cs_port,
+    cs_protocol,
+    cs_directory,
     remote_url,
     preserve_commits,
     force,
@@ -1046,6 +1160,14 @@ def replay(
       xorq catalog replay ./mirrored-catalog --dry-run
       # Replay into a new catalog and push to a fresh remote
       xorq catalog replay ./mirrored-catalog --env-file .env.target.s3 --remote-url git@github.com:acme/mirror-catalog.git
+      # Replay with S3 content store using CLI flags
+      xorq catalog replay ./mirrored-catalog --cs-bucket my-bucket --cs-region us-west-2
+      # Replay with a content store env file
+      xorq catalog replay ./mirrored-catalog --cs-env-file .env.content_store.s3
+      # Replay with a content store env prefix
+      xorq catalog replay ./mirrored-catalog --cs-env-prefix XORQ_CONTENT_STORE_S3_
+      # Replay into a local directory content store
+      xorq catalog replay ./mirrored-catalog --cs-directory /mnt/shared/store
     """
     from xorq.catalog.catalog import Catalog  # noqa: PLC0415
     from xorq.catalog.replay import Replayer  # noqa: PLC0415
@@ -1057,7 +1179,23 @@ def replay(
             replayer.print_plan()
             return
         annex = _resolve_annex_option(env_file, env_prefix, gcs)
-        content_store_config = _resolve_content_store_option(content_store_type, gcs)
+        field_kwargs = _collect_cs_field_kwargs(
+            cs_bucket,
+            cs_catalog_id,
+            cs_region,
+            cs_prefix,
+            cs_host,
+            cs_port,
+            cs_protocol,
+            cs_directory,
+        )
+        content_store_config = _resolve_content_store_option(
+            content_store_type,
+            gcs,
+            cs_env_file=cs_env_file,
+            cs_env_prefix=cs_env_prefix,
+            **field_kwargs,
+        )
         _check_backend_exclusive_cli(content_store_config, annex)
         target = Catalog.from_repo_path(
             target_path, annex=annex, content_store_config=content_store_config

--- a/python/xorq/catalog/content_store.py
+++ b/python/xorq/catalog/content_store.py
@@ -622,3 +622,40 @@ _CONTENT_STORE_CONFIG_CLASSES: dict[ContentStoreType, type[ContentStoreConfig]] 
     ContentStoreType.DIRECTORY: DirectoryContentStoreConfig,
     ContentStoreType.S3: S3ContentStoreConfig,
 }
+
+
+_PREFIX_TO_CONTENT_STORE_CONFIG: dict[str, type[ContentStoreConfig]] = {
+    "XORQ_CONTENT_STORE_S3_": S3ContentStoreConfig,
+    "XORQ_CONTENT_STORE_DIRECTORY_": DirectoryContentStoreConfig,
+}
+
+
+def content_store_config_from_prefix(
+    prefix: str, *, gcs: bool = False, **kwargs: Any
+) -> ContentStoreConfig:
+    cls = _PREFIX_TO_CONTENT_STORE_CONFIG.get(prefix)
+    if cls is None:
+        raise ValueError(
+            f"Unknown content store prefix {prefix!r}. "
+            f"Expected one of: {', '.join(_PREFIX_TO_CONTENT_STORE_CONFIG)}"
+        )
+    if gcs and cls is S3ContentStoreConfig:
+        return cls.from_env_gcs(**kwargs)
+    return cls.from_env(**kwargs)
+
+
+def content_store_config_from_env_file(
+    env_file: str | Path, *, gcs: bool = False, **kwargs: Any
+) -> ContentStoreConfig:
+    from xorq.common.utils.env_utils import parse_env_file  # noqa: PLC0415
+
+    env_vars = parse_env_file(env_file)
+    os.environ.update(env_vars)
+    keys = env_vars.keys()
+    for prefix in _PREFIX_TO_CONTENT_STORE_CONFIG:
+        if any(k.startswith(prefix) for k in keys):
+            return content_store_config_from_prefix(prefix, gcs=gcs, **kwargs)
+    raise ValueError(
+        f"Could not determine content store type from {env_file}. "
+        f"Expected keys with prefix: {', '.join(_PREFIX_TO_CONTENT_STORE_CONFIG)}"
+    )

--- a/python/xorq/catalog/tests/test_cli_init_crud.py
+++ b/python/xorq/catalog/tests/test_cli_init_crud.py
@@ -519,6 +519,256 @@ def test_init_content_store_conflicts_with_env_file(
     assert "mutually exclusive" in result.output
 
 
+# --- init --cs-* flags ---
+
+
+def test_init_cs_bucket_auto_detects_s3(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_BUCKET", raising=False)
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_CATALOG_ID", raising=False)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY", "secret")
+
+    mock_store = MagicMock()
+    with patch("xorq.catalog.content_store.make_boto3_client", return_value=mock_store):
+        repo_path = str(tmp_path / "auto-s3")
+        result = runner.invoke(
+            cli,
+            [
+                "--path",
+                repo_path,
+                "init",
+                "--cs-bucket",
+                "my-bucket",
+                "--cs-region",
+                "us-west-2",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        config = ContentStoreConfig.from_yaml(Path(repo_path) / "content_store.yaml")
+        assert config.bucket == "my-bucket"
+        assert config.region == "us-west-2"
+
+
+def test_init_cs_directory_auto_detects_directory(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XORQ_CONTENT_STORE_DIRECTORY_DIRECTORY", raising=False)
+    monkeypatch.delenv("XORQ_CONTENT_STORE_DIRECTORY_CATALOG_ID", raising=False)
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    repo_path = str(tmp_path / "auto-dir")
+    result = runner.invoke(
+        cli,
+        ["--path", repo_path, "init", "--cs-directory", str(store_dir)],
+    )
+    assert result.exit_code == 0, result.output
+    catalog = Catalog.from_kwargs(path=repo_path, init=False)
+    assert isinstance(catalog.backend, GitPointerBackend)
+
+
+def test_init_cs_bucket_with_content_store_s3(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_BUCKET", raising=False)
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_CATALOG_ID", raising=False)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY", "secret")
+
+    mock_store = MagicMock()
+    with patch("xorq.catalog.content_store.make_boto3_client", return_value=mock_store):
+        repo_path = str(tmp_path / "explicit-s3")
+        result = runner.invoke(
+            cli,
+            [
+                "--path",
+                repo_path,
+                "init",
+                "--content-store",
+                "s3",
+                "--cs-bucket",
+                "explicit-bucket",
+                "--cs-prefix",
+                "data/",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        config = ContentStoreConfig.from_yaml(Path(repo_path) / "content_store.yaml")
+        assert config.bucket == "explicit-bucket"
+        assert config.prefix == "data"
+
+
+def test_init_cs_s3_endpoint_fields(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_BUCKET", raising=False)
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_CATALOG_ID", raising=False)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY", "secret")
+
+    mock_store = MagicMock()
+    with patch("xorq.catalog.content_store.make_boto3_client", return_value=mock_store):
+        repo_path = str(tmp_path / "minio-catalog")
+        result = runner.invoke(
+            cli,
+            [
+                "--path",
+                repo_path,
+                "init",
+                "--cs-bucket",
+                "minio-bucket",
+                "--cs-host",
+                "minio.local",
+                "--cs-port",
+                "9000",
+                "--cs-protocol",
+                "http",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        config = ContentStoreConfig.from_yaml(Path(repo_path) / "content_store.yaml")
+        assert config.host == "minio.local"
+        assert config.port == 9000
+        assert config.protocol == "http"
+
+
+def test_init_cs_env_file(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_BUCKET", raising=False)
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_CATALOG_ID", raising=False)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY", "secret")
+
+    env_file = tmp_path / ".env.cs.s3"
+    env_file.write_text(
+        "XORQ_CONTENT_STORE_S3_BUCKET=envfile-bucket\n"
+        "XORQ_CONTENT_STORE_S3_REGION=eu-west-1\n"
+    )
+    mock_store = MagicMock()
+    with patch("xorq.catalog.content_store.make_boto3_client", return_value=mock_store):
+        repo_path = str(tmp_path / "envfile-catalog")
+        result = runner.invoke(
+            cli,
+            ["--path", repo_path, "init", "--cs-env-file", str(env_file)],
+        )
+        assert result.exit_code == 0, result.output
+        config = ContentStoreConfig.from_yaml(Path(repo_path) / "content_store.yaml")
+        assert config.bucket == "envfile-bucket"
+        assert config.region == "eu-west-1"
+
+
+def test_init_cs_env_prefix(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_BUCKET", "prefix-bucket")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_REGION", "us-east-1")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_CATALOG_ID", raising=False)
+
+    mock_store = MagicMock()
+    with patch("xorq.catalog.content_store.make_boto3_client", return_value=mock_store):
+        repo_path = str(tmp_path / "prefix-catalog")
+        result = runner.invoke(
+            cli,
+            [
+                "--path",
+                repo_path,
+                "init",
+                "--cs-env-prefix",
+                "XORQ_CONTENT_STORE_S3_",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        config = ContentStoreConfig.from_yaml(Path(repo_path) / "content_store.yaml")
+        assert config.bucket == "prefix-bucket"
+
+
+def test_init_cs_env_file_and_prefix_mutually_exclusive(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    env_file = tmp_path / ".env.cs"
+    env_file.write_text("XORQ_CONTENT_STORE_S3_BUCKET=b\n")
+    repo_path = str(tmp_path / "bad-catalog")
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            repo_path,
+            "init",
+            "--cs-env-file",
+            str(env_file),
+            "--cs-env-prefix",
+            "XORQ_CONTENT_STORE_S3_",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_init_content_store_and_cs_env_file_mutually_exclusive(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_BUCKET", "b")
+    monkeypatch.delenv("XORQ_CONTENT_STORE_S3_CATALOG_ID", raising=False)
+    env_file = tmp_path / ".env.cs"
+    env_file.write_text("XORQ_CONTENT_STORE_S3_BUCKET=b\n")
+    repo_path = str(tmp_path / "bad-catalog")
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            repo_path,
+            "init",
+            "--content-store",
+            "s3",
+            "--cs-env-file",
+            str(env_file),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_init_cs_orphan_fields_without_type_or_bucket(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    repo_path = str(tmp_path / "orphan-catalog")
+    result = runner.invoke(
+        cli,
+        ["--path", repo_path, "init", "--cs-region", "us-west-2"],
+    )
+    assert result.exit_code != 0
+    assert "--cs-bucket" in result.output or "--cs-directory" in result.output
+
+
+def test_init_cs_catalog_id(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XORQ_CONTENT_STORE_DIRECTORY_DIRECTORY", raising=False)
+    monkeypatch.delenv("XORQ_CONTENT_STORE_DIRECTORY_CATALOG_ID", raising=False)
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    repo_path = str(tmp_path / "catid-catalog")
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            repo_path,
+            "init",
+            "--cs-directory",
+            str(store_dir),
+            "--cs-catalog-id",
+            "my-custom-id",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    config = ContentStoreConfig.from_yaml(Path(repo_path) / "content_store.yaml")
+    assert config.catalog_id == "my-custom-id"
+
+
 # --- gc command ---
 
 

--- a/python/xorq/catalog/tests/test_s3_content_store.py
+++ b/python/xorq/catalog/tests/test_s3_content_store.py
@@ -11,9 +11,12 @@ from botocore.exceptions import ClientError  # noqa: E402
 
 from xorq.catalog.content_store import (  # noqa: E402
     ContentIntegrityError,
+    DirectoryContentStoreConfig,
     S3ContentStore,
     S3ContentStoreConfig,
     compute_sha256,
+    content_store_config_from_env_file,
+    content_store_config_from_prefix,
 )
 from xorq.catalog.s3_utils import make_boto3_client  # noqa: E402
 
@@ -355,3 +358,125 @@ def test_s3_content_store_list_keys_empty(
 
     assert list(store.list_keys()) == []
     assert list(store.list_keys(prefix="cat")) == []
+
+
+# --- content_store_config_from_prefix ---
+
+
+def _clear_cs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "XORQ_CONTENT_STORE_S3_BUCKET",
+        "XORQ_CONTENT_STORE_S3_CATALOG_ID",
+        "XORQ_CONTENT_STORE_S3_PREFIX",
+        "XORQ_CONTENT_STORE_S3_REGION",
+        "XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID",
+        "XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY",
+        "XORQ_CONTENT_STORE_S3_AWS_SESSION_TOKEN",
+        "XORQ_CONTENT_STORE_S3_HOST",
+        "XORQ_CONTENT_STORE_S3_PORT",
+        "XORQ_CONTENT_STORE_S3_PROTOCOL",
+        "XORQ_CONTENT_STORE_DIRECTORY_DIRECTORY",
+        "XORQ_CONTENT_STORE_DIRECTORY_CATALOG_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_config_from_prefix_s3(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_cs_env(monkeypatch)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_BUCKET", "pfx-bucket")
+    config = content_store_config_from_prefix("XORQ_CONTENT_STORE_S3_")
+    assert isinstance(config, S3ContentStoreConfig)
+    assert config.bucket == "pfx-bucket"
+
+
+def test_config_from_prefix_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_cs_env(monkeypatch)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_DIRECTORY_DIRECTORY", str(tmp_path))
+    config = content_store_config_from_prefix("XORQ_CONTENT_STORE_DIRECTORY_")
+    assert isinstance(config, DirectoryContentStoreConfig)
+    assert config.directory == tmp_path
+
+
+def test_config_from_prefix_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown content store prefix"):
+        content_store_config_from_prefix("XORQ_BOGUS_")
+
+
+def test_config_from_prefix_gcs(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_cs_env(monkeypatch)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_BUCKET", "gcs-bucket")
+    config = content_store_config_from_prefix("XORQ_CONTENT_STORE_S3_", gcs=True)
+    assert isinstance(config, S3ContentStoreConfig)
+    assert config.host == "storage.googleapis.com"
+    assert config.protocol == "https"
+
+
+def test_config_from_prefix_kwargs_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_cs_env(monkeypatch)
+    monkeypatch.setenv("XORQ_CONTENT_STORE_S3_BUCKET", "env-bucket")
+    config = content_store_config_from_prefix(
+        "XORQ_CONTENT_STORE_S3_", bucket="kwarg-bucket", region="eu-west-1"
+    )
+    assert config.bucket == "kwarg-bucket"
+    assert config.region == "eu-west-1"
+
+
+# --- content_store_config_from_env_file ---
+
+
+def test_config_from_env_file_s3(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_cs_env(monkeypatch)
+    env_file = tmp_path / ".env.cs.s3"
+    env_file.write_text(
+        "XORQ_CONTENT_STORE_S3_BUCKET=file-bucket\n"
+        "XORQ_CONTENT_STORE_S3_REGION=ap-southeast-1\n"
+    )
+    config = content_store_config_from_env_file(str(env_file))
+    assert isinstance(config, S3ContentStoreConfig)
+    assert config.bucket == "file-bucket"
+    assert config.region == "ap-southeast-1"
+
+
+def test_config_from_env_file_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_cs_env(monkeypatch)
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    env_file = tmp_path / ".env.cs.dir"
+    env_file.write_text(f"XORQ_CONTENT_STORE_DIRECTORY_DIRECTORY={store_dir}\n")
+    config = content_store_config_from_env_file(str(env_file))
+    assert isinstance(config, DirectoryContentStoreConfig)
+    assert config.directory == store_dir
+
+
+def test_config_from_env_file_invalid_prefix(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env.bad"
+    env_file.write_text("SOME_RANDOM_VAR=hello\n")
+    with pytest.raises(ValueError, match="Could not determine content store type"):
+        content_store_config_from_env_file(str(env_file))
+
+
+def test_config_from_env_file_gcs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_cs_env(monkeypatch)
+    env_file = tmp_path / ".env.cs.gcs"
+    env_file.write_text("XORQ_CONTENT_STORE_S3_BUCKET=gcs-bucket\n")
+    config = content_store_config_from_env_file(str(env_file), gcs=True)
+    assert isinstance(config, S3ContentStoreConfig)
+    assert config.host == "storage.googleapis.com"
+
+
+def test_config_from_env_file_kwargs_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_cs_env(monkeypatch)
+    env_file = tmp_path / ".env.cs.s3"
+    env_file.write_text("XORQ_CONTENT_STORE_S3_BUCKET=file-bucket\n")
+    config = content_store_config_from_env_file(str(env_file), bucket="override-bucket")
+    assert config.bucket == "override-bucket"

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -212,6 +212,72 @@ content_store_option = click.option(
 )
 
 
+def cs_env_options(fn):
+    fn = click.option(
+        "--cs-env-prefix",
+        default=None,
+        help=(
+            "Env-var prefix for the content store"
+            " (e.g. XORQ_CONTENT_STORE_S3_; mutually exclusive with --cs-env-file)."
+        ),
+    )(fn)
+    fn = click.option(
+        "--cs-env-file",
+        type=click.Path(exists=True, dir_okay=False),
+        default=None,
+        help=(
+            "Env file for the content store (mutually exclusive with --cs-env-prefix)."
+        ),
+    )(fn)
+    return fn
+
+
+def cs_field_options(fn):
+    fn = click.option(
+        "--cs-directory",
+        default=None,
+        help="Local directory for a directory content store.",
+    )(fn)
+    fn = click.option(
+        "--cs-protocol",
+        type=click.Choice(["http", "https"]),
+        default=None,
+        help="Protocol for S3-compatible endpoint.",
+    )(fn)
+    fn = click.option(
+        "--cs-port",
+        type=int,
+        default=None,
+        help="Port for S3-compatible endpoint.",
+    )(fn)
+    fn = click.option(
+        "--cs-host",
+        default=None,
+        help="Host for S3-compatible endpoint (e.g. minio.example.com).",
+    )(fn)
+    fn = click.option(
+        "--cs-prefix",
+        default=None,
+        help="Key prefix within the S3 bucket.",
+    )(fn)
+    fn = click.option(
+        "--cs-region",
+        default=None,
+        help="AWS region for the S3 bucket.",
+    )(fn)
+    fn = click.option(
+        "--cs-catalog-id",
+        default=None,
+        help="Catalog ID for content store key namespacing (auto-generated if omitted).",
+    )(fn)
+    fn = click.option(
+        "--cs-bucket",
+        default=None,
+        help="S3 bucket name for the content store.",
+    )(fn)
+    return fn
+
+
 json_option = click.option(
     "--json",
     "as_json",

--- a/python/xorq/env_templates/.env.catalog.content_store.directory.template
+++ b/python/xorq/env_templates/.env.catalog.content_store.directory.template
@@ -1,2 +1,4 @@
+# Unique ID to namespace content (auto-generated UUID if omitted)
 XORQ_CONTENT_STORE_DIRECTORY_CATALOG_ID=
+# Required: local filesystem path for content storage
 XORQ_CONTENT_STORE_DIRECTORY_DIRECTORY=

--- a/python/xorq/env_templates/.env.catalog.content_store.s3.template
+++ b/python/xorq/env_templates/.env.catalog.content_store.s3.template
@@ -1,10 +1,16 @@
+# Unique ID to namespace keys in the bucket (auto-generated UUID if omitted)
 XORQ_CONTENT_STORE_S3_CATALOG_ID=
+# Required: S3 bucket name
 XORQ_CONTENT_STORE_S3_BUCKET=
+# Optional key prefix within the bucket
 XORQ_CONTENT_STORE_S3_PREFIX=
+# AWS region (e.g. us-west-2)
 XORQ_CONTENT_STORE_S3_REGION=
+# AWS credentials (leave blank to use default credential chain)
 XORQ_CONTENT_STORE_S3_AWS_ACCESS_KEY_ID=
 XORQ_CONTENT_STORE_S3_AWS_SECRET_ACCESS_KEY=
 XORQ_CONTENT_STORE_S3_AWS_SESSION_TOKEN=
+# S3-compatible endpoint overrides (MinIO, GCS via HMAC, etc.)
 XORQ_CONTENT_STORE_S3_HOST=
 XORQ_CONTENT_STORE_S3_PORT=
 XORQ_CONTENT_STORE_S3_PROTOCOL=


### PR DESCRIPTION
## Summary
- Expose non-secret content store fields as CLI options (`--cs-bucket`, `--cs-region`, `--cs-prefix`, `--cs-host`, `--cs-port`, `--cs-protocol`, `--cs-directory`, `--cs-catalog-id`)
- Add `--cs-env-file` / `--cs-env-prefix` for loading config from dotenv files or env var prefixes
- Auto-detection infers S3 from `--cs-bucket` and directory from `--cs-directory`, so `--content-store` is no longer required when a distinguishing field is provided

## Test plan
- [ ] 20 new tests covering CLI flag parsing, auto-detection, env file loading, and error cases
- [ ] Verify existing catalog CLI tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)