### PR TITLE
fix: uncached strips caches nested in Flight/UDF opaque sub-exprs

### DIFF
--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -30,28 +30,9 @@ from xorq.vendor.ibis.expr.operations import Node, Relation
 def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
     if kwargs:
         node = node.__recreate__(kwargs)
-
-    match node:
-        case CachedNode():
-            return node.parent.op().replace(replace_cache_table)
-        case RemoteTable():
-            return node.remote_expr.op().replace(replace_cache_table)
-        case FlightExpr() | FlightUDXF():
-            input_expr = node.input_expr.op().replace(replace_cache_table).to_expr()
-            return node.__recreate__(
-                dict(zip(node.__argnames__, node.__args__)) | {"input_expr": input_expr}
-            )
-        case _:
-            from xorq.expr.udf import ExprScalarUDF  # noqa: PLC0415
-
-            if isinstance(node, ExprScalarUDF):
-                cke = (
-                    node.computed_kwargs_expr.op()
-                    .replace(replace_cache_table)
-                    .to_expr()
-                )
-                return node.with_computed_kwargs_expr(cke)
-            return node
+    if isinstance(node, CachedNode):
+        return node.parent.op()
+    return node
 
 
 # https://stackoverflow.com/questions/6703594/is-the-result-of-itertools-tee-thread-safe-python

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -27,7 +27,7 @@ from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node, Relation
 
 
-def replace_cache_table(node, kwargs):
+def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
     if kwargs:
         node = node.__recreate__(kwargs)
 
@@ -36,7 +36,21 @@ def replace_cache_table(node, kwargs):
             return node.parent.op().replace(replace_cache_table)
         case RemoteTable():
             return node.remote_expr.op().replace(replace_cache_table)
+        case FlightExpr() | FlightUDXF():
+            input_expr = node.input_expr.op().replace(replace_cache_table).to_expr()
+            return node.__recreate__(
+                dict(zip(node.__argnames__, node.__args__)) | {"input_expr": input_expr}
+            )
         case _:
+            from xorq.expr.udf import ExprScalarUDF  # noqa: PLC0415
+
+            if isinstance(node, ExprScalarUDF):
+                cke = (
+                    node.computed_kwargs_expr.op()
+                    .replace(replace_cache_table)
+                    .to_expr()
+                )
+                return node.with_computed_kwargs_expr(cke)
             return node
 
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -30,8 +30,8 @@ from xorq.vendor.ibis.expr.operations import Node, Relation
 def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
     if kwargs:
         node = node.__recreate__(kwargs)
-    if isinstance(node, CachedNode):
-        return node.parent.op()
+    while isinstance(node, CachedNode):
+        node = node.parent.op()
     return node
 
 

--- a/python/xorq/tests/test_ls_accessor.py
+++ b/python/xorq/tests/test_ls_accessor.py
@@ -4,16 +4,21 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from toolz import identity
 
 import xorq.api as xo
+import xorq.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations.relations as rel
+from xorq import udf
 from xorq.backends.xorq_datafusion import Backend
 from xorq.caching import (
     ParquetCache,
     ParquetSnapshotCache,
 )
 from xorq.common.utils.graph_utils import walk_nodes
-from xorq.expr.relations import CachedNode
+from xorq.expr.relations import CachedNode, FlightExpr, FlightUDXF
+from xorq.expr.udf import ExprScalarUDF
+from xorq.vendor import ibis
 
 
 @pytest.fixture
@@ -130,6 +135,96 @@ def test_uncached_strips_cache_inside_remote_expr(tmp_path: Path) -> None:
 
     result = expr.ls.uncached
     assert not walk_nodes((CachedNode,), result)
+
+
+def test_uncached_strips_cache_inside_flight_expr(tmp_path: Path) -> None:
+    con = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3]}), "t")
+    cache = ParquetSnapshotCache.from_kwargs(source=con, relative_path=tmp_path)
+    cached = t.cache(cache=cache)
+    expr = FlightExpr(
+        name="test_flight",
+        schema=cached.schema(),
+        source=con,
+        input_expr=cached,
+        unbound_expr=xo.table(cached.schema(), name="u"),
+        make_server=identity,
+        make_connection=identity,
+    ).to_expr()
+
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CachedNode,), expr.ls.uncached)
+
+
+def test_uncached_strips_cache_inside_flight_udxf(tmp_path: Path) -> None:
+    con = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3]}), "t")
+    cache = ParquetSnapshotCache.from_kwargs(source=con, relative_path=tmp_path)
+    cached = t.cache(cache=cache)
+
+    class DummyUDXF:
+        schema_in_required = None
+
+        @staticmethod
+        def schema_in_condition(sch):
+            return True
+
+        @staticmethod
+        def calc_schema_out(sch):
+            return sch
+
+    expr = FlightUDXF(
+        name="test_udxf",
+        schema=cached.schema(),
+        source=con,
+        input_expr=cached,
+        udxf=DummyUDXF,
+        make_server=identity,
+        make_connection=identity,
+    ).to_expr()
+
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CachedNode,), expr.ls.uncached)
+
+
+def test_uncached_strips_cache_inside_expr_scalar_udf(tmp_path: Path) -> None:
+    con = xo.connect()
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    data = con.register(df, "data").select("x")
+    schema = data.schema()
+    cache = ParquetSnapshotCache.from_kwargs(source=con, relative_path=tmp_path)
+
+    @udf.agg.pandas_df(schema=schema, return_type=dt.float64, name="my_sum")
+    def my_sum(frame):
+        return frame["x"].astype(float).sum()
+
+    cached = data.cache(cache=cache)
+    computed_kwargs_expr = my_sum.on_expr(cached).name("my_sum").as_table()
+
+    predict_udf = udf.make_pandas_expr_udf(
+        computed_kwargs_expr=computed_kwargs_expr,
+        fn=lambda value, frame, **kw: (frame["x"] + float(value)).astype(float),
+        schema=ibis.schema({"x": dt.float64}),
+        name="add_sum",
+        return_type=dt.float64,
+        post_process_fn=identity,
+    )
+
+    expr = data.mutate(out=predict_udf.on_expr(data)).as_table()
+
+    assert walk_nodes((ExprScalarUDF,), expr)
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CachedNode,), expr.ls.uncached)
+
+
+def test_uncached_strips_nested_cached_nodes(tmp_path: Path) -> None:
+    con = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3]}), "t")
+    cache = ParquetSnapshotCache.from_kwargs(source=con, relative_path=tmp_path)
+    expr = t.cache(cache=cache).cache(cache=cache)
+
+    assert len(walk_nodes((CachedNode,), expr)) == 2
+    assert not walk_nodes((CachedNode,), expr.ls.uncached)
 
 
 @pytest.mark.postgres

