### PR TITLE
fix: execution pipeline descends into opaque sub-exprs

### DIFF
--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -4,11 +4,18 @@ import contextlib
 import contextvars
 import pathlib
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 
 from attr import field, frozen
 from attr.validators import instance_of
 
 from xorq.common.constants import READ_IDENTITY_KEYS
+
+
+if TYPE_CHECKING:
+    from xorq_dasher import Hasher
+
+    from xorq.vendor.ibis import Expr
 
 
 # Per-outer-call memo for ``SnapshotStrategy.normalize_databasetable``.
@@ -133,10 +140,14 @@ class SnapshotStrategy(CacheStrategy):
         ]
         return snapshot_hasher(*extra)
 
-    def _replace_remote_table(self, expr, local_hasher):
+    def _replace_remote_table(self, expr: Expr, local_hasher: Hasher) -> Expr:
+        from xorq.common.utils.graph_utils import (  # noqa: PLC0415
+            replace_nodes,
+            walk_nodes,
+        )
         from xorq.expr.relations import RemoteTable  # noqa: PLC0415
 
-        if expr.op().find(RemoteTable):
+        if walk_nodes((RemoteTable,), expr):
 
             def rename(node, kwargs):
                 if isinstance(node, RemoteTable):
@@ -149,7 +160,7 @@ class SnapshotStrategy(CacheStrategy):
                     )
                 return node.__recreate__(kwargs) if kwargs else node
 
-            return expr.op().replace(rename).to_expr()
+            return replace_nodes(rename, expr).to_expr()
         return expr
 
     @staticmethod

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -121,7 +121,7 @@ def replace_nodes(replacer, expr):
                 remote_expr = _replace_sub(op.remote_expr.op())
                 return do_recreate(op, _kwargs, remote_expr=remote_expr)
             case rel.CachedNode():
-                parent = _replace_sub(op.parent.op())
+                parent = _replace_sub(to_node(op.parent))
                 return do_recreate(op, _kwargs, parent=parent)
             case rel.FlightExpr() | rel.FlightUDXF():
                 input_expr = _replace_sub(op.input_expr.op())
@@ -137,7 +137,8 @@ def replace_nodes(replacer, expr):
                     raise ValueError(f"unhandled opaque op {type(op)}")
                 return op
 
-    initial_op = expr.op() if hasattr(expr, "op") else expr
+    # hasattr(x, "op") is unreliable: some Nodes have an `op` field (e.g. IntervalAdd)
+    initial_op = to_node(expr)
     op = initial_op.replace(process_node)
     return op
 

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -242,7 +242,7 @@ def _register_and_transform_cache_tables(expr):
             )
         return node
 
-    out = op.replace(fn)
+    out = replace_nodes(fn, expr)
 
     return out.to_expr()
 
@@ -275,7 +275,7 @@ def _transform_deferred_reads(expr):
                 node = node.__recreate__(_kwargs)
         return node
 
-    expr = expr.op().replace(replace_read).to_expr()
+    expr = replace_nodes(replace_read, expr).to_expr()
     return expr, dt_to_read
 
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -584,7 +584,9 @@ _count = itertools.count()
 
 
 @tracer.start_as_current_span("register_and_transform_remote_tables")
-def register_and_transform_remote_tables(expr, **kwargs):
+def register_and_transform_remote_tables(
+    expr: Expr, **kwargs: Any
+) -> tuple[Expr, dict]:
     created = {}
 
     op = expr.op()
@@ -650,6 +652,8 @@ def register_and_transform_remote_tables(expr, **kwargs):
 
         return node
 
+    # Intentionally op.replace, not replace_nodes: mark_remote_table has side effects
+    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr)
     expr = op.replace(replacer).to_expr()
     return expr, created
 

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -24,7 +24,7 @@ from xorq.caching import (
     SourceCache,
     SourceSnapshotCache,
 )
