### PR TITLE
refactor(api): bundle execution cleanup into ExecutionResources

### DIFF
--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -215,7 +215,7 @@ class SourceStorage(CacheStorage):
                 from xorq.expr.api import _transform_expr  # noqa: PLC0415
 
                 # must transform for Read ops: create_table expects a vanilla ibis expr
-                (transformed, _, _) = _transform_expr(value.to_expr())
+                (transformed, _) = _transform_expr(value.to_expr())
                 self.source.create_table(key, transformed)
             else:
                 assert hasattr(self.source, "read_record_batches")

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 import pyarrow as pa
 import toolz
+from attr import field, frozen
 
 import xorq.vendor.ibis.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
@@ -433,57 +434,76 @@ def _resolve_params(params):
     return name_values
 
 
-def _close_and_join_drains(drains: list) -> None:
-    errors: list[BaseException] = []
-    for d in drains:
-        try:
-            d.close()
-        except BaseException as exc:  # noqa: BLE001
-            errors.append(exc)
-    for d in drains:
-        try:
-            d.join()
-        except BaseException as exc:  # noqa: BLE001
-            errors.append(exc)
-    raise_collected_errors("drain failures", errors)
+@frozen
+class ExecutionResources:
+    """Resources allocated while transforming an expr for execution that must
+    be released once execution finishes or fails.
 
+    ``created`` maps the names of intermediate tables/views to the backend that
+    owns them; they are dropped on cleanup. ``drains`` are writer iterators
+    (tee pass-throughs) that must be closed and joined.
+    """
 
-def _drop_created_tables(created: dict) -> None:
-    # Drop every table even if one fails, so a single bad drop never strands the
-    # rest (created may hold several entries: tee + remote-table placeholders).
-    errors: list[BaseException] = []
-    for table_name, conn in created.items():
-        try:
-            conn.drop_table(table_name, force=True)
-        except Exception:
+    created: dict = field(factory=dict)
+    drains: list = field(factory=list)
+
+    def _close_and_join_drains(self) -> None:
+        errors: list[BaseException] = []
+        for d in self.drains:
             try:
-                conn.drop_view(table_name)
+                d.close()
             except BaseException as exc:  # noqa: BLE001
                 errors.append(exc)
-    raise_collected_errors("failed to drop created tables", errors)
+        for d in self.drains:
+            try:
+                d.join()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+        raise_collected_errors("drain failures", errors)
 
+    def _drop_created_tables(self) -> None:
+        # Drop every table even if one fails, so a single bad drop never strands
+        # the rest (created may hold several entries: tee + remote-table placeholders).
+        errors: list[BaseException] = []
+        for table_name, conn in self.created.items():
+            try:
+                conn.drop_table(table_name, force=True)
+            except Exception:
+                try:
+                    conn.drop_view(table_name)
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+        raise_collected_errors("failed to drop created tables", errors)
 
-def _run_cleanup(drains: list, created: dict) -> None:
-    """Close/join drains and drop created tables, surfacing every failure.
+    def cleanup(self) -> None:
+        """Close/join drains and drop created tables, surfacing every failure.
 
-    Both steps always run even if the first raises, so a drain failure never
-    leaks the temp tables and a drop failure never hides a drain failure.
-    """
-    cleanup_errors: list[BaseException] = []
-    try:
-        _close_and_join_drains(drains)
-    except BaseException as exc:  # noqa: BLE001
-        cleanup_errors.append(exc)
-    try:
-        _drop_created_tables(created)
-    except BaseException as exc:  # noqa: BLE001
-        cleanup_errors.append(exc)
-    raise_collected_errors("execution cleanup failed", cleanup_errors)
+        Both steps always run even if the first raises, so a drain failure never
+        leaks the temp tables and a drop failure never hides a drain failure.
+        """
+        cleanup_errors: list[BaseException] = []
+        try:
+            self._close_and_join_drains()
+        except BaseException as exc:  # noqa: BLE001
+            cleanup_errors.append(exc)
+        try:
+            self._drop_created_tables()
+        except BaseException as exc:  # noqa: BLE001
+            cleanup_errors.append(exc)
+        raise_collected_errors("execution cleanup failed", cleanup_errors)
 
 
 @tracer.start_as_current_span("_transform_expr")