--- a/python/xorq/tests/test_ls_accessor.py
+++ b/python/xorq/tests/test_ls_accessor.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 import xorq.api as xo
@@ -7,7 +10,10 @@ import xorq.vendor.ibis.expr.operations.relations as rel
 from xorq.backends.xorq_datafusion import Backend
 from xorq.caching import (
     ParquetCache,
+    ParquetSnapshotCache,
 )
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import CachedNode
 
 
 @pytest.fixture
@@ -111,6 +117,19 @@ def test_has_cached(cached_two, cached_two_joined):
 @pytest.mark.postgres
 def test_uncached(cached_two):
     assert cached_two.ls.has_cached and not cached_two.ls.uncached.ls.has_cached
+
+
+def test_uncached_strips_cache_inside_remote_expr(tmp_path: Path) -> None:
+    """uncached must strip CachedNodes nested inside opaque sub-expressions."""
+    cona = xo.connect()
+    conb = xo.connect()
+    t = cona.register(pd.DataFrame({"a": [1, 2, 3]}), "t")
+    cache = ParquetSnapshotCache.from_kwargs(source=cona, relative_path=tmp_path)
+    cached = t.cache(cache=cache)
+    expr = cached.into_backend(conb, "moved")
+
+    result = expr.ls.uncached
+    assert not walk_nodes((CachedNode,), result)
 
 
 @pytest.mark.postgres

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -1219,11 +1219,11 @@ class LETSQLAccessor:
             The expression with all `CachedNode` layers stripped. Returned
             unchanged when the graph has no cache nodes.
         """
+        from xorq.common.utils.graph_utils import replace_nodes
         from xorq.expr.relations import replace_cache_table
 
         if self.has_cached:
-            op = self.expr.op()
-            return op.replace(replace_cache_table).to_expr()
+            return replace_nodes(replace_cache_table, self.expr).to_expr()
         else:
             return self.expr
 

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -1219,13 +1219,11 @@ class LETSQLAccessor:
             The expression with all `CachedNode` layers stripped. Returned
             unchanged when the graph has no cache nodes.
         """
-        from xorq.expr.relations import CachedNode, RemoteTable, replace_cache_table
+        from xorq.expr.relations import replace_cache_table
 
         if self.has_cached:
             op = self.expr.op()
-            return op.replace(
-                replace_cache_table, filter=(RemoteTable, CachedNode)
-            ).to_expr()
+            return op.replace(replace_cache_table).to_expr()
         else:
             return self.expr
 


### PR DESCRIPTION
## Summary

- `replace_cache_table` (used by `.uncached`) manually descended into `CachedNode.parent` and `RemoteTable.remote_expr` but missed `FlightExpr.input_expr`, `FlightUDXF.input_expr`, and `ExprScalarUDF.computed_kwargs_expr`
- Refactored `replace_cache_table` to delegate opaque sub-expression traversal to `replace_nodes` from `graph_utils`, which already handles all opaque types with memoization and raises on unhandled types
- `replace_cache_table` is now 5 lines — it only unwraps `CachedNode` layers; all opaque-node recursion is handled by `replace_nodes`
- Use `while` instead of `if` to unwrap all `CachedNode` layers, fixing nested caches (e.g. `t.cache().cache()`)

## Test plan

- [x] New test: `.uncached` strips caches nested inside `RemoteTable.remote_expr`
- [x] New test: `.uncached` strips caches nested inside `FlightExpr.input_expr`
- [x] New test: `.uncached` strips caches nested inside `FlightUDXF.input_expr`
- [x] New test: `.uncached` strips caches nested inside `ExprScalarUDF.computed_kwargs_expr`
- [x] New test: `.uncached` strips nested `CachedNode` layers (`t.cache().cache()`)
- [x] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)