### PR TITLE
fix(deps): move cityhash to sqlite optional-dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "attrs>=24.1.0; python_version >= '3.10' and python_version < '4.0'",
     "pyarrow>=13.0.0,<22; python_version >= '3.10' and python_version < '4.0'",
     "structlog>=24.2.0,<26; python_version >= '3.10' and python_version < '4.0'",
-    "cityhash>=0.4.7,<1 ; python_version >= '3.10' and python_version < '4.0'",
     "pandas>=1.5.3,<3 ; python_version >= '3.10' and python_version < '4.0'",
     "pyarrow-hotfix>=0.4,<1 ; python_version >= '3.10' and python_version < '4.0'",
     "atpublic>=5.1",
@@ -124,6 +123,7 @@ postgres = [
 ]
 sqlite = [
     "adbc-driver-sqlite>=1.4.0",
+    "cityhash>=0.4.7,<1",
 ]
 gizmosql = [
     "adbc-driver-gizmosql>=1.1.5",

--- a/python/xorq/vendor/ibis/backends/sqlite/udf.py
+++ b/python/xorq/vendor/ibis/backends/sqlite/udf.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
-from cityhash import CityHash32
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -248,6 +246,8 @@ def uuid():
 
 @udf(skip_if_exists=True, deterministic=True)
 def city_hash_32(x):
+    from cityhash import CityHash32
+
     return CityHash32(str(x))
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -6091,7 +6091,6 @@ source = { editable = "." }
 dependencies = [
     { name = "atpublic" },
     { name = "attrs" },
-    { name = "cityhash" },
     { name = "click" },
     { name = "cloudpickle" },
     { name = "cryptography" },
@@ -6178,6 +6177,7 @@ snowflake = [
 ]
 sqlite = [
     { name = "adbc-driver-sqlite" },
+    { name = "cityhash" },
 ]
 trino = [
     { name = "trino" },
@@ -6241,7 +6241,7 @@ requires-dist = [
     { name = "atpublic", specifier = ">=5.1" },
     { name = "attrs", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=24.1.0" },
     { name = "boring-semantic-layer", marker = "extra == 'bsl'", specifier = ">=0.3.13" },
-    { name = "cityhash", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=0.4.7,<1" },
+    { name = "cityhash", marker = "extra == 'sqlite'", specifier = ">=0.4.7,<1" },
     { name = "click", specifier = ">=8.0" },
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "cryptography", specifier = ">=45.0.3" },


### PR DESCRIPTION
## Summary
- `cityhash` is only imported in `python/xorq/vendor/ibis/backends/sqlite/udf.py` — move it from core `dependencies` to the `sqlite` optional-dependency group
- Reduces install footprint for users who don't use the sqlite backend

## Test plan
- [ ] Verify `uv pip install xorq` no longer pulls in `cityhash`
- [ ] Verify `uv pip install xorq[sqlite]` does pull in `cityhash`
- [ ] Run sqlite backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)