-from xorq.caching.strategy import snapshot_normalize_read
+from xorq.caching.strategy import SnapshotStrategy, snapshot_normalize_read
 from xorq.catalog.backend import GitBackend
 from xorq.catalog.catalog import Catalog
 from xorq.common.constants import READ_IDENTITY_KEYS
@@ -1579,7 +1579,7 @@ def test_mark_reads_relocatable_is_idempotent(sample_parquet: pathlib.Path) -> N
     assert tokenize(once) == tokenize(twice)
 
 
-def test_cache_dir_reaches_remote_expr_nested_cache(tmp_path):
+def test_cache_dir_reaches_remote_expr_nested_cache(tmp_path: pathlib.Path) -> None:
     cona = xo.connect()
     conb = xo.connect()
     t = cona.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "t")
@@ -1602,3 +1602,51 @@ def test_cache_dir_reaches_remote_expr_nested_cache(tmp_path):
     assert cached_nodes
     for cn in cached_nodes:
         assert cn.cache.storage.base_path == target
+
+
+# ---------------------------------------------------------------------------
+# Execution pipeline descends into opaque sub-expressions
+# ---------------------------------------------------------------------------
+
+
+def test_execution_handles_cache_in_remote_expr(tmp_path: pathlib.Path) -> None:
+    """Caches nested inside RemoteTable.remote_expr must be executed."""
+    cona = xo.connect()
+    conb = xo.connect()
+    t = cona.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "t")
+    cache = ParquetSnapshotCache.from_kwargs(
+        source=cona, relative_path="c", base_path=tmp_path
+    )
+    cached = t.mutate(s=t.a + t.b).cache(cache=cache)
+    expr = cached.into_backend(conb, "moved")
+
+    # Verify that there really is a CachedNode nested inside a RemoteTable
+    remote_tables = walk_nodes((RemoteTable,), expr)
+    assert remote_tables, "expected at least one RemoteTable"
+    nested_caches = [
+        cn for rt in remote_tables for cn in walk_nodes((CachedNode,), rt.remote_expr)
+    ]
+    assert nested_caches, "expected a CachedNode nested in remote_expr"
+
+    # Should execute without error — the cache inside remote_expr gets found
+    result = expr.execute()
+    assert len(result) == 3
+
+
+def test_hashing_handles_remote_table_in_opaque_subexpr(tmp_path: pathlib.Path) -> None:
+    """_replace_remote_table must find RemoteTables nested in opaque sub-exprs."""
+    cona = xo.connect()
+    conb = xo.connect()
+    t = cona.register(pd.DataFrame({"x": [10, 20]}), "t")
+    inner_cache = ParquetSnapshotCache.from_kwargs(
+        source=cona, relative_path="inner", base_path=tmp_path / "inner"
+    )
+    cached = t.cache(cache=inner_cache)
+    expr = cached.into_backend(conb, "moved")
+
+    # Hashing the expression should not raise, and the key should be stable
+    strategy = SnapshotStrategy(key_prefix="test-")
+    key1 = strategy.calc_key(expr)
+    key2 = strategy.calc_key(expr)
+    assert key1 == key2
+    assert key1.startswith("test-snapshot-")

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -13,10 +13,13 @@ import pyarrow.parquet as pq
 import pytest
 import toolz
 import yaml12
+from toolz import identity
 
 import xorq.api as xo
+import xorq.expr.datatypes as dt
 import xorq.vendor.ibis as ibis
 import xorq.vendor.ibis.expr.operations.relations as rel
