### PR TITLE
docs(concepts): expand explanation stubs (#2029)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -102,6 +102,7 @@ website:
           contents:
             - concepts/understanding_xorq/what_is_xorq.qmd
             - concepts/understanding_xorq/why_deferred_execution.qmd
+            - concepts/understanding_xorq/why_content_addressed_artifacts.qmd
             - concepts/understanding_xorq/catalog_as_executable_memory.qmd
             - concepts/understanding_xorq/expression_types.qmd
         - id: execution-backends-section

--- a/docs/concepts/understanding_xorq/why_content_addressed_artifacts.qmd
+++ b/docs/concepts/understanding_xorq/why_content_addressed_artifacts.qmd
@@ -1,0 +1,123 @@
+---
+title: "Content-addressed artifacts"
+---
+
+Most systems name things by *where* or *when*: a path, a timestamp, a
+version number someone bumped by hand. Xorq names things by *what they contain*. An
+artifact's name is a deterministic hash of the computation that produces it, so
+identical computations get identical names and different computations get
+different names—automatically, with no bookkeeping. This is **content
+addressing**, and it's the mechanism underneath both Xorq's
+[cache](intelligent_caching_system.qmd) and its
+[catalog](catalog_as_executable_memory.qmd).
+
+This page explains what that hash is, why Xorq is built around it, and what it
+buys you in practice.
+
+## What gets hashed
+
+The hash is computed over the [expression
+graph](why_deferred_execution.qmd)—the tree of operations you built—not over the
+data the graph produces and not over the wall-clock time you built it. Two
+expressions that describe the same computation hash to the same value; change any
+operation in the graph and the hash changes.
+
+You can see this directly. The same pipeline built twice produces the same hash;
+widen the filter and you get a different one:
+
+```{python}
+import xorq.api as xo
+
+con = xo.connect()
+iris = xo.examples.iris.fetch(backend=con)
+
+def pipeline(threshold):
+    return (
+        iris.filter(xo._.sepal_length > threshold)
+        .group_by("species")
+        .agg(n=xo._.species.count())
+    )
+
+a = pipeline(6)
+b = pipeline(6)   # same computation
+c = pipeline(5)   # one operand changed
+
+print(f"a: {a.ls.tokenized}")
+print(f"b: {b.ls.tokenized}")
+print(f"c: {c.ls.tokenized}")
+print(f"a == b (same pipeline):     {a.ls.tokenized == b.ls.tokenized}")
+print(f"a == c (filter changed):    {a.ls.tokenized == c.ls.tokenized}")
+```
+
+The hash is deterministic and stable across processes and machines: it depends
+only on the structure of the computation, so the same pipeline run tomorrow on
+another host produces the same name. Note that it fingerprints the
+*specification*, not the bytes of the output—a run can still differ in timestamps
+or floating-point rounding, but its identity as a computation is fixed.
+
+## Why Xorq uses it
+
+Three properties fall out of naming by content, and Xorq leans on all three.
+
+**Reproducibility.** A name that's a function of the computation is a name that
+can't drift. `final_v2_fixed.parquet` tells you nothing about what's inside;
+`8b4472fbeb97` *is* the computation. If you have the hash, you can ask for
+exactly that artifact and know you got the right one.
+
+**Cache validity.** A cache is only useful if you can answer whether this exact
+computation has run before. Content addressing makes that a dictionary lookup: hash the
+expression, check whether the key exists. Xorq's
+[`ModificationTimeStrategy`](intelligent_caching_system.qmd) folds the source's
+change metadata into the hash, so when upstream data changes the key changes, the
+old key misses, and the result recomputes. Invalidation isn't a timer or a
+watcher—it's a key that stops matching when its inputs change.
+
+**Artifact identity.** When two artifacts share a hash they *are* the same
+computation; when the hashes differ, something in the graph or its inputs
+changed. The name can't lie about what the artifact does. That honesty is what
+lets a catalog dedupe, share, and reuse entries without trusting a human-chosen
+label.
+
+## What it means in practice
+
+The practical payoff is that *reuse is automatic*. Build the same pipeline twice
+and the second build is a no-op—the artifact already exists under that name, so
+there is nothing to recompute and nothing to ask. You never write "did someone
+already produce this?" logic; identical computations collapse to one artifact by
+construction.
+
+This is the opposite of prose or vector memory, which has to dedupe explicitly—
+comparing embeddings or running similarity heuristics—because two records of the
+same fact look different on disk. Content addressing makes that question
+disappear.
+
+## Connection to the catalog
+
+A [Xorq catalog](catalog_as_executable_memory.qmd) is a git repository of build
+artifacts, and content addressing is how it names them. Each entry is a zipped
+build named by its content hash:
+
+```
+git-catalogs/penguins
+├── aliases
+│   └── penguins-agg.zip -> ../entries/fa2122f6a9e9.zip
+├── entries
+│   └── fa2122f6a9e9.zip
+└── metadata
+    └── fa2122f6a9e9.zip.metadata.yaml
+```
+
+The hash is the identity; an **alias** is a human-readable symlink—
+`penguins-agg`—pointing at whatever hash is current. As the pipeline evolves the
+hash moves and the alias follows. The hash answers *what is this*; the alias
+answers *which one do I want*. Because the name is derived from the computation,
+the catalog gets deduplication, honest provenance, and conflict-free sharing for
+free—the same git repo two people clone can never disagree about what an entry
+contains.
+
+::: {.callout-tip}
+### Where to go next
+- [Deferred execution](why_deferred_execution.qmd)—the graph that gets hashed.
+- [Caching](intelligent_caching_system.qmd)—how the hash becomes a cache key and drives invalidation.
+- [The catalog as executable memory](catalog_as_executable_memory.qmd)—how content-addressed entries become shareable, runnable memory.
+:::

--- a/docs/concepts/understanding_xorq/why_deferred_execution.qmd
+++ b/docs/concepts/understanding_xorq/why_deferred_execution.qmd
@@ -2,5 +2,131 @@
 title: "Deferred Execution"
 ---
 
-Deferred execution is a core architectural principle in Xorq that builds computational graphs rather than immediately executing operations. This approach enables powerful optimizations, cross-engine portability, and efficient resource management - similar to how [Polars Lazy](https://docs.pola.rs/user-guide/concepts/lazy-api/), and [Dask Delayed](https://docs.dask.org/en/stable/delayed.html) work, but specifically designed for ML pipelines and multi-engine data workflows.
+Deferred execution is the architectural choice that everything else in Xorq
+builds on. When you chain operations on a Xorq expression, nothing runs. Xorq
+records *what you asked for* as a graph of operations and waits. Computation
+happens only when you explicitly ask for results—`.execute()`, `.to_pandas()`,
+`.to_pyarrow()`. The same approach drives [Polars
+Lazy](https://docs.pola.rs/user-guide/concepts/lazy-api/) and [Dask
+Delayed](https://docs.dask.org/en/stable/delayed.html), but Xorq applies it to
+ML pipelines that span multiple engines.
 
+This page explains why the deferral is there and what you get for it. For a
+hands-on walkthrough of when computation fires, see the
+[Defer query execution](../../getting_started/understand_deferred_execution.qmd)
+tutorial.
+
+## What "deferred" means here
+
+A Xorq expression is a description, not a result. `iris.filter(...)` returns
+another expression; `.group_by(...).agg(...)` returns another still. Each call
+adds a node to an **expression graph**—a tree of operations rooted at a source
+table—and returns immediately without touching data. The graph is a value you
+can inspect, hash, serialize, and pass around. It's not the answer; it's the
+plan for computing the answer.
+
+Because the plan is a first-class object, Xorq can look at the *whole* pipeline
+before it runs any of it. An eager system sees one operation at a time and must
+commit to a result before it knows what comes next. A deferred system sees the
+filter, the join, the aggregation, and the cache boundary all at once, and gets
+to decide how to run them together.
+
+## Why it matters for ML pipelines
+
+ML pipelines are where the payoff shows up, for three reasons.
+
+**Full-pipeline optimization.** With the entire graph in hand, Xorq can prune
+columns that nothing downstream reads, push filters closer to the source so less
+data moves, and collapse redundant steps. Run the operations eagerly and each
+one materializes its result before the next is even known, so none of these
+rewrites are possible.
+
+**Cross-engine routing.** A real pipeline rarely lives in one engine. You might
+read from Postgres, do a heavy join in DuckDB, and run a model in Python. Because
+the graph names every backend boundary explicitly, Xorq can route each part to
+the engine that suits it and stream the data across the boundary—without you
+hand-coding the transfers. The graph is what makes
+[multi-engine execution](multi_engine_execution.qmd) automatic instead of manual.
+
+**A portable artifact.** A deferred graph can be serialized to a manifest and
+re-run elsewhere. That's what lets a build become a catalog entry: the plan
+travels, and a different machine reproduces the computation from it.
+
+## Eager versus deferred
+
+The difference is concrete. Build an expression and it stays an expression—no
+data has moved yet:
+
+```{python}
+import xorq.api as xo
+
+con = xo.connect()
+iris = xo.examples.iris.fetch(backend=con)
+
+# Deferred: still an expression; the full plan is visible to Xorq.
+deferred = (
+    iris.filter(xo._.sepal_length > 6)
+    .group_by("species")
+    .agg(avg_width=xo._.sepal_width.mean())
+)
+
+print(f"deferred is still an expression: {type(deferred).__module__}.{type(deferred).__name__}")
+```
+
+Force execution after the first step instead, and you hold materialized data—a
+table—that Xorq can no longer optimize or chain:
+
+```{python}
+# Eager: execute() runs now and returns data, so optimization stops here.
+immediate = iris.filter(xo._.sepal_length > 6).execute()
+
+print(f"immediate is materialized data: {type(immediate).__module__}.{type(immediate).__name__}")
+print(f"rows: {len(immediate)}")
+```
+
+In the eager line, the filter runs against the full table before the group-by
+exists, so Xorq can't fuse the two or push the predicate down. In the deferred
+graph, the filter, group-by, and aggregation are one plan; Xorq optimizes and
+runs them as a unit when you finally call `.execute()`:
+
+```{python}
+result = deferred.execute()
+print(result)
+```
+
+## The tradeoff
+
+Deferral isn't free. The result you want isn't there until you ask for it, and
+an expression that looks complete may still be hiding an error that surfaces only
+at execution time. The graph adds a layer of indirection between your code and
+your data, and debugging sometimes means reasoning about a plan rather than
+inspecting a value.
+
+The fix is to execute deliberately. Call `.execute()` early when you genuinely
+need materialized data—an exploratory peek at a sample, a value you have to
+branch on in Python, a result you'll hand to a library that doesn't speak Xorq.
+The rule of thumb: defer while you're still describing the pipeline, materialize
+when you've crossed into needing the data itself. Executing too early just throws
+away optimization Xorq would otherwise have done for you.
+
+## Connection to caching
+
+Deferred execution is what makes Xorq's [caching](intelligent_caching_system.qmd)
+possible at all. Because the pipeline is a known graph before it runs, Xorq can
+attach a cache to any node and compute a stable key for the computation that node
+represents. `.cache()` doesn't run anything—it inserts a `CachedNode` into the
+graph. On execution Xorq walks the graph, and at each cached node either reuses a
+stored result or computes and stores it.
+
+That only works because the structure is known up front. An eager system has no
+graph to attach a cache to and no way to ask whether this exact computation has
+run before—the computation is already gone by the time you'd ask. A deferred graph
+gives every node a stable identity, which is the same property that powers
+[content-addressed artifacts](why_content_addressed_artifacts.qmd).
+
+::: {.callout-tip}
+### Where to go next
+- [Defer query execution](../../getting_started/understand_deferred_execution.qmd)—a hands-on walkthrough of when computation fires.
+- [Multi-engine execution](multi_engine_execution.qmd)—how the graph routes work across backends.
+- [Caching](intelligent_caching_system.qmd)—how a known graph becomes cacheable nodes.
+:::


### PR DESCRIPTION
## What

Phase 2b of the docs IA work (#2023). Expands the thin Explanation concept pages.

- **`why_deferred_execution.qmd`** — expanded from a 1-line stub to a standalone
  explanation (~800 words of prose). Covers: graph-not-results model, why it
  matters for ML pipelines (full-pipeline optimization, cross-engine routing,
  portable artifact), an executable eager-vs-deferred example, the tradeoff and
  when to `.execute()` early, and the connection to caching.
- **`why_content_addressed_artifacts.qmd`** (new) — what gets hashed, why Xorq
  uses it (reproducibility, cache validity, artifact identity), automatic reuse,
  and the catalog connection. Includes an executable demo showing
  same-pipeline → same-hash via `expr.ls.tokenized`.
- **`intelligent_caching_system.qmd`** — assessed; already substantive (>800
  words of prose), so left as-is per the issue's skip clause.
- Registered the new page in the Concepts → Fundamentals nav.

## Verification

- All `{python}` code blocks are executable; both pages `quarto render` clean
  with no error cells.
- `vale` passes with 0 errors / 0 warnings / 0 suggestions, matching the
  existing concept pages.
- Cross-links resolve to existing pages.

Refs #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)