### PR TITLE
fix: cache dir nested remote expr

### DIFF
--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -815,8 +815,7 @@ class ExprLoader:
         )
 
         # replace_nodes (not op.replace) so the rewrite reaches CachedNodes
-        # nested in opaque sub-exprs (e.g. a cache behind into_backend); native
-        # replace skips those, leaving base_path=None and ignoring cache_dir.
+        # nested inside opaque sub-exprs like RemoteTable.remote_expr.
         def replacer(node, kwargs):
             if isinstance(node, CachedNode) and isinstance(
                 node.cache, parquet_cache_types

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -814,11 +814,9 @@ class ExprLoader:
             ParquetTTLSnapshotCache,
         )
 
-        # Use replace_nodes (not the native op.replace) so the rewrite reaches
-        # CachedNodes nested inside opaque sub-expressions (e.g. a cache behind
-        # an into_backend, under RemoteTable.remote_expr). Native replace does
-        # not descend into those, so such a cache would keep base_path=None and
-        # silently resolve to the default cache dir, ignoring cache_dir.
+        # replace_nodes (not op.replace) so the rewrite reaches CachedNodes
+        # nested in opaque sub-exprs (e.g. a cache behind into_backend); native
+        # replace skips those, leaving base_path=None and ignoring cache_dir.
         def replacer(node, kwargs):
             if isinstance(node, CachedNode) and isinstance(
                 node.cache, parquet_cache_types

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -808,27 +808,29 @@ class ExprLoader:
 
     @staticmethod
     def replace_base_path(expr, base_path):
-        def replace(node, kwargs):
+        parquet_cache_types = (
+            ParquetCache,
+            ParquetSnapshotCache,
+            ParquetTTLSnapshotCache,
+        )
+
+        # Use replace_nodes (not the native op.replace) so the rewrite reaches
+        # CachedNodes nested inside opaque sub-expressions (e.g. a cache behind
+        # an into_backend, under RemoteTable.remote_expr). Native replace does
+        # not descend into those, so such a cache would keep base_path=None and
+        # silently resolve to the default cache dir, ignoring cache_dir.
+        def replacer(node, kwargs):
             if isinstance(node, CachedNode) and isinstance(
-                node.cache,
-                (ParquetCache, ParquetSnapshotCache, ParquetTTLSnapshotCache),
+                node.cache, parquet_cache_types
             ):
                 evolved = evolve(
                     node.cache,
-                    storage=evolve(
-                        node.cache.storage,
-                        base_path=base_path,
-                    ),
+                    storage=evolve(node.cache.storage, base_path=base_path),
                 )
-                return node.__recreate__(
-                    dict(zip(node.argnames, node.args)) | {"cache": evolved}
-                )
-            elif kwargs:
-                return node.__recreate__(kwargs)
-            else:
-                return node
+                return recreate(node, **((kwargs or {}) | {"cache": evolved}))
+            return node.__recreate__(kwargs) if kwargs else node
 
-        return expr.op().replace(replace).to_expr()
+        return replace_nodes(replacer, expr).to_expr()
 
 
 @functools.wraps(ExprLoader)

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -37,7 +37,7 @@ from xorq.common.utils.file_utils import normalize_read_path_md5sum
 from xorq.common.utils.graph_utils import find_all_sources, walk_nodes
 from xorq.common.utils.name_utils import get_uid_prefix
 from xorq.conftest import array_types_df
-from xorq.expr.relations import CachedNode, Read
+from xorq.expr.relations import CachedNode, Read, RemoteTable
 from xorq.ibis_yaml.compiler import (
     ArtifactStore,
     DumpFiles,
@@ -1577,3 +1577,36 @@ def test_mark_reads_relocatable_is_idempotent(sample_parquet: pathlib.Path) -> N
     assert once_kw == twice_kw
 
     assert tokenize(once) == tokenize(twice)
+
+
+def test_cache_dir_reaches_remote_expr_nested_cache(tmp_path):
+    # load_expr(cache_dir=...) must rewrite base_path on CachedNodes nested
+    # inside opaque sub-expressions -- here a RemoteTable.remote_expr created
+    # by into_backend. Regression: replace_base_path used the native
+    # op.replace, which does not descend into remote_expr, so such caches kept
+    # base_path=None and silently resolved to the default cache dir, ignoring
+    # cache_dir.
+    cona = xo.connect()
+    conb = xo.connect()
+    t = cona.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "t")
+    cache = ParquetSnapshotCache.from_kwargs(
+        source=cona, relative_path="c", base_path=tmp_path / "buildcache"
+    )
+    cached = t.mutate(s=t.a + t.b).cache(cache=cache)
+    expr = cached.into_backend(conb, "moved")
+
+    # the cache really is nested under a RemoteTable.remote_expr (so the
+    # native op.replace would miss it)
+    assert any(
+        walk_nodes((CachedNode,), rt.remote_expr)
+        for rt in walk_nodes((RemoteTable,), expr)
+    )
+
+    build_path = build_expr(expr, builds_dir=tmp_path / "builds")
+    target = tmp_path / "cache_target"
+    loaded = load_expr(build_path, cache_dir=str(target))
+
+    cached_nodes = walk_nodes((CachedNode,), loaded)
+    assert cached_nodes
+    for cn in cached_nodes:
+        assert cn.cache.storage.base_path == target

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1580,12 +1580,6 @@ def test_mark_reads_relocatable_is_idempotent(sample_parquet: pathlib.Path) -> N
 
 
 def test_cache_dir_reaches_remote_expr_nested_cache(tmp_path):
-    # load_expr(cache_dir=...) must rewrite base_path on CachedNodes nested
-    # inside opaque sub-expressions -- here a RemoteTable.remote_expr created
-    # by into_backend. Regression: replace_base_path used the native
-    # op.replace, which does not descend into remote_expr, so such caches kept
-    # base_path=None and silently resolved to the default cache dir, ignoring
-    # cache_dir.
     cona = xo.connect()
     conb = xo.connect()
     t = cona.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "t")
@@ -1595,8 +1589,6 @@ def test_cache_dir_reaches_remote_expr_nested_cache(tmp_path):
     cached = t.mutate(s=t.a + t.b).cache(cache=cache)
     expr = cached.into_backend(conb, "moved")
 
-    # the cache really is nested under a RemoteTable.remote_expr (so the
-    # native op.replace would miss it)
     assert any(
         walk_nodes((CachedNode,), rt.remote_expr)
         for rt in walk_nodes((RemoteTable,), expr)


### PR DESCRIPTION
## Summary

- `replace_base_path` used ibis's native `op.replace`, which doesn't descend into opaque sub-expressions (`RemoteTable.remote_expr`, `CachedNode.parent`, etc.). Caches nested behind `into_backend` kept `base_path=None`, silently ignoring `cache_dir`.
- Switch to `replace_nodes`, which recurses into opaque fields — the same helper other rewriters already use.
- Add regression test: build a cache inside `remote_expr` via `into_backend`, then verify `load_expr(cache_dir=...)` rewrites `base_path` on the nested `CachedNode`.

## Test plan

- [x] New test `test_cache_dir_reaches_remote_expr_nested_cache` covers the regression path
- [x] Existing test suite passes