+from xorq import udf
 from xorq.caching import (
     ParquetCache,
     ParquetSnapshotCache,
@@ -38,6 +41,7 @@ from xorq.common.utils.graph_utils import find_all_sources, walk_nodes
 from xorq.common.utils.name_utils import get_uid_prefix
 from xorq.conftest import array_types_df
 from xorq.expr.relations import CachedNode, Read, RemoteTable
+from xorq.expr.udf import ExprScalarUDF
 from xorq.ibis_yaml.compiler import (
     ArtifactStore,
     DumpFiles,
@@ -1650,3 +1654,54 @@ def test_hashing_handles_remote_table_in_opaque_subexpr(tmp_path: pathlib.Path) 
     key2 = strategy.calc_key(expr)
     assert key1 == key2
     assert key1.startswith("test-snapshot-")
+
+
+def test_execution_handles_remote_table_in_computed_kwargs_expr(
+    tmp_path: pathlib.Path,
+) -> None:
+    """RemoteTables nested inside ExprScalarUDF.computed_kwargs_expr must be
+    materialized lazily when the UDF is compiled, not during the outer
+    register_and_transform_remote_tables pass (which intentionally skips
+    opaque sub-expressions)."""
+    cona = xo.connect()
+    conb = xo.connect()
+
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    data = cona.register(df, "data").select("x")
+    schema = data.schema()
+
+    @udf.agg.pandas_df(schema=schema, return_type=dt.float64, name="my_sum")
+    def my_sum(frame):
+        return frame["x"].astype(float).sum()
+
+    # Build computed_kwargs_expr with a RemoteTable: aggregate on data moved
+    # to a different backend, so the expression tree contains a RemoteTable.
+    remote_data = data.into_backend(conb, "remote_data")
+    computed_kwargs_expr = my_sum.on_expr(remote_data).name("my_sum").as_table()
+
+    # Verify the RemoteTable is actually nested inside the computed_kwargs_expr
+    assert walk_nodes((RemoteTable,), computed_kwargs_expr), (
+        "expected a RemoteTable in computed_kwargs_expr"
+    )
+
+    predict_udf = udf.make_pandas_expr_udf(
+        computed_kwargs_expr=computed_kwargs_expr,
+        fn=lambda value, frame, **kw: (frame["x"] + float(value)).astype(float),
+        schema=ibis.schema({"x": dt.float64}),
+        name="add_remote_sum",
+        return_type=dt.float64,
+        post_process_fn=identity,
+    )
+
+    expr = data.mutate(out=predict_udf.on_expr(data)).as_table()
+
+    # The outer expression contains an ExprScalarUDF whose computed_kwargs_expr
+    # holds a RemoteTable — this RemoteTable is opaque to op.replace and must
+    # be materialized lazily during _compile_pyarrow_expr_udf.
+    assert walk_nodes((ExprScalarUDF,), expr)
+
+    result = expr.execute()
+    assert len(result) == 3
+    # my_sum(1+2+3) = 6.0; each row: x + 6.0
+    expected_out = [7.0, 8.0, 9.0]
+    assert list(result["out"]) == expected_out


### PR DESCRIPTION
## Summary

- Switch pure structural rewrites (`_replace_remote_table`, `_register_and_transform_cache_tables`, `_transform_deferred_reads`) from ibis's `op.replace` to `replace_nodes`, which recursively descends into opaque sub-expressions (`RemoteTable.remote_expr`, `CachedNode.parent`, `FlightExpr.input_expr`, `ExprScalarUDF.computed_kwargs_expr`)
- Keep `register_and_transform_remote_tables` on `op.replace` — its replacer has side effects (`mark_remote_table`) that must not fire for RemoteTables nested inside `ExprScalarUDF.computed_kwargs_expr`, which are handled lazily during UDF execution
- Fix `_replace_remote_table` guard (`op().find`) to use `walk_nodes`
- Fix `replace_nodes` CachedNode case to use `to_node(op.parent)` since parent can be a Node after the replacer runs
- Fix `replace_nodes` entry point to use `to_node(expr)` instead of `hasattr(expr, "op")` which false-positives on arithmetic ops like `IntervalAdd`

## Test plan

- [x] New tests verify execution and hashing handle nested opaque sub-exprs
- [x] `demonstrate_ir_two_categorical` and `sklearn_home_run_prediction` examples pass
- [x] `deferred_fit_transform_example` passes
- [x] `test_interval_arithmetic` passes
- [x] Full `test_compiler.py` suite passes (92 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)