### PR TITLE
test: add file_utils.file_digest coverage

### DIFF
--- a/python/xorq/common/utils/tests/test_file_utils.py
+++ b/python/xorq/common/utils/tests/test_file_utils.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+
+from xorq.common.utils.file_utils import file_digest
+
+
+def test_file_digest_str_path(tmp_path):
+    p = tmp_path / "data.bin"
+    p.write_bytes(b"hello")
+    expected = hashlib.md5(b"hello").hexdigest()
+    assert file_digest(str(p)) == expected
+
+
+def test_file_digest_path_object(tmp_path):
+    p = tmp_path / "data.bin"
+    p.write_bytes(b"hello")
+    expected = hashlib.md5(b"hello").hexdigest()
+    assert file_digest(p) == expected
+
+
+def test_file_digest_cached_returns_same(tmp_path):
+    p = tmp_path / "data.bin"
+    p.write_bytes(b"hello")
+    first = file_digest(p)
+    second = file_digest(p)
+    assert first == second
+
+
+def test_file_digest_unsupported_type_raises():
+    obj = io.BytesIO(b"hello")
+    if hasattr(hashlib, "file_digest"):
+        with pytest.raises(ValueError, match="Don't know how to handle type"):
+            file_digest(obj)
+    else:
+        result = file_digest(obj)
+        assert result == hashlib.md5(b"hello").hexdigest()


### PR DESCRIPTION
## Summary
- Add tests for `file_digest` in `xorq.common.utils.file_utils` — previously untested
- Covers str paths, Path objects, caching consistency, and the `ValueError` branch for unsupported types on Python 3.11+

Follow-up to #2070 (relocatable reads), which refactored `file_digest` to add caching and a new code path.

## Test plan
- [x] `pytest python/xorq/common/utils/tests/test_file_utils.py` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)