### PR TITLE
Transform scope

### DIFF
--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -203,15 +203,13 @@ class SourceStorage(CacheStorage):
 
         if is_remote(value):
             if is_single_backend(self, value):
-                from xorq.expr.api import _transform_expr  # noqa: PLC0415
+                from xorq.expr.api import transformed  # noqa: PLC0415
 
                 # must transform for Read ops: create_table expects a vanilla ibis expr
-                (transformed, _, _caches) = _transform_expr(value.to_expr())
-                try:
-                    self.source.create_table(key, transformed)
-                finally:
-                    for cache in _caches:
-                        cache.close()
+                # full close is safe here: create_table is an eager server-side
+                # CTAS and get(key) below never references the placeholders
+                with transformed(value.to_expr()) as transformed_expr:
+                    self.source.create_table(key, transformed_expr)
             else:
                 assert hasattr(self.source, "read_record_batches")
                 # read_record_batches will create durable table in out-of-core fashion

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -19,7 +20,6 @@ from xorq.common.utils.caching_utils import find_backend
 from xorq.common.utils.defer_utils import (  # noqa: F403
     deferred_read_csv,
     deferred_read_parquet,
-    rbr_wrapper,
 )
 from xorq.common.utils.graph_utils import replace_nodes, walk_nodes
 from xorq.common.utils.io_utils import (
@@ -403,7 +403,12 @@ def _resolve_params(params):
 
 @tracer.start_as_current_span("_transform_expr")
 def _transform_expr(expr, params=None, **kwargs):
-    """Transform an expression for execution, binding any named scalar parameters."""
+    """Transform an expression for execution, binding any named scalar parameters.
+
+    Returns ``(expr, scope)``: the scope owns every resource the transform
+    materialized (upstream readers, StreamCaches, placeholder tables) and the
+    caller must close it once the transformed expr is consumed.
+    """
     name_values = _resolve_params(params)
     expr = (
         bind_params(expr, name_values)
@@ -412,9 +417,25 @@ def _transform_expr(expr, params=None, **kwargs):
     )
     expr = _remove_tag_nodes(expr)
     expr = _register_and_transform_cache_tables(expr)
-    expr, created, caches = register_and_transform_remote_tables(expr, **kwargs)
-    expr, dt_to_read = _transform_deferred_reads(expr)
-    return (expr, created, caches)
+    expr, scope = register_and_transform_remote_tables(expr, **kwargs)
+    try:
+        expr, dt_to_read = _transform_deferred_reads(expr)
+    except Exception:
+        scope.close()
+        raise
+    return (expr, scope)
+
+
+@contextmanager
+def transformed(expr, **kwargs):
+    """Transform ``expr`` and yield it with a guaranteed full scope close.
+
+    For eager call sites only: the body must fully materialize the result
+    before exiting (placeholder tables are dropped on exit).
+    """
+    (expr, scope) = _transform_expr(expr, **kwargs)
+    with scope:
+        yield expr
 
 
 def _pandas_execute(con, expr: ir.Expr, **kwargs):
@@ -429,14 +450,11 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
         df = node.to_rbr().read_pandas(timestamp_as_object=True)
         return expr.__pandas_result__(df)
     params = kwargs.pop("params", None)
-    expr, created, caches = _transform_expr(expr, params=params)
 
     span.set_attribute("engine", "pandas")
-    try:
+    # full close is safe here: con.execute returns a materialized DataFrame
+    with transformed(expr, params=params) as expr:
         return con.execute(expr, **kwargs)
-    finally:
-        for cache in caches:
-            cache.close()
 
 
 @tracer.start_as_current_span("to_pyarrow_batches")
@@ -472,22 +490,18 @@ def to_pyarrow_batches(
         span.set_attribute("engine", "flight")
         return expr.op().to_rbr()
     params = kwargs.pop("params", None)
-    expr, created, caches = _transform_expr(expr, params=params)
-    con, _ = find_backend(expr.op(), use_default=True)
+    expr, scope = _transform_expr(expr, params=params)
+    try:
+        con, _ = find_backend(expr.op(), use_default=True)
+        span.set_attribute("engine", con.name)
+        reader = con.to_pyarrow_batches(expr, chunk_size=chunk_size, **kwargs)
+    except Exception:
+        scope.close()
+        raise
 
-    span.set_attribute("engine", con.name)
-    reader = con.to_pyarrow_batches(expr, chunk_size=chunk_size, **kwargs)
-
-    def clean_up():
-        for table_name, conn in created.items():
-            try:
-                conn.drop_table(table_name, force=True)
-            except Exception:
-                conn.drop_view(table_name)
-        for cache in caches:
-            cache.close()
-
-    return otel_instrument_reader(rbr_wrapper(reader, clean_up))
+    # cleanup stays deferred to the result reader's exhaustion/collection:
+    # the backends scan the placeholders lazily while the reader drains
+    return otel_instrument_reader(scope.bind(reader))
 
 
 def to_pyarrow(expr: ir.Expr, **kwargs: Any):
@@ -636,14 +650,11 @@ def to_json(
 
 
 def get_plans(expr):
-    _expr, _, _caches = _transform_expr(expr)
-    try:
+    # full close is safe here: EXPLAIN is materialized via to_pandas inside
+    with transformed(expr) as _expr:
         con, _ = find_backend(_expr.op())
         sql = f"EXPLAIN {to_sql(_expr)}"
         return con.con.sql(sql).to_pandas().set_index("plan_type")["plan"].to_dict()
-    finally:
-        for cache in _caches:
-            cache.close()
 
 
 def get_object_metadata(path: str, **kwargs: Any) -> dict:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import weakref
 from collections import Counter
 from typing import Any, Callable
 
@@ -9,6 +10,7 @@ from batchcorder import StreamCache
 from opentelemetry import trace
 
 from xorq.backends.xorq_datafusion import connect as xo_connect
+from xorq.common.utils.logging_utils import get_logger
 from xorq.common.utils.otel_utils import tracer
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
@@ -23,6 +25,9 @@ from xorq.vendor.ibis.common.collections import (
 from xorq.vendor.ibis.expr import operations as ops
 from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node
+
+
+logger = get_logger(__name__)
 
 
 def replace_cache_table(node, kwargs):
@@ -608,12 +613,126 @@ def count_remote_table_readers(expr):
     return {node: max(1, counts[name]) for node, name in sentinels.items()}
 
 
+def drop_placeholder(con, table_name):
+    """Best-effort drop of a placeholder registered by ``read_record_batches``.
+
+    duckdb registers the StreamCache as a VIEW, so ``drop_table`` always
+    raises a kind-mismatch there (``force=True`` does not suppress it) and
+    ``drop_view`` is the real path; pandas raises KeyError on a missing
+    table even with ``force=True``, hence the inner suppression --
+    ``force=True`` alone cannot make this idempotent across backends.
+    """
+    try:
+        con.drop_table(table_name, force=True)
+    except Exception:
+        try:
+            con.drop_view(table_name, force=True)
+        except Exception:
+            pass
+
+
+class TransformScope:
+    """Owns every resource materialized while transforming an expr.
+
+    Upstream readers, StreamCaches and registered placeholder tables enter
+    the scope at acquisition time via the ``adopt*`` methods; ``close`` runs
+    the cleanups in LIFO order (drop placeholder, close cache, close
+    upstream reader per RemoteTable), is idempotent, and step-isolated: a
+    failing cleanup is logged and never skips the others. Closing drops the
+    scope's references to the adopted objects so refcount-zero finalization
+    can release generator-backed readers (pyarrow's
+    ``RecordBatchReader.close`` does not finalize a wrapped generator).
+    """
+
+    def __init__(self):
+        self._entries = []
+        self._closed = False
+        self.created = {}
+
+    @property
+    def closed(self):
+        return self._closed
+
+    def adopt(self, label, cleanup, kind="resource"):
+        self._entries.append((kind, label, cleanup))
+
+    def adopt_reader(self, reader):
+        self.adopt("reader", reader.close)
+        return reader
+
+    def adopt_cache(self, cache):
+        self.adopt("cache", cache.close)
+        return cache
+
+    def adopt_table(self, con, table_name):
+        self.created[table_name] = con
+        self.adopt(
+            table_name, functools.partial(drop_placeholder, con, table_name), "table"
+        )
+        return table_name
+
+    def close(self, drop_tables=True):
+        """Release everything the scope owns; idempotent, never raises.
+
+        ``drop_tables=False`` leaves the placeholder tables registered for
+        callers whose result still references them after this returns
+        (see ``prepare_create_table_from_expr``).
+        """
+        if self._closed:
+            return
+        self._closed = True
+        (entries, self._entries) = (self._entries, [])
+        for kind, label, cleanup in reversed(entries):
+            if kind == "table" and not drop_tables:
+                continue
+            try:
+                cleanup()
+            except Exception:
+                logger.warning(
+                    "transform scope cleanup step failed",
+                    kind=kind,
+                    label=label,
+                    exc_info=True,
+                )
+
+    def bind(self, reader):
+        """Defer this scope's close to ``reader``'s exhaustion or collection.
+
+        Cleanup must stay deferred on the streaming path: duckdb/datafusion
+        scan the placeholder when the result reader is drained, and dropping
+        the duckdb view mid-drain silently truncates results. The wrapping
+        generator's ``finally`` fires on full drain; the ``weakref.finalize``
+        backstop covers readers abandoned before the first read (a
+        never-started generator never runs its ``finally``). Note that on
+        pyarrow 21 ``reader.close()`` alone does not finalize the wrapped
+        generator -- cleanup then fires when the last reference drops.
+        """
+
+        def gen():
+            try:
+                yield from reader
+            finally:
+                self.close()
+
+        out = pa.RecordBatchReader.from_batches(reader.schema, gen())
+        # NB: the finalize registry holds ``self`` via ``self.close``; the
+        # scope must never hold a strong reference to ``out`` or both become
+        # immortal.
+        weakref.finalize(out, self.close)
+        return out
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
     expr: Expr, **kwargs: Any
-) -> tuple[Expr, dict, list]:
-    created = {}
-    caches = []
+) -> tuple[Expr, TransformScope]:
+    scope = TransformScope()
     # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
     # outer ``**kwargs``; capture the through-kwargs here so they reach
     # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
@@ -633,16 +752,21 @@ def register_and_transform_remote_tables(
             # (``fields.len() == num_children``). The reader already carries the
             # true schema; column coercion is the consumer's job
             # (``read_record_batches`` -> ``_select_and_cast``).
-            cache = StreamCache(
-                remote_expr.to_pyarrow_batches(),
-                max_readers=reader_counts.get(node),
+            reader = scope.adopt_reader(remote_expr.to_pyarrow_batches())
+            cache = scope.adopt_cache(
+                StreamCache(
+                    reader,
+                    max_readers=reader_counts.get(node),
+                )
             )
-            caches.append(cache)
-            table_name = gen_name()
+            # adopt before registering: a partial failure inside
+            # read_record_batches (register, then raise) can't strand the
+            # placeholder, and drop_placeholder is a no-op if it never
+            # registered
+            table_name = scope.adopt_table(node.source, gen_name())
             result = node.source.read_record_batches(
                 cache, table_name=table_name, **read_kwargs
             )
-            created[table_name] = node.source
             return result.op()
 
         if kwargs:
@@ -653,14 +777,13 @@ def register_and_transform_remote_tables(
     try:
         expr = op.replace(replacer).to_expr()
     except Exception:
-        for cache in caches:
-            cache.close()
+        scope.close()
         raise
-    if caches:
+    if scope.created:
         trace.get_current_span().add_event(
-            "remote_table.replace", {"remote_table.count": len(caches)}
+            "remote_table.replace", {"remote_table.count": len(scope.created)}
         )
-    return expr, created, caches
+    return expr, scope
 
 
 def render_backend(con):
@@ -722,9 +845,13 @@ def prepare_create_table_from_expr(con: Any, expr: Expr, **kwargs: Any) -> Expr:
     expr_backend = expr._find_backend()  # xorq-style: disable=protected-access
     if expr_backend != con:
         raise ValueError(f"expr backend must be {con}, is {expr_backend}")
-    (table, _, _caches) = _transform_expr(expr, **kwargs)
+    (table, scope) = _transform_expr(expr, **kwargs)
     try:
         return table
     finally:
-        for cache in _caches:
-            cache.close()
+        # The sole caller (snowflake create_table) compiles and runs CTAS
+        # against the returned expr -- and thus its placeholder tables --
+        # AFTER this returns, so the placeholders must stay registered;
+        # snowflake's eager adbc_ingest drained the caches during the
+        # transform, which is what makes closing them here safe.
+        scope.close(drop_tables=False)

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -1,0 +1,365 @@
+"""Lifecycle regression tests for ``TransformScope``.
+
+Every resource materialized while transforming an expr -- upstream readers,
+StreamCaches, registered placeholder tables -- is owned by a TransformScope
+so cleanup survives planning failures, cleanup-chain aborts and abandoned
+result readers.
+"""
+
+import functools
+import gc
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+import xorq.api as xo
+import xorq.expr.relations as relations
+from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.expr.api import get_plans, to_pyarrow_batches
+from xorq.expr.relations import (
+    TransformScope,
+    prepare_create_table_from_expr,
+    register_and_transform_remote_tables,
+)
+from xorq.tests.util import assert_frame_equal
+
+
+pytest.importorskip("duckdb")
+
+
+@pytest.fixture
+def recording_caches(monkeypatch):
+    instances = []
+
+    class RecordingStreamCache(relations.StreamCache):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.close_count = 0
+            instances.append(self)
+
+        def close(self):
+            self.close_count += 1
+            super().close()
+
+    monkeypatch.setattr(relations, "StreamCache", RecordingStreamCache)
+    return instances
+
+
+def make_remote_expr(target):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    return rt.filter(rt.a > 1)
+
+
+def assert_all_closed_once(caches):
+    assert caches and all(cache.close_count == 1 for cache in caches)
+
+
+def test_scope_close_is_idempotent():
+    events = []
+    scope = TransformScope()
+    scope.adopt("one", functools.partial(events.append, "one"))
+    scope.close()
+    scope.close()
+    assert scope.closed
+    assert events == ["one"]
+
+
+def test_scope_close_is_lifo():
+    events = []
+    scope = TransformScope()
+    for label in ("first", "second", "third"):
+        scope.adopt(label, functools.partial(events.append, label))
+    scope.close()
+    assert events == ["third", "second", "first"]
+
+
+def test_scope_failing_cleanup_does_not_skip_others():
+    events = []
+    scope = TransformScope()
+
+    def boom():
+        events.append("boom")
+        raise RuntimeError("cleanup failed")
+
+    scope.adopt("inner", functools.partial(events.append, "inner"))
+    scope.adopt("boom", boom)
+    scope.adopt("outer", functools.partial(events.append, "outer"))
+    scope.close()
+    assert events == ["outer", "boom", "inner"]
+
+
+def test_scope_context_manager_closes():
+    events = []
+    with TransformScope() as scope:
+        scope.adopt("one", functools.partial(events.append, "one"))
+    assert scope.closed
+    assert events == ["one"]
+
+
+def test_scope_close_can_leave_tables():
+    events = []
+    scope = TransformScope()
+    scope.adopt("cache", functools.partial(events.append, "cache"))
+    scope.adopt("tbl", functools.partial(events.append, "drop"), "table")
+    scope.close(drop_tables=False)
+    assert scope.closed
+    assert events == ["cache"]
+
+
+def test_drop_placeholder_handles_views_and_missing_names():
+    con = xo.duckdb.connect()
+    table = pa.table({"a": [1]})
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches())
+    # duckdb registers record batch readers as a VIEW
+    con.read_record_batches(reader, table_name="ph")
+    assert "ph" in con.list_tables()
+    relations.drop_placeholder(con, "ph")
+    assert "ph" not in con.list_tables()
+    # missing name: must not raise
+    relations.drop_placeholder(con, "ph")
+
+
+def test_planning_failure_releases_resources(recording_caches, monkeypatch):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("planning failed")
+
+    monkeypatch.setattr(type(target), "to_pyarrow_batches", boom)
+    with pytest.raises(RuntimeError, match="planning failed"):
+        to_pyarrow_batches(expr)
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_natural_planning_failure_releases_resources(recording_caches):
+    target = xo.duckdb.connect()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    expr = rt.mutate(c=rt.b.cast("int64"))
+    with pytest.raises(Exception, match="(?i)convert"):
+        expr.execute()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_deferred_read_failure_releases_resources(recording_caches):
+    target = xo.duckdb.connect()
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    missing = deferred_read_parquet(
+        "/nonexistent/missing.parquet",
+        con=target,
+        schema=xo.schema({"a": "int64"}),
+    )
+    expr = rt.union(missing)
+    with pytest.raises(ValueError, match="At least one path is required"):
+        expr.execute()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_failing_drop_does_not_skip_cache_close(recording_caches, monkeypatch):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+
+    def boom(self, name, *args, **kwargs):
+        raise RuntimeError("drop failed")
+
+    monkeypatch.setattr(type(target), "drop_table", boom)
+    monkeypatch.setattr(type(target), "drop_view", boom)
+    reader.read_all()
+    assert_all_closed_once(recording_caches)
+
+
+def test_get_plans_drops_placeholders(recording_caches):
+    con = xo.connect()
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    expr = xo.memtable(df).into_backend(con, "rt_tbl")
+    plans = get_plans(expr)
+    assert plans
+    assert_all_closed_once(recording_caches)
+    assert con.list_tables() == []
+
+
+def test_table_sql_failure_does_not_leak(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    with pytest.raises(Exception, match="rt_tbl does not exist"):
+        expr.sql("SELECT * FROM rt_tbl")
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []
+
+
+def test_prepare_create_table_keeps_placeholders(recording_caches):
+    # the sole caller (snowflake create_table) runs CTAS against the
+    # placeholder after prepare returns: tables must stay registered while
+    # the caches are closed
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    table = prepare_create_table_from_expr(target, expr)
+    assert table is not None
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() != []
+
+
+def test_stream_full_drain_closes_once(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+    table = reader.read_all()
+    assert table.num_rows == 2
+    (cache,) = recording_caches
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+    # releasing the drained reader is a no-op (idempotent close)
+    del reader
+    gc.collect()
+    assert cache.close_count == 1
+
+
+def test_stream_abandoned_reader_gc_closes(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+    (cache,) = recording_caches
+    assert cache.close_count == 0
+    assert target.list_tables() != []
+    # never read a single batch: the weakref.finalize backstop must fire
+    del reader
+    gc.collect()
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+
+
+def test_stream_explicit_close_then_release(recording_caches):
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    reader = to_pyarrow_batches(expr)
+    # pyarrow does not finalize wrapped generators on close(); cleanup
+    # fires when the last reference drops
+    reader.close()
+    del reader
+    gc.collect()
+    (cache,) = recording_caches
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+
+
+def test_stream_early_termination_then_close(recording_caches):
+    target = xo.duckdb.connect()
+    df = pd.DataFrame({"a": range(1000)})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    reader = to_pyarrow_batches(rt.limit(1))
+    batch = reader.read_next_batch()
+    assert len(batch) == 1
+    reader.close()
+    del reader
+    gc.collect()
+    (cache,) = recording_caches
+    assert cache.close_count == 1
+    assert target.list_tables() == []
+
+
+@pytest.mark.parametrize(
+    "connect",
+    [xo.duckdb.connect, xo.connect],
+    ids=["duckdb", "xorq"],
+)
+def test_into_backend_executes_correctly(connect):
+    target = connect()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    expr = rt.filter(rt.a > 1).select("a", "b")
+    result = expr.execute().reset_index(drop=True)
+    expected = df[df.a > 1].reset_index(drop=True)
+    assert_frame_equal(result, expected)
+    assert target.list_tables() == []
+
+
+@pytest.mark.parametrize(
+    "connect",
+    [xo.duckdb.connect, xo.connect],
+    ids=["duckdb", "xorq"],
+)
+def test_into_backend_fanout_executes_correctly(connect):
+    target = connect()
+    df = pd.DataFrame({"id": [1, 2], "v": [10, 20]})
+    rt = xo.memtable(df).into_backend(target, "rt_tbl")
+    expr = rt.join(rt, "id")
+    result = expr.execute()
+    assert len(result) == 2
+    assert target.list_tables() == []
+
+
+def test_bind_closes_at_drain_not_gc():
+    # the generator finally in bind() must fire AT exhaustion, not at GC:
+    # drain the bound reader directly while still holding a strong reference
+    # to it (the public path can mask the distinction -- the otel wrapper
+    # drops its reference at drain, letting the finalize backstop fire at the
+    # same moment under refcounting)
+    closed = []
+    scope = TransformScope()
+    scope.adopt("marker", functools.partial(closed.append, True))
+    schema = pa.schema([("a", pa.int64())])
+    inner = pa.RecordBatchReader.from_batches(
+        schema, iter([pa.RecordBatch.from_pydict({"a": [1, 2]})])
+    )
+    bound = scope.bind(inner)
+    bound.read_all()
+    assert closed == [True], "bind must close at exhaustion, not at reader GC"
+    del bound
+
+
+def test_scope_close_closes_adopted_readers():
+    class StubReader:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    scope = TransformScope()
+    stub = scope.adopt_reader(StubReader())
+    scope.close()
+    assert stub.closed
+
+
+def test_replacer_adopts_reader_cache_and_table():
+    # ownership contract: one (reader, cache, table) triple per RemoteTable,
+    # adopted in acquisition order so close() runs table -> cache -> reader
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    _, scope = register_and_transform_remote_tables(expr.op().to_expr())
+    try:
+        labels = [(kind, label) for kind, label, _ in scope._entries]
+        assert labels == [
+            ("resource", "reader"),
+            ("resource", "cache"),
+            ("table", next(iter(scope.created))),
+        ]
+    finally:
+        scope.close()
+    assert target.list_tables() == []
+
+
+def test_partial_read_record_batches_failure_drops_placeholder(
+    recording_caches, monkeypatch
+):
+    # register-then-raise inside read_record_batches: the pre-adopted
+    # placeholder must still be dropped
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+
+    def register_then_boom(self, source, table_name=None):
+        self.con.register(table_name, source)
+        raise RuntimeError("partial registration failure")
+
+    monkeypatch.setattr(type(target), "read_record_batches", register_then_boom)
+    with pytest.raises(RuntimeError, match="partial registration failure"):
+        expr.execute()
+    assert_all_closed_once(recording_caches)
+    assert target.list_tables() == []

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -257,13 +257,14 @@ def test_into_backend_duckdb(pg):
         .select(player_id="playerID", year_id="yearID_right")
     )
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     res = ddb.con.sql(query).df()
+    scope.close()
 
-    assert len(created) == 1
-    registered_name = next(iter(created))
+    assert len(scope.created) == 1
+    registered_name = next(iter(scope.created))
     assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
 
@@ -274,13 +275,14 @@ def test_into_backend_duckdb_expr(pg):
     t = pg.table("batting").into_backend(ddb, "ls_batting")
     expr = t.join(t, "playerID").limit(15).select(_.playerID * 2)
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     res = ddb.con.sql(query).df()
+    scope.close()
 
-    assert len(created) == 1
-    registered_name = next(iter(created))
+    assert len(scope.created) == 1
+    registered_name = next(iter(scope.created))
     assert query.count(registered_name) == 2
     assert 0 < len(res) <= 15
 
@@ -290,14 +292,15 @@ def test_into_backend_duckdb_trino(trino_table):
     db_con = xo.duckdb.connect()
     expr = trino_table.head(10_000).into_backend(db_con).pipe(make_merged)
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
     query = ibis.to_sql(expr, dialect="duckdb")
 
     df = db_con.con.sql(query).df()  # to bypass execute hotfix
+    scope.close()
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(created) == 1
+    assert len(scope.created) == 1
 
 
 @pytest.mark.trino
@@ -312,13 +315,14 @@ def test_multiple_into_backend_duckdb_xorq(trino_table):
         .into_backend(ls_con)[lambda t: t.orderstatus == "F"]
     )
 
-    expr, created, _caches = register_and_transform_remote_tables(expr)
+    expr, scope = register_and_transform_remote_tables(expr)
 
     df = expr.execute()
+    scope.close()
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
-    assert len(created) == 1
+    assert len(scope.created) == 1
 
 
 @pytest.mark.trino

--- a/python/xorq/vendor/ibis/expr/types/relations.py
+++ b/python/xorq/vendor/ibis/expr/types/relations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import itertools
 import operator
 import re
@@ -3300,13 +3299,14 @@ class Table(Expr, _FixedTextJupyterMixin):
             name = util.gen_name("sql_query")
             expr = self
 
-        from xorq.expr.api import _transform_expr
+        from xorq.expr.api import transformed
 
-        (expr, _, _caches) = _transform_expr(expr)
-
-        with contextlib.ExitStack() as stack:
-            for cache in _caches:
-                stack.enter_context(contextlib.closing(cache))
+        # full close (placeholder drops included) on exit: only the schema
+        # probe runs while the scope is open. The returned SQLStringView
+        # embeds the transformed child, but executing it over RemoteTables
+        # already fails at alias-name resolution before the released
+        # resources could matter; closing here at least stops the leak.
+        with transformed(expr) as expr:
             schema = backend._get_sql_string_view_schema(
                 name=name, table=expr, query=query
             )


### PR DESCRIPTION
`TransformScope` owns everything the transform materializes: upstream readers, StreamCaches, and the placeholder tables registered in target backends. Resources are adopted the moment they're acquired inside the replacer, and close() is idempotent and step-isolated, so a failed drop can't skip the remaining cleanups. Call sites reduce to:

```python
with transformed(expr, params=params) as texpr:
    return con.execute(texpr)
```

The streaming path keeps its deferred cleanup via `scope.bind(reader)`: generator finally on full drain, plus a weakref.finalize backstop for abandoned readers.

This fixes the leaks from the review thread: caches and placeholder tables stranded when planning or a deferred read fails after registration, the unguarded drop_view in clean_up skipping all cache closes on failure, and get_plans never dropping the tables it registers. One deliberate exception: prepare_create_table_from_expr closes with `drop_tables=False` because snowflake's create_table runs CTAS against the placeholders after it returns.