### PR TITLE
fix(duckdb): single-pass lowering for asof_join

### DIFF
--- a/python/xorq/backends/duckdb/tests/test_asof_join.py
+++ b/python/xorq/backends/duckdb/tests/test_asof_join.py
@@ -1,7 +1,9 @@
 import operator
+from datetime import datetime, timedelta
 
 import pytest
 
+import xorq.api as xo
 from xorq.vendor import ibis
 
 
@@ -99,3 +101,140 @@ def test_keyed_asof_join_with_tolerance(
 
     # check that time is equal in value, if not dtype
     tm.assert_series_equal(result["time"], expected["time"], check_dtype=False)
+
+
+# regression tests for xorq-labs/xorq#983: the tolerance lowering used to
+# reference the left source twice (filter + re-join), which silently broke
+# one-shot inputs and could fan out on duplicate left keys. The single-pass
+# null-out lowering must keep every left row exactly once.
+
+
+@pytest.fixture(scope="module")
+def sensors_df():
+    return pd.DataFrame(
+        {
+            "site": ["a", "b", "a", "b", "a"],
+            "humidity": [0.3, 0.4, 0.5, 0.6, 0.7],
+            "event_time": [
+                datetime(2024, 11, 16, 12, 0, 15, 500000),
+                datetime(2024, 11, 16, 12, 0, 15, 700000),
+                datetime(2024, 11, 17, 18, 12, 14, 950000),
+                datetime(2024, 11, 17, 18, 12, 15, 120000),
+                datetime(2024, 11, 18, 18, 12, 15, 100000),
+            ],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def events_df():
+    return pd.DataFrame(
+        {
+            "site": ["a", "b", "a"],
+            "event_type": ["cloud coverage", "rain start", "rain stop"],
+            "event_time": [
+                datetime(2024, 11, 16, 12, 0, 15, 400000),
+                datetime(2024, 11, 17, 18, 12, 15, 100000),
+                datetime(2024, 11, 18, 18, 12, 15, 100000),
+            ],
+        }
+    )
+
+
+def test_asof_tolerance_preserves_unmatched_left_rows(
+    duckdb_con, sensors_df, events_df
+):
+    # every left row must survive; out-of-tolerance matches get NULL right cols
+    left = duckdb_con.create_table("sensors_tol", sensors_df)
+    right = duckdb_con.create_table("events_tol", events_df)
+    expr = left.asof_join(
+        right, on="event_time", predicates="site", tolerance=timedelta(seconds=1)
+    )
+    result = expr.execute().sort_values(["site", "humidity"]).reset_index(drop=True)
+
+    assert len(result) == len(sensors_df)
+    matched = result.dropna(subset=["event_type"]).set_index("humidity")["event_type"]
+    assert matched.to_dict() == {
+        0.3: "cloud coverage",
+        0.6: "rain start",
+        0.7: "rain stop",
+    }
+    # the two out-of-tolerance rows are present with NULL right columns
+    assert set(result.loc[result["event_type"].isna(), "humidity"]) == {0.4, 0.5}
+
+
+def test_asof_tolerance_one_shot_reader(sensors_df, events_df):
+    # the actual issue #983: into_backend registers one-shot RecordBatchReaders;
+    # a double-scan lowering reads 0 rows on the second pass.
+    con = xo.duckdb.connect()
+    sensors = ibis.memtable(sensors_df)
+    events = ibis.memtable(events_df)
+    expr = (
+        sensors.into_backend(con, "sensors_rbr")
+        .asof_join(
+            events.into_backend(con, "events_rbr"),
+            on="event_time",
+            predicates="site",
+            tolerance=timedelta(seconds=1),
+        )
+        .order_by(["site", "humidity"])
+    )
+    result = expr.execute()
+
+    assert len(result) == len(sensors_df)
+    matched = result.dropna(subset=["event_type"]).set_index("humidity")["event_type"]
+    assert matched.to_dict() == {
+        0.3: "cloud coverage",
+        0.6: "rain start",
+        0.7: "rain stop",
+    }
+
+
+def test_asof_tolerance_boundary_inclusive(duckdb_con):
+    # a match exactly at the tolerance boundary must be kept (inclusive window)
+    left = duckdb_con.create_table(
+        "boundary_left",
+        pd.DataFrame(
+            {"key": [1], "time": [datetime(2024, 1, 1, 0, 0, 10)], "lv": [1.0]}
+        ),
+    )
+    right = duckdb_con.create_table(
+        "boundary_right",
+        pd.DataFrame(
+            {"key": [1], "time": [datetime(2024, 1, 1, 0, 0, 8)], "rv": [2.0]}
+        ),
+    )
+    expr = left.asof_join(
+        right, on="time", predicates="key", tolerance=timedelta(seconds=2)
+    )
+    result = expr.execute()
+    assert result["rv"].notna().all()
+    assert result["rv"].iloc[0] == 2.0
+
+
+def test_asof_tolerance_duplicate_left_keys(duckdb_con):
+    # duplicate left `on` values within a predicate group: the old re-join on
+    # left_on == right_on could fan out / mismatch; single pass keeps 1 row each
+    left = duckdb_con.create_table(
+        "dup_left",
+        pd.DataFrame(
+            {
+                "key": [1, 1, 1],
+                "time": [datetime(2024, 1, 1, 0, 0, 5)] * 3,
+                "lv": [10.0, 20.0, 30.0],
+            }
+        ),
+    )
+    right = duckdb_con.create_table(
+        "dup_right",
+        pd.DataFrame(
+            {"key": [1], "time": [datetime(2024, 1, 1, 0, 0, 5)], "rv": [99.0]}
+        ),
+    )
+    expr = left.asof_join(
+        right, on="time", predicates="key", tolerance=timedelta(seconds=1)
+    )
+    result = expr.execute()
+    # no fan-out: exactly the 3 left rows, each matched to the single right row
+    assert len(result) == 3
+    assert (result["rv"] == 99.0).all()

--- a/python/xorq/backends/duckdb/tests/test_asof_join.py
+++ b/python/xorq/backends/duckdb/tests/test_asof_join.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import pytest
 
 import xorq.api as xo
+from xorq.backends.duckdb import Backend
 from xorq.vendor import ibis
 
 
@@ -110,7 +111,7 @@ def test_keyed_asof_join_with_tolerance(
 
 
 @pytest.fixture(scope="module")
-def sensors_df():
+def sensors_df() -> "pd.DataFrame":
     return pd.DataFrame(
         {
             "site": ["a", "b", "a", "b", "a"],
@@ -127,7 +128,7 @@ def sensors_df():
 
 
 @pytest.fixture(scope="module")
-def events_df():
+def events_df() -> "pd.DataFrame":
     return pd.DataFrame(
         {
             "site": ["a", "b", "a"],
@@ -142,8 +143,10 @@ def events_df():
 
 
 def test_asof_tolerance_preserves_unmatched_left_rows(
-    duckdb_con, sensors_df, events_df
-):
+    duckdb_con: Backend,
+    sensors_df: "pd.DataFrame",
+    events_df: "pd.DataFrame",
+) -> None:
     # every left row must survive; out-of-tolerance matches get NULL right cols
     left = duckdb_con.create_table("sensors_tol", sensors_df)
     right = duckdb_con.create_table("events_tol", events_df)
@@ -163,7 +166,9 @@ def test_asof_tolerance_preserves_unmatched_left_rows(
     assert set(result.loc[result["event_type"].isna(), "humidity"]) == {0.4, 0.5}
 
 
-def test_asof_tolerance_one_shot_reader(sensors_df, events_df):
+def test_asof_tolerance_one_shot_reader(
+    sensors_df: "pd.DataFrame", events_df: "pd.DataFrame"
+) -> None:
     # the actual issue #983: into_backend registers one-shot RecordBatchReaders;
     # a double-scan lowering reads 0 rows on the second pass.
     con = xo.duckdb.connect()
@@ -190,7 +195,7 @@ def test_asof_tolerance_one_shot_reader(sensors_df, events_df):
     }
 
 
-def test_asof_tolerance_boundary_inclusive(duckdb_con):
+def test_asof_tolerance_boundary_inclusive(duckdb_con: Backend) -> None:
     # a match exactly at the tolerance boundary must be kept (inclusive window)
     left = duckdb_con.create_table(
         "boundary_left",
@@ -212,7 +217,7 @@ def test_asof_tolerance_boundary_inclusive(duckdb_con):
     assert result["rv"].iloc[0] == 2.0
 
 
-def test_asof_tolerance_duplicate_left_keys(duckdb_con):
+def test_asof_tolerance_duplicate_left_keys(duckdb_con: Backend) -> None:
     # duplicate left `on` values within a predicate group: the old re-join on
     # left_on == right_on could fan out / mismatch; single pass keeps 1 row each
     left = duckdb_con.create_table(
@@ -238,3 +243,44 @@ def test_asof_tolerance_duplicate_left_keys(duckdb_con):
     # no fan-out: exactly the 3 left rows, each matched to the single right row
     assert len(result) == 3
     assert (result["rv"] == 99.0).all()
+
+
+def test_asof_tolerance_multi_table_left_chain(duckdb_con: Backend) -> None:
+    # the left side is itself a multi-link join chain: the null-out projection
+    # discriminates columns by field origin, so columns from the earlier link
+    # (bv) must stay untouched while only the asof right columns (cv) get nulled
+    a = duckdb_con.create_table(
+        "chain_a",
+        pd.DataFrame(
+            {
+                "key": [1, 1],
+                "time": [
+                    datetime(2024, 1, 1, 0, 0, 10),
+                    datetime(2024, 1, 1, 0, 1, 40),
+                ],
+                "av": [1.0, 2.0],
+            }
+        ),
+    )
+    b = duckdb_con.create_table(
+        "chain_b",
+        pd.DataFrame({"key": [1], "bv": [7.0]}),
+    )
+    c = duckdb_con.create_table(
+        "chain_c",
+        pd.DataFrame(
+            {"key": [1], "time": [datetime(2024, 1, 1, 0, 0, 9)], "cv": [99.0]}
+        ),
+    )
+    left = a.join(b, "key")
+    expr = left.asof_join(
+        c, on="time", predicates="key", tolerance=timedelta(seconds=2)
+    ).order_by("av")
+    result = expr.execute()
+
+    # both left-chain rows preserved; earlier-link column bv untouched
+    assert len(result) == 2
+    assert (result["bv"] == 7.0).all()
+    # in-tolerance row keeps cv, out-of-tolerance row is nulled
+    assert result["cv"].tolist()[0] == 99.0
+    assert pd.isna(result["cv"].tolist()[1])

--- a/python/xorq/backends/pandas/kernels.py
+++ b/python/xorq/backends/pandas/kernels.py
@@ -370,6 +370,7 @@ generic = {
 
 
 columnwise = {
+    ops.Between: lambda df: df["arg"].between(df["lower_bound"], df["upper_bound"]),
     ops.Clip: lambda df: df["arg"].clip(lower=df["lower"], upper=df["upper"]),
     ops.IfElse: lambda df: df["true_expr"].where(
         df["bool_expr"], other=df["false_null_expr"]

--- a/python/xorq/vendor/ibis/expr/types/joins.py
+++ b/python/xorq/vendor/ibis/expr/types/joins.py
@@ -310,15 +310,21 @@ class Join(Table):
     ):
         predicates = util.promote_list(predicates)
         if tolerance is not None:
-            # `tolerance` parameter is mimicking the pandas API, but we express
-            # it at the expression level by a sequence of operations:
-            # 1. perform the `asof` join with the `on` an `predicates` parameters
+            # `tolerance` mimics the pandas API. We lower it to a single asof
+            # join followed by a null-out projection (xorq-labs/xorq#983):
+            # 1. perform the `asof` join with the `on` and `predicates` params
             #    where the `on` parameter is an inequality predicate
-            # 2. filter the asof join result using the `tolerance` parameter and
-            #    the `on` parameter
-            # 3. perform a left join between the original left table and the
-            #    filtered asof join result using the left operand of the `on` parameter but this
-            #    time as an equality predicate
+            # 2. select left columns unchanged and null out each right column
+            #    on rows whose asof match falls outside the tolerance window
+            #
+            # The previous lowering filtered the asof result then re-joined the
+            # original left table back in to restore the dropped left rows. That
+            # referenced the left source twice, so a one-shot input (e.g. a
+            # RecordBatchReader registered via `into_backend`) was consumed by
+            # the first physical scan and the second read 0 rows. The re-join on
+            # `left_on == right_on` could also fan out when `left_on` was not
+            # unique per predicate group. Nulling out the right columns over the
+            # single asof join (which is already left-preserving) avoids both.
             if isinstance(on, str):
                 # self is always a JoinChain so reference one of the join tables
                 left_on = self.op().values[on].to_expr()
@@ -336,20 +342,28 @@ class Join(Table):
             joined = self.asof_join(
                 right, on=on, predicates=predicates, lname=lname, rname=rname
             )
-            filtered = joined.filter(
-                left_on <= right_on + tolerance, left_on >= right_on - tolerance
-            )
-            (right_on,) = filtered.bind(left_on)
 
-            # without joining twice the table would not contain the rows from
-            # the left table that do not match any row from the right table
-            # given the tolerance filter
-            result = self.left_join(
-                filtered, predicates=[left_on == right_on] + predicates
+            # bind `on` operands to their disambiguated post-join columns; a
+            # NULL `right_on` (left row with no match) makes `within` NULL, so
+            # the ifelse falls to the NULL branch — the desired output.
+            (bound_left_on,) = joined.bind(left_on)
+            (bound_right_on,) = joined.bind(right_on)
+            within = (bound_left_on <= bound_right_on + tolerance) & (
+                bound_left_on >= bound_right_on - tolerance
             )
-            values = {**filtered.op().values, **self.op().values}
 
-            return result.select(**values)
+            # distinguish right columns by field origin (the relation the Field
+            # references), not by name, to stay robust under lname/rname.
+            join_chain = joined.op()
+            right_rel = join_chain.rest[-1].table
+            values = {}
+            for name, field in join_chain.values.items():
+                col = field.to_expr()
+                if field.rel is right_rel:
+                    col = within.ifelse(col, ibis.null(col.type()))
+                values[name] = col
+
+            return joined.select(**values)
 
         chain = self.op()
         right = right.op()

--- a/python/xorq/vendor/ibis/expr/types/joins.py
+++ b/python/xorq/vendor/ibis/expr/types/joins.py
@@ -354,6 +354,7 @@ class Join(Table):
 
             # distinguish right columns by field origin (the relation the Field
             # references), not by name, to stay robust under lname/rname.
+            # JoinChain.values are always ops.Field nodes, so `field.rel` exists.
             join_chain = joined.op()
             right_rel = join_chain.rest[-1].table
             values = {}

--- a/python/xorq/vendor/ibis/expr/types/joins.py
+++ b/python/xorq/vendor/ibis/expr/types/joins.py
@@ -348,8 +348,8 @@ class Join(Table):
             # the ifelse falls to the NULL branch — the desired output.
             (bound_left_on,) = joined.bind(left_on)
             (bound_right_on,) = joined.bind(right_on)
-            within = (bound_left_on <= bound_right_on + tolerance) & (
-                bound_left_on >= bound_right_on - tolerance
+            within = bound_left_on.between(
+                bound_right_on - tolerance, bound_right_on + tolerance
             )
 
             # distinguish right columns by field origin (the relation the Field


### PR DESCRIPTION
## Problem

Closes #983.

`asof_join(tolerance=...)` produced wrong results when the left source was a one-shot input — a `pyarrow.RecordBatchReader` registered via `into_backend`.

The tolerance lowering rewrote the join as:
1. `inner = L ASOF LEFT JOIN R ON inequality AND predicates`
2. `filtered = inner WHERE left_on BETWEEN right_on - tol AND right_on + tol`
3. `result = L LEFT JOIN filtered ON left_on == right_on AND predicates`

Step 3 existed only to restore left rows dropped by the step-2 filter, so the compiled SQL referenced the **left source twice**. DuckDB inlines both references into two physical scans; a one-shot reader is consumed by whichever scan runs first, and the second reads **0 rows** → nondeterministically empty or all-NULL output. The step-3 re-join on `left_on == right_on` could also fan out / mis-match on duplicate `left_on` values within a predicate group.

## Fix

Replace filter + re-join with a **null-out projection** over a single `ASOF LEFT JOIN`. The asof join is already left-preserving, so out-of-tolerance matches just need their right columns nulled, not the row dropped and recovered:

```
1. inner  = L ASOF LEFT JOIN R ON inequality AND predicates   -- single pass over L
2. result = inner.select(<left cols unchanged>,
              <right col c> := within_tolerance.ifelse(c, NULL))
```

- Each source referenced exactly once → safe for one-shot readers.
- Right columns identified by **field origin** (the relation the `Field` references), not by name → robust under `lname`/`rname`.
- A NULL `right_on` (left row with no asof match) makes `within` NULL → `ifelse` falls to the NULL branch, the correct output.

## Verification

- `scripts/count_source_passes.py`: with tolerance, `sensors_rbr` now `1` (was 2), 2 plan scan operators (was 3).
- Issue #983 repro: one-shot reader and materialized inputs give identical non-empty results — (a,0.3)→cloud coverage, (b,0.6)→rain start, (a,0.7)→rain stop; remaining left rows present with NULL right columns.
- All existing asof tests pass.

## Tests added

`python/xorq/backends/duckdb/tests/test_asof_join.py`:
- unmatched left rows preserved with NULL right columns
- one-shot `RecordBatchReader` via `into_backend` (the issue itself)
- match exactly at the tolerance boundary (inclusive)
- duplicate `left_on` values within a predicate group (old re-join fan-out hazard)

## Note on vendoring

This diverges from upstream ibis. The change is commented with a reference to #983 so future vendor syncs don't silently revert it. The double-reference lowering is broken upstream too for any non-rescannable source — worth upstreaming as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)