### PR TITLE
refactor(ibis_yaml): lighter, agent-friendly expr.yaml output (-48% bytes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,7 @@ markers = [
     "gcs",
     "snapshot_check",
     "slow",
+    "metrics: ibis_yaml size/perf characterization harness (run on demand)",
     "datafusion: Apache Datafusion tests",
     "duckdb: DuckDB tests",
 

--- a/python/xorq/ibis_yaml/common.py
+++ b/python/xorq/ibis_yaml/common.py
@@ -44,6 +44,12 @@ class Registry:
         self.dtypes = dict(dtypes)
         self.nodes = dict(nodes)
         self.schemas = dict(schemas)
+        # write-side state for sequential, human/agent-friendly node labels
+        # (e.g. "@project_2"). Maps a node's content hash -> its assigned label
+        # so structurally-equal nodes dedup to one entry and labels are stable
+        # in registration (toposort) order across rebuilds of the same expr.
+        self._label_counter = 0
+        self._hash_to_label = {}
 
     def getstate(self):
         return freeze(
@@ -95,7 +101,15 @@ class Registry:
                 with SnapshotStrategy().normalization_context(node.to_expr()):
                     node_hash = tokenize(untagged_repr)
         op_name = node_dict.get("op", "unknown").lower()
-        node_ref = f"@{op_name}_{node_hash[: config.hash_length]}"
+        # sequential label keyed by content hash: equal nodes share a label
+        # (structural dedup), and the content hash stays in the body as
+        # `snapshot_hash` for cache alignment.
+        if node_hash in self._hash_to_label:
+            node_ref = self._hash_to_label[node_hash]
+        else:
+            node_ref = f"@{op_name}_{self._label_counter}"
+            self._label_counter += 1
+            self._hash_to_label[node_hash] = node_ref
         node_dict_with_hash = freeze(node_dict | {"snapshot_hash": node_hash})
         if isinstance(node, Read) and "read_path" in dict(node.read_kwargs):
             # Reads whose parquet was materialized into the build bundle carry
@@ -116,8 +130,11 @@ class Registry:
                 node_dict_with_hash | {"read_kwargs": modified_read_kwargs}
             )
         self.nodes.setdefault(node_ref, node_dict_with_hash)
-        frozen = freeze({RefEnum.node_ref: node_ref})
-        return frozen
+        # emit the reference as the bare "@..." sigil string rather than a
+        # {node_ref: "@..."} wrapper dict — every parent/relation/table/etc.
+        # reference drops a line. The loader resolves any "@"-prefixed string
+        # that is a registered node key back to the node.
+        return node_ref
 
     def register_schema(self, schema):
         frozen_schema = freeze(
@@ -243,6 +260,13 @@ def translate_from_yaml(yaml_dict: dict, context: TranslationContext) -> Any:
     match yaml_dict:
         case None:
             return None
+        case str() if (
+            context is not None
+            and yaml_dict.startswith("@")
+            and yaml_dict in context.registry.nodes
+        ):
+            # bare "@..." sigil reference to a hoisted node
+            return context.get_node(yaml_dict)
         case bool() | int() | float() | str():
             return yaml_dict
         case {RefEnum.dtype_ref: dtype_ref, **rest}:

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -237,14 +237,18 @@ class YamlExpressionTranslator:
         )
         with SnapshotStrategy().normalization_context(expr):
             expr_dict = translate_to_yaml(expr, context)
-            expr_dict = freeze(
-                expr_dict
-                | {
-                    RefEnum.schema_ref: context.registry.register_schema(expr.schema())
-                    if hasattr(expr, "schema")
-                    else None,
-                }
+            # a hoisted top expression comes back as a bare "@..." sigil string;
+            # re-wrap it so the document's `expression` is always a mapping
+            if isinstance(expr_dict, str):
+                expr_dict = {RefEnum.node_ref: expr_dict}
+            # only the top expression of a *table* carries a schema; scalar/column
+            # expressions have none, so omit the null schema_ref rather than emit it
+            schema_ref = (
+                {RefEnum.schema_ref: context.registry.register_schema(expr.schema())}
+                if hasattr(expr, "schema")
+                else {}
             )
+            expr_dict = freeze(expr_dict | schema_ref)
             return freeze(
                 {
                     "definitions": context.definitions,

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "72b14013938b",
-  "expr.yaml": "4151ab5b0edc839c47b0b7df1b1b6238",
+  "expr.yaml": "d95f03710aea8c88c61ab86b8c983ae7",
   "expr_metadata.json": "53dd5c0dec74c2942236da3bf4547754",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -4,7 +4,7 @@
   "8907ecd78b8c.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "1569fa2c7c9f512176a545e521dd79f6",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
-  "expr.yaml": "c812c1fb7e40c648ddd20e1ea5124a47",
+  "expr.yaml": "4d541dfcc63b4d7b3928d3ce8e4bdd8c",
   "expr_metadata.json": "d1039cd408c447984c1599935291244f",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -4,7 +4,7 @@
   "8907ecd78b8c.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "d2ba95a6587082eb55386c11f201e398",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
-  "expr.yaml": "740150aafc34e726b6f1e19761255ee3",
+  "expr.yaml": "bd17d3f5663c7596bf240c551d2a9e67",
   "expr_metadata.json": "dbd168e419d90203592fa81f76e140ed",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"

--- a/python/xorq/ibis_yaml/tests/test_arithmetic.py
+++ b/python/xorq/ibis_yaml/tests/test_arithmetic.py
@@ -1,5 +1,10 @@
+import xorq.expr.datatypes as dt
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+
+
+# NB: derived value ops no longer serialize their (computed) result dtype; it is
+# re-inferred on load. These tests therefore assert the result dtype on the expr
+# directly (round-trip equality below proves the dtype survives reconstruction).
 
 
 def test_add(compiler):
@@ -14,12 +19,8 @@ def test_add(compiler):
     assert expression["left"]["value"] == 5
     assert expression["right"]["op"] == "Literal"
     assert expression["right"]["value"] == 3
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Int8",
-        "nullable": True,
-    }
+    assert "type" not in expression
+    assert expr.type() == dt.int8
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -37,12 +38,7 @@ def test_subtract(compiler):
     assert expression["left"]["value"] == 5
     assert expression["right"]["op"] == "Literal"
     assert expression["right"]["value"] == 3
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Int8",
-        "nullable": True,
-    }
+    assert expr.type() == dt.int8
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -60,12 +56,7 @@ def test_multiply(compiler):
     assert expression["left"]["value"] == 5
     assert expression["right"]["op"] == "Literal"
     assert expression["right"]["value"] == 3
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Int8",
-        "nullable": True,
-    }
+    assert expr.type() == dt.int8
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -83,12 +74,7 @@ def test_divide(compiler):
     assert expression["left"]["value"] == 6.0
     assert expression["right"]["op"] == "Literal"
     assert expression["right"]["value"] == 2.0
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Float64",
-        "nullable": True,
-    }
+    assert expr.type() == dt.float64
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -102,12 +88,7 @@ def test_mixed_arithmetic(compiler):
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
     assert expression["op"] == "Multiply"
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Float64",
-        "nullable": True,
-    }
+    assert expr.type() == dt.float64
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)

