### PR TITLE
feat(writes): WAP (write-audit-publish) library

### DIFF
--- a/examples/wap_audit_iceberg.py
+++ b/examples/wap_audit_iceberg.py
@@ -74,7 +74,7 @@ fail_expr = (
 )
 
 
-if __name__ == "__pytest_main__":
+if __name__ in ("__main__", "__pytest_main__"):
     prev_count = 0
     for label, expr in pipeline:
         out = expr.execute()

--- a/examples/wap_audit_iceberg.py
+++ b/examples/wap_audit_iceberg.py
@@ -44,6 +44,8 @@ atexit.register(shutil.rmtree, tmp)
 warehouse = str(Path(tmp) / "warehouse")
 con = xo.pyiceberg.connect(warehouse_path=warehouse)
 
+# binds `con` up front and returns a curried builder, so one `wap` reuses the
+# connection across exprs (unlike parquet, which pipes the flat factory directly)
 wap = make_iceberg_wap_expr(con, FINAL)
 
 create_expr = (
@@ -88,6 +90,8 @@ if __name__ in ("__main__", "__pytest_main__"):
         cur_count = len(con.table(FINAL).execute())
         if prev_count:
             assert cur_count == prev_count + 4, "validated batch should append"
+        else:
+            assert cur_count == 4, "create should publish the first batch"
         print(f"  -> {label}; final now has {cur_count} rows\n")
         prev_count = cur_count
 
@@ -102,5 +106,26 @@ if __name__ in ("__main__", "__pytest_main__"):
     # staging branch retained so rejected data can be inspected
     assert STAGING in ice2.refs(), "staging branch should be retained for inspection"
     print("  -> audit failed; staging branch retained, main untouched\n")
+
+    # reuse-after-failure: the retained staging branch blocks an identical retry,
+    # since create-mode refuses to recreate an existing branch. Drop it to retry.
+    try:
+        fail_expr.execute()
+    except ValueError as exc:
+        assert "already exists" in str(exc), exc
+        print("  -> retry refused: staging branch from the failed run still exists")
+    else:
+        raise AssertionError("retry should refuse to recreate the retained branch")
+
+    ice2.manage_snapshots().remove_branch(STAGING).commit()
+    out = fail_expr.execute()
+    assert not out["passed"].iloc[0], "same bad data still fails the audit"
+    assert not out["published"].iloc[0], "failing retry must not publish"
+    assert len(con2.table(FINAL).execute()) == 0, (
+        "main must stay empty after failing retry"
+    )
+    ice2 = con2.catalog.load_table(f"{con2.namespace}.{FINAL}")
+    assert STAGING in ice2.refs(), "staging branch is retained again for inspection"
+    print("  -> staging branch dropped; retry runs again (audit still fails)\n")
 
     pytest_examples_passed = True

--- a/examples/wap_audit_iceberg.py
+++ b/examples/wap_audit_iceberg.py
@@ -1,0 +1,106 @@
+"""Write-Audit-Publish (WAP) into an Iceberg table via branch-based isolation.
+
+WAP is a publish gate built from existing primitives — no dedicated API needed.
+The audit aggregate is a pipeline breaker, so the tee'd write fully drains the
+staging branch before the publish decision runs.
+
+  * **Write**   `tee(BackendWriteThrough)` writes to a staging branch on the Iceberg table.
+  * **Audit**   `agg` UDAF drains the stream into a single `bool`.
+  * **Publish** Pass: fast-forward main to the staging snapshot, then remove the
+    branch. Fail: staging branch retained for inspection, main untouched.
+    Both paths are metadata-only — zero data rewritten.
+
+DQ check from real soil/sensor pipelines: readings must sit in a plausible °C
+range; out-of-range (often a Fahrenheit/Celsius mixup) fails the audit.
+"""
+
+from __future__ import annotations
+
+import atexit
+import shutil
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+import xorq.api as xo
+from xorq.writes import make_iceberg_wap_expr
+
+
+STAGING = "staging"
+FINAL = "sensor_readings"
+
+good = {"sensor": ["s1", "s2", "s3", "s4"], "temp_c": [9.4, 10.1, 11.8, 9.9]}
+good2 = {"sensor": ["s5", "s6", "s7", "s8"], "temp_c": [10.0, 9.7, 11.2, 10.4]}
+bad = {"sensor": ["s1", "s2", "s3", "s4"], "temp_c": [9.4, 10.1, 88.0, 9.9]}
+
+
+def audit_in_range(df: pd.DataFrame) -> bool:
+    return bool(df["temp_c"].between(-10.0, 50.0).all())
+
+
+tmp = tempfile.mkdtemp()
+atexit.register(shutil.rmtree, tmp)
+warehouse = str(Path(tmp) / "warehouse")
+con = xo.pyiceberg.connect(warehouse_path=warehouse)
+
+wap = make_iceberg_wap_expr(con, FINAL)
+
+create_expr = (
+    xo.connect()
+    .register(xo.memtable(good), table_name="src_good")
+    .pipe(wap, STAGING, FINAL, audit_in_range)
+)
+
+append_expr = (
+    xo.connect()
+    .register(xo.memtable(good2), table_name="src_good2")
+    .pipe(wap, STAGING, FINAL, audit_in_range)
+)
+
+# execute in order: append_expr depends on create_expr having run first
+pipeline = [
+    ("create", create_expr),
+    ("append", append_expr),
+]
+
+warehouse2 = str(Path(tmp) / "warehouse2")
+con2 = xo.pyiceberg.connect(warehouse_path=warehouse2)
+
+fail_expr = (
+    xo.connect()
+    .register(xo.memtable(bad), table_name="src_bad")
+    .pipe(make_iceberg_wap_expr(con2, FINAL), STAGING, FINAL, audit_in_range)
+)
+
+
+if __name__ == "__pytest_main__":
+    prev_count = 0
+    for label, expr in pipeline:
+        out = expr.execute()
+        print(f"PASS ({label}):", out.to_string(index=False))
+
+        assert out["passed"].iloc[0]
+        assert out["published"].iloc[0]
+        assert FINAL in con.list_tables(), "published data should exist at final"
+        ice = con.catalog.load_table(f"{con.namespace}.{FINAL}")
+        assert STAGING not in ice.refs(), "staging branch should be cleaned up"
+        cur_count = len(con.table(FINAL).execute())
+        if prev_count:
+            assert cur_count == prev_count + 4, "validated batch should append"
+        print(f"  -> {label}; final now has {cur_count} rows\n")
+        prev_count = cur_count
+
+    # fail: bad data -> staging branch kept for inspection, main untouched
+    out = fail_expr.execute()
+    print("FAIL:", out.to_string(index=False))
+
+    assert not out["passed"].iloc[0]
+    assert not out["published"].iloc[0]
+    assert FINAL in con2.list_tables(), "table should exist (created for branching)"
+    ice2 = con2.catalog.load_table(f"{con2.namespace}.{FINAL}")
+    # staging branch retained so rejected data can be inspected
+    assert STAGING in ice2.refs(), "staging branch should be retained for inspection"
+    print("  -> audit failed; staging branch retained, main untouched\n")
+
+    pytest_examples_passed = True

--- a/examples/wap_audit_parquet.py
+++ b/examples/wap_audit_parquet.py
@@ -1,4 +1,4 @@
-"""Write-Audit-Publish (WAP) into a Parquet file via copy-on-pass.
+"""Write-Audit-Publish (WAP) into a Parquet file via merge-on-pass.
 
 WAP is a publish gate built from existing primitives — no dedicated API needed.
 The audit aggregate is a pipeline breaker, so the tee'd write fully drains the
@@ -6,7 +6,8 @@ staging file before the publish decision runs.
 
   * **Write**   `tee(ParquetWriteThrough)` writes to a staging Parquet file.
   * **Audit**   `agg` UDAF drains the stream into a single `bool`.
-  * **Publish** Pass: copy staging -> final; staging retained.
+  * **Publish** Pass: merge staging into final, then consume staging — so
+    repeated passing runs accumulate, matching the iceberg strategies.
     Fail: staging retained for inspection, final untouched.
 
 DQ check: every value in column ``a`` must be non-null; null values fail the
@@ -64,8 +65,17 @@ if __name__ in ("__main__", "__pytest_main__"):
     assert out["passed"].iloc[0]
     assert out["published"].iloc[0]
     assert Path(final).exists(), "published data should exist at final"
-    assert Path(staging).exists(), "staging is retained after the copy"
+    assert not Path(staging).exists(), "staging is consumed on publish"
+    assert len(pd.read_parquet(final)) == 4
     print(f"  -> published {len(pd.read_parquet(final))} rows to final\n")
+
+    # append: a second passing run accumulates into final (staging was consumed,
+    # so create-mode stages fresh, and publish merges into the existing final).
+    out = pass_expr.execute()
+    assert out["published"].iloc[0]
+    assert len(pd.read_parquet(final)) == 8, "passing runs accumulate in final"
+    assert not Path(staging).exists(), "staging is consumed on each publish"
+    print("  -> second pass appended; final now has 8 rows\n")
 
     # fail: audit fails -> nothing published, staging retained
     out = fail_expr.execute()

--- a/examples/wap_audit_parquet.py
+++ b/examples/wap_audit_parquet.py
@@ -78,4 +78,22 @@ if __name__ in ("__main__", "__pytest_main__"):
     assert Path(fail_staging).exists(), "rejected data is retained in staging"
     print("  -> audit failed; rejected data retained at staging, final absent\n")
 
+    # reuse-after-failure: the retained staging file blocks an identical retry,
+    # since create-mode refuses to clobber it. Clear it (or stage elsewhere) first.
+    # The writer's FileExistsError crosses Arrow's C Data interface as a ValueError.
+    try:
+        fail_expr.execute()
+    except ValueError as exc:
+        assert "already exists" in str(exc), exc
+        print("  -> retry refused: staging from the failed run still exists")
+    else:
+        raise AssertionError("retry should refuse to clobber retained staging")
+
+    Path(fail_staging).unlink()
+    out = fail_expr.execute()
+    assert not out["passed"].iloc[0], "same bad data still fails the audit"
+    assert not out["published"].iloc[0], "failing retry must not publish"
+    assert not Path(fail_final).exists(), "final must stay absent after failing retry"
+    print("  -> staging cleared; retry runs again (audit still fails on bad data)\n")
+
     pytest_examples_passed = True

--- a/examples/wap_audit_parquet.py
+++ b/examples/wap_audit_parquet.py
@@ -1,0 +1,81 @@
+"""Write-Audit-Publish (WAP) into a Parquet file via copy-on-pass.
+
+WAP is a publish gate built from existing primitives — no dedicated API needed.
+The audit aggregate is a pipeline breaker, so the tee'd write fully drains the
+staging file before the publish decision runs.
+
+  * **Write**   `tee(ParquetWriteThrough)` writes to a staging Parquet file.
+  * **Audit**   `agg` UDAF drains the stream into a single `bool`.
+  * **Publish** Pass: copy staging -> final; staging retained.
+    Fail: staging retained for inspection, final untouched.
+
+DQ check: every value in column ``a`` must be non-null; null values fail the
+audit before publish.
+"""
+
+from __future__ import annotations
+
+import atexit
+import shutil
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+import xorq.api as xo
+from xorq.writes import make_parquet_wap_expr
+
+
+data = {"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]}
+bad_data = {"a": [1, None, 3, 4], "b": ["w", "x", "y", "z"]}
+
+
+def audit_no_nulls(df: pd.DataFrame) -> bool:
+    return bool(df["a"].notna().all())
+
+
+tmp = tempfile.mkdtemp()
+atexit.register(shutil.rmtree, tmp)
+staging = str(Path(tmp) / "staging.parquet")
+final = str(Path(tmp) / "final.parquet")
+
+pass_expr = (
+    xo.connect()
+    .register(xo.memtable(data), table_name="src_pass")
+    .pipe(make_parquet_wap_expr, staging, final, audit_no_nulls)
+)
+
+fail_staging = str(Path(tmp) / "fail_staging.parquet")
+fail_final = str(Path(tmp) / "fail_final.parquet")
+
+fail_expr = (
+    xo.connect()
+    .register(xo.memtable(bad_data), table_name="src_fail")
+    .pipe(make_parquet_wap_expr, fail_staging, fail_final, audit_no_nulls)
+)
+
+
+if __name__ == "__pytest_main__":
+    # pass: audit succeeds -> data published to final
+    out = pass_expr.execute()
+    print("PASS path receipt:")
+    print(out.to_string(index=False))
+
+    assert out["passed"].iloc[0]
+    assert out["published"].iloc[0]
+    assert Path(final).exists(), "published data should exist at final"
+    assert Path(staging).exists(), "staging is retained after the copy"
+    print(f"  -> published {len(pd.read_parquet(final))} rows to final\n")
+
+    # fail: audit fails -> nothing published, staging retained
+    out = fail_expr.execute()
+    print("FAIL path receipt:")
+    print(out.to_string(index=False))
+
+    assert not out["passed"].iloc[0]
+    assert not out["published"].iloc[0]
+    assert not Path(fail_final).exists(), "failing audit must not publish"
+    assert Path(fail_staging).exists(), "rejected data is retained in staging"
+    print("  -> audit failed; rejected data retained at staging, final absent\n")
+
+    pytest_examples_passed = True

--- a/examples/wap_audit_parquet.py
+++ b/examples/wap_audit_parquet.py
@@ -69,8 +69,7 @@ if __name__ in ("__main__", "__pytest_main__"):
     assert len(pd.read_parquet(final)) == 4
     print(f"  -> published {len(pd.read_parquet(final))} rows to final\n")
 
-    # append: a second passing run accumulates into final (staging was consumed,
-    # so create-mode stages fresh, and publish merges into the existing final).
+    # append: a second passing run accumulates into final.
     out = pass_expr.execute()
     assert out["published"].iloc[0]
     assert len(pd.read_parquet(final)) == 8, "passing runs accumulate in final"
@@ -88,9 +87,8 @@ if __name__ in ("__main__", "__pytest_main__"):
     assert Path(fail_staging).exists(), "rejected data is retained in staging"
     print("  -> audit failed; rejected data retained at staging, final absent\n")
 
-    # reuse-after-failure: the retained staging file blocks an identical retry,
-    # since create-mode refuses to clobber it. Clear it (or stage elsewhere) first.
-    # The writer's FileExistsError crosses Arrow's C Data interface as a ValueError.
+    # reuse-after-failure: the retained staging file blocks an identical retry;
+    # clear it (or stage elsewhere) first.
     try:
         fail_expr.execute()
     except ValueError as exc:

--- a/examples/wap_audit_parquet.py
+++ b/examples/wap_audit_parquet.py
@@ -55,7 +55,7 @@ fail_expr = (
 )
 
 
-if __name__ == "__pytest_main__":
+if __name__ in ("__main__", "__pytest_main__"):
     # pass: audit succeeds -> data published to final
     out = pass_expr.execute()
     print("PASS path receipt:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,14 @@ known-first-party = ["xorq"]
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 lines-after-imports = 2
 
+[tool.xorq-style.print]
+# Example scripts print receipts to stdout by design. allow-files matches on
+# basename only (no globs), so list each example explicitly as it's touched.
+allow-files = [
+    "wap_audit_iceberg.py",
+    "wap_audit_parquet.py",
+]
+
 [tool.codespell]
 skip = "*.lock,.direnv,.git,docs/_freeze/**/html.json"
 ignore-regex = '\b(DOUB|i[if]f|I[IF]F|lamduh|AFE|crate|ba|fpr)\b'

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -16,6 +16,7 @@ from xorq.vendor.ibis.backends.sql import SQLBackend
 from xorq.vendor.ibis.expr import schema as sch
 from xorq.vendor.ibis.expr import types as ir
 from xorq.vendor.ibis.util import gen_name
+from xorq.writes.enums import WriteMode
 
 
 def parse_url(url: str) -> Dict[str, Any]:
@@ -297,27 +298,19 @@ class Backend(SQLBackend):
         self,
         reader: Union[pa.RecordBatchReader, pa.ChunkedArray],
         table_name: Optional[str] = None,
-        mode: str = "create",
+        mode: WriteMode = WriteMode.CREATE,
         branch: Optional[str] = None,
     ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
         data = pa.Table.from_batches(reader, reader.schema)
 
         if branch is None:
-            if mode == "create":
+            if mode == WriteMode.CREATE:
                 self.create_table(name=table_name, obj=data, database=self.namespace)
             else:
-                self.insert(table_name, data, mode="append")
+                self.insert(table_name, data, mode=WriteMode.APPEND)
         else:
             full_name = f"{self.namespace}.{table_name}"
-            data = data.cast(
-                pa.schema(
-                    [
-                        pa.field(name, type=typ)
-                        for name, typ in zip(data.schema.names, data.schema.types)
-                    ]
-                )
-            )
 
             if not self.catalog.table_exists(full_name):
                 ice = self.catalog.create_table(
@@ -328,17 +321,13 @@ class Backend(SQLBackend):
             else:
                 ice = self.catalog.load_table(full_name)
 
-            if mode == "create" and branch in ice.refs():
+            if mode == WriteMode.CREATE and branch in ice.refs():
                 raise ValueError(
                     f"Branch {branch!r} already exists on table {full_name}"
                 )
 
             if branch not in ice.refs():
                 current = ice.current_snapshot()
-                if current is None:
-                    raise ValueError(
-                        f"Table {full_name} has no snapshot to branch from"
-                    )
                 ice.manage_snapshots().create_branch(
                     current.snapshot_id, branch
                 ).commit()

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -315,9 +315,12 @@ class Backend(SQLBackend):
         self,
         reader: Union[pa.RecordBatchReader, pa.ChunkedArray],
         table_name: Optional[str] = None,
-        mode: WriteMode = WriteMode.CREATE,
+        mode: WriteMode | str = WriteMode.CREATE,
         branch: Optional[str] = None,
     ) -> ir.Table:
+        # Callers on the write-through path hand us the wire string (mode.value);
+        # normalize at the boundary so the body always works with the enum.
+        mode = WriteMode(mode)
         table_name = table_name or gen_name("read_record_batches")
         full_name = f"{self.namespace}.{table_name}"
         schema = reader.schema
@@ -337,6 +340,10 @@ class Backend(SQLBackend):
                     raise ValueError(f"Unsupported write mode: {mode!r}")
         else:
             if not exists:
+                # A branch must point at a snapshot, and a freshly created table
+                # has none. Seed one empty snapshot so create_branch below has a
+                # base; the seed carries no rows and becomes ancestor history once
+                # the branch is fast-forwarded into main at publish.
                 ice = self.catalog.create_table(identifier=full_name, schema=schema)
                 ice.append(schema.empty_table())
                 ice = self.catalog.load_table(full_name)
@@ -367,10 +374,17 @@ class Backend(SQLBackend):
         return self.table(table_name)
 
     def publish_branch(self, table_name: str, branch: str) -> None:
-        # Fast-forward the table's main snapshot to the staging branch tip,
-        # then drop the branch.
+        # Repoint main at the staging branch tip, then drop the branch. This is a
+        # fast-forward, NOT a merge: set_current_snapshot overwrites the main
+        # pointer, so any commits made to main since the branch was cut would be
+        # discarded. Safe under WAP because main only ever advances via publish.
         full_name = f"{self.namespace}.{table_name}"
         ice = self.catalog.load_table(full_name)
+        if branch not in ice.refs():
+            raise RuntimeError(
+                f"staging branch {branch!r} missing at publish on {full_name}: "
+                "the audit ran before the staging write committed (async sink?)"
+            )
         staging_snap = ice.refs()[branch].snapshot_id
         ice.manage_snapshots().set_current_snapshot(staging_snap).commit()
         ice = self.catalog.load_table(full_name)
@@ -379,10 +393,18 @@ class Backend(SQLBackend):
     def publish_staging_table(self, staging: str, final: str) -> None:
         # Repoint metadata instead of copying rows: register staging's parquet
         # data files into final, then drop staging's catalog entry. add_files is
-        # metadata-only (reads footers, not rows) and drop_table only removes the
-        # catalog entry, so the files now live under final without being rewritten.
+        # metadata-only (reads footers, not rows). This relies on pyiceberg's
+        # Catalog.drop_table contract — it removes only the catalog entry and does
+        # NOT purge data files (purge_table is the separate, opt-in API) — so the
+        # files now live under final without being rewritten. A catalog that
+        # purged on drop would delete the files out from under final.
         full_staging = f"{self.namespace}.{staging}"
         full_final = f"{self.namespace}.{final}"
+        if not self.catalog.table_exists(full_staging):
+            raise RuntimeError(
+                f"staging table {full_staging!r} missing at publish: the audit ran "
+                "before the staging write committed (async sink?)"
+            )
         staged_tbl = self.catalog.load_table(full_staging)
         data_files = [task.file.file_path for task in staged_tbl.scan().plan_files()]
         if not self.catalog.table_exists(full_final):

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -294,6 +294,23 @@ class Backend(SQLBackend):
     def _get_schema_using_query(self, query: str) -> sch.Schema:
         raise NotImplementedError("_get_schema_using_query")
 
+    @staticmethod
+    def _stream_reader_to_parquet(
+        ice: IcebergTable, reader: pa.RecordBatchReader
+    ) -> str:
+        import pyarrow.parquet as pq  # noqa: PLC0415
+
+        file_path = f"{ice.location()}/data/{gen_name('add_files')}.parquet"
+        # add_files references files in place, so write under the table location.
+        output = ice.io.new_output(file_path).create(overwrite=True)
+        try:
+            with pq.ParquetWriter(output, reader.schema) as writer:
+                for batch in reader:
+                    writer.write_batch(batch)
+        finally:
+            output.close()
+        return file_path
+
     def read_record_batches(
         self,
         reader: Union[pa.RecordBatchReader, pa.ChunkedArray],
@@ -302,26 +319,26 @@ class Backend(SQLBackend):
         branch: Optional[str] = None,
     ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
-        data = pa.Table.from_batches(reader, reader.schema)
+        full_name = f"{self.namespace}.{table_name}"
+        schema = reader.schema
+        exists = self.catalog.table_exists(full_name)
 
         if branch is None:
             match mode:
                 case WriteMode.CREATE:
-                    self.create_table(
-                        name=table_name, obj=data, database=self.namespace
-                    )
+                    if exists:
+                        raise ValueError(f"Table {full_name} already exists")
+                    ice = self.catalog.create_table(identifier=full_name, schema=schema)
                 case WriteMode.APPEND:
-                    self.insert(table_name, data, mode=mode)
+                    if not exists:
+                        raise ValueError(f"Table {full_name} does not exist")
+                    ice = self.catalog.load_table(full_name)
                 case _:
                     raise ValueError(f"Unsupported write mode: {mode!r}")
         else:
-            full_name = f"{self.namespace}.{table_name}"
-
-            if not self.catalog.table_exists(full_name):
-                ice = self.catalog.create_table(
-                    identifier=full_name, schema=data.schema
-                )
-                ice.append(data.schema.empty_table())
+            if not exists:
+                ice = self.catalog.create_table(identifier=full_name, schema=schema)
+                ice.append(schema.empty_table())
                 ice = self.catalog.load_table(full_name)
             else:
                 ice = self.catalog.load_table(full_name)
@@ -338,12 +355,43 @@ class Backend(SQLBackend):
                 ).commit()
                 ice = self.catalog.load_table(full_name)
 
-            with ice.transaction() as tx:
-                tx.append(data, branch=branch)
+        file_path = self._stream_reader_to_parquet(ice, reader)
+        # File names are unique per call, so the duplicate scan is unneeded and
+        # also raises on tables whose only snapshot has zero data files.
+        with ice.transaction() as tx:
+            if branch is None:
+                tx.add_files([file_path], check_duplicate_files=False)
+            else:
+                tx.add_files([file_path], check_duplicate_files=False, branch=branch)
 
         return self.table(table_name)
 
-    def list_snapshots(self, database=None) -> dict[str, int]:
+    def publish_branch(self, table_name: str, branch: str) -> None:
+        # Fast-forward the table's main snapshot to the staging branch tip,
+        # then drop the branch.
+        full_name = f"{self.namespace}.{table_name}"
+        ice = self.catalog.load_table(full_name)
+        staging_snap = ice.refs()[branch].snapshot_id
+        ice.manage_snapshots().set_current_snapshot(staging_snap).commit()
+        ice = self.catalog.load_table(full_name)
+        ice.manage_snapshots().remove_branch(branch).commit()
+
+    def publish_staging_table(self, staging: str, final: str) -> None:
+        # Repoint metadata instead of copying rows: register staging's parquet
+        # data files into final, then drop staging's catalog entry. add_files is
+        # metadata-only (reads footers, not rows) and drop_table only removes the
+        # catalog entry, so the files now live under final without being rewritten.
+        full_staging = f"{self.namespace}.{staging}"
+        full_final = f"{self.namespace}.{final}"
+        staged_tbl = self.catalog.load_table(full_staging)
+        data_files = [task.file.file_path for task in staged_tbl.scan().plan_files()]
+        if not self.catalog.table_exists(full_final):
+            self.catalog.create_table(identifier=full_final, schema=staged_tbl.schema())
+        if data_files:
+            self.catalog.load_table(full_final).add_files(data_files)
+        self.drop_table(staging)
+
+    def list_snapshots(self, database: Optional[str] = None) -> dict[str, int]:
         database = database or self.namespace
         table_names = [t[1] for t in self.catalog.list_tables(database)]
 

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -297,11 +297,56 @@ class Backend(SQLBackend):
         self,
         reader: Union[pa.RecordBatchReader, pa.ChunkedArray],
         table_name: Optional[str] = None,
+        mode: str = "create",
+        branch: Optional[str] = None,
     ) -> ir.Table:
         table_name = table_name or gen_name("read_record_batches")
-        table = pa.Table.from_batches(reader, reader.schema)
+        data = pa.Table.from_batches(reader, reader.schema)
 
-        self.create_table(name=table_name, obj=table, database=self.namespace)
+        if branch is None:
+            if mode == "create":
+                self.create_table(name=table_name, obj=data, database=self.namespace)
+            else:
+                self.insert(table_name, data, mode="append")
+        else:
+            full_name = f"{self.namespace}.{table_name}"
+            data = data.cast(
+                pa.schema(
+                    [
+                        pa.field(name, type=typ)
+                        for name, typ in zip(data.schema.names, data.schema.types)
+                    ]
+                )
+            )
+
+            if not self.catalog.table_exists(full_name):
+                ice = self.catalog.create_table(
+                    identifier=full_name, schema=data.schema
+                )
+                ice.append(data.schema.empty_table())
+                ice = self.catalog.load_table(full_name)
+            else:
+                ice = self.catalog.load_table(full_name)
+
+            if mode == "create" and branch in ice.refs():
+                raise ValueError(
+                    f"Branch {branch!r} already exists on table {full_name}"
+                )
+
+            if branch not in ice.refs():
+                current = ice.current_snapshot()
+                if current is None:
+                    raise ValueError(
+                        f"Table {full_name} has no snapshot to branch from"
+                    )
+                ice.manage_snapshots().create_branch(
+                    current.snapshot_id, branch
+                ).commit()
+                ice = self.catalog.load_table(full_name)
+
+            with ice.transaction() as tx:
+                tx.append(data, branch=branch)
+
         return self.table(table_name)
 
     def list_snapshots(self, database=None) -> dict[str, int]:

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -379,11 +379,16 @@ class Backend(SQLBackend):
         # pointer, so any commits made to main since the branch was cut would be
         # discarded. Safe under WAP because main only ever advances via publish.
         full_name = f"{self.namespace}.{table_name}"
-        ice = self.catalog.load_table(full_name)
-        if branch not in ice.refs():
+        # An empty stream never opens the sink writer, so the table itself is
+        # never created (it is created lazily inside read_record_batches).
+        missing = not self.catalog.table_exists(full_name)
+        ice = None if missing else self.catalog.load_table(full_name)
+        if missing or branch not in ice.refs():
             raise RuntimeError(
-                f"staging branch {branch!r} missing at publish on {full_name}: "
-                "the audit ran before the staging write committed (async sink?)"
+                f"staging branch {branch!r} missing at publish on {full_name}. "
+                "The sink opens its writer on the first batch, so either the "
+                "audited input was empty (no batch, no artifact) or the staging "
+                "write has not committed yet (async sink?)."
             )
         staging_snap = ice.refs()[branch].snapshot_id
         ice.manage_snapshots().set_current_snapshot(staging_snap).commit()
@@ -402,8 +407,10 @@ class Backend(SQLBackend):
         full_final = f"{self.namespace}.{final}"
         if not self.catalog.table_exists(full_staging):
             raise RuntimeError(
-                f"staging table {full_staging!r} missing at publish: the audit ran "
-                "before the staging write committed (async sink?)"
+                f"staging table {full_staging!r} missing at publish. The sink "
+                "opens its writer on the first batch, so either the audited "
+                "input was empty (no batch, no artifact) or the staging write "
+                "has not committed yet (async sink?)."
             )
         staged_tbl = self.catalog.load_table(full_staging)
         data_files = [task.file.file_path for task in staged_tbl.scan().plan_files()]

--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -305,10 +305,15 @@ class Backend(SQLBackend):
         data = pa.Table.from_batches(reader, reader.schema)
 
         if branch is None:
-            if mode == WriteMode.CREATE:
-                self.create_table(name=table_name, obj=data, database=self.namespace)
-            else:
-                self.insert(table_name, data, mode=WriteMode.APPEND)
+            match mode:
+                case WriteMode.CREATE:
+                    self.create_table(
+                        name=table_name, obj=data, database=self.namespace
+                    )
+                case WriteMode.APPEND:
+                    self.insert(table_name, data, mode=mode)
+                case _:
+                    raise ValueError(f"Unsupported write mode: {mode!r}")
         else:
             full_name = f"{self.namespace}.{table_name}"
 

--- a/python/xorq/backends/pyiceberg/tests/conftest.py
+++ b/python/xorq/backends/pyiceberg/tests/conftest.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 
 import xorq.api as xo
+from xorq.backends.pyiceberg import Backend
 
 
 QUOTES_TABLE_NAME = "quotes"
@@ -59,3 +64,9 @@ def iceberg_con(tmp_path_factory, quotes_df):
 @pytest.fixture(scope="session")
 def quotes_table(iceberg_con):
     return iceberg_con.table(QUOTES_TABLE_NAME)
+
+
+@pytest.fixture
+def fresh_con(tmp_path: Path) -> Backend:
+    warehouse_path = str(tmp_path / "warehouse")
+    return xo.pyiceberg.connect(warehouse_path=warehouse_path)

--- a/python/xorq/backends/pyiceberg/tests/test_backend_internals.py
+++ b/python/xorq/backends/pyiceberg/tests/test_backend_internals.py
@@ -1,0 +1,64 @@
+"""Unit coverage for pyiceberg Backend helpers and error paths."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from xorq.backends.pyiceberg import Backend, parse_url
+
+
+def test_parse_url_path_only() -> None:
+    cfg = parse_url("file:///tmp/wh")
+    assert cfg["warehouse_path"] == "tmp/wh"
+    assert cfg["namespace"] == "default"
+    assert cfg["catalog_type"] == "sql"
+
+
+def test_parse_url_netloc_and_query() -> None:
+    cfg = parse_url("s3://bucket/path?namespace=ns&catalog_name=cat")
+    assert cfg["warehouse_path"] == "bucket/path"
+    assert cfg["namespace"] == "ns"
+    assert cfg["catalog_name"] == "cat"
+
+
+def test_from_url_delegates_to_parse_url() -> None:
+    assert Backend._from_url("file:///tmp/wh") == parse_url("file:///tmp/wh")
+
+
+def test_version_is_str(fresh_con: Backend) -> None:
+    assert isinstance(fresh_con.version, str)
+
+
+def test_create_table_exists_raises(fresh_con: Backend) -> None:
+    fresh_con.create_table("t", pd.DataFrame({"a": [1]}))
+    with pytest.raises(ValueError, match="already exists"):
+        fresh_con.create_table("t", pd.DataFrame({"a": [2]}))
+
+
+def test_create_table_overwrite(fresh_con: Backend) -> None:
+    fresh_con.create_table("t", pd.DataFrame({"a": [1]}))
+    fresh_con.create_table("t", pd.DataFrame({"a": [9, 9]}), overwrite=True)
+    assert fresh_con.table("t").execute()["a"].tolist() == [9, 9]
+
+
+def test_insert_nonexistent_raises(fresh_con: Backend) -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        fresh_con.insert("nope", pd.DataFrame({"a": [1]}))
+
+
+def test_insert_append_accumulates(fresh_con: Backend) -> None:
+    fresh_con.create_table("t", pd.DataFrame({"a": [1, 2, 3]}))
+    fresh_con.insert("t", pd.DataFrame({"a": [4]}))
+    assert sorted(fresh_con.table("t").execute()["a"].tolist()) == [1, 2, 3, 4]
+
+
+def test_list_tables_like_filters(fresh_con: Backend) -> None:
+    fresh_con.create_table("cats", pd.DataFrame({"a": [1]}))
+    fresh_con.create_table("dogs", pd.DataFrame({"a": [1]}))
+    assert fresh_con.list_tables(like="cat*") == ["cats"]
+
+
+def test_get_schema_using_query_not_implemented(fresh_con: Backend) -> None:
+    with pytest.raises(NotImplementedError):
+        fresh_con._get_schema_using_query("select 1")

--- a/python/xorq/backends/pyiceberg/tests/test_backend_internals.py
+++ b/python/xorq/backends/pyiceberg/tests/test_backend_internals.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from xorq.backends.pyiceberg import Backend, parse_url
+from xorq.writes.enums import WriteMode
+
+
+def _reader(df: pd.DataFrame) -> pa.RecordBatchReader:
+    return pa.Table.from_pandas(df).to_reader()
 
 
 def test_parse_url_path_only() -> None:
@@ -62,3 +68,48 @@ def test_list_tables_like_filters(fresh_con: Backend) -> None:
 def test_get_schema_using_query_not_implemented(fresh_con: Backend) -> None:
     with pytest.raises(NotImplementedError):
         fresh_con._get_schema_using_query("select 1")
+
+
+def test_read_record_batches_append_without_branch(fresh_con: Backend) -> None:
+    fresh_con.read_record_batches(
+        _reader(pd.DataFrame({"a": [1, 2]})), table_name="t", mode=WriteMode.CREATE
+    )
+    fresh_con.read_record_batches(
+        _reader(pd.DataFrame({"a": [3]})), table_name="t", mode=WriteMode.APPEND
+    )
+    assert sorted(fresh_con.table("t").execute()["a"].tolist()) == [1, 2, 3]
+
+
+def test_read_record_batches_branch_create_then_append(fresh_con: Backend) -> None:
+    fresh_con.read_record_batches(
+        _reader(pd.DataFrame({"a": [1, 2]})),
+        table_name="t",
+        mode=WriteMode.CREATE,
+        branch="staging",
+    )
+    fresh_con.read_record_batches(
+        _reader(pd.DataFrame({"a": [3]})),
+        table_name="t",
+        mode=WriteMode.APPEND,
+        branch="staging",
+    )
+    ice = fresh_con.catalog.load_table(f"{fresh_con.namespace}.t")
+    assert "staging" in ice.refs()
+    branch_rows = ice.scan(snapshot_id=ice.refs()["staging"].snapshot_id).to_arrow()
+    assert sorted(branch_rows["a"].to_pylist()) == [1, 2, 3]
+
+
+def test_read_record_batches_branch_create_twice_raises(fresh_con: Backend) -> None:
+    fresh_con.read_record_batches(
+        _reader(pd.DataFrame({"a": [1]})),
+        table_name="t",
+        mode=WriteMode.CREATE,
+        branch="staging",
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        fresh_con.read_record_batches(
+            _reader(pd.DataFrame({"a": [2]})),
+            table_name="t",
+            mode=WriteMode.CREATE,
+            branch="staging",
+        )

--- a/python/xorq/backends/pyiceberg/tests/test_wap.py
+++ b/python/xorq/backends/pyiceberg/tests/test_wap.py
@@ -1,0 +1,106 @@
+"""WAP (Write-Audit-Publish) over the pyiceberg backend.
+
+Both strategies go through ``make_iceberg_wap_expr``:
+
+  * branch-based (``make_iceberg_wap_expr(con, table_name)``): staging branch
+    is fast-forwarded into main on pass, retained on fail.
+  * table-based (``make_iceberg_wap_expr(con)``): staging table is copied into
+    final and dropped on pass, retained on fail.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+
+import xorq.api as xo
+import xorq.vendor.ibis.expr.types as ir
+from xorq.backends.pyiceberg import Backend
+from xorq.writes import make_iceberg_wap_expr
+
+
+FINAL = "final"
+STAGING = "staging"
+
+good = {"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]}
+bad = {"a": [1, None, 3, 4], "b": ["w", "x", "y", "z"]}
+
+
+def no_nulls(df: pd.DataFrame) -> bool:
+    return bool(df["a"].notna().all())
+
+
+def _wap_expr(
+    wap: Callable[..., ir.Table], data: dict[str, list], table_name: str
+) -> ir.Table:
+    return (
+        xo.connect()
+        .register(xo.memtable(data), table_name=table_name)
+        .pipe(wap, STAGING, FINAL, no_nulls)
+    )
+
+
+def _refs(con: Backend) -> dict:
+    return con.catalog.load_table(f"{con.namespace}.{FINAL}").refs()
+
+
+def test_branch_wap_pass(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con, FINAL)
+    out = _wap_expr(wap, good, "src_good").execute()
+
+    assert out["passed"].iloc[0]
+    assert out["published"].iloc[0]
+    assert STAGING not in _refs(fresh_con), "staging branch should be removed"
+    assert len(fresh_con.table(FINAL).execute()) == 4
+
+
+def test_branch_wap_fail(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con, FINAL)
+    out = _wap_expr(wap, bad, "src_bad").execute()
+
+    assert not out["passed"].iloc[0]
+    assert not out["published"].iloc[0]
+    assert STAGING in _refs(fresh_con), "rejected staging branch is retained"
+    ice = fresh_con.catalog.load_table(f"{fresh_con.namespace}.{FINAL}")
+    main_snap = ice.current_snapshot()
+    assert main_snap is None or len(ice.scan().to_arrow()) == 0, (
+        "failing audit must not publish data to main branch"
+    )
+
+
+def test_branch_wap_append(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con, FINAL)
+    _wap_expr(wap, good, "src1").execute()
+    _wap_expr(wap, good, "src2").execute()
+
+    assert len(fresh_con.table(FINAL).execute()) == 8
+
+
+def test_table_wap_pass(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con)
+    out = _wap_expr(wap, good, "src_good").execute()
+
+    assert out["passed"].iloc[0]
+    assert out["published"].iloc[0]
+    assert FINAL in fresh_con.list_tables()
+    assert STAGING not in fresh_con.list_tables(), "staging table dropped after publish"
+    assert len(fresh_con.table(FINAL).execute()) == 4
+
+
+def test_table_wap_fail(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con)
+    out = _wap_expr(wap, bad, "src_bad").execute()
+
+    assert not out["passed"].iloc[0]
+    assert not out["published"].iloc[0]
+    assert FINAL not in fresh_con.list_tables(), "failing audit must not publish"
+    assert STAGING in fresh_con.list_tables(), "rejected staging table is retained"
+
+
+def test_table_wap_append(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con)
+    _wap_expr(wap, good, "src1").execute()
+    _wap_expr(wap, good, "src2").execute()
+
+    assert len(fresh_con.table(FINAL).execute()) == 8

--- a/python/xorq/backends/pyiceberg/tests/test_wap.py
+++ b/python/xorq/backends/pyiceberg/tests/test_wap.py
@@ -13,11 +13,16 @@ from __future__ import annotations
 from typing import Callable
 
 import pandas as pd
+import pytest
 
 import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
 from xorq.backends.pyiceberg import Backend
 from xorq.writes import make_iceberg_wap_expr
+from xorq.writes.wap import FINAL as FINAL_COL
+from xorq.writes.wap import PASSED as PASSED_COL
+from xorq.writes.wap import STAGING as STAGING_COL
+from xorq.writes.wap import make_publish_with_iceberg
 
 
 FINAL = "final"
@@ -104,3 +109,43 @@ def test_table_wap_append(fresh_con: Backend) -> None:
     _wap_expr(wap, good, "src2").execute()
 
     assert len(fresh_con.table(FINAL).execute()) == 8
+
+
+def test_table_wap_publish_does_not_purge_staging_files(fresh_con: Backend) -> None:
+    # The table strategy promotes by repointing metadata: staging's parquet
+    # files are registered into final, then staging's catalog entry is dropped.
+    # The drop must not purge those files, or final reads stale/missing data.
+    wap = make_iceberg_wap_expr(fresh_con)
+    _wap_expr(wap, good, "src_good").execute()
+
+    assert STAGING not in fresh_con.list_tables()
+    published = fresh_con.table(FINAL).execute().sort_values("a")
+    assert published["a"].tolist() == good["a"]
+    assert published["b"].tolist() == good["b"]
+
+
+def test_branch_wap_rerun_after_fail_raises(fresh_con: Backend) -> None:
+    # A failed audit retains the staging branch. Re-running against the same
+    # target then writes mode=CREATE into a branch that already exists, which
+    # the backend rejects rather than silently appending to stale staging data.
+    wap = make_iceberg_wap_expr(fresh_con, FINAL)
+    _wap_expr(wap, bad, "src_bad").execute()
+    assert STAGING in _refs(fresh_con)
+
+    with pytest.raises(ValueError, match="already exists"):
+        _wap_expr(wap, good, "src_retry").execute()
+
+
+def test_iceberg_publish_guard_rejects_multi_row(fresh_con: Backend) -> None:
+    # The publish UDF assumes the audit aggregate collapsed to exactly one row;
+    # guard against a contract break upstream.
+    publish = make_publish_with_iceberg(fresh_con)
+    df = pd.DataFrame(
+        {
+            STAGING_COL: [STAGING, STAGING],
+            FINAL_COL: [FINAL, FINAL],
+            PASSED_COL: [True, True],
+        }
+    )
+    with pytest.raises(ValueError, match="expected 1 row"):
+        publish.fn(df)

--- a/python/xorq/backends/pyiceberg/tests/test_wap.py
+++ b/python/xorq/backends/pyiceberg/tests/test_wap.py
@@ -112,9 +112,7 @@ def test_table_wap_append(fresh_con: Backend) -> None:
 
 
 def test_table_wap_publish_does_not_purge_staging_files(fresh_con: Backend) -> None:
-    # The table strategy promotes by repointing metadata: staging's parquet
-    # files are registered into final, then staging's catalog entry is dropped.
-    # The drop must not purge those files, or final reads stale/missing data.
+    # Regression: dropping staging must leave final's just-registered files intact.
     wap = make_iceberg_wap_expr(fresh_con)
     _wap_expr(wap, good, "src_good").execute()
 
@@ -125,9 +123,7 @@ def test_table_wap_publish_does_not_purge_staging_files(fresh_con: Backend) -> N
 
 
 def test_branch_wap_rerun_after_fail_raises(fresh_con: Backend) -> None:
-    # A failed audit retains the staging branch. Re-running against the same
-    # target then writes mode=CREATE into a branch that already exists, which
-    # the backend rejects rather than silently appending to stale staging data.
+    # A retained staging branch blocks an identical retry rather than appending.
     wap = make_iceberg_wap_expr(fresh_con, FINAL)
     _wap_expr(wap, bad, "src_bad").execute()
     assert STAGING in _refs(fresh_con)
@@ -137,8 +133,7 @@ def test_branch_wap_rerun_after_fail_raises(fresh_con: Backend) -> None:
 
 
 def test_iceberg_publish_guard_rejects_multi_row(fresh_con: Backend) -> None:
-    # The publish UDF assumes the audit aggregate collapsed to exactly one row;
-    # guard against a contract break upstream.
+    # Publish expects the audit aggregate to collapse to exactly one row.
     publish = make_publish_with_iceberg(fresh_con)
     df = pd.DataFrame(
         {

--- a/python/xorq/backends/pyiceberg/tests/test_wap.py
+++ b/python/xorq/backends/pyiceberg/tests/test_wap.py
@@ -18,6 +18,7 @@ import pytest
 import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
 from xorq.backends.pyiceberg import Backend
+from xorq.vendor.ibis import _
 from xorq.writes import make_iceberg_wap_expr
 from xorq.writes.wap import FINAL as FINAL_COL
 from xorq.writes.wap import PASSED as PASSED_COL
@@ -130,6 +131,30 @@ def test_branch_wap_rerun_after_fail_raises(fresh_con: Backend) -> None:
 
     with pytest.raises(ValueError, match="already exists"):
         _wap_expr(wap, good, "src_retry").execute()
+
+
+def _empty_wap_expr(wap: Callable[..., ir.Table], table_name: str) -> ir.Table:
+    return (
+        xo.connect()
+        .register(xo.memtable(good), table_name=table_name)
+        .filter(_.a > 1000)
+        .pipe(wap, STAGING, FINAL, no_nulls)
+    )
+
+
+def test_branch_wap_empty_input_fails_fast(fresh_con: Backend) -> None:
+    # An empty stream never opens the sink writer, so no staging branch is
+    # created. Publish fails fast naming the empty-input cause.
+    wap = make_iceberg_wap_expr(fresh_con, FINAL)
+    with pytest.raises(RuntimeError, match="missing at publish.*empty"):
+        _empty_wap_expr(wap, "src_empty").execute()
+
+
+def test_table_wap_empty_input_fails_fast(fresh_con: Backend) -> None:
+    wap = make_iceberg_wap_expr(fresh_con)
+    with pytest.raises(RuntimeError, match="missing at publish.*empty"):
+        _empty_wap_expr(wap, "src_empty").execute()
+    assert FINAL not in fresh_con.list_tables(), "empty input must not publish"
 
 
 def test_iceberg_publish_guard_rejects_multi_row(fresh_con: Backend) -> None:

--- a/python/xorq/tests/test_wap.py
+++ b/python/xorq/tests/test_wap.py
@@ -87,9 +87,7 @@ def test_parquet_publish_guard_rejects_multi_row() -> None:
 
 
 def test_parquet_wap_rerun_after_fail_raises(tmp_path: Path) -> None:
-    # A failed audit retains the staging file. Re-running against the same target
-    # then writes create-mode over an existing file, which the sink refuses
-    # rather than silently clobbering (FileExistsError surfaces as ValueError).
+    # A retained staging file blocks an identical retry rather than clobbering.
     staging = str(tmp_path / "staging.parquet")
     final = str(tmp_path / "final.parquet")
     _wap_expr(bad, staging, final, "src_bad").execute()
@@ -100,8 +98,7 @@ def test_parquet_wap_rerun_after_fail_raises(tmp_path: Path) -> None:
 
 
 def test_parquet_publish_requires_staging_present(tmp_path: Path) -> None:
-    # Backstop for the WAP ordering invariant: publishing before the staging
-    # write committed (e.g. an async sink) raises rather than publishing nothing.
+    # Publishing with staging absent raises rather than publishing nothing.
     final = tmp_path / "final.parquet"
     publish = _make_publish_with_parquet()
     df = pd.DataFrame(

--- a/python/xorq/tests/test_wap.py
+++ b/python/xorq/tests/test_wap.py
@@ -14,12 +14,13 @@ import pytest
 
 import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
+from xorq.vendor.ibis import _
 from xorq.writes import make_parquet_wap_expr
 from xorq.writes.wap import (
     FINAL,
     PASSED,
     STAGING,
-    _make_publish_with_parquet,
+    make_publish_with_parquet,
 )
 
 
@@ -74,7 +75,7 @@ def test_parquet_wap_fail(tmp_path: Path) -> None:
 
 
 def test_parquet_publish_guard_rejects_multi_row() -> None:
-    publish = _make_publish_with_parquet()
+    publish = make_publish_with_parquet()
     df = pd.DataFrame(
         {
             STAGING: ["s.parquet", "s.parquet"],
@@ -97,10 +98,27 @@ def test_parquet_wap_rerun_after_fail_raises(tmp_path: Path) -> None:
         _wap_expr(good, staging, final, "src_retry").execute()
 
 
+def test_parquet_wap_empty_input_fails_fast(tmp_path: Path) -> None:
+    # An empty stream never opens the sink writer, so no staging artifact is
+    # produced. Publish fails fast with a message naming the empty-input cause
+    # rather than silently publishing nothing.
+    staging = str(tmp_path / "staging.parquet")
+    final = str(tmp_path / "final.parquet")
+    expr = (
+        xo.connect()
+        .register(xo.memtable(good), table_name="src_empty")
+        .filter(_.a > 1000)
+        .pipe(make_parquet_wap_expr, staging, final, no_nulls)
+    )
+    with pytest.raises(RuntimeError, match="missing at publish.*empty"):
+        expr.execute()
+    assert not Path(final).exists(), "empty input must not publish"
+
+
 def test_parquet_publish_requires_staging_present(tmp_path: Path) -> None:
     # Publishing with staging absent raises rather than publishing nothing.
     final = tmp_path / "final.parquet"
-    publish = _make_publish_with_parquet()
+    publish = make_publish_with_parquet()
     df = pd.DataFrame(
         {
             STAGING: [str(tmp_path / "missing.parquet")],

--- a/python/xorq/tests/test_wap.py
+++ b/python/xorq/tests/test_wap.py
@@ -47,8 +47,19 @@ def test_parquet_wap_pass(tmp_path: Path) -> None:
     assert out["passed"].iloc[0]
     assert out["published"].iloc[0]
     assert Path(final).exists()
-    assert Path(staging).exists(), "staging is retained after the copy"
+    assert not Path(staging).exists(), "staging is consumed on publish"
     assert len(pd.read_parquet(final)) == 4
+
+
+def test_parquet_wap_append(tmp_path: Path) -> None:
+    # Repeated passing runs accumulate in final, matching the iceberg strategies.
+    staging = str(tmp_path / "staging.parquet")
+    final = str(tmp_path / "final.parquet")
+    _wap_expr(good, staging, final, "src1").execute()
+    _wap_expr(good, staging, final, "src2").execute()
+
+    assert len(pd.read_parquet(final)) == 8
+    assert not Path(staging).exists(), "staging is consumed on each publish"
 
 
 def test_parquet_wap_fail(tmp_path: Path) -> None:
@@ -72,4 +83,33 @@ def test_parquet_publish_guard_rejects_multi_row() -> None:
         }
     )
     with pytest.raises(ValueError, match="expected 1 row"):
+        publish.fn(df)
+
+
+def test_parquet_wap_rerun_after_fail_raises(tmp_path: Path) -> None:
+    # A failed audit retains the staging file. Re-running against the same target
+    # then writes create-mode over an existing file, which the sink refuses
+    # rather than silently clobbering (FileExistsError surfaces as ValueError).
+    staging = str(tmp_path / "staging.parquet")
+    final = str(tmp_path / "final.parquet")
+    _wap_expr(bad, staging, final, "src_bad").execute()
+    assert Path(staging).exists()
+
+    with pytest.raises(ValueError, match="already exists"):
+        _wap_expr(good, staging, final, "src_retry").execute()
+
+
+def test_parquet_publish_requires_staging_present(tmp_path: Path) -> None:
+    # Backstop for the WAP ordering invariant: publishing before the staging
+    # write committed (e.g. an async sink) raises rather than publishing nothing.
+    final = tmp_path / "final.parquet"
+    publish = _make_publish_with_parquet()
+    df = pd.DataFrame(
+        {
+            STAGING: [str(tmp_path / "missing.parquet")],
+            FINAL: [str(final)],
+            PASSED: [True],
+        }
+    )
+    with pytest.raises(RuntimeError, match="missing at publish"):
         publish.fn(df)

--- a/python/xorq/tests/test_wap.py
+++ b/python/xorq/tests/test_wap.py
@@ -1,0 +1,75 @@
+"""Unit coverage for the parquet WAP (Write-Audit-Publish) strategy.
+
+The iceberg strategies are covered in
+``xorq/backends/pyiceberg/tests/test_wap.py``; this keeps the backend-agnostic
+parquet path tested alongside the rest of the writes layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import xorq.api as xo
+import xorq.vendor.ibis.expr.types as ir
+from xorq.writes import make_parquet_wap_expr
+from xorq.writes.wap import (
+    FINAL,
+    PASSED,
+    STAGING,
+    _make_publish_with_parquet,
+)
+
+
+good = {"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]}
+bad = {"a": [1, None, 3, 4], "b": ["w", "x", "y", "z"]}
+
+
+def no_nulls(df: pd.DataFrame) -> bool:
+    return bool(df["a"].notna().all())
+
+
+def _wap_expr(data: dict, staging: str, final: str, table_name: str) -> ir.Table:
+    return (
+        xo.connect()
+        .register(xo.memtable(data), table_name=table_name)
+        .pipe(make_parquet_wap_expr, staging, final, no_nulls)
+    )
+
+
+def test_parquet_wap_pass(tmp_path: Path) -> None:
+    staging = str(tmp_path / "staging.parquet")
+    final = str(tmp_path / "final.parquet")
+    out = _wap_expr(good, staging, final, "src_good").execute()
+
+    assert out["passed"].iloc[0]
+    assert out["published"].iloc[0]
+    assert Path(final).exists()
+    assert Path(staging).exists(), "staging is retained after the copy"
+    assert len(pd.read_parquet(final)) == 4
+
+
+def test_parquet_wap_fail(tmp_path: Path) -> None:
+    staging = str(tmp_path / "staging.parquet")
+    final = str(tmp_path / "final.parquet")
+    out = _wap_expr(bad, staging, final, "src_bad").execute()
+
+    assert not out["passed"].iloc[0]
+    assert not out["published"].iloc[0]
+    assert not Path(final).exists(), "failing audit must not publish"
+    assert Path(staging).exists(), "rejected data is retained in staging"
+
+
+def test_parquet_publish_guard_rejects_multi_row() -> None:
+    publish = _make_publish_with_parquet()
+    df = pd.DataFrame(
+        {
+            STAGING: ["s.parquet", "s.parquet"],
+            FINAL: ["f.parquet", "f.parquet"],
+            PASSED: [True, True],
+        }
+    )
+    with pytest.raises(ValueError, match="expected 1 row"):
+        publish.fn(df)

--- a/python/xorq/writes/__init__.py
+++ b/python/xorq/writes/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from xorq.writes.enums import WriteMode
+from xorq.writes.wap import (
+    make_iceberg_wap_expr,
+    make_parquet_wap_expr,
+)
 from xorq.writes.write_through import (
     BackendWriteThrough,
     DrainingIterator,
@@ -19,4 +23,6 @@ __all__ = [
     "WriteMode",
     "WritePrimaryWriteThrough",
     "WriteThrough",
+    "make_iceberg_wap_expr",
+    "make_parquet_wap_expr",
 ]

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -87,10 +87,10 @@ def _make_publish_with_parquet() -> PublishUDF:
     def publish_with_parquet(df: pd.DataFrame) -> list[bool]:
         if len(df) != 1:
             raise ValueError(f"expected 1 row, got {len(df)}")
-        staging, final, passed = df.values[0]
+        row = df.iloc[0]
         written = False
-        if passed:
-            shutil.copy2(staging, final)
+        if row[PASSED]:
+            shutil.copy2(row[STAGING], row[FINAL])
             written = True
         return [written]
 
@@ -147,14 +147,14 @@ def make_publish_with_iceberg(
     def publish_with_iceberg(df: pd.DataFrame) -> list[bool]:
         if len(df) != 1:
             raise ValueError(f"expected 1 row, got {len(df)}")
-        staging, final, passed = df.values[0]
+        row = df.iloc[0]
         written = False
-        if passed:
+        if row[PASSED]:
             if branch:
                 # staging=branch name, final=table name for the branch strategy
-                con.publish_branch(final, staging)
+                con.publish_branch(row[FINAL], row[STAGING])
             else:
-                con.publish_staging_table(staging, final)
+                con.publish_staging_table(row[STAGING], row[FINAL])
             written = True
         return [written]
 

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING, Any, Callable
+
+from toolz import curry
+
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from xorq.vendor.ibis.backends import BaseBackend
+    from xorq.vendor.ibis.expr.types import Table
+    from xorq.writes.write_through import (
+        BackendWriteThrough,
+        ParquetWriteThrough,
+        WriteThrough,
+    )
+
+STAGING = "staging"
+FINAL = "final"
+PASSED = "passed"
+PUBLISHED = "published"
+
+
+@curry
+def audit_expr(
+    expr: Table, audit_fn: Callable[[pd.DataFrame], bool], name: str
+) -> Table:
+    import xorq.expr.datatypes as dt  # noqa: PLC0415
+    from xorq.expr.udf import agg  # noqa: PLC0415
+
+    return agg.pandas_df(
+        fn=audit_fn,
+        schema=expr.schema(),
+        return_type=dt.boolean,
+        name=name,
+    ).on_expr(expr)
+
+
+@curry
+def make_wap_expr(
+    expr: Table,
+    staging: str,
+    final: str,
+    audit_fn: Callable[[pd.DataFrame], bool],
+    make_sink: Callable[[str], WriteThrough],
+    publish: Any,
+) -> Table:
+    from xorq.vendor.ibis.expr.types.generic import literal  # noqa: PLC0415
+
+    wap_expr = (
+        expr.tee(make_sink(staging))
+        .aggregate(**{PASSED: audit_expr(audit_fn=audit_fn, name=PASSED)})
+        .mutate(**{STAGING: literal(staging), FINAL: literal(final)})
+        .mutate(**{PUBLISHED: publish.on_expr})
+    )
+    return wap_expr
+
+
+def _make_sink_with_parquet(path: str) -> ParquetWriteThrough:
+    from xorq.writes.enums import WriteMode  # noqa: PLC0415
+    from xorq.writes.write_through import ParquetWriteThrough  # noqa: PLC0415
+
+    return ParquetWriteThrough(path=path, mode=WriteMode.CREATE)
+
+
+def _make_publish_with_parquet() -> Any:
+    import xorq.expr.datatypes as dt  # noqa: PLC0415
+    from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
+    from xorq.vendor.ibis import schema  # noqa: PLC0415
+
+    @make_pandas_udf(
+        schema=schema({STAGING: str, FINAL: str, PASSED: bool}),
+        return_type=dt.boolean,
+        name="publish_with_parquet",
+    )
+    def publish_with_parquet(df: pd.DataFrame) -> list[bool]:
+        if len(df) != 1:
+            raise ValueError(f"expected 1 row, got {len(df)}")
+        staging, final, passed = df.values[0]
+        written = False
+        if passed:
+            shutil.copy2(staging, final)
+            written = True
+        return [written]
+
+    return publish_with_parquet
+
+
+def make_parquet_wap_expr(
+    expr: Table,
+    staging: str,
+    final: str,
+    audit_fn: Callable[[pd.DataFrame], bool],
+) -> Table:
+    return make_wap_expr(
+        expr,
+        staging,
+        final,
+        audit_fn,
+        make_sink=_make_sink_with_parquet,
+        publish=_make_publish_with_parquet(),
+    )
+
+
+@curry
+def make_sink_with_iceberg(
+    con: BaseBackend, staging: str, table_name: str | None = None
+) -> BackendWriteThrough:
+    from xorq.writes.enums import WriteMode  # noqa: PLC0415
+    from xorq.writes.write_through import BackendWriteThrough  # noqa: PLC0415
+
+    # Branch strategy (table_name set): write to a staging branch of table_name.
+    # Table strategy (table_name None): write to a staging table named `staging`.
+    if table_name is None:
+        return BackendWriteThrough(con=con, table_name=staging, mode=WriteMode.CREATE)
+    return BackendWriteThrough(
+        con=con,
+        table_name=table_name,
+        mode=WriteMode.CREATE,
+        kwargs={"branch": staging},
+    )
+
+
+def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
+    import xorq.expr.datatypes as dt  # noqa: PLC0415
+    from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
+    from xorq.vendor.ibis import schema  # noqa: PLC0415
+    from xorq.writes.enums import WriteMode  # noqa: PLC0415
+
+    @make_pandas_udf(
+        schema=schema({STAGING: str, FINAL: str, PASSED: bool}),
+        return_type=dt.boolean,
+        name="publish_with_iceberg_branch" if branch else "publish_with_iceberg",
+    )
+    def publish_with_iceberg(df: pd.DataFrame) -> list[bool]:
+        if len(df) != 1:
+            raise ValueError(f"expected 1 row, got {len(df)}")
+        staging, final, passed = df.values[0]
+        written = False
+        if passed:
+            if branch:
+                # staging=branch name, final=table name for the branch strategy
+                full_name = f"{con.namespace}.{final}"
+                ice = con.catalog.load_table(full_name)
+                staging_snap = ice.refs()[staging].snapshot_id
+                ice.manage_snapshots().set_current_snapshot(staging_snap).commit()
+                ice = con.catalog.load_table(full_name)
+                ice.manage_snapshots().remove_branch(staging).commit()
+            else:
+                staged = con.table(staging).execute()
+                if final in con.list_tables():
+                    con.insert(final, staged, mode=WriteMode.APPEND)
+                else:
+                    con.create_table(final, staged, overwrite=True)
+                con.drop_table(staging)
+            written = True
+        return [written]
+
+    return publish_with_iceberg
+
+
+def make_iceberg_wap_expr(
+    con: BaseBackend, table_name: str | None = None
+) -> Callable[..., Table]:
+    # Passing table_name selects the branch strategy on that table; otherwise
+    # the table strategy stages into a separate table named by the caller.
+    return make_wap_expr(
+        make_sink=make_sink_with_iceberg(con, table_name=table_name),
+        publish=make_publish_with_iceberg(con, branch=table_name is not None),
+    )

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import shutil
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Protocol
 
 from toolz import curry
@@ -58,6 +58,18 @@ def make_wap_expr(
 ) -> Table:
     from xorq.vendor.ibis.expr.types.generic import literal  # noqa: PLC0415
 
+    # Load-bearing ordering invariant: the staging write must fully commit before
+    # publish reads it. `tee` writes to staging as a side effect as batches pass
+    # through; `.aggregate` is a pipeline breaker that has to pull the *entire*
+    # tee'd stream to produce its single `passed` row, so the staging write is
+    # drained to completion before that row flows into the publish `.mutate`.
+    #
+    # This holds only because the default sinks write inline in the draining
+    # thread (ParquetWriteThrough; per-batch BackendWriteThrough). A
+    # background-threaded sink (ThreadedBackendWriteThrough / WritePrimaryWriteThrough)
+    # would break it: draining the read side does not join the write thread, so
+    # publish could run before staging commits. The publish UDFs raise if the
+    # staging artifact is missing as a backstop against that.
     wap_expr = (
         expr.tee(make_sink(staging))
         .aggregate(**{PASSED: audit_expr(audit_fn=audit_fn, name=PASSED)})
@@ -75,6 +87,9 @@ def _make_sink_with_parquet(path: str) -> ParquetWriteThrough:
 
 
 def _make_publish_with_parquet() -> PublishUDF:
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pq  # noqa: PLC0415
+
     import xorq.expr.datatypes as dt  # noqa: PLC0415
     from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
     from xorq.vendor.ibis import schema  # noqa: PLC0415
@@ -90,7 +105,35 @@ def _make_publish_with_parquet() -> PublishUDF:
         row = df.iloc[0]
         written = False
         if row[PASSED]:
-            shutil.copy2(row[STAGING], row[FINAL])
+            staging = Path(row[STAGING])
+            final = Path(row[FINAL])
+            # Backstop for the ordering invariant in make_wap_expr: if the audit
+            # really drained the inline staging write, the file is here by now.
+            if not staging.exists():
+                raise RuntimeError(
+                    f"staging {str(staging)!r} missing at publish: the audit ran "
+                    "before the staging write committed (async sink?)"
+                )
+            # Append into final, then consume staging — mirrors the iceberg
+            # strategies (add_files / fast-forward main, then drop the staging
+            # table / branch). Parquet has no metadata-only append, so we rewrite:
+            # read both sides, write to a temp in final's dir, then swap. The temp
+            # shares final's filesystem, so .replace is an atomic same-fs rename;
+            # reading staging via pyarrow works across filesystems.
+            final.parent.mkdir(parents=True, exist_ok=True)
+            tables = [pq.read_table(staging)]
+            if final.exists():
+                tables.insert(0, pq.read_table(final))
+            merged = final.with_name(final.name + ".merge.tmp")
+            try:
+                pq.write_table(pa.concat_tables(tables), merged)
+                merged.replace(final)
+            except BaseException:
+                merged.unlink(missing_ok=True)
+                raise
+            # final now holds staging's rows; removing staging is cleanup, so a
+            # failure here must not mask a successful publish.
+            staging.unlink(missing_ok=True)
             written = True
         return [written]
 
@@ -171,10 +214,16 @@ def make_iceberg_wap_expr(
     # Passing table_name selects the branch strategy on that table; otherwise
     # the table strategy stages into a separate table named by the caller.
     #
-    # On audit failure the staging branch (branch strategy) or staging table
-    # (table strategy) is retained for inspection. Re-running against the same
-    # target then fails because the stale staging ref still exists; remove it
-    # first or stage under a fresh name before retrying.
+    # Executing a WAP expr is NOT idempotent: publish runs as a side effect of
+    # execution, so re-executing publishes again. Every strategy appends to final
+    # on each pass run and consumes staging (iceberg: fast-forward / add_files
+    # then drop the branch/table; parquet: merge then unlink), so repeated passing
+    # runs accumulate in final.
+    #
+    # On audit failure the staging branch (branch strategy), staging table
+    # (table strategy), or staging file (parquet) is retained for inspection.
+    # Re-running against the same target then fails because the stale staging ref
+    # still exists; remove it first or stage under a fresh name before retrying.
     return make_wap_expr(
         make_sink=make_sink_with_iceberg(con, table_name=table_name),
         publish=make_publish_with_iceberg(con, branch=table_name is not None),

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import shutil
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable, Protocol
 
 from toolz import curry
 
@@ -10,12 +10,20 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from xorq.vendor.ibis.backends import BaseBackend
-    from xorq.vendor.ibis.expr.types import Table
+    from xorq.vendor.ibis.expr.types import Table, Value
     from xorq.writes.write_through import (
         BackendWriteThrough,
         ParquetWriteThrough,
         WriteThrough,
     )
+
+    class PublishUDF(Protocol):
+        """UDF constructor returned by make_pandas_udf for the publish step."""
+
+        fn: Callable[[pd.DataFrame], list[bool]]
+
+        def on_expr(self, e: Table) -> Value: ...
+
 
 # Column-name contract shared by the audit/publish UDF schemas and the mutate keys.
 STAGING = "staging"
@@ -46,7 +54,7 @@ def make_wap_expr(
     final: str,
     audit_fn: Callable[[pd.DataFrame], bool],
     make_sink: Callable[[str], WriteThrough],
-    publish: Any,
+    publish: PublishUDF,
 ) -> Table:
     from xorq.vendor.ibis.expr.types.generic import literal  # noqa: PLC0415
 
@@ -66,7 +74,7 @@ def _make_sink_with_parquet(path: str) -> ParquetWriteThrough:
     return ParquetWriteThrough(path=path, mode=WriteMode.CREATE)
 
 
-def _make_publish_with_parquet() -> Any:
+def _make_publish_with_parquet() -> PublishUDF:
     import xorq.expr.datatypes as dt  # noqa: PLC0415
     from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
     from xorq.vendor.ibis import schema  # noqa: PLC0415
@@ -124,7 +132,7 @@ def make_sink_with_iceberg(
     )
 
 
-def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
+def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> PublishUDF:
     import xorq.expr.datatypes as dt  # noqa: PLC0415
     from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
     from xorq.vendor.ibis import schema  # noqa: PLC0415

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -58,18 +58,13 @@ def make_wap_expr(
 ) -> Table:
     from xorq.vendor.ibis.expr.types.generic import literal  # noqa: PLC0415
 
-    # Load-bearing ordering invariant: the staging write must fully commit before
-    # publish reads it. `tee` writes to staging as a side effect as batches pass
-    # through; `.aggregate` is a pipeline breaker that has to pull the *entire*
-    # tee'd stream to produce its single `passed` row, so the staging write is
-    # drained to completion before that row flows into the publish `.mutate`.
-    #
-    # This holds only because the default sinks write inline in the draining
-    # thread (ParquetWriteThrough; per-batch BackendWriteThrough). A
-    # background-threaded sink (ThreadedBackendWriteThrough / WritePrimaryWriteThrough)
-    # would break it: draining the read side does not join the write thread, so
-    # publish could run before staging commits. The publish UDFs raise if the
-    # staging artifact is missing as a backstop against that.
+    # Load-bearing ordering invariant: staging must fully commit before publish
+    # reads it. `tee` writes staging as a side effect while batches pass; the
+    # `.aggregate` pipeline breaker pulls the *entire* stream to produce `passed`,
+    # so staging is drained before that row reaches publish. This holds only for
+    # sinks that write inline in the draining thread (the defaults) — a
+    # background-threaded sink would let publish run before staging commits, which
+    # is why the publish UDFs raise if the staging artifact is missing.
     wap_expr = (
         expr.tee(make_sink(staging))
         .aggregate(**{PASSED: audit_expr(audit_fn=audit_fn, name=PASSED)})
@@ -107,19 +102,15 @@ def _make_publish_with_parquet() -> PublishUDF:
         if row[PASSED]:
             staging = Path(row[STAGING])
             final = Path(row[FINAL])
-            # Backstop for the ordering invariant in make_wap_expr: if the audit
-            # really drained the inline staging write, the file is here by now.
             if not staging.exists():
                 raise RuntimeError(
                     f"staging {str(staging)!r} missing at publish: the audit ran "
                     "before the staging write committed (async sink?)"
                 )
-            # Append into final, then consume staging — mirrors the iceberg
-            # strategies (add_files / fast-forward main, then drop the staging
-            # table / branch). Parquet has no metadata-only append, so we rewrite:
-            # read both sides, write to a temp in final's dir, then swap. The temp
-            # shares final's filesystem, so .replace is an atomic same-fs rename;
-            # reading staging via pyarrow works across filesystems.
+            # Parquet has no metadata-only append, so accumulating into final
+            # means a rewrite: concat both sides into a temp in final's dir, then
+            # swap. The temp shares final's filesystem, so .replace is an atomic
+            # same-fs rename; reading staging via pyarrow works across filesystems.
             final.parent.mkdir(parents=True, exist_ok=True)
             tables = [pq.read_table(staging)]
             if final.exists():
@@ -207,23 +198,15 @@ def make_publish_with_iceberg(
 def make_iceberg_wap_expr(
     con: PyIcebergBackend, table_name: str | None = None
 ) -> Callable[..., Table]:
-    # Unlike make_parquet_wap_expr (a flat function), this is a factory that binds
-    # `con` up front and returns a curried builder, so it composes with `.pipe()`
-    # and can be reused across exprs without re-threading the connection.
+    # Factory that binds `con` and returns a curried builder, so it composes with
+    # `.pipe()`. table_name set -> branch strategy on that table; None -> table
+    # strategy staging into a separate table.
     #
-    # Passing table_name selects the branch strategy on that table; otherwise
-    # the table strategy stages into a separate table named by the caller.
-    #
-    # Executing a WAP expr is NOT idempotent: publish runs as a side effect of
-    # execution, so re-executing publishes again. Every strategy appends to final
-    # on each pass run and consumes staging (iceberg: fast-forward / add_files
-    # then drop the branch/table; parquet: merge then unlink), so repeated passing
-    # runs accumulate in final.
-    #
-    # On audit failure the staging branch (branch strategy), staging table
-    # (table strategy), or staging file (parquet) is retained for inspection.
-    # Re-running against the same target then fails because the stale staging ref
-    # still exists; remove it first or stage under a fresh name before retrying.
+    # Executing a WAP expr is NOT idempotent: publish is a side effect of
+    # execution, every strategy appends to final on a pass and consumes staging,
+    # so re-executing accumulates. On audit failure staging is retained for
+    # inspection, which then blocks an identical retry (create-mode refuses the
+    # stale ref) — drop it or stage under a fresh name to retry.
     return make_wap_expr(
         make_sink=make_sink_with_iceberg(con, table_name=table_name),
         publish=make_publish_with_iceberg(con, branch=table_name is not None),

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -162,20 +162,11 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
 
 
 def make_iceberg_wap_expr(
-    expr: Table,
-    staging: str,
-    final: str,
-    audit_fn: Callable[[pd.DataFrame], bool],
-    con: BaseBackend,
-    table_name: str | None = None,
-) -> Table:
+    con: BaseBackend, table_name: str | None = None
+) -> Callable[..., Table]:
     # Passing table_name selects the branch strategy on that table; otherwise
     # the table strategy stages into a separate table named by the caller.
     return make_wap_expr(
-        expr,
-        staging,
-        final,
-        audit_fn,
         make_sink=make_sink_with_iceberg(con, table_name=table_name),
         publish=make_publish_with_iceberg(con, branch=table_name is not None),
     )

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -162,11 +162,20 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
 
 
 def make_iceberg_wap_expr(
-    con: BaseBackend, table_name: str | None = None
-) -> Callable[..., Table]:
+    expr: Table,
+    staging: str,
+    final: str,
+    audit_fn: Callable[[pd.DataFrame], bool],
+    con: BaseBackend,
+    table_name: str | None = None,
+) -> Table:
     # Passing table_name selects the branch strategy on that table; otherwise
     # the table strategy stages into a separate table named by the caller.
     return make_wap_expr(
+        expr,
+        staging,
+        final,
+        audit_fn,
         make_sink=make_sink_with_iceberg(con, table_name=table_name),
         publish=make_publish_with_iceberg(con, branch=table_name is not None),
     )

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         WriteThrough,
     )
 
+# Column-name contract shared by the audit/publish UDF schemas and the mutate keys.
 STAGING = "staging"
 FINAL = "final"
 PASSED = "passed"
@@ -149,11 +150,11 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
                 ice = con.catalog.load_table(full_name)
                 ice.manage_snapshots().remove_branch(staging).commit()
             else:
-                staged = con.table(staging).execute()
+                staged = con.table(staging)
                 if final in con.list_tables():
                     con.insert(final, staged, mode=WriteMode.APPEND)
                 else:
-                    con.create_table(final, staged, overwrite=True)
+                    con.create_table(final, staged)
                 con.drop_table(staging)
             written = True
         return [written]
@@ -166,6 +167,11 @@ def make_iceberg_wap_expr(
 ) -> Callable[..., Table]:
     # Passing table_name selects the branch strategy on that table; otherwise
     # the table strategy stages into a separate table named by the caller.
+    #
+    # On audit failure the staging branch (branch strategy) or staging table
+    # (table strategy) is retained for inspection. Re-running against the same
+    # target then fails because the stale staging ref still exists; remove it
+    # first or stage under a fresh name before retrying.
     return make_wap_expr(
         make_sink=make_sink_with_iceberg(con, table_name=table_name),
         publish=make_publish_with_iceberg(con, branch=table_name is not None),

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -128,7 +128,6 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
     import xorq.expr.datatypes as dt  # noqa: PLC0415
     from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
     from xorq.vendor.ibis import schema  # noqa: PLC0415
-    from xorq.writes.enums import WriteMode  # noqa: PLC0415
 
     @make_pandas_udf(
         schema=schema({STAGING: str, FINAL: str, PASSED: bool}),
@@ -150,11 +149,23 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
                 ice = con.catalog.load_table(full_name)
                 ice.manage_snapshots().remove_branch(staging).commit()
             else:
-                staged = con.table(staging)
-                if final in con.list_tables():
-                    con.insert(final, staged, mode=WriteMode.APPEND)
-                else:
-                    con.create_table(final, staged)
+                # Repoint the metadata instead of copying rows: register
+                # staging's parquet data files into final, then drop staging's
+                # catalog entry. add_files is metadata-only (reads footers, not
+                # rows) and con.drop_table only removes the catalog entry, so
+                # the files now live under final without ever being rewritten.
+                full_staging = f"{con.namespace}.{staging}"
+                full_final = f"{con.namespace}.{final}"
+                staged_tbl = con.catalog.load_table(full_staging)
+                data_files = [
+                    task.file.file_path for task in staged_tbl.scan().plan_files()
+                ]
+                if not con.catalog.table_exists(full_final):
+                    con.catalog.create_table(
+                        identifier=full_final, schema=staged_tbl.schema()
+                    )
+                if data_files:
+                    con.catalog.load_table(full_final).add_files(data_files)
                 con.drop_table(staging)
             written = True
         return [written]
@@ -165,6 +176,10 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Any:
 def make_iceberg_wap_expr(
     con: BaseBackend, table_name: str | None = None
 ) -> Callable[..., Table]:
+    # Unlike make_parquet_wap_expr (a flat function), this is a factory that binds
+    # `con` up front and returns a curried builder, so it composes with `.pipe()`
+    # and can be reused across exprs without re-threading the connection.
+    #
     # Passing table_name selects the branch strategy on that table; otherwise
     # the table strategy stages into a separate table named by the caller.
     #

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -74,14 +74,14 @@ def make_wap_expr(
     return wap_expr
 
 
-def _make_sink_with_parquet(path: str) -> ParquetWriteThrough:
+def make_sink_with_parquet(path: str) -> ParquetWriteThrough:
     from xorq.writes.enums import WriteMode  # noqa: PLC0415
     from xorq.writes.write_through import ParquetWriteThrough  # noqa: PLC0415
 
     return ParquetWriteThrough(path=path, mode=WriteMode.CREATE)
 
 
-def _make_publish_with_parquet() -> PublishUDF:
+def make_publish_with_parquet() -> PublishUDF:
     import pyarrow.parquet as pq  # noqa: PLC0415
 
     import xorq.expr.datatypes as dt  # noqa: PLC0415
@@ -103,8 +103,10 @@ def _make_publish_with_parquet() -> PublishUDF:
             final = Path(row[FINAL])
             if not staging.exists():
                 raise RuntimeError(
-                    f"staging {str(staging)!r} missing at publish: the audit ran "
-                    "before the staging write committed (async sink?)"
+                    f"staging {str(staging)!r} missing at publish. The sink opens "
+                    "its writer on the first batch, so either the audited input "
+                    "was empty (no batch, no artifact) or the staging write has "
+                    "not committed yet (async sink?)."
                 )
             # Parquet has no metadata-only append, so accumulating into final
             # means a rewrite: stream each source batch-by-batch into a temp in
@@ -112,12 +114,23 @@ def _make_publish_with_parquet() -> PublishUDF:
             # temp shares final's filesystem, so .replace is an atomic same-fs
             # rename; reading staging via pyarrow works across filesystems.
             final.parent.mkdir(parents=True, exist_ok=True)
-            sources = [final, staging] if final.exists() else [staging]
+            staging_schema = pq.ParquetFile(staging).schema_arrow
+            sources = [staging]
+            if final.exists():
+                # Accumulating means concatenating both files through one writer,
+                # so a divergent final would only fail mid-stream on write_batch.
+                # Compare up front to fail fast (and before any temp is created).
+                final_schema = pq.ParquetFile(final).schema_arrow
+                if not staging_schema.equals(final_schema, check_metadata=False):
+                    raise ValueError(
+                        "cannot publish: staging schema does not match existing "
+                        f"final schema.\n  staging: {staging_schema}\n"
+                        f"  final:   {final_schema}"
+                    )
+                sources = [final, staging]
             merged = final.with_name(final.name + ".merge.tmp")
             try:
-                with pq.ParquetWriter(
-                    merged, pq.ParquetFile(staging).schema_arrow
-                ) as writer:
+                with pq.ParquetWriter(merged, staging_schema) as writer:
                     for src in sources:
                         for batch in pq.ParquetFile(src).iter_batches():
                             writer.write_batch(batch)
@@ -145,8 +158,8 @@ def make_parquet_wap_expr(
         staging,
         final,
         audit_fn,
-        make_sink=_make_sink_with_parquet,
-        publish=_make_publish_with_parquet(),
+        make_sink=make_sink_with_parquet,
+        publish=make_publish_with_parquet(),
     )
 
 

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -9,7 +9,7 @@ from toolz import curry
 if TYPE_CHECKING:
     import pandas as pd
 
-    from xorq.vendor.ibis.backends import BaseBackend
+    from xorq.backends.pyiceberg import Backend as PyIcebergBackend
     from xorq.vendor.ibis.expr.types import Table, Value
     from xorq.writes.write_through import (
         BackendWriteThrough,
@@ -115,7 +115,7 @@ def make_parquet_wap_expr(
 
 @curry
 def make_sink_with_iceberg(
-    con: BaseBackend, staging: str, table_name: str | None = None
+    con: PyIcebergBackend, staging: str, table_name: str | None = None
 ) -> BackendWriteThrough:
     from xorq.writes.enums import WriteMode  # noqa: PLC0415
     from xorq.writes.write_through import BackendWriteThrough  # noqa: PLC0415
@@ -132,7 +132,9 @@ def make_sink_with_iceberg(
     )
 
 
-def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> PublishUDF:
+def make_publish_with_iceberg(
+    con: PyIcebergBackend, branch: bool = False
+) -> PublishUDF:
     import xorq.expr.datatypes as dt  # noqa: PLC0415
     from xorq.expr.udf import make_pandas_udf  # noqa: PLC0415
     from xorq.vendor.ibis import schema  # noqa: PLC0415
@@ -150,31 +152,9 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Publish
         if passed:
             if branch:
                 # staging=branch name, final=table name for the branch strategy
-                full_name = f"{con.namespace}.{final}"
-                ice = con.catalog.load_table(full_name)
-                staging_snap = ice.refs()[staging].snapshot_id
-                ice.manage_snapshots().set_current_snapshot(staging_snap).commit()
-                ice = con.catalog.load_table(full_name)
-                ice.manage_snapshots().remove_branch(staging).commit()
+                con.publish_branch(final, staging)
             else:
-                # Repoint the metadata instead of copying rows: register
-                # staging's parquet data files into final, then drop staging's
-                # catalog entry. add_files is metadata-only (reads footers, not
-                # rows) and con.drop_table only removes the catalog entry, so
-                # the files now live under final without ever being rewritten.
-                full_staging = f"{con.namespace}.{staging}"
-                full_final = f"{con.namespace}.{final}"
-                staged_tbl = con.catalog.load_table(full_staging)
-                data_files = [
-                    task.file.file_path for task in staged_tbl.scan().plan_files()
-                ]
-                if not con.catalog.table_exists(full_final):
-                    con.catalog.create_table(
-                        identifier=full_final, schema=staged_tbl.schema()
-                    )
-                if data_files:
-                    con.catalog.load_table(full_final).add_files(data_files)
-                con.drop_table(staging)
+                con.publish_staging_table(staging, final)
             written = True
         return [written]
 
@@ -182,7 +162,7 @@ def make_publish_with_iceberg(con: BaseBackend, branch: bool = False) -> Publish
 
 
 def make_iceberg_wap_expr(
-    con: BaseBackend, table_name: str | None = None
+    con: PyIcebergBackend, table_name: str | None = None
 ) -> Callable[..., Table]:
     # Unlike make_parquet_wap_expr (a flat function), this is a factory that binds
     # `con` up front and returns a curried builder, so it composes with `.pipe()`

--- a/python/xorq/writes/wap.py
+++ b/python/xorq/writes/wap.py
@@ -82,7 +82,6 @@ def _make_sink_with_parquet(path: str) -> ParquetWriteThrough:
 
 
 def _make_publish_with_parquet() -> PublishUDF:
-    import pyarrow as pa  # noqa: PLC0415
     import pyarrow.parquet as pq  # noqa: PLC0415
 
     import xorq.expr.datatypes as dt  # noqa: PLC0415
@@ -108,16 +107,20 @@ def _make_publish_with_parquet() -> PublishUDF:
                     "before the staging write committed (async sink?)"
                 )
             # Parquet has no metadata-only append, so accumulating into final
-            # means a rewrite: concat both sides into a temp in final's dir, then
-            # swap. The temp shares final's filesystem, so .replace is an atomic
-            # same-fs rename; reading staging via pyarrow works across filesystems.
+            # means a rewrite: stream each source batch-by-batch into a temp in
+            # final's dir (only one batch is ever held in memory), then swap. The
+            # temp shares final's filesystem, so .replace is an atomic same-fs
+            # rename; reading staging via pyarrow works across filesystems.
             final.parent.mkdir(parents=True, exist_ok=True)
-            tables = [pq.read_table(staging)]
-            if final.exists():
-                tables.insert(0, pq.read_table(final))
+            sources = [final, staging] if final.exists() else [staging]
             merged = final.with_name(final.name + ".merge.tmp")
             try:
-                pq.write_table(pa.concat_tables(tables), merged)
+                with pq.ParquetWriter(
+                    merged, pq.ParquetFile(staging).schema_arrow
+                ) as writer:
+                    for src in sources:
+                        for batch in pq.ParquetFile(src).iter_batches():
+                            writer.write_batch(batch)
                 merged.replace(final)
             except BaseException:
                 merged.unlink(missing_ok=True)

--- a/python/xorq/writes/write_through.py
+++ b/python/xorq/writes/write_through.py
@@ -200,10 +200,11 @@ class BackendWriteThrough(WriteThrough):
         sig = inspect.signature(self.con.read_record_batches)
         return "mode" in sig.parameters
 
-    def _ingest(self, reader: pa.RecordBatchReader, mode: str) -> None:
+    def _ingest(self, reader: pa.RecordBatchReader, mode: WriteMode) -> None:
         kw = dict(self.kwargs)
         if self._supports_mode:
-            kw["mode"] = mode
+            # Backends (and ADBC under them) expect the wire string, not the enum.
+            kw["mode"] = mode.value
         self.con.read_record_batches(reader, table_name=self.table_name, **kw)
 
     def write_through(
@@ -225,10 +226,10 @@ class BackendWriteThrough(WriteThrough):
         for batch in batches:
             reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])
             if first:
-                mode = "create" if self.mode is WriteMode.CREATE else "append"
+                mode = self.mode
                 first = False
             else:
-                mode = "append"
+                mode = WriteMode.APPEND
             self._ingest(reader, mode)
             yield batch
 
@@ -259,7 +260,7 @@ class BackendWriteThrough(WriteThrough):
             yield batch
         if collected:
             reader = pa.RecordBatchReader.from_batches(collected[0].schema, collected)
-            self._ingest(reader, self.mode.value)
+            self._ingest(reader, self.mode)
 
 
 @frozen
@@ -315,7 +316,7 @@ class ThreadedBackendWriteThrough(BackendWriteThrough):
 
             try:
                 reader = pa.RecordBatchReader.from_batches(schema, drain())
-                self._ingest(reader, self.mode.value)
+                self._ingest(reader, self.mode)
             except BaseException as exc:  # noqa: BLE001
                 error.append(exc)
             finally:


### PR DESCRIPTION
## Summary
- Adds a write-audit-publish (WAP) library at `python/xorq/writes/wap.py` with parquet and iceberg strategies (table-based and branch-based).
- Wires iceberg backend support and tests; includes runnable examples for both parquet and iceberg flows.

## Dependency
> [!IMPORTANT]
> **Stacked on #2089** (`feat: add TeeNode for deferred sinks`, branch `adr-0014`). This PR is based against `adr-0014`, not `main`. Merge/review #2089 first; rebase onto `main` once it lands.

## Notes
- `make_iceberg_wap_expr` is intentionally a backend-bound factory (returns a curried builder) rather than a flat function like `make_parquet_wap_expr`, so it composes with `.pipe()` and can be reused across exprs. A flat-form refactor was explored and reverted (see commit history) because it breaks those call sites.

## Test plan
- [ ] `pytest python/xorq/backends/pyiceberg/tests/test_wap.py`
- [ ] `pytest python/xorq/backends/pyiceberg/tests/test_backend_internals.py`
- [ ] Run `examples/wap_audit_parquet.py` and `examples/wap_audit_iceberg.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)