### PR TITLE
feat: add relocatable reads support

### DIFF
--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -21,6 +21,7 @@ from xorq_dasher.rules.expr import (
 )
 
 import xorq.vendor.ibis.expr.operations as ops
+from xorq.common.constants import READ_IDENTITY_KEYS
 from xorq.common.utils.dasher import (
     HASHER,
     fqn,
@@ -63,8 +64,6 @@ def snapshot_normalize_read(read):
             tpls = (("path", str(path)),)
         case _:
             raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    from xorq.common.constants import READ_IDENTITY_KEYS  # noqa: PLC0415
-
     tpls += tuple((k, v) for k, v in read.read_kwargs if k in READ_IDENTITY_KEYS)
     return ("snapshot_normalize_read", read.schema, tpls)
 

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -63,7 +63,9 @@ def snapshot_normalize_read(read):
             tpls = (("path", str(path)),)
         case _:
             raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    tpls += tuple((k, v) for k, v in read.read_kwargs if k in Read.IDENTITY_KEYS)
+    from xorq.common.constants import READ_IDENTITY_KEYS  # noqa: PLC0415
+
+    tpls += tuple((k, v) for k, v in read.read_kwargs if k in READ_IDENTITY_KEYS)
     return ("snapshot_normalize_read", read.schema, tpls)
 
 

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -63,9 +63,7 @@ def snapshot_normalize_read(read):
             tpls = (("path", str(path)),)
         case _:
             raise NotImplementedError(f'Don\'t know how to deal with path "{path}"')
-    tpls += tuple(
-        (k, v) for k, v in read.read_kwargs if k in ("mode", "schema", "temporary")
-    )
+    tpls += tuple((k, v) for k, v in read.read_kwargs if k in Read.IDENTITY_KEYS)
     return ("snapshot_normalize_read", read.schema, tpls)
 
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -223,6 +223,7 @@ def build_command(
     builds_dir="builds",
     cache_dir=None,
     debug: bool = False,
+    relocate_reads: bool = False,
     emit_build_path_to=None,
 ):
     """
@@ -272,7 +273,11 @@ def build_command(
             )
 
     build_path = build_expr(
-        expr, builds_dir=builds_dir, cache_dir=Path(cache_dir), debug=debug
+        expr,
+        builds_dir=builds_dir,
+        cache_dir=Path(cache_dir),
+        debug=debug,
+        relocate_reads=relocate_reads,
     )
     expr_hash = build_path.name
     span.add_event("build.outputs", {"expr_hash": expr_hash})
@@ -1091,6 +1096,11 @@ def uv_run_unbound(
     help="Output SQL files and other debug artifacts.",
 )
 @click.option(
+    "--relocate-reads",
+    is_flag=True,
+    help="Bundle all local-file Read nodes into the build artifact.",
+)
+@click.option(
     "--emit-build-path-to",
     type=click.Path(),
     default=None,
@@ -1100,7 +1110,15 @@ def uv_run_unbound(
         "subprocess consumer needs the path unambiguously."
     ),
 )
-def build(script_path, expr_name, builds_dir, cache_dir, debug, emit_build_path_to):
+def build(
+    script_path: str,
+    expr_name: str,
+    builds_dir: str,
+    cache_dir: str,
+    debug: bool,
+    relocate_reads: bool,
+    emit_build_path_to: str | None,
+) -> None:
     """Compile a Xorq expression into a reusable build artifact.
 
     Loads the script, finds the expression variable, and writes serialized
@@ -1125,6 +1143,7 @@ def build(script_path, expr_name, builds_dir, cache_dir, debug, emit_build_path_
         builds_dir,
         cache_dir,
         debug,
+        relocate_reads=relocate_reads,
         emit_build_path_to=emit_build_path_to,
     )
 

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
+
+READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
+
+READ_EXCLUDE_KEYS = ("hash_path", "read_path", "relocatable")

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -5,4 +5,4 @@ REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
 
 READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
 
-READ_EXCLUDE_KEYS = ("hash_path", "read_path", "relocatable")
+READ_EXCLUDE_KEYS = frozenset({"hash_path", "read_path", "relocatable"})

--- a/python/xorq/common/utils/dasher/_paths.py
+++ b/python/xorq/common/utils/dasher/_paths.py
@@ -17,6 +17,8 @@ import urllib.request
 
 import yaml12
 
+from xorq.common.constants import REMOTE_SCHEMES
+
 
 # Catalog-extract tempdir prefix. ``xorq.catalog.expr_utils.load_expr_from_zip``
 # extracts each load into a fresh ``tempfile.mkdtemp(prefix="xorq-catalog-")``,
@@ -26,8 +28,6 @@ import yaml12
 # ``xorq-catalog-<…>/`` segment, leaving the build-hashed suffix (which IS
 # content-addressed and stable across reloads). Owned by ADR-0007.
 _CATALOG_EXTRACT_DIR_RE = re.compile(r".*/xorq-catalog-[^/]+/")
-
-_REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
 
 
 def _canonicalize_catalog_path(s: str) -> tuple[str, bool]:
@@ -94,7 +94,7 @@ def _stat_or_canonical(path: str) -> tuple:
     """
 
     if isinstance(path, str) and (
-        path.startswith(_REMOTE_SCHEMES) or pathlib.Path(path).is_absolute()
+        path.startswith(REMOTE_SCHEMES) or pathlib.Path(path).is_absolute()
     ):
         return _normalize_path_stat(path)
     return ("canonical-build-path", path)
@@ -112,7 +112,7 @@ def _extract_duckdb_file_paths(sql_ddl: str) -> tuple[str, ...]:
     tree = sg.parse_one(sql_ddl, dialect="duckdb")
 
     def canon(raw):
-        if raw.startswith(_REMOTE_SCHEMES):
+        if raw.startswith(REMOTE_SCHEMES):
             return raw
         p = pathlib.Path(raw)
         absolute = str(p if p.is_absolute() else pathlib.Path("/") / raw)
@@ -157,7 +157,7 @@ def _extract_datafusion_plan_paths(ep_str: str) -> tuple[str, ...]:
     (groups,) = parsed.values()
     out = []
     for raw in itertools.chain.from_iterable(groups):
-        if raw.startswith(_REMOTE_SCHEMES):
+        if raw.startswith(REMOTE_SCHEMES):
             out.append(raw)
             continue
         p = pathlib.Path(raw)
@@ -168,7 +168,6 @@ def _extract_datafusion_plan_paths(ep_str: str) -> tuple[str, ...]:
 
 
 __all__ = [
-    "_REMOTE_SCHEMES",
     "_canonicalize_catalog_path",
     "_extract_datafusion_plan_paths",
     "_extract_duckdb_file_paths",

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -95,9 +95,9 @@ def _normalize_single_path(path, read_kwargs, read):
 
 
 def _read_extra_kwargs(read):
-    return tuple(
-        (k, v) for k, v in read.read_kwargs if k in ("mode", "schema", "temporary")
-    )
+    from xorq.expr.relations import Read  # noqa: PLC0415
+
+    return tuple((k, v) for k, v in read.read_kwargs if k in Read.IDENTITY_KEYS)
 
 
 def _normalize_duckdb_databasetable_xorq(dt):

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -20,10 +20,10 @@ from xorq_dasher.rules.expr import (
     normalize_remote_table,
 )
 
+from xorq.common.constants import READ_IDENTITY_KEYS, REMOTE_SCHEMES
 from xorq.common.utils.dasher._gap_rules import normalize_ibis_schema
 from xorq.common.utils.dasher._opaque import _MISSING, _rename_unbound_xorq
 from xorq.common.utils.dasher._paths import (
-    _REMOTE_SCHEMES,
     _extract_datafusion_plan_paths,
     _extract_duckdb_file_paths,
     _normalize_path_stat,
@@ -83,7 +83,7 @@ def _normalize_read_xorq(read):
 def _normalize_single_path(path, read_kwargs, read):
     """Normalize a single string path for Read tokenization."""
 
-    if path.startswith(_REMOTE_SCHEMES):
+    if path.startswith(REMOTE_SCHEMES):
         stat_kwargs = {k: v for k, v in read_kwargs.items() if k != "hash_path"}
         return _normalize_path_stat(path, **stat_kwargs)
     elif not pathlib.Path(path).is_absolute() and path == read_kwargs.get("read_path"):
@@ -95,9 +95,7 @@ def _normalize_single_path(path, read_kwargs, read):
 
 
 def _read_extra_kwargs(read):
-    from xorq.expr.relations import Read  # noqa: PLC0415
-
-    return tuple((k, v) for k, v in read.read_kwargs if k in Read.IDENTITY_KEYS)
+    return tuple((k, v) for k, v in read.read_kwargs if k in READ_IDENTITY_KEYS)
 
 
 def _normalize_duckdb_databasetable_xorq(dt):

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -153,13 +153,13 @@ def deferred_read_csv(
 
     Parameters
     ----------
-    con : Backend
+    path : str or Path
+        The path to the CSV file to be read. This can be a local file path or a URL.
+
+    con : Backend, optional
         The connection object representing the backend where the CSV will be read.
         This can be any backend that supports reading CSV files (pandas, duckdb,
         postgres, etc.).
-
-    path : str or Path
-        The path to the CSV file to be read. This can be a local file path or a URL.
 
     table_name : str, optional
         The name to give to the resulting table in the backend. If not provided,
@@ -209,10 +209,7 @@ def deferred_read_csv(
             method, path, table_name, schema=schema, **kwargs
         )
     if relocatable:
-        read_kwargs = read_kwargs + (
-            ("relocatable", True),
-            ("read_path", relocatable_read_path(path)),
-        )
+        read_kwargs = read_kwargs + (("relocatable", True),)
         normalize_method = normalize_read_path_md5sum
     return Read(
         method_name=method_name,
@@ -242,18 +239,18 @@ def deferred_read_parquet(
 
     Parameters
     ----------
-    con : Backend
-        The connection object representing the backend where the Parquet data will be read.
-
     path : str or Path
         The path to the Parquet file or directory to be read.
+
+    con : Backend, optional
+        The connection object representing the backend where the Parquet data will be read.
 
     table_name : str, optional
         The name to give to the resulting table in the backend. If not provided,
         a unique name will be generated automatically.
 
     normalize_method : Callable, optional
-     The method that returns the values to be used in the hashing of the Read operation.
+        The method that returns the values to be used in the hashing of the Read operation.
 
     relocatable : bool, optional
         When True, ``xorq build`` will copy the backing file into the build
@@ -262,10 +259,10 @@ def deferred_read_parquet(
     **kwargs : dict
         Additional keyword arguments passed to the backend's read_parquet method.
 
-     Returns
-     -------
-     Expr
-         An expression representing the deferred read operation.
+    Returns
+    -------
+    Expr
+        An expression representing the deferred read operation.
     """
 
     method_name = "read_parquet"
@@ -279,10 +276,7 @@ def deferred_read_parquet(
         kwargs.setdefault("mode", "replace")
     read_kwargs = make_read_kwargs(method, path, table_name=table_name, **kwargs)
     if relocatable:
-        read_kwargs = read_kwargs + (
-            ("relocatable", True),
-            ("read_path", relocatable_read_path(path)),
-        )
+        read_kwargs = read_kwargs + (("relocatable", True),)
         normalize_method = normalize_read_path_md5sum
     return Read(
         method_name=method_name,

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -57,11 +57,11 @@ def normalize_read_path_md5sum(path):
     return (("content-md5sum", file_digest(path)),)
 
 
-def relocatable_read_path(path: str | Path) -> str:
+def relocatable_read_path(path: str | Path) -> tuple[str, str]:
     from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
 
     path = Path(path)
-    return f"reads/{tokenize(normalize_read_path_md5sum(path))}{path.suffix}"
+    return ("reads", f"{tokenize(normalize_read_path_md5sum(path))}{path.suffix}")
 
 
 def normalize_read_path_stat(path):

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -57,6 +57,13 @@ def normalize_read_path_md5sum(path):
     return (("content-md5sum", file_digest(path)),)
 
 
+def relocatable_read_path(path: str | Path) -> str:
+    from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
+
+    path = Path(path)
+    return f"reads/{tokenize(normalize_read_path_md5sum(path))}{path.suffix}"
+
+
 def normalize_read_path_stat(path):
     stat = path.stat()
     tpls = tuple(
@@ -130,6 +137,7 @@ def deferred_read_csv(
     table_name: str | None = None,
     schema: Schema | None = None,
     normalize_method: Callable = normalize_read_path_stat,
+    relocatable: bool = False,
     **kwargs,
 ) -> ir.Table:
     """
@@ -160,6 +168,10 @@ def deferred_read_csv(
     schema : Schema, optional
         The schema definition for the CSV data. If not provided, the schema will
         be inferred from the data by sampling the CSV file.
+
+    relocatable : bool, optional
+        When True, ``xorq build`` will copy the backing file into the build
+        artifact and rewrite the path so the archive is self-contained.
 
     kwargs : Any
         Additional keyword arguments that will be passed to the backend's read_csv
@@ -196,6 +208,12 @@ def deferred_read_csv(
         read_kwargs = make_read_kwargs(
             method, path, table_name, schema=schema, **kwargs
         )
+    if relocatable:
+        read_kwargs = read_kwargs + (
+            ("relocatable", True),
+            ("read_path", relocatable_read_path(path)),
+        )
+        normalize_method = normalize_read_path_md5sum
     return Read(
         method_name=method_name,
         name=table_name,
@@ -212,6 +230,7 @@ def deferred_read_parquet(
     table_name: str | None = None,
     schema: Schema | None = None,
     normalize_method: Callable = normalize_read_path_stat,
+    relocatable: bool = False,
     **kwargs,
 ) -> ir.Table:
     """
@@ -236,6 +255,10 @@ def deferred_read_parquet(
     normalize_method : Callable, optional
      The method that returns the values to be used in the hashing of the Read operation.
 
+    relocatable : bool, optional
+        When True, ``xorq build`` will copy the backing file into the build
+        artifact and rewrite the path so the archive is self-contained.
+
     **kwargs : dict
         Additional keyword arguments passed to the backend's read_parquet method.
 
@@ -255,6 +278,12 @@ def deferred_read_parquet(
     if con.name in _ADBC_BACKENDS:
         kwargs.setdefault("mode", "replace")
     read_kwargs = make_read_kwargs(method, path, table_name=table_name, **kwargs)
+    if relocatable:
+        read_kwargs = read_kwargs + (
+            ("relocatable", True),
+            ("read_path", relocatable_read_path(path)),
+        )
+        normalize_method = normalize_read_path_md5sum
     return Read(
         method_name=method_name,
         name=table_name,

--- a/python/xorq/common/utils/file_utils.py
+++ b/python/xorq/common/utils/file_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import hashlib
 import itertools
 from contextlib import closing
@@ -21,14 +22,52 @@ def _manual_file_digest(
         return obj.hexdigest()
 
 
+@functools.cache
+def _cached_file_digest(
+    path: str,
+    dev: int,
+    ino: int,
+    mtime_ns: int,
+    size: int,
+    algorithm: str = "md5",
+    chunk_size: int = 2**20,
+) -> str:
+    digest = getattr(hashlib, algorithm)
+    if hasattr(hashlib, "file_digest"):
+        with Path(path).open("rb") as fh:
+            return hashlib.file_digest(fh, digest).hexdigest()
+    return _manual_file_digest(Path(path), digest, size=chunk_size)
+
+
+def _digest_to_algorithm(digest: Callable) -> str | None:
+    algo = digest.__name__.removeprefix("openssl_")
+    if hasattr(hashlib, algo):
+        return algo
+    return None
+
+
 def file_digest(
     path: str | Path, digest: Callable = hashlib.md5, size: int = 2**20
 ) -> str:
-    if hasattr(hashlib, "file_digest"):
+    if isinstance(path, (str, Path)):
+        p = Path(path)
+        st = p.stat()
+        algo = _digest_to_algorithm(digest)
+        if algo is not None:
+            return _cached_file_digest(
+                str(p.resolve()),
+                st.st_dev,
+                st.st_ino,
+                st.st_mtime_ns,
+                st.st_size,
+                algo,
+                size,
+            )
+        with p.open("rb") as fh:
+            return hashlib.file_digest(fh, digest).hexdigest()
+    elif hasattr(hashlib, "file_digest"):
         if isinstance(path, ZipExtFile):
             return hashlib.file_digest(path, digest).hexdigest()
-        if isinstance(path, (str, Path)):
-            with Path(path).open("rb") as fh:
-                return hashlib.file_digest(fh, digest).hexdigest()
         raise ValueError(f"Don't know how to handle type {type(path)}")
-    return _manual_file_digest(path, digest, size=size)
+    else:
+        return _manual_file_digest(path, digest, size=size)

--- a/python/xorq/common/utils/file_utils.py
+++ b/python/xorq/common/utils/file_utils.py
@@ -63,8 +63,10 @@ def file_digest(
                 algo,
                 size,
             )
-        with p.open("rb") as fh:
-            return hashlib.file_digest(fh, digest).hexdigest()
+        if hasattr(hashlib, "file_digest"):
+            with p.open("rb") as fh:
+                return hashlib.file_digest(fh, digest).hexdigest()
+        return _manual_file_digest(p, digest, size=size)
     elif hasattr(hashlib, "file_digest"):
         if isinstance(path, ZipExtFile):
             return hashlib.file_digest(path, digest).hexdigest()

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -566,9 +566,11 @@ class Read(ops.DatabaseTable):
     read_kwargs: Any = ()
     normalize_method: Callable = None
 
+    IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
+
     def make_dt(self):
         method = getattr(self.source, self.method_name)
-        _exclude = ("hash_path", "read_path")
+        _exclude = ("hash_path", "read_path", "relocatable")
         args = tuple(v for k, v in self.read_kwargs if k == "hash_path")
         kwargs = {k: v for k, v in self.read_kwargs if k not in _exclude}
         dt = method(*args, **kwargs).op()

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -567,12 +567,11 @@ class Read(ops.DatabaseTable):
     normalize_method: Callable = None
 
     def make_dt(self):
-        method = getattr(self.source, self.method_name)
         from xorq.common.constants import READ_EXCLUDE_KEYS  # noqa: PLC0415
 
-        _exclude = READ_EXCLUDE_KEYS
+        method = getattr(self.source, self.method_name)
         args = tuple(v for k, v in self.read_kwargs if k == "hash_path")
-        kwargs = {k: v for k, v in self.read_kwargs if k not in _exclude}
+        kwargs = {k: v for k, v in self.read_kwargs if k not in READ_EXCLUDE_KEYS}
         dt = method(*args, **kwargs).op()
         return dt
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -566,11 +566,11 @@ class Read(ops.DatabaseTable):
     read_kwargs: Any = ()
     normalize_method: Callable = None
 
-    IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
-
     def make_dt(self):
         method = getattr(self.source, self.method_name)
-        _exclude = ("hash_path", "read_path", "relocatable")
+        from xorq.common.constants import READ_EXCLUDE_KEYS  # noqa: PLC0415
+
+        _exclude = READ_EXCLUDE_KEYS
         args = tuple(v for k, v in self.read_kwargs if k == "hash_path")
         kwargs = {k: v for k, v in self.read_kwargs if k not in _exclude}
         dt = method(*args, **kwargs).op()

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -526,8 +526,7 @@ class ExprDumper:
         if "hash_path" not in kw:
             raise ValueError("relocatable Read must have hash_path")
         source_path = Path(kw["hash_path"])
-        rp = relocatable_read_path(source_path)
-        path_parts = tuple(rp.split("/", 1))
+        path_parts = relocatable_read_path(source_path)
         path = self.artifact_store.get_path(*path_parts)
         writer = functools.partial(
             self.artifact_store.copy_file,

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -72,9 +72,9 @@ from xorq.ibis_yaml.common import (
 )
 from xorq.ibis_yaml.config import config
 from xorq.ibis_yaml.enums import (
+    BundledSourceTypes,
     DumpFiles,
     ExprKind,
-    InlineSourceTypes,
     RefEnum,
     RegistryEnum,
 )
@@ -112,7 +112,7 @@ def _is_relocatable_read(node: Any) -> bool:
     """Return True if *node* is a Read already marked ``relocatable``."""
     if not isinstance(node, Read):
         return False
-    return dict(node.read_kwargs).get("relocatable", False)
+    return any(k == "relocatable" and v for k, v in node.read_kwargs)
 
 
 def _mark_reads_relocatable(expr: ir.Expr) -> ir.Expr:
@@ -297,17 +297,15 @@ def _sanitize_generated_names(expr, normalize_method):
                 )
         else:
             if prefix := get_uid_prefix(node.name):
-                # Relocatable reads carry their own normalize_method (md5sum)
-                # to ensure hash parity between the per-call API and the flag.
-                nm = (
+                read_nm = (
                     node.normalize_method
                     if _is_relocatable_read(node)
                     else normalize_method
                 )
-                table_name = f"{prefix}{tokenize(recreate(node, name='name', normalize_method=nm).to_expr())}"
+                table_name = f"{prefix}{tokenize(recreate(node, name='name', normalize_method=read_nm).to_expr())}"
                 replacements[node] = recreate(
                     change_read_table_name(node, table_name=table_name),
-                    normalize_method=nm,
+                    normalize_method=read_nm,
                 )
     op = expr.op()
     if replacements:
@@ -509,7 +507,7 @@ class ExprDumper:
         return (path, writer)
 
     def _prepare_memtable(self, mt, which):
-        assert which in InlineSourceTypes
+        assert which in BundledSourceTypes
         table = mt.to_expr().to_pyarrow()
         filename = f"{tokenize(table)}.parquet"
         path_parts = (which, filename)
@@ -654,7 +652,7 @@ class ExprDumper:
         replacements = {}
         for node in walk_nodes((InMemoryTable, DatabaseTable), expr):
             if isinstance(node, InMemoryTable):
-                which = InlineSourceTypes.inmemory
+                which = BundledSourceTypes.inmemory
                 # The `inmemory` marker flags this Read for memtable
                 # reconstruction on load; InMemoryTable data is deterministic,
                 # so content-hash normalization keeps the YAML reproducible
@@ -663,7 +661,7 @@ class ExprDumper:
                 con_kwargs = {}
             elif _is_relocatable_read(node):
                 path, writer = self._prepare_relocatable_read(node)
-                which = InlineSourceTypes.read
+                which = BundledSourceTypes.read
                 read_path = f"{which}/{path.name}"
                 new_kwargs = update_read_kwargs(
                     node.read_kwargs,
@@ -681,7 +679,7 @@ class ExprDumper:
             ):
                 continue
             else:
-                which = InlineSourceTypes.database_table
+                which = BundledSourceTypes.database_table
                 type_kwargs = {}
                 con_kwargs = {"con": node.source}
 
@@ -783,7 +781,7 @@ class ExprLoader:
         def resolve_read(dr):
             kw = dict(dr.read_kwargs)
             path = expr_path.joinpath(kw["read_path"])
-            if InlineSourceTypes.inmemory in kw:
+            if BundledSourceTypes.inmemory in kw:
                 df = (
                     pq.read_schema(path).empty_table().to_pandas()
                     if read_only_parquet_metadata

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -3,6 +3,7 @@ import functools
 import json
 import operator
 import pathlib
+import shutil
 import sys
 import warnings
 from pathlib import Path
@@ -40,6 +41,7 @@ from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.defer_utils import (
     normalize_read_path_md5sum,
     normalize_read_path_stat,
+    relocatable_read_path,
 )
 from xorq.common.utils.graph_utils import (
     find_all_sources,
@@ -90,6 +92,48 @@ def _ensure_translate_registered():
 
 memory_backends = ("pandas", "duckdb", "datafusion", "xorq_datafusion")
 table_like_ops = tuple(o for o in opaque_ops if issubclass(o, DatabaseTable))
+_REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
+
+
+def _is_relocatable_candidate(node: Any) -> bool:
+    """Local-file Read that has not yet been marked ``relocatable``."""
+    if not isinstance(node, Read):
+        return False
+    kw = dict(node.read_kwargs)
+    if kw.get("relocatable", False):
+        return False
+    hash_path = kw.get("hash_path")
+    if hash_path is None:
+        return False
+    return not str(hash_path).startswith(_REMOTE_SCHEMES)
+
+
+def _is_relocatable_read(node: Any) -> bool:
+    if not isinstance(node, Read):
+        return False
+    return dict(node.read_kwargs).get("relocatable", False)
+
+
+def _mark_reads_relocatable(expr: ir.Expr) -> ir.Expr:
+    """Inject ``relocatable=True`` into all local-file Read nodes."""
+
+    def _relocate(node, kwargs):
+        if _is_relocatable_candidate(node):
+            kw = dict(node.read_kwargs)
+            source_path = Path(kw["hash_path"])
+            new_kwargs = node.read_kwargs + (
+                ("relocatable", True),
+                ("read_path", relocatable_read_path(source_path)),
+            )
+            args = dict(zip(node.__argnames__, node.__args__)) | {
+                "read_kwargs": new_kwargs,
+                "normalize_method": normalize_read_path_md5sum,
+            }
+            return node.__recreate__((kwargs or {}) | args)
+        return node.__recreate__(kwargs) if kwargs else node
+
+    op = replace_nodes(_relocate, expr.op())
+    return op.to_expr()
 
 
 def _to_yaml_safe(data):
@@ -153,6 +197,12 @@ class ArtifactStore:
         with self._write(*path_parts) as (path, f):
             pq.write_table(table, path)
         return path
+
+    def copy_file(self, source: pathlib.Path, *path_parts: str) -> pathlib.Path:
+        dest = self.get_path(*path_parts)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+        return dest
 
     def exists(self, *path_parts) -> bool:
         return self.get_path(*path_parts).exists()
@@ -395,18 +445,22 @@ class ExprDumper:
     builds_dir: root directory where expr builds are stored
     cache_dir: optional directory for parquet cache files
     debug: when True, output SQL files and debug artifacts (sql.yaml, deferred_reads.yaml)
+    relocate_reads: when True, copy local-file Read sources into the build artifact
     """
 
     expr = field(validator=instance_of(ir.Expr))
     builds_dir = field(validator=instance_of(Path), converter=Path, default="./builds")
     cache_dir = field(validator=optional(instance_of(Path)), factory=get_xorq_cache_dir)
     debug = field(validator=instance_of(bool), default=False)
+    relocate_reads = field(validator=instance_of(bool), default=False)
     read_normalize_method = field(
         validator=is_callable(), default=normalize_read_path_stat
     )
 
     def __attrs_post_init__(self):
         expr = canonicalize_expr(self.expr, self.read_normalize_method)
+        if self.relocate_reads:
+            expr = _mark_reads_relocatable(expr)
         object.__setattr__(self, "expr", expr)
         attrname = "cache_dir"
         match value := getattr(self, attrname):
@@ -459,6 +513,23 @@ class ExprDumper:
         writer = functools.partial(
             self.artifact_store.write_parquet,
             table,
+            *path_parts,
+        )
+        return (path, writer)
+
+    def _prepare_relocatable_read(
+        self, read_node: Read
+    ) -> tuple[Path, functools.partial]:
+        kw = dict(read_node.read_kwargs)
+        if "hash_path" not in kw:
+            raise ValueError("relocatable Read must have hash_path")
+        source_path = Path(kw["hash_path"])
+        rp = relocatable_read_path(source_path)
+        path_parts = tuple(rp.split("/", 1))
+        path = self.artifact_store.get_path(*path_parts)
+        writer = functools.partial(
+            self.artifact_store.copy_file,
+            source_path,
             *path_parts,
         )
         return (path, writer)
@@ -586,6 +657,20 @@ class ExprDumper:
                 # across processes and rebuild timestamps.
                 type_kwargs = {str(which): True}
                 con_kwargs = {}
+            elif _is_relocatable_read(node):
+                path, writer = self._prepare_relocatable_read(node)
+                which = MemtableTypes.read
+                read_path = f"{which}/{path.name}"
+                new_kwargs = update_read_kwargs(
+                    node.read_kwargs,
+                    (("hash_path", path), ("read_path", read_path)),
+                )
+                args = dict(zip(node.__argnames__, node.__args__)) | {
+                    "read_kwargs": new_kwargs
+                }
+                path_to_writer[path] = writer
+                replacements[node] = node.__recreate__(args)
+                continue
             elif (
                 isinstance(node, table_like_ops)
                 or node.source.name not in memory_backends
@@ -702,10 +787,12 @@ class ExprLoader:
                 )
                 return ibis.memtable(df, schema=dr.schema, name=dr.name).op()
             resolved_kwargs = update_read_kwargs(dr.read_kwargs, (("hash_path", path),))
+            relocatable = kw.get("relocatable", False)
             args = dict(zip(dr.__argnames__, dr.__args__)) | {
                 "read_kwargs": resolved_kwargs
             }
-            return dr.__recreate__(args).make_dt()
+            node = dr.__recreate__(args)
+            return node if relocatable else node.make_dt()
 
         drs = tuple(
             dr for dr in walk_nodes(Read, loaded) if "read_path" in dict(dr.read_kwargs)

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -35,6 +35,7 @@ from xorq.caching import (
     SnapshotStrategy,
 )
 from xorq.common.compat import StrEnum
+from xorq.common.constants import REMOTE_SCHEMES
 from xorq.common.exceptions import UnboundExpressionError
 from xorq.common.utils.caching_utils import get_xorq_cache_dir
 from xorq.common.utils.dasher import tokenize
@@ -73,7 +74,7 @@ from xorq.ibis_yaml.config import config
 from xorq.ibis_yaml.enums import (
     DumpFiles,
     ExprKind,
-    MemtableTypes,
+    InlineSourceTypes,
     RefEnum,
     RegistryEnum,
 )
@@ -92,7 +93,6 @@ def _ensure_translate_registered():
 
 memory_backends = ("pandas", "duckdb", "datafusion", "xorq_datafusion")
 table_like_ops = tuple(o for o in opaque_ops if issubclass(o, DatabaseTable))
-_REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
 
 
 def _is_relocatable_candidate(node: Any) -> bool:
@@ -105,10 +105,11 @@ def _is_relocatable_candidate(node: Any) -> bool:
     hash_path = kw.get("hash_path")
     if hash_path is None:
         return False
-    return not str(hash_path).startswith(_REMOTE_SCHEMES)
+    return not str(hash_path).startswith(REMOTE_SCHEMES)
 
 
 def _is_relocatable_read(node: Any) -> bool:
+    """Return True if *node* is a Read already marked ``relocatable``."""
     if not isinstance(node, Read):
         return False
     return dict(node.read_kwargs).get("relocatable", False)
@@ -119,12 +120,7 @@ def _mark_reads_relocatable(expr: ir.Expr) -> ir.Expr:
 
     def _relocate(node, kwargs):
         if _is_relocatable_candidate(node):
-            kw = dict(node.read_kwargs)
-            source_path = Path(kw["hash_path"])
-            new_kwargs = node.read_kwargs + (
-                ("relocatable", True),
-                ("read_path", relocatable_read_path(source_path)),
-            )
+            new_kwargs = node.read_kwargs + (("relocatable", True),)
             args = dict(zip(node.__argnames__, node.__args__)) | {
                 "read_kwargs": new_kwargs,
                 "normalize_method": normalize_read_path_md5sum,
@@ -301,10 +297,17 @@ def _sanitize_generated_names(expr, normalize_method):
                 )
         else:
             if prefix := get_uid_prefix(node.name):
-                table_name = f"{prefix}{tokenize(recreate(node, name='name', normalize_method=normalize_method).to_expr())}"
+                # Relocatable reads carry their own normalize_method (md5sum)
+                # to ensure hash parity between the per-call API and the flag.
+                nm = (
+                    node.normalize_method
+                    if _is_relocatable_read(node)
+                    else normalize_method
+                )
+                table_name = f"{prefix}{tokenize(recreate(node, name='name', normalize_method=nm).to_expr())}"
                 replacements[node] = recreate(
                     change_read_table_name(node, table_name=table_name),
-                    normalize_method=normalize_method,
+                    normalize_method=nm,
                 )
     op = expr.op()
     if replacements:
@@ -458,9 +461,10 @@ class ExprDumper:
     )
 
     def __attrs_post_init__(self):
-        expr = canonicalize_expr(self.expr, self.read_normalize_method)
+        expr = self.expr
         if self.relocate_reads:
             expr = _mark_reads_relocatable(expr)
+        expr = canonicalize_expr(expr, self.read_normalize_method)
         object.__setattr__(self, "expr", expr)
         attrname = "cache_dir"
         match value := getattr(self, attrname):
@@ -505,7 +509,7 @@ class ExprDumper:
         return (path, writer)
 
     def _prepare_memtable(self, mt, which):
-        assert which in MemtableTypes
+        assert which in InlineSourceTypes
         table = mt.to_expr().to_pyarrow()
         filename = f"{tokenize(table)}.parquet"
         path_parts = (which, filename)
@@ -650,7 +654,7 @@ class ExprDumper:
         replacements = {}
         for node in walk_nodes((InMemoryTable, DatabaseTable), expr):
             if isinstance(node, InMemoryTable):
-                which = MemtableTypes.inmemory
+                which = InlineSourceTypes.inmemory
                 # The `inmemory` marker flags this Read for memtable
                 # reconstruction on load; InMemoryTable data is deterministic,
                 # so content-hash normalization keeps the YAML reproducible
@@ -659,7 +663,7 @@ class ExprDumper:
                 con_kwargs = {}
             elif _is_relocatable_read(node):
                 path, writer = self._prepare_relocatable_read(node)
-                which = MemtableTypes.read
+                which = InlineSourceTypes.read
                 read_path = f"{which}/{path.name}"
                 new_kwargs = update_read_kwargs(
                     node.read_kwargs,
@@ -677,7 +681,7 @@ class ExprDumper:
             ):
                 continue
             else:
-                which = MemtableTypes.database_table
+                which = InlineSourceTypes.database_table
                 type_kwargs = {}
                 con_kwargs = {"con": node.source}
 
@@ -779,7 +783,7 @@ class ExprLoader:
         def resolve_read(dr):
             kw = dict(dr.read_kwargs)
             path = expr_path.joinpath(kw["read_path"])
-            if MemtableTypes.inmemory in kw:
+            if InlineSourceTypes.inmemory in kw:
                 df = (
                     pq.read_schema(path).empty_table().to_pandas()
                     if read_only_parquet_metadata

--- a/python/xorq/ibis_yaml/enums.py
+++ b/python/xorq/ibis_yaml/enums.py
@@ -31,6 +31,7 @@ class ExprKind(StrEnum):
 class MemtableTypes(StrEnum):
     inmemory = "memtables"
     database_table = "database_tables"
+    read = "reads"
 
 
 class RefEnum(StrEnum):

--- a/python/xorq/ibis_yaml/enums.py
+++ b/python/xorq/ibis_yaml/enums.py
@@ -28,7 +28,7 @@ class ExprKind(StrEnum):
     ExprBuilder = "expr_builder"
 
 
-class MemtableTypes(StrEnum):
+class InlineSourceTypes(StrEnum):
     inmemory = "memtables"
     database_table = "database_tables"
     read = "reads"

--- a/python/xorq/ibis_yaml/enums.py
+++ b/python/xorq/ibis_yaml/enums.py
@@ -28,7 +28,7 @@ class ExprKind(StrEnum):
     ExprBuilder = "expr_builder"
 
 
-class InlineSourceTypes(StrEnum):
+class BundledSourceTypes(StrEnum):
     inmemory = "memtables"
     database_table = "database_tables"
     read = "reads"

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -27,6 +27,7 @@ from xorq.caching import (
 from xorq.caching.strategy import snapshot_normalize_read
 from xorq.catalog.backend import GitBackend
 from xorq.catalog.catalog import Catalog
+from xorq.common.constants import READ_IDENTITY_KEYS
 from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.defer_utils import (
     deferred_read_csv,
@@ -1259,6 +1260,23 @@ def test_relocate_reads_flag_changes_build_hash(
     assert default_path.name != reloc_path.name
 
 
+def test_relocatable_api_and_flag_produce_same_hash(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """relocatable=True at construction and --relocate-reads at build time produce the same build hash."""
+    table = pa.table({"x": [1, 2, 3]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    api_t = deferred_read_parquet(parquet_path, relocatable=True)
+    api_path = build_expr(api_t, builds_dir=builds_dir / "api")
+
+    plain_t = deferred_read_parquet(parquet_path)
+    flag_path = build_expr(plain_t, builds_dir=builds_dir / "flag", relocate_reads=True)
+
+    assert api_path.name == flag_path.name
+
+
 def test_relocatable_read_no_local_path_warning(
     builds_dir: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
@@ -1332,8 +1350,8 @@ def test_mark_reads_relocatable_skips_remote(tmp_path: pathlib.Path) -> None:
 
 
 def test_identity_keys_includes_relocatable() -> None:
-    """Read.IDENTITY_KEYS must contain 'relocatable'."""
-    assert "relocatable" in Read.IDENTITY_KEYS
+    """READ_IDENTITY_KEYS must contain 'relocatable'."""
+    assert "relocatable" in READ_IDENTITY_KEYS
 
 
 def test_tokenize_differs_by_relocatable(tmp_path: pathlib.Path) -> None:
@@ -1464,6 +1482,18 @@ def test_warn_on_local_path_skips_when_read_path_present() -> None:
     items = (
         ("hash_path", "/absolute/local/file.parquet"),
         ("read_path", "reads/abc123.parquet"),
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_on_local_path(items)
+    assert caught == []
+
+
+def test_warn_on_local_path_skips_when_relocatable_flag_set() -> None:
+    """warn_on_local_path should not warn when relocatable=True even without read_path."""
+    items = (
+        ("hash_path", "/absolute/local/file.parquet"),
+        ("relocatable", True),
     )
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1137,6 +1137,13 @@ def test_tokenize_missing_path_still_raises(parquet_dir):
         tokenize(bad.to_expr())
 
 
+@pytest.fixture
+def sample_parquet(tmp_path: pathlib.Path) -> pathlib.Path:
+    path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3]}), path)
+    return path
+
+
 def test_relocatable_read_parquet(
     builds_dir: pathlib.Path, tmp_path: pathlib.Path
 ) -> None:
@@ -1231,15 +1238,11 @@ def test_relocatable_read_multiple_joined(
 
 
 def test_relocatable_changes_build_hash(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """relocatable=True must produce a different build hash than the default."""
-    table = pa.table({"x": [1, 2, 3]})
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(table, parquet_path)
-
-    plain = deferred_read_parquet(parquet_path)
-    reloc = deferred_read_parquet(parquet_path, relocatable=True)
+    plain = deferred_read_parquet(sample_parquet)
+    reloc = deferred_read_parquet(sample_parquet, relocatable=True)
 
     plain_path = build_expr(plain, builds_dir=builds_dir)
     reloc_path = build_expr(reloc, builds_dir=builds_dir)
@@ -1247,45 +1250,33 @@ def test_relocatable_changes_build_hash(
 
 
 def test_relocate_reads_flag_changes_build_hash(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """--relocate-reads must produce a different build hash than the default."""
-    table = pa.table({"x": [1, 2, 3]})
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(table, parquet_path)
-
-    t = deferred_read_parquet(parquet_path)
+    t = deferred_read_parquet(sample_parquet)
     default_path = build_expr(t, builds_dir=builds_dir)
     reloc_path = build_expr(t, builds_dir=builds_dir, relocate_reads=True)
     assert default_path.name != reloc_path.name
 
 
 def test_relocatable_api_and_flag_produce_same_hash(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """relocatable=True at construction and --relocate-reads at build time produce the same build hash."""
-    table = pa.table({"x": [1, 2, 3]})
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(table, parquet_path)
-
-    api_t = deferred_read_parquet(parquet_path, relocatable=True)
+    api_t = deferred_read_parquet(sample_parquet, relocatable=True)
     api_path = build_expr(api_t, builds_dir=builds_dir / "api")
 
-    plain_t = deferred_read_parquet(parquet_path)
+    plain_t = deferred_read_parquet(sample_parquet)
     flag_path = build_expr(plain_t, builds_dir=builds_dir / "flag", relocate_reads=True)
 
     assert api_path.name == flag_path.name
 
 
 def test_relocatable_read_no_local_path_warning(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """Relocatable reads should not emit the local-path warning during build."""
-    table = pa.table({"x": [1, 2, 3]})
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(table, parquet_path)
-
-    t = deferred_read_parquet(parquet_path, relocatable=True)
+    t = deferred_read_parquet(sample_parquet, relocatable=True)
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         build_expr(t, builds_dir=builds_dir)
@@ -1297,14 +1288,10 @@ def test_relocatable_read_no_local_path_warning(
 
 
 def test_relocatable_survives_round_trip(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """A relocatable Read should stay relocatable after build → load."""
-    table = pa.table({"x": [1, 2, 3]})
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(table, parquet_path)
-
-    t = deferred_read_parquet(parquet_path, relocatable=True)
+    t = deferred_read_parquet(sample_parquet, relocatable=True)
     build_path = build_expr(t, builds_dir=builds_dir)
     loaded = load_expr(build_path)
 
@@ -1315,13 +1302,9 @@ def test_relocatable_survives_round_trip(
     assert "read_path" in kw
 
 
-def test_mark_reads_relocatable_skips_remote(tmp_path: pathlib.Path) -> None:
+def test_mark_reads_relocatable_skips_remote(sample_parquet: pathlib.Path) -> None:
     """_mark_reads_relocatable should not inject relocatable for remote paths."""
-    table = pa.table({"x": [1, 2, 3]})
-    parquet_path = tmp_path / "local.parquet"
-    pq.write_table(table, parquet_path)
-
-    local_t = deferred_read_parquet(parquet_path)
+    local_t = deferred_read_parquet(sample_parquet)
     local_read = list(walk_nodes(Read, local_t))[0]
 
     remote_read = Read(
@@ -1354,24 +1337,20 @@ def test_identity_keys_includes_relocatable() -> None:
     assert "relocatable" in READ_IDENTITY_KEYS
 
 
-def test_tokenize_differs_by_relocatable(tmp_path: pathlib.Path) -> None:
+def test_tokenize_differs_by_relocatable(sample_parquet: pathlib.Path) -> None:
     """Two Reads differing only in relocatable should produce different tokens."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
-
-    plain = deferred_read_parquet(parquet_path)
-    reloc = deferred_read_parquet(parquet_path, relocatable=True)
+    plain = deferred_read_parquet(sample_parquet)
+    reloc = deferred_read_parquet(sample_parquet, relocatable=True)
 
     assert tokenize(plain) != tokenize(reloc)
 
 
-def test_snapshot_normalize_read_differs_by_relocatable(tmp_path: pathlib.Path) -> None:
+def test_snapshot_normalize_read_differs_by_relocatable(
+    sample_parquet: pathlib.Path,
+) -> None:
     """snapshot_normalize_read should yield different results when relocatable differs."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1]}), parquet_path)
-
-    plain = deferred_read_parquet(parquet_path)
-    reloc = deferred_read_parquet(parquet_path, relocatable=True)
+    plain = deferred_read_parquet(sample_parquet)
+    reloc = deferred_read_parquet(sample_parquet, relocatable=True)
 
     plain_read = list(walk_nodes(Read, plain))[0]
     reloc_read = list(walk_nodes(Read, reloc))[0]
@@ -1395,22 +1374,18 @@ def test_is_relocatable_candidate_not_a_read() -> None:
     assert not _is_relocatable_candidate(node)
 
 
-def test_is_relocatable_candidate_already_relocatable(tmp_path: pathlib.Path) -> None:
+def test_is_relocatable_candidate_already_relocatable(
+    sample_parquet: pathlib.Path,
+) -> None:
     """A Read that is already relocatable is not a candidate (no double-marking)."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1]}), parquet_path)
-
-    t = deferred_read_parquet(parquet_path, relocatable=True)
+    t = deferred_read_parquet(sample_parquet, relocatable=True)
     read = list(walk_nodes(Read, t))[0]
     assert not _is_relocatable_candidate(read)
 
 
-def test_is_relocatable_candidate_no_hash_path(tmp_path: pathlib.Path) -> None:
+def test_is_relocatable_candidate_no_hash_path(sample_parquet: pathlib.Path) -> None:
     """A Read with no hash_path is not a candidate."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1]}), parquet_path)
-
-    t = deferred_read_parquet(parquet_path)
+    t = deferred_read_parquet(sample_parquet)
     read = list(walk_nodes(Read, t))[0]
     no_hash = Read(
         method_name=read.method_name,
@@ -1423,12 +1398,9 @@ def test_is_relocatable_candidate_no_hash_path(tmp_path: pathlib.Path) -> None:
     assert not _is_relocatable_candidate(no_hash)
 
 
-def test_is_relocatable_candidate_local_path(tmp_path: pathlib.Path) -> None:
+def test_is_relocatable_candidate_local_path(sample_parquet: pathlib.Path) -> None:
     """A normal local-file Read IS a candidate."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1]}), parquet_path)
-
-    t = deferred_read_parquet(parquet_path)
+    t = deferred_read_parquet(sample_parquet)
     read = list(walk_nodes(Read, t))[0]
     assert _is_relocatable_candidate(read)
 
@@ -1489,18 +1461,6 @@ def test_warn_on_local_path_skips_when_read_path_present() -> None:
     assert caught == []
 
 
-def test_warn_on_local_path_skips_when_relocatable_flag_set() -> None:
-    """warn_on_local_path should not warn when relocatable=True even without read_path."""
-    items = (
-        ("hash_path", "/absolute/local/file.parquet"),
-        ("relocatable", True),
-    )
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        warn_on_local_path(items)
-    assert caught == []
-
-
 def test_warn_on_local_path_warns_for_non_relocatable_local(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -1522,13 +1482,10 @@ def test_warn_on_local_path_warns_for_non_relocatable_local(
 
 
 def test_loaded_relocatable_is_read_not_database_table(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """After load, a relocatable Read should remain a Read node, not DatabaseTable."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
-
-    t = deferred_read_parquet(parquet_path, relocatable=True)
+    t = deferred_read_parquet(sample_parquet, relocatable=True)
     build_path = build_expr(t, builds_dir=builds_dir)
     loaded = load_expr(build_path)
 
@@ -1546,13 +1503,10 @@ def test_loaded_relocatable_is_read_not_database_table(
 
 
 def test_loaded_non_relocatable_becomes_database_table(
-    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:
     """After load, a non-relocatable Read should be resolved to a DatabaseTable."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
-
-    t = deferred_read_parquet(parquet_path)
+    t = deferred_read_parquet(sample_parquet)
     build_path = build_expr(t, builds_dir=builds_dir)
     loaded = load_expr(build_path)
 
@@ -1565,12 +1519,9 @@ def test_loaded_non_relocatable_becomes_database_table(
 # ---------------------------------------------------------------------------
 
 
-def test_mark_reads_relocatable_is_idempotent(tmp_path: pathlib.Path) -> None:
+def test_mark_reads_relocatable_is_idempotent(sample_parquet: pathlib.Path) -> None:
     """Calling _mark_reads_relocatable twice should not double-wrap."""
-    parquet_path = tmp_path / "data.parquet"
-    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
-
-    t = deferred_read_parquet(parquet_path)
+    t = deferred_read_parquet(sample_parquet)
     once = _mark_reads_relocatable(t)
     twice = _mark_reads_relocatable(once)
 

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -5,9 +5,11 @@ import json
 import os
 import pathlib
 import tempfile
+import warnings
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 import toolz
 import yaml12
@@ -22,10 +24,12 @@ from xorq.caching import (
     SourceCache,
     SourceSnapshotCache,
 )
+from xorq.caching.strategy import snapshot_normalize_read
 from xorq.catalog.backend import GitBackend
 from xorq.catalog.catalog import Catalog
 from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.defer_utils import (
+    deferred_read_csv,
     deferred_read_parquet,
     normalize_read_path_md5sum,
 )
@@ -39,12 +43,15 @@ from xorq.ibis_yaml.compiler import (
     ExprKind,
     RefEnum,
     _extract_sql_queries,
+    _is_relocatable_candidate,
+    _mark_reads_relocatable,
     _sanitize_generated_names,
     build_expr,
     load_expr,
 )
 from xorq.ibis_yaml.config import config
 from xorq.ibis_yaml.sql import find_relations
+from xorq.ibis_yaml.translate import warn_on_local_path
 from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.common.collections import FrozenOrderedDict
 
@@ -1127,3 +1134,422 @@ def test_tokenize_missing_path_still_raises(parquet_dir):
 
     with pytest.raises(FileNotFoundError, match="memtables/does-not-exist"):
         tokenize(bad.to_expr())
+
+
+def test_relocatable_read_parquet(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """A relocatable Read should survive deletion of the original file."""
+    table = pa.table({"x": [1, 2, 3], "y": [4, 5, 6]})
+    parquet_path = tmp_path / "input.parquet"
+    pq.write_table(table, parquet_path)
+
+    t = deferred_read_parquet(parquet_path, relocatable=True)
+    expr = t.filter(t.x > 1)
+    build_path = build_expr(expr, builds_dir=builds_dir)
+
+    reads_dir = build_path / "reads"
+    assert reads_dir.exists(), "reads/ directory should be created"
+    parquet_files = list(reads_dir.glob("*.parquet"))
+    assert len(parquet_files) == 1
+
+    parquet_path.unlink()
+
+    loaded = load_expr(build_path)
+    result = loaded.execute()
+    assert len(result) == 2
+    assert list(result.x) == [2, 3]
+
+
+def test_relocatable_read_via_relocate_reads_flag(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """--relocate-reads should bundle even non-relocatable Read nodes."""
+    table = pa.table({"a": [10, 20], "b": [30, 40]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    t = deferred_read_parquet(parquet_path)
+    build_path = build_expr(t, builds_dir=builds_dir, relocate_reads=True)
+
+    reads_dir = build_path / "reads"
+    assert reads_dir.exists()
+    assert list(reads_dir.glob("*.parquet"))
+
+    parquet_path.unlink()
+
+    loaded = load_expr(build_path)
+    result = loaded.execute()
+    assert len(result) == 2
+
+
+def test_relocatable_read_csv(builds_dir: pathlib.Path, tmp_path: pathlib.Path) -> None:
+    """A CSV Read with relocatable=True should copy the CSV into the archive."""
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("x,y\n1,4\n2,5\n3,6\n")
+
+    t = deferred_read_csv(csv_path, relocatable=True)
+    expr = t.filter(t.x > 1)
+    build_path = build_expr(expr, builds_dir=builds_dir)
+
+    reads_dir = build_path / "reads"
+    assert reads_dir.exists()
+    assert list(reads_dir.glob("*.csv"))
+
+    csv_path.unlink()
+
+    loaded = load_expr(build_path)
+    result = loaded.execute()
+    assert len(result) == 2
+    assert sorted(result.x.tolist()) == [2, 3]
+
+
+def test_relocatable_read_multiple_joined(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """Two relocatable reads joined in one expression should both be bundled."""
+    pq.write_table(pa.table({"key": [1, 2], "val_a": [10, 20]}), tmp_path / "a.parquet")
+    pq.write_table(pa.table({"key": [1, 2], "val_b": [30, 40]}), tmp_path / "b.parquet")
+
+    a = deferred_read_parquet(tmp_path / "a.parquet", relocatable=True)
+    b = deferred_read_parquet(tmp_path / "b.parquet", relocatable=True)
+    expr = a.join(b, "key")
+    build_path = build_expr(expr, builds_dir=builds_dir)
+
+    reads_dir = build_path / "reads"
+    assert len(list(reads_dir.glob("*.parquet"))) == 2
+
+    (tmp_path / "a.parquet").unlink()
+    (tmp_path / "b.parquet").unlink()
+
+    loaded = load_expr(build_path)
+    result = loaded.execute()
+    assert len(result) == 2
+    assert sorted(result.val_a.tolist()) == [10, 20]
+    assert sorted(result.val_b.tolist()) == [30, 40]
+
+
+def test_relocatable_changes_build_hash(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """relocatable=True must produce a different build hash than the default."""
+    table = pa.table({"x": [1, 2, 3]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    plain = deferred_read_parquet(parquet_path)
+    reloc = deferred_read_parquet(parquet_path, relocatable=True)
+
+    plain_path = build_expr(plain, builds_dir=builds_dir)
+    reloc_path = build_expr(reloc, builds_dir=builds_dir)
+    assert plain_path.name != reloc_path.name
+
+
+def test_relocate_reads_flag_changes_build_hash(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """--relocate-reads must produce a different build hash than the default."""
+    table = pa.table({"x": [1, 2, 3]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    t = deferred_read_parquet(parquet_path)
+    default_path = build_expr(t, builds_dir=builds_dir)
+    reloc_path = build_expr(t, builds_dir=builds_dir, relocate_reads=True)
+    assert default_path.name != reloc_path.name
+
+
+def test_relocatable_read_no_local_path_warning(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """Relocatable reads should not emit the local-path warning during build."""
+    table = pa.table({"x": [1, 2, 3]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    t = deferred_read_parquet(parquet_path, relocatable=True)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        build_expr(t, builds_dir=builds_dir)
+
+    local_path_warnings = [
+        w for w in caught if "local filesystem path" in str(w.message)
+    ]
+    assert local_path_warnings == [], [str(w.message) for w in local_path_warnings]
+
+
+def test_relocatable_survives_round_trip(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """A relocatable Read should stay relocatable after build → load."""
+    table = pa.table({"x": [1, 2, 3]})
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(table, parquet_path)
+
+    t = deferred_read_parquet(parquet_path, relocatable=True)
+    build_path = build_expr(t, builds_dir=builds_dir)
+    loaded = load_expr(build_path)
+
+    reads = list(walk_nodes(Read, loaded))
+    assert len(reads) == 1
+    kw = dict(reads[0].read_kwargs)
+    assert kw.get("relocatable") is True
+    assert "read_path" in kw
+
+
+def test_mark_reads_relocatable_skips_remote(tmp_path: pathlib.Path) -> None:
+    """_mark_reads_relocatable should not inject relocatable for remote paths."""
+    table = pa.table({"x": [1, 2, 3]})
+    parquet_path = tmp_path / "local.parquet"
+    pq.write_table(table, parquet_path)
+
+    local_t = deferred_read_parquet(parquet_path)
+    local_read = list(walk_nodes(Read, local_t))[0]
+
+    remote_read = Read(
+        method_name=local_read.method_name,
+        name="remote_table",
+        schema=local_read.schema,
+        source=local_read.source,
+        read_kwargs=(("hash_path", "s3://bucket/data.parquet"),),
+        normalize_method=local_read.normalize_method,
+    )
+    expr = local_t.join(remote_read.to_expr(), "x")
+
+    marked = _mark_reads_relocatable(expr)
+    reads = list(walk_nodes(Read, marked))
+    for read in reads:
+        kw = dict(read.read_kwargs)
+        if kw.get("hash_path") == "s3://bucket/data.parquet":
+            assert not kw.get("relocatable", False)
+        else:
+            assert kw.get("relocatable") is True
+
+
+# ---------------------------------------------------------------------------
+# IDENTITY_KEYS — relocatable affects tokenization and snapshot keys
+# ---------------------------------------------------------------------------
+
+
+def test_identity_keys_includes_relocatable() -> None:
+    """Read.IDENTITY_KEYS must contain 'relocatable'."""
+    assert "relocatable" in Read.IDENTITY_KEYS
+
+
+def test_tokenize_differs_by_relocatable(tmp_path: pathlib.Path) -> None:
+    """Two Reads differing only in relocatable should produce different tokens."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
+
+    plain = deferred_read_parquet(parquet_path)
+    reloc = deferred_read_parquet(parquet_path, relocatable=True)
+
+    assert tokenize(plain) != tokenize(reloc)
+
+
+def test_snapshot_normalize_read_differs_by_relocatable(tmp_path: pathlib.Path) -> None:
+    """snapshot_normalize_read should yield different results when relocatable differs."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1]}), parquet_path)
+
+    plain = deferred_read_parquet(parquet_path)
+    reloc = deferred_read_parquet(parquet_path, relocatable=True)
+
+    plain_read = list(walk_nodes(Read, plain))[0]
+    reloc_read = list(walk_nodes(Read, reloc))[0]
+
+    assert snapshot_normalize_read(plain_read) != snapshot_normalize_read(reloc_read)
+
+
+# ---------------------------------------------------------------------------
+# _is_relocatable_candidate edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_is_relocatable_candidate_not_a_read() -> None:
+    """Non-Read nodes are never candidates."""
+    node = rel.DatabaseTable(
+        name="t",
+        schema=ibis.schema({"x": "int64"}),
+        source=ibis.duckdb.connect(),
+        namespace=rel.Namespace(database=None, catalog=None),
+    )
+    assert not _is_relocatable_candidate(node)
+
+
+def test_is_relocatable_candidate_already_relocatable(tmp_path: pathlib.Path) -> None:
+    """A Read that is already relocatable is not a candidate (no double-marking)."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1]}), parquet_path)
+
+    t = deferred_read_parquet(parquet_path, relocatable=True)
+    read = list(walk_nodes(Read, t))[0]
+    assert not _is_relocatable_candidate(read)
+
+
+def test_is_relocatable_candidate_no_hash_path(tmp_path: pathlib.Path) -> None:
+    """A Read with no hash_path is not a candidate."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1]}), parquet_path)
+
+    t = deferred_read_parquet(parquet_path)
+    read = list(walk_nodes(Read, t))[0]
+    no_hash = Read(
+        method_name=read.method_name,
+        name=read.name,
+        schema=read.schema,
+        source=read.source,
+        read_kwargs=tuple((k, v) for k, v in read.read_kwargs if k != "hash_path"),
+        normalize_method=read.normalize_method,
+    )
+    assert not _is_relocatable_candidate(no_hash)
+
+
+def test_is_relocatable_candidate_local_path(tmp_path: pathlib.Path) -> None:
+    """A normal local-file Read IS a candidate."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1]}), parquet_path)
+
+    t = deferred_read_parquet(parquet_path)
+    read = list(walk_nodes(Read, t))[0]
+    assert _is_relocatable_candidate(read)
+
+
+# ---------------------------------------------------------------------------
+# ArtifactStore.copy_file
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_store_copy_file(tmp_path: pathlib.Path) -> None:
+    """copy_file should copy the file and create parent directories."""
+    source = tmp_path / "source.txt"
+    source.write_text("hello")
+
+    store = ArtifactStore(root_path=tmp_path / "store")
+    dest = store.copy_file(source, "sub", "copied.txt")
+
+    assert dest.exists()
+    assert dest.read_text() == "hello"
+    assert dest == store.get_path("sub", "copied.txt")
+
+
+def test_artifact_store_copy_file_overwrites(tmp_path: pathlib.Path) -> None:
+    """copy_file should overwrite an existing destination."""
+    source = tmp_path / "source.txt"
+    source.write_text("new content")
+
+    store = ArtifactStore(root_path=tmp_path / "store")
+    dest = store.get_path("out.txt")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("old content")
+
+    store.copy_file(source, "out.txt")
+    assert dest.read_text() == "new content"
+
+
+def test_artifact_store_copy_file_missing_source(tmp_path: pathlib.Path) -> None:
+    """copy_file should raise when the source file does not exist."""
+    store = ArtifactStore(root_path=tmp_path / "store")
+    with pytest.raises(FileNotFoundError):
+        store.copy_file(tmp_path / "nonexistent.txt", "out.txt")
+
+
+# ---------------------------------------------------------------------------
+# warn_on_local_path changes
+# ---------------------------------------------------------------------------
+
+
+def test_warn_on_local_path_skips_when_read_path_present() -> None:
+    """warn_on_local_path should not warn when read_path is set (relocatable reads)."""
+    items = (
+        ("hash_path", "/absolute/local/file.parquet"),
+        ("read_path", "reads/abc123.parquet"),
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_on_local_path(items)
+    assert caught == []
+
+
+def test_warn_on_local_path_warns_for_non_relocatable_local(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Non-relocatable local reads should still warn with the updated message."""
+    local_file = tmp_path / "file.parquet"
+    local_file.write_bytes(b"data")
+    items = (("hash_path", str(local_file)),)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_on_local_path(items)
+    assert len(caught) == 1
+    assert "relocatable=True" in str(caught[0].message)
+    assert "--relocate-reads" in str(caught[0].message)
+
+
+# ---------------------------------------------------------------------------
+# ExprLoader — relocatable reads stay as Read nodes, not DatabaseTable
+# ---------------------------------------------------------------------------
+
+
+def test_loaded_relocatable_is_read_not_database_table(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """After load, a relocatable Read should remain a Read node, not DatabaseTable."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
+
+    t = deferred_read_parquet(parquet_path, relocatable=True)
+    build_path = build_expr(t, builds_dir=builds_dir)
+    loaded = load_expr(build_path)
+
+    reads = list(walk_nodes(Read, loaded))
+    assert len(reads) == 1, "relocatable Read should survive as Read, not be converted"
+
+    dts = [
+        n
+        for n in walk_nodes((rel.DatabaseTable,), loaded)
+        if type(n) is rel.DatabaseTable and not isinstance(n, Read)
+    ]
+    assert dts == [], (
+        "relocatable Read should not be converted to a plain DatabaseTable"
+    )
+
+
+def test_loaded_non_relocatable_becomes_database_table(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    """After load, a non-relocatable Read should be resolved to a DatabaseTable."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
+
+    t = deferred_read_parquet(parquet_path)
+    build_path = build_expr(t, builds_dir=builds_dir)
+    loaded = load_expr(build_path)
+
+    reads = [r for r in walk_nodes(Read, loaded) if "read_path" in dict(r.read_kwargs)]
+    assert reads == [], "non-relocatable Read should be resolved to DatabaseTable"
+
+
+# ---------------------------------------------------------------------------
+# _mark_reads_relocatable is idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_mark_reads_relocatable_is_idempotent(tmp_path: pathlib.Path) -> None:
+    """Calling _mark_reads_relocatable twice should not double-wrap."""
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
+
+    t = deferred_read_parquet(parquet_path)
+    once = _mark_reads_relocatable(t)
+    twice = _mark_reads_relocatable(once)
+
+    once_reads = list(walk_nodes(Read, once))
+    twice_reads = list(walk_nodes(Read, twice))
+    assert len(once_reads) == len(twice_reads) == 1
+
+    once_kw = dict(once_reads[0].read_kwargs)
+    twice_kw = dict(twice_reads[0].read_kwargs)
+    assert once_kw == twice_kw
+
+    assert tokenize(once) == tokenize(twice)

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1449,16 +1449,34 @@ def test_artifact_store_copy_file_missing_source(tmp_path: pathlib.Path) -> None
 # ---------------------------------------------------------------------------
 
 
-def test_warn_on_local_path_skips_when_read_path_present() -> None:
-    """warn_on_local_path should not warn when read_path is set (relocatable reads)."""
+def test_warn_on_local_path_skips_when_relocatable(tmp_path: pathlib.Path) -> None:
+    """warn_on_local_path should not warn when relocatable=True."""
+    local_file = tmp_path / "file.parquet"
+    local_file.write_bytes(b"data")
     items = (
-        ("hash_path", "/absolute/local/file.parquet"),
-        ("read_path", "reads/abc123.parquet"),
+        ("hash_path", str(local_file)),
+        ("relocatable", True),
     )
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         warn_on_local_path(items)
     assert caught == []
+
+
+def test_warn_on_local_path_warns_when_read_path_but_not_relocatable(
+    tmp_path: pathlib.Path,
+) -> None:
+    """read_path alone does not suppress the warning — only relocatable does."""
+    local_file = tmp_path / "file.parquet"
+    local_file.write_bytes(b"data")
+    items = (
+        ("hash_path", str(local_file)),
+        ("read_path", "database_tables/abc123.parquet"),
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warn_on_local_path(items)
+    assert len(caught) == 1
 
 
 def test_warn_on_local_path_warns_for_non_relocatable_local(

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1302,6 +1302,31 @@ def test_relocatable_survives_round_trip(
     assert "read_path" in kw
 
 
+def test_relocatable_rebuild_from_loaded_expr(
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
+) -> None:
+    """A loaded relocatable expr can be re-built and the result still executes.
+
+    This is why relocatable reads stay as Read nodes after load rather than
+    being eagerly resolved to DatabaseTable: the relocatable marker must
+    survive so a subsequent build_expr can re-bundle the file.
+    """
+    t = deferred_read_parquet(sample_parquet, relocatable=True)
+    first_build = build_expr(t, builds_dir=builds_dir / "first")
+    loaded = load_expr(first_build)
+
+    second_build = build_expr(loaded, builds_dir=builds_dir / "second")
+
+    sample_parquet.unlink()
+    first_build_reads = list((first_build / "reads").glob("*"))
+    for f in first_build_reads:
+        f.unlink()
+
+    result = load_expr(second_build).execute()
+    assert len(result) == 3
+    assert sorted(result.x.tolist()) == [1, 2, 3]
+
+
 def test_mark_reads_relocatable_skips_remote(sample_parquet: pathlib.Path) -> None:
     """_mark_reads_relocatable should not inject relocatable for remote paths."""
     local_t = deferred_read_parquet(sample_parquet)

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -573,7 +573,7 @@ def warn_on_local_path(items: Iterable[tuple[str, Any]]) -> None:
         return not parsed.scheme or parsed.scheme == "file"
 
     kw = dict(items)
-    if "read_path" in kw or kw.get("relocatable", False):
+    if kw.get("relocatable", False):
         return
     if path := next((v for k, v in kw.items() if k in ("hash_path", "source")), None):
         f = toolz.excepts((ValueError, AttributeError), is_local_path)

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -568,8 +568,8 @@ def _remotetable_from_yaml(yaml_dict: dict, context: TranslationContext) -> ir.E
 def warn_on_local_path(items: Iterable[tuple[str, Any]]) -> None:
     from urllib.parse import urlparse  # noqa: PLC0415
 
-    def is_local_path(any: str | Path) -> bool:
-        parsed = urlparse(any)
+    def is_local_path(value: str | Path) -> bool:
+        parsed = urlparse(value)
         return not parsed.scheme or parsed.scheme == "file"
 
     kw = dict(items)

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -5,7 +5,7 @@ import datetime
 import decimal
 import functools
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -565,7 +565,7 @@ def _remotetable_from_yaml(yaml_dict: dict, context: TranslationContext) -> ir.E
     return remote_table_expr
 
 
-def warn_on_local_path(items: dict) -> None:
+def warn_on_local_path(items: Iterable[tuple[str, Any]]) -> None:
     from urllib.parse import urlparse  # noqa: PLC0415
 
     def is_local_path(any: str | Path) -> bool:
@@ -573,7 +573,7 @@ def warn_on_local_path(items: dict) -> None:
         return not parsed.scheme or parsed.scheme == "file"
 
     kw = dict(items)
-    if "read_path" in kw:
+    if "read_path" in kw or kw.get("relocatable", False):
         return
     if path := next((v for k, v in kw.items() if k in ("hash_path", "source")), None):
         f = toolz.excepts((ValueError, AttributeError), is_local_path)

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -572,14 +572,18 @@ def warn_on_local_path(items: dict) -> None:
         parsed = urlparse(any)
         return not parsed.scheme or parsed.scheme == "file"
 
-    if path := next(
-        (v for k, v in dict(items).items() if k in ("hash_path", "source")), None
-    ):
+    kw = dict(items)
+    if "read_path" in kw:
+        return
+    if path := next((v for k, v in kw.items() if k in ("hash_path", "source")), None):
         f = toolz.excepts((ValueError, AttributeError), is_local_path)
         paths = normalize_filenames(path)
         if any(map(f, paths)):
             warnings.warn(
-                "The Read op path is using a local filesystem path, running the build may not work in other environments.",
+                "The Read op path is using a local filesystem path, running"
+                " the build may not work in other environments. Consider"
+                " using relocatable=True in deferred_read_parquet/deferred_read_csv"
+                " or --relocate-reads when building.",
                 stacklevel=2,
             )
 

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -99,7 +99,7 @@ def test_build_command_relocate_reads(tmp_path: Path) -> None:
 
     script = tmp_path / "script.py"
     script.write_text(
-        f"from xorq.common.utils.defer_utils import deferred_read_parquet\n"
+        "from xorq.common.utils.defer_utils import deferred_read_parquet\n"
         f"expr = deferred_read_parquet('{parquet_path}')\n"
     )
     builds_dir = tmp_path / "builds"

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -92,6 +92,26 @@ def test_build_command_function(tmp_path, fixture_dir):
     assert builds_dir.exists()
 
 
+def test_build_command_relocate_reads(tmp_path: Path) -> None:
+    """--relocate-reads flag should plumb through build_command and bundle local files."""
+    parquet_path = tmp_path / "input.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3]}), parquet_path)
+
+    script = tmp_path / "script.py"
+    script.write_text(
+        f"from xorq.common.utils.defer_utils import deferred_read_parquet\n"
+        f"expr = deferred_read_parquet('{parquet_path}')\n"
+    )
+    builds_dir = tmp_path / "builds"
+    build_command(str(script), "expr", str(builds_dir), relocate_reads=True)
+
+    build_dirs = list(builds_dir.iterdir())
+    assert len(build_dirs) == 1
+    reads_dir = build_dirs[0] / "reads"
+    assert reads_dir.exists(), "reads/ directory should be created by relocate_reads"
+    assert list(reads_dir.glob("*.parquet"))
+
+
 def test_build_command(tmp_path, fixture_dir):
     builds_dir = tmp_path / "builds"
     script_path = fixture_dir / "pipeline.py"


### PR DESCRIPTION
## Summary
- Bundle local-file Read nodes into build artifacts so expressions can be executed without access to the original source files
- Add `--relocate-reads` CLI flag to `xorq build` for opting in to file bundling
- Use content-hash normalization for relocatable reads to ensure deterministic build hashes
- Extract `Read.IDENTITY_KEYS` for consistent key handling across caching and tokenization
- Comprehensive test coverage for relocatable reads (round-trip, CSV/Parquet, multi-join, idempotency, edge cases)

## Test plan
- [x] Relocatable parquet reads survive deletion of original file
- [x] `--relocate-reads` flag bundles non-relocatable Read nodes
- [x] CSV reads with relocatable flag work correctly
- [x] Multiple joined relocatable reads are all bundled
- [x] Relocatable flag changes build hash
- [x] Remote schemes (http, s3, gs) are skipped by relocatable marking
- [x] Round-trip preserves relocatable flag
- [x] Idempotency of `_mark_reads_relocatable`
- [x] `xorq-check-style` passes on all changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)