--- a/python/xorq/ibis_yaml/tests/test_basic.py
+++ b/python/xorq/ibis_yaml/tests/test_basic.py
@@ -5,7 +5,6 @@ import pytest
 
 import xorq.vendor.ibis as ibis
 from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
 def test_unbound_table(t, compiler):
@@ -28,11 +27,10 @@ def test_field(t, compiler):
     expression = yaml_dict["expression"]
     assert expression["op"] == "Field"
     assert expression["name"] == "a"
-    assert get_dtype_yaml(yaml_dict, expression) == {
-        "op": "DataType",
-        "type": "Int64",
-        "nullable": True,
-    }
+    # Field no longer serializes its (computed) dtype; it is re-inferred from the
+    # relation schema on load.
+    assert "type" not in expression
+    assert expr.type().name == "Int64"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -46,14 +44,9 @@ def test_literal(compiler):
     expression = yaml_dict["expression"]
     assert expression["op"] == "Literal"
     assert expression["value"] == 42
-    dtype_yaml = yaml_dict["definitions"][RegistryEnum.dtypes][
-        expression["type"][RefEnum.dtype_ref]
-    ]
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Int8",
-        "nullable": True,
-    }
+    # dtypes are inlined as their canonical ibis string
+    assert expression["type"] == "int8"
+    assert expression["type"] == str(lit.type())
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(lit)
@@ -87,7 +80,8 @@ def test_primitive_types(compiler, primitive):
 
     expression = yaml_dict["expression"]
     assert expression["op"] == "Literal"
-    assert get_dtype_yaml(yaml_dict, expression)["type"] == expected_type
+    assert expression["type"] == str(lit.type())
+    assert lit.type().name == expected_type
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(lit)
@@ -107,7 +101,8 @@ def test_temporal_types(compiler):
         yaml_dict = compiler.to_yaml(lit)
         expression = yaml_dict["expression"]
         assert expression["op"] == "Literal"
-        assert get_dtype_yaml(yaml_dict, expression)["type"] == expected_type
+        assert expression["type"] == str(lit.type())
+        assert lit.type().name == expected_type
 
         roundtrip_expr = compiler.from_yaml(yaml_dict)
         assert roundtrip_expr.equals(lit)
@@ -120,9 +115,10 @@ def test_decimal_type(compiler):
     yaml_dict = compiler.to_yaml(lit)
     expression = yaml_dict["expression"]
     assert expression["op"] == "Literal"
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml["type"] == "Decimal"
-    assert dtype_yaml["nullable"]
+    # parametric dtypes inline as their full ibis string, e.g. "decimal(5, 2)"
+    assert expression["type"] == str(lit.type())
+    assert expression["type"].startswith("decimal")
+    assert not expression["type"].startswith("!")  # nullable
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(lit)
@@ -133,12 +129,10 @@ def test_array_type(compiler):
     lit = ibis.literal([1, 2, 3])
     yaml_dict = compiler.to_yaml(lit)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    inner = get_dtype_yaml(yaml_dict, dtype_yaml, key="value_type")
     assert expression["op"] == "Literal"
     assert expression["value"] == (1, 2, 3)
-    assert dtype_yaml["type"] == "Array"
-    assert inner["type"] == "Int8"
+    assert expression["type"] == str(lit.type())
+    assert expression["type"] == "array<int8>"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(lit)
@@ -149,13 +143,9 @@ def test_map_type(compiler):
     lit = ibis.literal({"a": 1, "b": 2})
     yaml_dict = compiler.to_yaml(lit)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    key_dtype_yaml = get_dtype_yaml(yaml_dict, dtype_yaml, key="key_type")
-    value_dtype_yaml = get_dtype_yaml(yaml_dict, dtype_yaml, key="value_type")
     assert expression["op"] == "Literal"
-    assert dtype_yaml["type"] == "Map"
-    assert key_dtype_yaml["type"] == "String"
-    assert value_dtype_yaml["type"] == "Int8"
+    assert expression["type"] == str(lit.type())
+    assert expression["type"] == "map<string, int8>"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(lit)

--- a/python/xorq/ibis_yaml/tests/test_operations_boolean.py
+++ b/python/xorq/ibis_yaml/tests/test_operations_boolean.py
@@ -1,7 +1,6 @@
 from math import isnan
 
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
 def test_equals(compiler):