-def _transform_expr(expr, params=None, **kwargs):
-    """Transform an expression for execution, binding any named scalar parameters."""
+def _transform_expr(
+    expr: ir.Expr,
+    params: Mapping[str, Any] | None = None,
+    **kwargs: Any,
+) -> tuple[ir.Expr, ExecutionResources]:
+    """Transform an expression for execution, binding any named scalar parameters.
+
+    Returns ``(expr, resources)`` where ``resources`` is an `ExecutionResources`
+    bundling everything the caller must release once execution finishes.
+    """
     name_values = _resolve_params(params)
     expr = (
         bind_params(expr, name_values)
@@ -495,8 +515,8 @@ def _transform_expr(expr, params=None, **kwargs):
     expr, tee_created, drains = register_and_transform_tee_nodes(expr)
     expr, created = register_and_transform_remote_tables(expr, **kwargs)
     expr, dt_to_read = _transform_deferred_reads(expr)
-    created = {**created, **tee_created}
-    return (expr, created, drains)
+    resources = ExecutionResources(created={**created, **tee_created}, drains=drains)
+    return (expr, resources)
 
 
 def _pandas_execute(con, expr: ir.Expr, **kwargs):
@@ -509,14 +529,14 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
         df = node.to_rbr().read_pandas(timestamp_as_object=True)
         return expr.__pandas_result__(df)
     params = kwargs.pop("params", None)
-    expr, created, drains = _transform_expr(expr, params=params)
+    expr, resources = _transform_expr(expr, params=params)
 
     span.set_attribute("engine", "pandas")
     try:
         result = con.execute(expr, **kwargs)
     except BaseException as primary:
         try:
-            _run_cleanup(drains, created)
+            resources.cleanup()
         except BaseException as cleanup_exc:  # noqa: BLE001
             raise_collected_errors(
                 "execute failed and cleanup failed",
@@ -524,7 +544,7 @@ def _pandas_execute(con, expr: ir.Expr, **kwargs):
             )
         raise
     else:
-        _run_cleanup(drains, created)
+        resources.cleanup()
         return result
 
 
@@ -565,19 +585,16 @@ def to_pyarrow_batches(
         span.set_attribute("engine", "flight")
         return expr.op().to_rbr()
     params = kwargs.pop("params", None)
-    expr, created, drains = _transform_expr(expr, params=params)
+    expr, resources = _transform_expr(expr, params=params)
     con, _ = find_backend(expr.op(), use_default=True)
 
     span.set_attribute("engine", con.name)
-
-    def clean_up():
-        _run_cleanup(drains, created)
 
     try:
         reader = con.to_pyarrow_batches(expr, chunk_size=chunk_size, **kwargs)
     except BaseException as primary:
         try:
-            clean_up()
+            resources.cleanup()
         except BaseException as cleanup_exc:  # noqa: BLE001
             raise_collected_errors(
                 "to_pyarrow_batches failed and cleanup failed",
@@ -585,7 +602,7 @@ def to_pyarrow_batches(
             )
         raise
 
-    return otel_instrument_reader(rbr_wrapper(reader, clean_up))
+    return otel_instrument_reader(rbr_wrapper(reader, resources.cleanup))
 
 
 def to_pyarrow(expr: ir.Expr, **kwargs: Any):
@@ -736,7 +753,7 @@ def to_json(
 def get_plans(expr: ir.Expr) -> dict:
     # Strip tee nodes first (like to_sql): EXPLAIN is a non-executing path, so
     # it must not register a pass-through table or fire the side-effect write.
-    _expr, _, _ = _transform_expr(_remove_tee_nodes(expr))
+    _expr, _ = _transform_expr(_remove_tee_nodes(expr))
     con, _ = find_backend(_expr.op())
     sql = f"EXPLAIN {to_sql(_expr)}"
     return con.con.sql(sql).to_pandas().set_index("plan_type")["plan"].to_dict()

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -59,6 +59,8 @@ if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
 
+    from xorq.writes import DrainingIterator
+
 __all__ = (
     "execute",
     "calc_split_column",
@@ -444,8 +446,8 @@ class ExecutionResources:
     (tee pass-throughs) that must be closed and joined.
     """
 
-    created: dict = field(factory=dict)
-    drains: list = field(factory=list)
+    created: dict[str, BaseBackend] = field(factory=dict)
+    drains: list[DrainingIterator] = field(factory=list)
 
     def _close_and_join_drains(self) -> None:
         errors: list[BaseException] = []

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -810,5 +810,5 @@ def prepare_create_table_from_expr(con, expr, **kwargs):
 
     if (expr_backend := expr._find_backend()) != con:
         raise ValueError(f"expr backend must be {con}, is {expr_backend}")
-    (table, _, _) = _transform_expr(expr, **kwargs)
+    (table, _) = _transform_expr(expr, **kwargs)
     return table

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -15,9 +15,7 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.common.utils.node_utils import compute_expr_hash
 from xorq.common.utils.provenance_utils import get_expr_hash
 from xorq.expr.api import (
-    _close_and_join_drains,
-    _drop_created_tables,
-    _run_cleanup,
+    ExecutionResources,
     get_plans,
 )
 from xorq.expr.relations import (
@@ -639,7 +637,7 @@ def test_drop_created_tables_drops_all_and_raises(tmp_path: Path) -> None:
     created = {"a": good_a, "bad": bad, "b": good_b}
 
     with pytest.raises(ValueError, match="drop_view bad"):
-        _drop_created_tables(created)
+        ExecutionResources(created=created)._drop_created_tables()
 
     # the failing table in the middle did not strand the others
     assert good_a.dropped == ["a"]
@@ -665,9 +663,10 @@ def test_run_cleanup_joins_drains_before_dropping_tables() -> None:
         def drop_table(self, name: str, force: bool = False) -> None:
             log.append(("drop", name))
 
-    _run_cleanup(
-        [_RecordingDrain("d0"), _RecordingDrain("d1")], {"t0": _RecordingCon()}
-    )
+    ExecutionResources(
+        created={"t0": _RecordingCon()},
+        drains=[_RecordingDrain("d0"), _RecordingDrain("d1")],
+    ).cleanup()
 
     join_idx = [i for i, (action, _) in enumerate(log) if action == "join"]
     drop_idx = [i for i, (action, _) in enumerate(log) if action == "drop"]
@@ -692,7 +691,9 @@ def test_run_cleanup_drops_tables_even_if_drain_fails() -> None:
             dropped.append(name)
 
     with pytest.raises(ValueError, match="drain boom"):
-        _run_cleanup([_FailingDrain()], {"t0": _RecordingCon()})
+        ExecutionResources(
+            created={"t0": _RecordingCon()}, drains=[_FailingDrain()]
+        ).cleanup()
 
     assert dropped == ["t0"], "table was not dropped after the drain failed"
 
@@ -723,7 +724,7 @@ def test_close_and_join_drains_closes_all_when_one_close_fails() -> None:
     ]
 
     with pytest.raises(BaseException) as excinfo:  # noqa: PT011
-        _close_and_join_drains(drains)
+        ExecutionResources(drains=drains)._close_and_join_drains()
 
     assert ("close", "d0") in log and ("close", "d1") in log, (
         f"a close() failure skipped a later close(): {log}"
@@ -1456,7 +1457,9 @@ def test_run_cleanup_aggregates_drain_and_drop_failures() -> None:
 
     raised: BaseException | None = None
     try:
-        _run_cleanup([_FailingDrain()], {"leaked_tbl": _FailingCon()})
+        ExecutionResources(
+            created={"leaked_tbl": _FailingCon()}, drains=[_FailingDrain()]
+        ).cleanup()
     except BaseException as exc:  # noqa: BLE001
         raised = exc
 

--- a/python/xorq/vendor/ibis/expr/types/relations.py
+++ b/python/xorq/vendor/ibis/expr/types/relations.py
@@ -3307,7 +3307,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         # Strip tee nodes first: defining a SQL view is a non-executing path, so
         # it must not register a pass-through table or fire the side-effect
         # write. Tee is schema-preserving, so the view schema is unaffected.
-        (expr, _, _) = _transform_expr(_remove_tee_nodes(expr))
+        (expr, _) = _transform_expr(_remove_tee_nodes(expr))
 
         schema = backend._get_sql_string_view_schema(name=name, table=expr, query=query)
         node = ops.SQLStringView(child=expr.op(), query=query, schema=schema)


### PR DESCRIPTION
## Summary

Pure, behavior-preserving refactor that consolidates execution-cleanup state and logic into a single `@frozen` attrs class, `ExecutionResources`.

- Replace the loose `(created, drains)` tuple threaded out of `_transform_expr` and the three standalone helpers (`_close_and_join_drains`, `_drop_created_tables`, `_run_cleanup`) with `ExecutionResources` holding `created` + `drains`, exposing `cleanup()` (and the two private steps as methods).
- `_transform_expr` now returns `(expr, resources)` instead of `(expr, created, drains)`.
- `_pandas_execute` / `to_pyarrow_batches` call `resources.cleanup()`; `to_pyarrow_batches` drops its `clean_up` closure and hands the bound `resources.cleanup` method straight to `rbr_wrapper`.
- Non-executing / discarding call sites (`get_plans`, `caching/storage.py`, `relations.py:prepare_create_table_from_expr`, vendor `relations.py` view path) just unpack `(x, _)` — behavior unchanged.
- Cleanup ordering (close+join drains, then drop tables) and `raise_collected_errors` aggregation are preserved exactly.
- Fields are precisely typed: `created: dict[str, BaseBackend]`, `drains: list[DrainingIterator]` (matching the `register_and_transform_*` signatures; `DrainingIterator` imported under `TYPE_CHECKING`).

### Why

Two recently-landed features (TeeNode deferred writes, and incoming batchcorder StreamCache fan-out) both grow the "resources to release after execution" return value of `_transform_expr` and duplicate per-call-site cleanup. Bundling them into one object means the next addition is a single new field + a single new step in `cleanup()`, with no tuple-arity changes and no new `finally` blocks at call sites.

## Test plan

- [x] `ruff check` clean on all changed files; pre-commit hooks pass
- [x] cleanup-semantics tests in `test_write_through.py` migrated to construct `ExecutionResources` and pass (5/5)
- [x] `test_write_through.py` + `params/test_param_output_methods.py`: 116 passed, 1 skipped, 0 failed (6 repeated runs, serial; also clean under `-n auto`)
- [x] Re-checked the earlier "3 tee tests fail on clean `main`" note: could **not** reproduce. 12 serial + 8 xdist runs of `test_write_through.py` on `main` were all green, and ~40 runs total across branch/main never produced `generator already executing`. If those failures are real they appear to be a load/machine-dependent thread race outside this diff's surface — flagging for CI confirmation rather than asserting it as fact.