@@ -13,12 +12,8 @@ def test_equals(compiler):
     assert expression["op"] == "Equals"
     assert expression["left"]["value"] == 5
     assert expression["right"]["value"] == 5
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Boolean",
-        "nullable": True,
-    }
+    # Equals result dtype is re-inferred on load, not serialized.
+    assert expr.type().name == "Boolean"
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
 

--- a/python/xorq/ibis_yaml/tests/test_operations_cast.py
+++ b/python/xorq/ibis_yaml/tests/test_operations_cast.py
@@ -1,17 +1,20 @@
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+
+
+# NB: Cast serializes its target dtype under the `to` constructor arg as an
+# inline ibis string (the write-only result `type:` field was dropped). Implicit
+# casts (Add) have no `to`; their result dtype is re-inferred on load.
 
 
 def test_explicit_cast(compiler):
     expr = ibis.literal(42).cast("float64")
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "Cast"
     assert expression["arg"]["op"] == "Literal"
     assert expression["arg"]["value"] == 42
-    assert dtype_yaml["type"] == "Float64"
+    assert expression["to"] == "float64"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -23,12 +26,11 @@ def test_implicit_cast(compiler):
     expr = i + f
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "Add"
-    assert get_dtype_yaml(yaml_dict, expression["left"])["type"] == "Int8"
-    assert get_dtype_yaml(yaml_dict, expression["right"])["type"] == "Float64"
-    assert dtype_yaml["type"] == "Float64"
+    assert expression["left"]["type"] == "int8"
+    assert expression["right"]["type"] == "float64"
+    assert expr.type().name == "Float64"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -38,11 +40,10 @@ def test_string_cast(compiler):
     expr = ibis.literal("42").cast("int64")
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "Cast"
     assert expression["arg"]["value"] == "42"
-    assert dtype_yaml["type"] == "Int64"
+    assert expression["to"] == "int64"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
@@ -52,11 +53,10 @@ def test_timestamp_cast(compiler):
     expr = ibis.literal("2024-01-01").cast("timestamp")
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "Cast"
     assert expression["arg"]["value"] == "2024-01-01"
-    assert dtype_yaml["type"] == "Timestamp"
+    assert expression["to"] == "timestamp"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)

--- a/python/xorq/ibis_yaml/tests/test_operations_datetime.py
+++ b/python/xorq/ibis_yaml/tests/test_operations_datetime.py
@@ -8,7 +8,6 @@ import xorq.vendor.ibis as ibis
 import xorq.vendor.ibis.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations.temporal as tm
 from xorq.ibis_yaml.common import TranslationContext, translate_to_yaml
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
 def test_date_extract(compiler):
@@ -17,17 +16,15 @@ def test_date_extract(compiler):
     year = dt_expr.year()
     year_yaml = compiler.to_yaml(year)
     expression = year_yaml["expression"]
-    dtype_yaml = get_dtype_yaml(year_yaml, expression)
     assert expression["op"] == "ExtractYear"
     assert expression["arg"]["value"] == "2024-03-14T15:09:26"
-    assert dtype_yaml["type"] == "Int32"
+    assert year.type().name == "Int32"
     roundtrip_year = compiler.from_yaml(year_yaml)
     assert roundtrip_year.equals(year)
 
     month = dt_expr.month()
     month_yaml = compiler.to_yaml(month)
     expression = month_yaml["expression"]
-    dtype_yaml = get_dtype_yaml(month_yaml, expression)
     assert expression["op"] == "ExtractMonth"
     roundtrip_month = compiler.from_yaml(month_yaml)
     assert roundtrip_month.equals(month)
@@ -46,10 +43,9 @@ def test_time_extract(compiler):
     hour = dt_expr.hour()
     hour_yaml = compiler.to_yaml(hour)
     hour_expression = hour_yaml["expression"]
-    dtype_yaml = get_dtype_yaml(hour_yaml, hour_expression)
     assert hour_expression["op"] == "ExtractHour"
     assert hour_expression["arg"]["value"] == "2024-03-14T15:09:26"
-    assert dtype_yaml["type"] == "Int32"
+    assert hour.type().name == "Int32"
     roundtrip_hour = compiler.from_yaml(hour_yaml)
     assert roundtrip_hour.equals(hour)
 
@@ -75,20 +71,18 @@ def test_timestamp_arithmetic(compiler):
     plus_day = ts + delta
     yaml_dict = compiler.to_yaml(plus_day)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
     assert expression["op"] == "TimestampAdd"
-    assert dtype_yaml["type"] == "Timestamp"
-    assert get_dtype_yaml(yaml_dict, expression["right"])["type"] == "Interval"
+    assert plus_day.type().name == "Timestamp"
+    assert expression["right"]["type"].startswith("interval")
     roundtrip_plus = compiler.from_yaml(yaml_dict)
     assert roundtrip_plus.equals(plus_day)
 
     minus_day = ts - delta
     yaml_dict = compiler.to_yaml(minus_day)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
     assert expression["op"] == "TimestampSub"
-    assert dtype_yaml["type"] == "Timestamp"
-    assert get_dtype_yaml(yaml_dict, expression["right"])["type"] == "Interval"
+    assert minus_day.type().name == "Timestamp"
+    assert expression["right"]["type"].startswith("interval")
     roundtrip_minus = compiler.from_yaml(yaml_dict)
     assert roundtrip_minus.equals(minus_day)
 
@@ -99,9 +93,8 @@ def test_timestamp_diff(compiler):
     diff = ts2 - ts1
     yaml_dict = compiler.to_yaml(diff)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
     assert expression["op"] == "TimestampDiff"
-    assert dtype_yaml["type"] == "Interval"
+    assert diff.type().name == "Interval"
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(diff)
 
@@ -110,20 +103,18 @@ def test_temporal_unit_yaml(compiler):
     interval_date = ibis.literal(5, type=dt.Interval(unit=tm.DateUnit("D")))
     yaml_date = compiler.to_yaml(interval_date)
     expression_date = yaml_date["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_date, expression_date)
-    assert dtype_yaml["type"] == "Interval"
-    assert dtype_yaml["unit"]["name"] == "DateUnit"
-    assert dtype_yaml["unit"]["value"] == "D"
+    # interval dtype + unit inline in the canonical ibis string, e.g. "interval('D')"
+    assert expression_date["type"] == str(interval_date.type())
+    assert expression_date["type"].startswith("interval")
+    assert "'D'" in expression_date["type"]
     roundtrip_date = compiler.from_yaml(yaml_date)
     assert roundtrip_date.equals(interval_date)
 
     interval_time = ibis.literal(10, type=dt.Interval(unit=tm.TimeUnit("h")))
     yaml_time = compiler.to_yaml(interval_time)
     expression_time = yaml_time["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_time, expression_time)
-    assert dtype_yaml["type"] == "Interval"
-    assert dtype_yaml["unit"]["name"] == "TimeUnit"
-    assert dtype_yaml["unit"]["value"] == "h"
+    assert expression_time["type"] == str(interval_time.type())
+    assert "'h'" in expression_time["type"]
     roundtrip_time = compiler.from_yaml(yaml_time)
     assert roundtrip_time.equals(interval_time)
 

--- a/python/xorq/ibis_yaml/tests/test_relations.py
+++ b/python/xorq/ibis_yaml/tests/test_relations.py
@@ -14,7 +14,8 @@ def test_filter(compiler: YamlExpressionTranslator, t: ir.Table) -> None:
 
     assert expression["op"] == "Filter"
     assert expression["predicates"][0]["op"] == "Greater"
-    parent_ref = expression["parent"][RefEnum.node_ref]
+    # node references are now bare "@..." sigil strings
+    parent_ref = expression["parent"]
     parent = yaml_dict["definitions"][RegistryEnum.nodes][parent_ref]
     assert parent["op"] == "UnboundTable"
 
@@ -30,7 +31,7 @@ def test_projection(compiler, t):
     expression = yaml_dict["definitions"][RegistryEnum.nodes][node_ref]
 
     assert expression["op"] == "Project"
-    parent_ref = expression["parent"][RefEnum.node_ref]
+    parent_ref = expression["parent"]
     parent = yaml_dict["definitions"][RegistryEnum.nodes][parent_ref]
     assert parent["op"] == "UnboundTable"
     assert set(expression["values"]) == {"a", "b"}

--- a/python/xorq/ibis_yaml/tests/test_string_ops.py
+++ b/python/xorq/ibis_yaml/tests/test_string_ops.py
@@ -3,7 +3,6 @@ from pytest import param
 
 import xorq.api as xo
 import xorq.vendor.ibis as ibis
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
 
 
 def test_string_concat(compiler):
@@ -12,16 +11,11 @@ def test_string_concat(compiler):
     expr = s1 + s2
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "StringConcat"
     assert expression["arg"]["values"][0]["value"] == "hello"
     assert expression["arg"]["values"][1]["value"] == "world"
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "String",
-        "nullable": True,
-    }
+    assert expr.type().name == "String"
 
 
 def test_string_upper_lower(compiler):
@@ -59,15 +53,10 @@ def test_string_length(compiler):
     expr = s.length()
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "StringLength"
     assert expression["arg"]["value"] == "hello"
-    assert dtype_yaml == {
-        "op": "DataType",
-        "type": "Int32",
-        "nullable": True,
-    }
+    assert expr.type().name == "Int32"
 
 
 def test_string_substring(compiler):

--- a/python/xorq/ibis_yaml/tests/test_subquery.py
+++ b/python/xorq/ibis_yaml/tests/test_subquery.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
-from xorq.ibis_yaml.tests.conftest import get_dtype_yaml
+from xorq.ibis_yaml.enums import RegistryEnum
 
 
 def test_scalar_subquery(compiler, t):
@@ -11,7 +10,7 @@ def test_scalar_subquery(compiler, t):
     expression = yaml_dict["expression"]
 
     assert expression["op"] == "ScalarSubquery"
-    node_ref = expression["rel"][RefEnum.node_ref]
+    node_ref = expression["rel"]
     agg_expression = yaml_dict["definitions"][RegistryEnum.nodes][node_ref]
     assert agg_expression["op"] == "Aggregate"
 
@@ -30,7 +29,7 @@ def test_exists_subquery(compiler, con):
     expression = yaml_dict["expression"]
 
     assert expression["op"] == "ExistsSubquery"
-    node_ref = expression["rel"][RefEnum.node_ref]
+    node_ref = expression["rel"]
     assert yaml_dict["definitions"][RegistryEnum.nodes][node_ref]["op"] == "Filter"
 
     profiles = {con._profile.hash_name: con}
@@ -45,10 +44,9 @@ def test_in_subquery(compiler, con):
     expr = ops.InSubquery(t1.select("a"), t2.a).to_expr()
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
-    dtype_yaml = get_dtype_yaml(yaml_dict, expression)
 
     assert expression["op"] == "InSubquery"
-    assert dtype_yaml["type"] == "Boolean"
+    assert expr.type().name == "Boolean"
 
     profiles = {con._profile.hash_name: con}
     roundtrip_expr = compiler.from_yaml(yaml_dict, profiles)

--- a/python/xorq/ibis_yaml/tests/test_yaml_metrics.py
+++ b/python/xorq/ibis_yaml/tests/test_yaml_metrics.py
@@ -1,0 +1,141 @@
+"""Characterization + size/perf metrics harness for ibis_yaml serialization.
+
+Run on demand:
+
+    pytest python/xorq/ibis_yaml/tests/test_yaml_metrics.py -m metrics -s
+
+It serializes a fixed set of exprs (the TPC-H suite + a few simple shapes),
+records emitted-YAML byte/line counts and ``definitions`` entry counts, asserts
+round-trip equality, and writes a JSON report next to this file
+(``yaml_metrics_report.json``). If a baseline report exists
+(``yaml_metrics_baseline.json``) it prints a per-expr delta table so size wins
+are quantified phase-over-phase.
+
+This module is the gate referenced by the ibis-yaml node.map refactor plan:
+round-trip is the real correctness contract; bytes/lines/defs are the win
+metric.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import yaml12
+
+import xorq.vendor.ibis as ibis
+from xorq.ibis_yaml.common import translate_from_yaml, translate_to_yaml
+from xorq.ibis_yaml.compiler import YamlExpressionTranslator, _to_yaml_safe
+from xorq.ibis_yaml.tests.test_tpch import TPC_H
+
+
+HERE = Path(__file__).parent
+REPORT_PATH = HERE / "yaml_metrics_report.json"
+BASELINE_PATH = HERE / "yaml_metrics_baseline.json"
+
+pytestmark = pytest.mark.metrics
+
+
+def _simple_exprs():
+    t = ibis.table(
+        {
+            "a": "int64",
+            "b": "string",
+            "c": "float64",
+            "d": "timestamp",
+            "e": "date",
+        },
+        name="test_table",
+    )
+    yield "literal", ibis.literal(1)
+    yield "filter_project", t.filter(t.a > 1).select(t.a, t.b, doubled=t.c * 2.0)
+    yield "aggregate", t.group_by("b").aggregate(n=t.a.count(), mean_c=t.c.mean())
+    wide = t.select(*[t.a.name(f"col_{i}") for i in range(12)])
+    yield "wide_project", wide
+
+
+def _yaml_bytes(yaml_dict, tmp_path):
+    # write through the real serializer (incl. document markers) so byte counts
+    # match the on-disk expr.yaml artifact exactly
+    out = tmp_path / "expr.yaml"
+    yaml12.write_yaml(_to_yaml_safe(yaml_dict), out)
+    return out.read_bytes()
+
+
+def _measure(name, expr, con, tmp_path):
+    compiler = YamlExpressionTranslator
+    profiles = {con._profile.hash_name: con} if con is not None else {}
+
+    # perf: median of a few to_yaml calls (cold lru_cache cleared each round)
+    timings = []
+    yaml_dict = None
+    for _ in range(5):
+        translate_to_yaml.cache_clear()
+        translate_from_yaml.cache_clear()
+        t0 = time.perf_counter()
+        yaml_dict = compiler.to_yaml(expr, profiles)
+        timings.append(time.perf_counter() - t0)
+    timings.sort()
+    to_yaml_median_ms = timings[len(timings) // 2] * 1e3
+
+    raw = _yaml_bytes(yaml_dict, tmp_path)
+    defs = yaml_dict.get("definitions", {})
+
+    roundtrip_ok = None
+    try:
+        rt = compiler.from_yaml(yaml_dict, profiles)
+        roundtrip_ok = bool(rt.equals(expr))
+    except Exception as e:  # record, don't crash the harness
+        roundtrip_ok = f"ERROR: {type(e).__name__}: {e}"
+
+    return {
+        "bytes": len(raw),
+        "lines": raw.count(b"\n") + 1,
+        "n_dtypes": len(defs.get("dtypes", {})),
+        "n_nodes": len(defs.get("nodes", {})),
+        "n_schemas": len(defs.get("schemas", {})),
+        "to_yaml_median_ms": round(to_yaml_median_ms, 3),
+        "roundtrip_ok": roundtrip_ok,
+    }
+
+
+def test_yaml_metrics(request, con, tmp_path):
+    report = {}
+
+    for name, expr in _simple_exprs():
+        report[name] = _measure(name, expr, None, tmp_path)
+
+    for fixture_name in TPC_H:
+        expr = request.getfixturevalue(fixture_name)
+        report[fixture_name] = _measure(fixture_name, expr, con, tmp_path)
+
+    REPORT_PATH.write_text(json.dumps(report, indent=2, sort_keys=True))
+
+    # ---- print summary + delta vs baseline -------------------------------
+    totals = {k: sum(r[k] for r in report.values()) for k in ("bytes", "lines")}
+    baseline = json.loads(BASELINE_PATH.read_text()) if BASELINE_PATH.exists() else {}
+
+    print("\n=== ibis_yaml metrics ===")
+    header = f"{'expr':<20}{'bytes':>9}{'Δbytes':>9}{'lines':>7}{'dtypes':>7}{'nodes':>6}{'ms':>8}{'rt':>5}"
+    print(header)
+    print("-" * len(header))
+    for name in sorted(report):
+        r = report[name]
+        b0 = baseline.get(name, {}).get("bytes")
+        delta = f"{r['bytes'] - b0:+d}" if b0 is not None else "-"
+        rt = "ok" if r["roundtrip_ok"] is True else "FAIL"
+        print(
+            f"{name:<20}{r['bytes']:>9}{delta:>9}{r['lines']:>7}"
+            f"{r['n_dtypes']:>7}{r['n_nodes']:>6}{r['to_yaml_median_ms']:>8}{rt:>5}"
+        )
+    print("-" * len(header))
+    base_total = sum(v.get("bytes", 0) for v in baseline.values()) if baseline else None
+    dtot = f"{totals['bytes'] - base_total:+d}" if base_total else "-"
+    print(f"{'TOTAL':<20}{totals['bytes']:>9}{dtot:>9}{totals['lines']:>7}")
+    print(f"report written: {REPORT_PATH}")
+
+    # correctness gate: every expr must round-trip
+    failures = {
+        k: v["roundtrip_ok"] for k, v in report.items() if v["roundtrip_ok"] is not True
+    }
+    assert not failures, f"round-trip failures: {failures}"

--- a/python/xorq/ibis_yaml/tests/yaml_metrics_baseline.json
+++ b/python/xorq/ibis_yaml/tests/yaml_metrics_baseline.json
@@ -1,0 +1,236 @@
+{
+  "aggregate": {
+    "bytes": 2290,
+    "lines": 105,
+    "n_dtypes": 3,
+    "n_nodes": 2,
+    "n_schemas": 2,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 2.302
+  },
+  "filter_project": {
+    "bytes": 2981,
+    "lines": 132,
+    "n_dtypes": 5,
+    "n_nodes": 3,
+    "n_schemas": 2,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 3.54
+  },
+  "literal": {
+    "bytes": 233,
+    "lines": 17,
+    "n_dtypes": 1,
+    "n_nodes": 0,
+    "n_schemas": 0,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 0.117
+  },
+  "tpc_h01": {
+    "bytes": 9812,
+    "lines": 402,
+    "n_dtypes": 7,
+    "n_nodes": 3,
+    "n_schemas": 2,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 5.213
+  },
+  "tpc_h02": {
+    "bytes": 28596,
+    "lines": 1056,
+    "n_dtypes": 8,
+    "n_nodes": 20,
+    "n_schemas": 6,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 46.856
+  },
+  "tpc_h03": {
+    "bytes": 18357,
+    "lines": 711,
+    "n_dtypes": 12,
+    "n_nodes": 9,
+    "n_schemas": 4,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 18.84
+  },
+  "tpc_h04": {
+    "bytes": 7186,
+    "lines": 301,
+    "n_dtypes": 7,
+    "n_nodes": 5,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 7.001
+  },
+  "tpc_h05": {
+    "bytes": 25571,
+    "lines": 964,
+    "n_dtypes": 11,
+    "n_nodes": 15,
+    "n_schemas": 7,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 29.09
+  },
+  "tpc_h06": {
+    "bytes": 5555,
+    "lines": 233,
+    "n_dtypes": 7,
+    "n_nodes": 3,
+    "n_schemas": 2,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 4.856
+  },
+  "tpc_h07": {
+    "bytes": 19098,
+    "lines": 734,
+    "n_dtypes": 10,
+    "n_nodes": 13,
+    "n_schemas": 6,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 20.506
+  },
+  "tpc_h08": {
+    "bytes": 23993,
+    "lines": 917,
+    "n_dtypes": 12,
+    "n_nodes": 20,
+    "n_schemas": 8,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 46.144
+  },
+  "tpc_h09": {
+    "bytes": 17693,
+    "lines": 689,
+    "n_dtypes": 11,
+    "n_nodes": 15,
+    "n_schemas": 7,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 21.216
+  },
+  "tpc_h10": {
+    "bytes": 21661,
+    "lines": 837,
+    "n_dtypes": 12,
+    "n_nodes": 11,
+    "n_schemas": 5,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 21.453
+  },
+  "tpc_h11": {
+    "bytes": 12810,
+    "lines": 488,
+    "n_dtypes": 9,
+    "n_nodes": 11,
+    "n_schemas": 4,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 18.87
+  },
+  "tpc_h12": {
+    "bytes": 16538,
+    "lines": 632,
+    "n_dtypes": 10,
+    "n_nodes": 7,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 15.315
+  },
+  "tpc_h13": {
+    "bytes": 10694,
+    "lines": 416,
+    "n_dtypes": 9,
+    "n_nodes": 7,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 11.134
+  },
+  "tpc_h14": {
+    "bytes": 15812,
+    "lines": 601,
+    "n_dtypes": 11,
+    "n_nodes": 9,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 21.995
+  },
+  "tpc_h15": {
+    "bytes": 15084,
+    "lines": 575,
+    "n_dtypes": 11,
+    "n_nodes": 10,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 20.196
+  },
+  "tpc_h16": {
+    "bytes": 14264,
+    "lines": 550,
+    "n_dtypes": 8,
+    "n_nodes": 10,
+    "n_schemas": 4,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 15.508
+  },
+  "tpc_h17": {
+    "bytes": 14307,
+    "lines": 555,
+    "n_dtypes": 11,
+    "n_nodes": 10,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 25.817
+  },
+  "tpc_h18": {
+    "bytes": 19082,
+    "lines": 742,
+    "n_dtypes": 12,
+    "n_nodes": 12,
+    "n_schemas": 4,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 22.151
+  },
+  "tpc_h19": {
+    "bytes": 29918,
+    "lines": 948,
+    "n_dtypes": 11,
+    "n_nodes": 7,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 21.911
+  },
+  "tpc_h20": {
+    "bytes": 17175,
+    "lines": 676,
+    "n_dtypes": 11,
+    "n_nodes": 16,
+    "n_schemas": 6,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 33.606
+  },
+  "tpc_h21": {
+    "bytes": 17095,
+    "lines": 648,
+    "n_dtypes": 6,
+    "n_nodes": 13,
+    "n_schemas": 5,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 24.619
+  },
+  "tpc_h22": {
+    "bytes": 11612,
+    "lines": 456,
+    "n_dtypes": 10,
+    "n_nodes": 8,
+    "n_schemas": 3,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 15.43
+  },
+  "wide_project": {
+    "bytes": 4205,
+    "lines": 185,
+    "n_dtypes": 1,
+    "n_nodes": 2,
+    "n_schemas": 2,
+    "roundtrip_ok": true,
+    "to_yaml_median_ms": 1.583
+  }
+}

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -72,16 +72,15 @@ convert_to_schema_ref = convert_to_ref(RegistryEnum.schemas)
 
 @translate_to_yaml.register(ops.Node)
 def _object_to_yaml(obj: ops.Node, context: Any) -> dict:
+    # NB: the result ``dtype`` is intentionally NOT emitted. For ops whose dtype
+    # is a constructor parameter it is already serialized under its argname; for
+    # ops whose dtype is a computed property the loader re-infers it on
+    # construction. The old write-only ``type:`` field was never read back.
     return freeze(
         {"op": obj.__class__.__name__}
         | {
             name: context.translate_to_yaml(arg)
             for name, arg in zip(obj.argnames, obj.args)
-        }
-        | {
-            name: context.translate_to_yaml(getattr(obj, attribute))
-            for name, attribute in (("type", "dtype"),)
-            if hasattr(obj, attribute)
         }
     )
 
@@ -308,20 +307,13 @@ def _translate_literal_value(value: Any, dtype: dt.DataType) -> Any:
 
 
 @translate_to_yaml.register(dt.DataType)
-@convert_to_dtype_ref
-def _datatype_to_yaml(dtype: dt.DataType, context: TranslationContext) -> dict:
-    return freeze(
-        {
-            "op": "DataType",
-            "type": type(dtype).__name__,
-        }
-        | {
-            argname: context.translate_to_yaml(arg)
-            if context is not None
-            else translate_to_yaml(arg, context)
-            for argname, arg in zip(dtype.argnames, dtype.args)
-        }
-    )
+def _datatype_to_yaml(dtype: dt.DataType, context: TranslationContext) -> str:
+    # Inline dtypes as their canonical ibis string (e.g. "int64", "!int64",
+    # "decimal(15, 2)", "array<int64>"). This round-trips losslessly via
+    # dt.dtype()/op-level coercion and removes the entire `definitions.dtypes`
+    # table plus every per-field dtype_ref. The legacy {op: DataType, ...} dict
+    # form (and dtype_ref) is still accepted on load for old artifacts.
+    return str(dtype)
 
 
 @register_from_yaml_handler("DataType")
@@ -348,7 +340,6 @@ def _window_function_to_yaml(
     result = {
         "op": "WindowFunction",
         "args": [context.translate_to_yaml(op.func)],
-        "type": context.translate_to_yaml(op.dtype),
     }
 
     if op.group_by:
@@ -396,7 +387,6 @@ def _window_boundary_to_yaml(
             "op": "WindowBoundary",
             "value": context.translate_to_yaml(op.value),
             "preceding": op.preceding,
-            "type": context.translate_to_yaml(op.dtype),
         }
     )
 
@@ -407,21 +397,30 @@ def _window_boundary_from_yaml(yaml_dict: dict, context: TranslationContext) -> 
     return ops.WindowBoundary(value, preceding=yaml_dict["preceding"])
 
 
+def _namespace_yaml(namespace) -> dict:
+    """Emit ``namespace`` only when a catalog/database is actually set.
+
+    The loaders read it back with ``.get(...)`` defaulting to ``None``, so an
+    empty namespace (the common case) can be omitted entirely.
+    """
+    if namespace.catalog is None and namespace.database is None:
+        return {}
+    return {
+        "namespace": freeze(
+            {"catalog": namespace.catalog, "database": namespace.database}
+        )
+    }
+
+
 @translate_to_yaml.register(ops.UnboundTable)
 @convert_to_node_ref
 def _unbound_table_to_yaml(op: ops.UnboundTable, context: TranslationContext) -> dict:
-    namespace_dict = freeze(
-        {
-            "catalog": op.namespace.catalog,
-            "database": op.namespace.database,
-        }
-    )
     return freeze(
         {
             "op": "UnboundTable",
             "name": op.name,
-            "namespace": namespace_dict,
         }
+        | _namespace_yaml(op.namespace)
         | context.registry.register_schema(op.schema)
     )
 
@@ -441,20 +440,14 @@ def _unbound_table_from_yaml(yaml_dict: dict, context: TranslationContext) -> ir
 @convert_to_node_ref
 def _database_table_to_yaml(op: ops.DatabaseTable, context: TranslationContext) -> dict:
     profile_name = op.source._profile.hash_name
-    namespace_dict = freeze(
-        {
-            "catalog": op.namespace.catalog,
-            "database": op.namespace.database,
-        }
-    )
 
     node_dict = freeze(
         {
             "op": "DatabaseTable",
             "table": op.name,
             "profile": profile_name,
-            "namespace": namespace_dict,
         }
+        | _namespace_yaml(op.namespace)
         | context.registry.register_schema(op.schema)
     )
     return node_dict
@@ -718,7 +711,6 @@ def _lag_to_yaml(op: ops.Lag, context: TranslationContext) -> dict:
     result = {
         "op": "Lag",
         "arg": context.translate_to_yaml(op.arg),
-        "type": context.translate_to_yaml(op.dtype),
     }
 
     if op.offset is not None:
@@ -939,7 +931,6 @@ def _in_subquery_to_yaml(op: ops.InSubquery, context: TranslationContext) -> dic
             "op": "InSubquery",
             "needle": context.translate_to_yaml(op.needle),
             "haystack": context.translate_to_yaml(op.rel),
-            "type": context.translate_to_yaml(op.dtype),
         }
     )
 
@@ -957,7 +948,6 @@ def _field_to_yaml(op: ops.Field, context: TranslationContext) -> dict:
         "op": "Field",
         "name": op.name,
         "relation": context.translate_to_yaml(op.rel),
-        "type": context.translate_to_yaml(op.dtype),
     }
 
     if op.args and len(op.args) >= 2 and isinstance(op.args[1], str):

--- a/python/xorq/ibis_yaml/udf.py
+++ b/python/xorq/ibis_yaml/udf.py
@@ -71,17 +71,24 @@ def _scalar_udf_from_yaml(yaml_dict: dict, compiler: any) -> any:
     else:
         raise ValueError(f"Unsupported input type: {input_type_str}")
 
-    dtype = dt.dtype(yaml_dict["type"]["type"])
+    type_yaml = yaml_dict["type"]
+    # inline string form (new) or legacy {op: DataType, type: <classname>, ...} dict
+    dtype = dt.dtype(type_yaml["type"] if isinstance(type_yaml, dict) else type_yaml)
     class_name = yaml_dict.get("class_name", yaml_dict["func_name"])
 
     schema = {}
     for i, arg_yaml in enumerate(args_yaml):
         arg_name = f"arg{i}"
 
-        if RefEnum.node_ref in arg_yaml and (
-            node := compiler.definitions[RegistryEnum.nodes].get(
-                arg_yaml[RefEnum.node_ref]
-            )
+        # a hoisted arg is referenced as a bare "@..." sigil string (new) or a
+        # {node_ref: "@..."} wrapper (legacy)
+        node_ref = None
+        if isinstance(arg_yaml, str) and arg_yaml.startswith("@"):
+            node_ref = arg_yaml
+        elif isinstance(arg_yaml, dict) and RefEnum.node_ref in arg_yaml:
+            node_ref = arg_yaml[RefEnum.node_ref]
+        if node_ref and (
+            node := compiler.definitions[RegistryEnum.nodes].get(node_ref)
         ):
             if node.get("op") == "Field" and "name" in node:
                 arg_name = node["name"]
@@ -182,6 +189,29 @@ def kwargs_to_schema(kwargs):
     return schema
 
 
+def _coerce_meta_dtype(meta):
+    """Re-hydrate UDF dtypes from their inline string form.
+
+    dtypes now serialize as their ibis string (e.g. "float64"); the UDF op
+    class and its ``__config__`` (e.g. udwf ``return_type``/``input_types``)
+    need real ``dt.DataType`` objects. Legacy artifacts store already-built
+    DataTypes, which pass through unchanged.
+    """
+    meta = dict(meta)
+    if isinstance(meta.get("dtype"), str):
+        meta["dtype"] = dt.dtype(meta["dtype"])
+    config = meta.get("__config__")
+    if config is not None:
+        config = dict(config)
+        if isinstance(config.get("return_type"), str):
+            config["return_type"] = dt.dtype(config["return_type"])
+        input_types = config.get("input_types")
+        if input_types is not None and all(isinstance(x, str) for x in input_types):
+            config["input_types"] = type(input_types)(dt.dtype(x) for x in input_types)
+        meta["__config__"] = config
+    return meta
+
+
 @translate_to_yaml.register(ops.udf.AggUDF)
 def _aggudf_to_yaml(op: ops.udf.AggUDF, compiler: Any) -> dict:
     require_input_types((ops.udf.InputType.PYARROW,), op)
@@ -212,6 +242,7 @@ def _aggudf_from_yaml(yaml_dict: dict, compiler: any) -> any:
     (kwargs, meta) = (
         translate_from_yaml(yaml_dict[name], compiler) for name in ("kwargs", "meta")
     )
+    meta = _coerce_meta_dtype(meta)
     fields = {
         argname: Argument(pattern=rlz.ValueOf(typ), typehint=typ)
         for (argname, typ) in ((argname, arg.type()) for argname, arg in kwargs.items())
@@ -270,6 +301,7 @@ def _aggudf_from_yaml(yaml_dict: dict, compiler: any) -> any:
     (kwargs, meta) = (
         translate_from_yaml(yaml_dict[name], compiler) for name in ("kwargs", "meta")
     )
+    meta = _coerce_meta_dtype(meta)
     fields = {
         argname: Argument(pattern=rlz.ValueOf(typ), typehint=typ)
         for (argname, typ) in ((argname, arg.type()) for argname, arg in kwargs.items())


### PR DESCRIPTION
## Summary

Cuts serialized `expr.yaml` size **~48%** (381,622 → 197,839 bytes over the TPC-H suite + simple shapes) while preserving round-trip fidelity and content-addressing. Implements the content-cut phases of `plans/ibis-yaml-nodemap-refactor.md`; the `node.map` engine swap is intentionally **not** included (see below).

`snapshot_hash` and the build-hash directory names are unchanged, and loaders accept **both** the new and legacy forms, so existing build artifacts still load.

## Changes

| Change | Effect |
|---|---|
| Drop write-only `type:` on derived ops | dtype re-inferred on load; kept on `Literal` / `Cast.to` / UDF where it is actually read |
| Inline every dtype as its canonical ibis string (`int64`, `decimal(15, 2)`, `array<int64>`) | removes the entire `definitions.dtypes` table and all per-field `dtype_ref` wrappers |
| Omit null namespaces and null expression `schema_ref` | |
| Sequential node labels (`@project_2`) | replaces hash-suffixed labels; `snapshot_hash` stays in the node body |
| Bare `@...` sigil node refs | `parent: {node_ref: "@x"}` → `parent: "@x"` |

UDF `meta`/`__config__` dtypes (`return_type`, `input_types`) are re-hydrated from their inline string form on load.

## Verification

New `test_yaml_metrics.py` (marker: `metrics`) records bytes/lines/definition-counts and **asserts round-trip equality** over the TPC-H suite, diffing against `yaml_metrics_baseline.json` so the size win is quantified.

```
python -m pytest python/xorq/ibis_yaml/tests/test_yaml_metrics.py -m metrics -s
```

Every expr reports `rt=ok`; `to_yaml` timing is flat (engine untouched). All `ibis_yaml` tests pass (the only failures are pre-existing postgres tests with no DB running). `snapshot_hash` alignment (`test_node_utils`, `test_hashing_tag`) and the 3 regenerated build-stability snapshots pass. Test assertions were updated to the new shape with intent preserved (`expr.type()` / `str(dtype)`), none weakened or skipped.

## Not included: Phase 1 (node.map engine swap)

The current engine already dedups by op identity via `lru_cache`, and the load-bearing `snapshot_hash` `tokenize()` cost is paid identically under `node.map` → ~0 size gain, marginal perf, while `remote_table_scope`'s top-down context doesn't map cleanly to bottom-up traversal (round-trip risk). All measurable wins come from the content cuts above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)