### PR TITLE
refactor(builders): Rebuildable protocol for recovered builders

### DIFF
--- a/docs/adr/0016-rebuildable-protocol.md
+++ b/docs/adr/0016-rebuildable-protocol.md
@@ -1,0 +1,131 @@
+# ADR-0016: Rebuildable protocol for recovered builder objects
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+- **Deciders:** dlovell
+
+## Context
+
+ADR-0005 introduced the `TagHandler` registry: `from_tag_node(tag_node) -> object`
+recovers a live domain object (e.g. `FittedPipeline`, `ExprComposer`) from an
+expression's tags. That recovery half is fully general — a handler may return any
+object, and third parties register any tag via the `xorq.from_tag_node` entry-point
+group.
+
+The *consumption* half was not general. `catalog replay --rebuild` needs every
+recovered builder to re-emit its expression under a target catalog, but the recovered
+objects expose differently-shaped rebuild APIs:
+
+- `FittedPipeline.reemit(tag_node, rebuild_subexpr)` — recurses through its own
+  training/predict subtrees via the `rebuild_subexpr` closure.
+- `ExprComposer.with_inputs_translated(remap, to_catalog).expr` — translates a
+  self-contained recipe's catalog inputs and re-emits.
+
+`get_rebuild_dispatch` reconciled these by duck-typing: it sniffed for a `reemit`
+method, then for `with_inputs_translated` + an `expr` attribute, normalizing both to a
+single `dispatch(rebuild_subexpr, remap, to_catalog) -> Expr` closure. Anything that
+matched neither shape fell silently through to `None` — so a new third-party builder
+was *recoverable* but not *rebuildable*, with no named contract to implement.
+
+Reasonable people could disagree on whether to unify the two builders' construction
+APIs wholesale. A prototype against both classes showed they should not: their
+"create a new expr" verbs are genuinely different (`FittedPipeline` takes new input
+data plus an output-mode selector; `ExprComposer` is parameter-free recipe replay).
+Only the *rebuild* operation is common.
+
+## Decision drivers
+
+- Replace duck-typing with an explicit, discoverable contract.
+- Give third-party builders a single method to implement for `--rebuild` support.
+- Do not force-unify the divergent "build a new expr" APIs (predict/transform vs.
+  recipe replay) — that abstraction leaks.
+- No change to ADR-0005's recovery registry or `from_tag_node` semantics.
+
+## Decision
+
+### `Rebuildable` protocol
+
+Add a `runtime_checkable` `Rebuildable` protocol in
+`python/xorq/expr/builders/__init__.py`:
+
+```python
+@runtime_checkable
+class Rebuildable(Protocol):
+    def rebuild(
+        self, tag_node, rebuild_subexpr, remap, to_catalog
+    ) -> Expr: ...
+```
+
+The four arguments are the full context available at the dispatch site. Each
+implementation uses the ones relevant to its rebuild model and ignores the rest:
+
+- input-driven builders (`FittedPipeline`) use `tag_node` + `rebuild_subexpr` and
+  ignore `remap`/`to_catalog`;
+- recipe builders (`ExprComposer`) use `remap` + `to_catalog` and ignore
+  `tag_node`/`rebuild_subexpr`.
+
+### `get_rebuild_dispatch` collapses to one isinstance check
+
+The two domain-object duck-typing branches in `get_rebuild_dispatch` are replaced by a
+single `isinstance(builder, Rebuildable)` check
+(`python/xorq/expr/builders/__init__.py`). The handler-level `reemit` path (path 1,
+for builders whose `from_tag_node` does not carry the full recipe) is unchanged.
+
+### The two builders implement `rebuild`
+
+- `FittedPipeline.reemit` is renamed to `rebuild` with the widened signature; the body
+  is unchanged (`python/xorq/expr/ml/pipeline_lib.py`).
+- `ExprComposer` gains a `rebuild` method delegating to
+  `with_inputs_translated(remap, to_catalog).expr`
+  (`python/xorq/catalog/composer.py`). `with_inputs_translated` stays — the
+  `ExprKind.Composed` path in `replay.py` calls it directly.
+
+## Alternatives considered
+
+### Unify the "build a new expr" API too (`build(**params)`)
+
+Add a `build(**params) -> Expr` member alongside `rebuild`.
+
+Rejected because the two builders have incompatible construction models:
+`ExprComposer` is parameter-free (vary the expr by constructing a different composer),
+while `FittedPipeline.build` requires a new-data expr plus a method selector
+(predict / transform / predict_proba / decision_function). A shared `**params`
+signature carries no real contract; it only type-checks by being a catch-all. "Create
+a new expr" stays domain-specific.
+
+### Keep duck-typing, just document it
+
+Leave `get_rebuild_dispatch` sniffing for `reemit` / `with_inputs_translated`.
+
+Rejected because it leaves third-party builders with no discoverable contract and
+silently downgrades unmatched builders to non-rebuildable.
+
+### Put metadata introspection (`params()`) on the protocol
+
+Rejected as redundant with the handler's existing `extract_metadata(tag_node)`
+(ADR-0005), which already produces sidecar metadata from the tag.
+
+## Consequences
+
+### Positive
+
+- `get_rebuild_dispatch` drops from a three-way duck-typing sniff to one
+  `isinstance` check plus the handler path.
+- Third-party builders get a single, discoverable method (`rebuild`) to implement for
+  `catalog replay --rebuild` support.
+- ADR-0005's recovery registry is untouched; this is purely additive on the
+  consumption side.
+
+### Negative
+
+- `FittedPipeline.rebuild` accepts `remap`/`to_catalog` it ignores, and
+  `ExprComposer.rebuild` accepts `tag_node`/`rebuild_subexpr` it ignores. The unified
+  signature trades a little per-implementation noise for one dispatch contract.
+- Renaming `FittedPipeline.reemit` to `rebuild` is a breaking change for any external
+  caller that invoked `reemit` directly (in-tree there were none beyond the dispatch).
+
+## References
+
+- ADR-0005: ExprBuilder — registry-driven domain object recovery from tagged expressions
+- `python/xorq/expr/builders/__init__.py` — `Rebuildable`, `get_rebuild_dispatch`
+- `python/xorq/catalog/replay.py` — rebuild driver

--- a/docs/adr/2103-rebuildable-protocol.md
+++ b/docs/adr/2103-rebuildable-protocol.md
@@ -1,4 +1,4 @@
-# ADR-0016: Rebuildable protocol for recovered builder objects
+# ADR-2103: Rebuildable protocol for recovered builder objects
 
 - **Status:** Accepted
 - **Date:** 2026-06-22

--- a/python/xorq/catalog/composer.py
+++ b/python/xorq/catalog/composer.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 from attr import Attribute, field, frozen
 from attr.validators import deep_iterable, instance_of, optional
@@ -11,6 +15,10 @@ from xorq.catalog.bind import (
     bind,
 )
 from xorq.catalog.catalog import CatalogEntry
+
+
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr.types.core import Expr
 
 
 def _same_catalog(instance, attribute: Attribute, value):
@@ -85,8 +93,23 @@ class ExprComposer:
             alias=pinned_alias,
         )
 
+    def rebuild(
+        self,
+        tag_node: object,
+        rebuild_subexpr: Callable,
+        remap: dict,
+        to_catalog: object,
+    ) -> Expr:
+        """Rebuild the composed expression against *to_catalog* (``Rebuildable``).
+
+        ``tag_node``/``rebuild_subexpr`` are part of the :class:`Rebuildable`
+        contract but unused here: the composition recipe is self-contained, so
+        rebuilding is just translating its catalog inputs and re-emitting.
+        """
+        return self.with_inputs_translated(remap, to_catalog).expr
+
     @classmethod
-    def from_expr(cls, expr, catalog):
+    def from_expr(cls, expr: Expr, catalog: object) -> ExprComposer:
         """Recover an ExprComposer from a tagged expression.
 
         Walks the HashingTag nodes embedded by a prior ``ExprComposer.expr``

--- a/python/xorq/catalog/replay.py
+++ b/python/xorq/catalog/replay.py
@@ -20,10 +20,9 @@ back under any outer wrapping.
 
 Rebuild protocols (see ``xorq.expr.builders.get_rebuild_dispatch``):
   1. Handler-level ``reemit`` callable on the ``TagHandler``.
-  2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
-     (multi-output builders like ``FittedPipeline``).
-  3. Domain-object ``with_inputs_translated(remap, to_catalog)`` +
-     ``expr`` (single-output builders like ``ExprComposer``).
+  2. Domain object implementing the ``Rebuildable`` protocol
+     (``rebuild(tag_node, rebuild_subexpr, remap, to_catalog)``), e.g.
+     ``FittedPipeline`` and ``ExprComposer``.
 """
 
 from __future__ import annotations
@@ -124,7 +123,7 @@ def _rebuild_subexpr(expr, *, from_catalog, to_catalog, ctx):
       catalog tags inside the chain are rebuilt as part of the same
       composition.
     - Registered builder tag (``ExprKind.ExprBuilder``): dispatches via
-      the handler protocol. The handler's ``reemit`` recursively
+      the handler protocol. The recovered object's ``rebuild`` recursively
       rebuilds its own inputs via the ``rebuild_subexpr`` closure
       passed in; outer processing does not re-enter its subtree.
 
@@ -188,8 +187,8 @@ def _rebuild_subexpr(expr, *, from_catalog, to_catalog, ctx):
             if tag_name and tag_name in _get_from_tag_node_registry():
                 msg = (
                     f"rebuild: handler for tag {tag_name!r} has no rebuild "
-                    "protocol (handler.reemit, object.reemit, or "
-                    "object.with_inputs_translated)"
+                    "protocol (handler.reemit, or a Rebuildable object with "
+                    "a rebuild() method)"
                 )
                 if ctx.on_unrebuilt_builder is OnUnrebuiltBuilder.RAISE:
                     raise RuntimeError(msg)

--- a/python/xorq/catalog/tests/test_replay_rebuild_builders.py
+++ b/python/xorq/catalog/tests/test_replay_rebuild_builders.py
@@ -3,10 +3,9 @@
 Covers the generalized ``catalog replay --rebuild`` capability that
 delegates to registered ``TagHandler`` rebuild protocols:
   1. Handler-level ``reemit`` callable.
-  2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
-     (multi-output builders like ``FittedPipeline``).
-  3. Domain-object ``with_inputs_translated`` + ``expr`` (single-output
-     builders like ``ExprComposer``).
+  2. Domain object implementing the ``Rebuildable`` protocol
+     (``rebuild(tag_node, rebuild_subexpr, remap, to_catalog)``), e.g.
+     ``FittedPipeline`` and ``ExprComposer``.
 """
 
 from pathlib import Path
@@ -21,6 +20,11 @@ from xorq.catalog.enums import CatalogTag
 from xorq.catalog.replay import Replayer
 from xorq.catalog.tests.conftest import _replay_rebuild
 from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.builders import (
+    TagHandler,
+    get_rebuild_dispatch,
+    register_tag_handler,
+)
 from xorq.expr.ml.enums import FittedPipelineTagKey
 from xorq.expr.ml.pipeline_lib import (
     _FITTED_PIPELINE_REEMIT_TAGS,
@@ -112,60 +116,57 @@ def test_get_rebuild_dispatch_handler_level_reemit_wins(saved_registry):
     assert calls["from_tag_node"] == 0
 
 
-def test_get_rebuild_dispatch_single_output_returns_callable(saved_registry):
-    """A domain object with with_inputs_translated + expr returns a callable
-    that delegates to with_inputs_translated and reads `.expr`."""
-    from attr import field, frozen  # noqa: PLC0415
+def test_get_rebuild_dispatch_single_output_returns_callable(
+    saved_registry,
+):  # xorq-style: disable=type-annotations
+    """A Rebuildable that translates a self-contained recipe (uses remap /
+    to_catalog) returns a callable that delegates to its rebuild() method."""
+    calls = {"rebuild": 0, "remap": None}
 
-    from xorq.expr.builders import (  # noqa: PLC0415
-        TagHandler,
-        get_rebuild_dispatch,
-        register_tag_handler,
-    )
-
-    calls = {"with_inputs_translated": 0}
-
-    @frozen
-    class FakeBuilder:
-        tag = field()
-
-        def with_inputs_translated(self, remap, to_catalog):
-            calls["with_inputs_translated"] += 1
-            return self
-
-        @property
-        def expr(self):
-            return self.tag.parent.to_expr()
+    class FakeRecipeBuilder:
+        def rebuild(
+            self,
+            tag_node: object,
+            rebuild_subexpr: object,
+            remap: dict,
+            to_catalog: object,
+        ) -> object:
+            calls["rebuild"] += 1
+            calls["remap"] = remap
+            return tag_node.parent.to_expr()
 
     register_tag_handler(
         TagHandler(
             tag_names=("test_single_out",),
             extract_metadata=lambda tag_node: {"type": "test_single_out"},
-            from_tag_node=lambda tag_node: FakeBuilder(tag=tag_node),
+            from_tag_node=lambda tag_node: FakeRecipeBuilder(),
         )
     )
 
     raw = xo.memtable({"x": [1, 2, 3]}).tag("test_single_out")
     dispatch = get_rebuild_dispatch(raw.op())
     assert callable(dispatch)
-    dispatch(lambda expr: expr, {}, None)
-    assert calls["with_inputs_translated"] == 1
+    dispatch(lambda expr: expr, {"a": "b"}, None)
+    assert calls["rebuild"] == 1
+    assert calls["remap"] == {"a": "b"}
 
 
-def test_get_rebuild_dispatch_domain_object_reemit(saved_registry):
-    """A domain object with a reemit method returns a callable."""
-    from xorq.expr.builders import (  # noqa: PLC0415
-        TagHandler,
-        get_rebuild_dispatch,
-        register_tag_handler,
-    )
-
-    calls = {"reemit": 0}
+def test_get_rebuild_dispatch_input_driven_returns_callable(
+    saved_registry,
+):  # xorq-style: disable=type-annotations
+    """A Rebuildable that recurses via rebuild_subexpr returns a callable."""
+    calls = {"rebuild": 0}
 
     class FakeBuilder:
-        def reemit(self, tag_node, rebuild_subexpr):
-            calls["reemit"] += 1
-            return tag_node.parent.to_expr()
+        def rebuild(
+            self,
+            tag_node: object,
+            rebuild_subexpr: object,
+            remap: dict,
+            to_catalog: object,
+        ) -> object:
+            calls["rebuild"] += 1
+            return rebuild_subexpr(tag_node.parent.to_expr())
 
     register_tag_handler(
         TagHandler(
@@ -179,16 +180,13 @@ def test_get_rebuild_dispatch_domain_object_reemit(saved_registry):
     dispatch = get_rebuild_dispatch(raw.op())
     assert callable(dispatch)
     dispatch(lambda expr: expr, {}, None)
-    assert calls["reemit"] == 1
+    assert calls["rebuild"] == 1
 
 
-def test_get_rebuild_dispatch_no_protocol_returns_none(saved_registry):
-    """A domain object with neither reemit nor with_inputs_translated returns None."""
-    from xorq.expr.builders import (  # noqa: PLC0415
-        TagHandler,
-        get_rebuild_dispatch,
-        register_tag_handler,
-    )
+def test_get_rebuild_dispatch_no_protocol_returns_none(
+    saved_registry,
+):  # xorq-style: disable=type-annotations
+    """A domain object without a rebuild() method is not Rebuildable -> None."""
 
     class Bare:
         pass

--- a/python/xorq/expr/builders/__init__.py
+++ b/python/xorq/expr/builders/__init__.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import importlib.metadata
 from collections.abc import Callable
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, is_callable, optional
@@ -72,13 +72,44 @@ class TagHandler:
     )
     reemit: Optional[Callable] = field(default=None, validator=optional(is_callable()))
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if not self.tag_names:
             raise ValueError("TagHandler must declare at least one tag_name")
         if self.extract_metadata is None and self.from_tag_node is None:
             raise ValueError(
                 "TagHandler must have at least one of extract_metadata or from_tag_node"
             )
+
+
+@runtime_checkable
+class Rebuildable(Protocol):
+    """A recovered domain object that can re-emit its expression for rebuild.
+
+    Implemented by the objects returned from ``TagHandler.from_tag_node``
+    (e.g. ``FittedPipeline``, ``ExprComposer``). ``get_rebuild_dispatch``
+    routes ``catalog replay --rebuild`` through this single method, replacing
+    the earlier duck-typed dispatch over ``reemit`` / ``with_inputs_translated``.
+
+    The four arguments are the full context available at the dispatch site.
+    Implementations use whichever ones fit their rebuild model and ignore the
+    rest:
+
+    - input-driven builders (``FittedPipeline``) use ``tag_node`` +
+      ``rebuild_subexpr`` to recurse through their own subtrees, and ignore
+      ``remap`` / ``to_catalog``;
+    - recipe builders (``ExprComposer``) use ``remap`` + ``to_catalog`` to
+      translate a self-contained recipe, and ignore ``tag_node`` /
+      ``rebuild_subexpr``.
+    """
+
+    def rebuild(
+        self,
+        tag_node: "Tag | HashingTag",
+        rebuild_subexpr: Callable,
+        remap: dict,
+        to_catalog: object,
+    ) -> object:  # -> Expr
+        ...
 
 
 _FROM_TAG_NODE_REGISTRY: dict[str, TagHandler] = {}
@@ -184,17 +215,15 @@ def get_rebuild_dispatch(tag_node):
     Dispatch order:
       1. Handler-level ``reemit`` callable (e.g., BSL-shape builders whose
          ``from_tag_node`` does not carry the full recipe).
-      2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
-         (multi-output builders like ``FittedPipeline``).
-      3. Domain-object ``with_inputs_translated(remap, to_catalog)`` +
-         ``expr`` (single-output builders like ``ExprComposer``).
+      2. Domain object implementing the :class:`Rebuildable` protocol
+         (``FittedPipeline``, ``ExprComposer``, third-party builders).
 
-    All three paths are normalized to a single calling convention:
-    ``dispatch(rebuild_subexpr, remap, to_catalog) -> Expr``. Closures
-    for paths 1 and 2 ignore ``remap``/``to_catalog`` (their reemit
-    method recurses through ``rebuild_subexpr`` instead); the closure
-    for path 3 ignores ``rebuild_subexpr`` (``with_inputs_translated``
-    walks the recipe directly). The driver passes all three regardless.
+    Both paths are normalized to a single calling convention:
+    ``dispatch(rebuild_subexpr, remap, to_catalog) -> Expr``. The handler
+    closure (path 1) ignores ``remap``/``to_catalog`` (its reemit method
+    recurses through ``rebuild_subexpr`` instead); the protocol closure
+    (path 2) forwards all four context arguments and each ``rebuild``
+    implementation uses only the ones relevant to its rebuild model.
 
     Returns ``None`` when no handler matches or no rebuild path is available.
     """
@@ -211,15 +240,9 @@ def get_rebuild_dispatch(tag_node):
     builder = handler.from_tag_node(tag_node)
     if builder is None:
         return None
-    if callable(getattr(builder, "reemit", None)):
-        return lambda rebuild_subexpr, remap, to_catalog: builder.reemit(
-            tag_node, rebuild_subexpr
-        )
-    if callable(getattr(builder, "with_inputs_translated", None)) and hasattr(
-        builder, "expr"
-    ):
-        return lambda rebuild_subexpr, remap, to_catalog: (
-            builder.with_inputs_translated(remap, to_catalog).expr
+    if isinstance(builder, Rebuildable):
+        return lambda rebuild_subexpr, remap, to_catalog: builder.rebuild(
+            tag_node, rebuild_subexpr, remap, to_catalog
         )
     return None
 

--- a/python/xorq/expr/builders/__init__.py
+++ b/python/xorq/expr/builders/__init__.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import importlib.metadata
 from collections.abc import Callable
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 from attr import field, frozen
 from attr.validators import deep_iterable, instance_of, is_callable, optional
@@ -64,13 +64,44 @@ class TagHandler:
     )
     reemit: Optional[Callable] = field(default=None, validator=optional(is_callable()))
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         if not self.tag_names:
             raise ValueError("TagHandler must declare at least one tag_name")
         if self.extract_metadata is None and self.from_tag_node is None:
             raise ValueError(
                 "TagHandler must have at least one of extract_metadata or from_tag_node"
             )
+
+
+@runtime_checkable
+class Rebuildable(Protocol):
+    """A recovered domain object that can re-emit its expression for rebuild.
+
+    Implemented by the objects returned from ``TagHandler.from_tag_node``
+    (e.g. ``FittedPipeline``, ``ExprComposer``). ``get_rebuild_dispatch``
+    routes ``catalog replay --rebuild`` through this single method, replacing
+    the earlier duck-typed dispatch over ``reemit`` / ``with_inputs_translated``.
+
+    The four arguments are the full context available at the dispatch site.
+    Implementations use whichever ones fit their rebuild model and ignore the
+    rest:
+
+    - input-driven builders (``FittedPipeline``) use ``tag_node`` +
+      ``rebuild_subexpr`` to recurse through their own subtrees, and ignore
+      ``remap`` / ``to_catalog``;
+    - recipe builders (``ExprComposer``) use ``remap`` + ``to_catalog`` to
+      translate a self-contained recipe, and ignore ``tag_node`` /
+      ``rebuild_subexpr``.
+    """
+
+    def rebuild(
+        self,
+        tag_node: "Tag | HashingTag",
+        rebuild_subexpr: Callable,
+        remap: dict,
+        to_catalog: object,
+    ) -> object:  # -> Expr
+        ...
 
 
 _FROM_TAG_NODE_REGISTRY: dict[str, TagHandler] = {}
@@ -176,17 +207,15 @@ def get_rebuild_dispatch(tag_node):
     Dispatch order:
       1. Handler-level ``reemit`` callable (e.g., BSL-shape builders whose
          ``from_tag_node`` does not carry the full recipe).
-      2. Domain-object ``reemit(tag_node, rebuild_subexpr)`` method
-         (multi-output builders like ``FittedPipeline``).
-      3. Domain-object ``with_inputs_translated(remap, to_catalog)`` +
-         ``expr`` (single-output builders like ``ExprComposer``).
+      2. Domain object implementing the :class:`Rebuildable` protocol
+         (``FittedPipeline``, ``ExprComposer``, third-party builders).
 
-    All three paths are normalized to a single calling convention:
-    ``dispatch(rebuild_subexpr, remap, to_catalog) -> Expr``. Closures
-    for paths 1 and 2 ignore ``remap``/``to_catalog`` (their reemit
-    method recurses through ``rebuild_subexpr`` instead); the closure
-    for path 3 ignores ``rebuild_subexpr`` (``with_inputs_translated``
-    walks the recipe directly). The driver passes all three regardless.
+    Both paths are normalized to a single calling convention:
+    ``dispatch(rebuild_subexpr, remap, to_catalog) -> Expr``. The handler
+    closure (path 1) ignores ``remap``/``to_catalog`` (its reemit method
+    recurses through ``rebuild_subexpr`` instead); the protocol closure
+    (path 2) forwards all four context arguments and each ``rebuild``
+    implementation uses only the ones relevant to its rebuild model.
 
     Returns ``None`` when no handler matches or no rebuild path is available.
     """
@@ -203,15 +232,9 @@ def get_rebuild_dispatch(tag_node):
     builder = handler.from_tag_node(tag_node)
     if builder is None:
         return None
-    if callable(getattr(builder, "reemit", None)):
-        return lambda rebuild_subexpr, remap, to_catalog: builder.reemit(
-            tag_node, rebuild_subexpr
-        )
-    if callable(getattr(builder, "with_inputs_translated", None)) and hasattr(
-        builder, "expr"
-    ):
-        return lambda rebuild_subexpr, remap, to_catalog: (
-            builder.with_inputs_translated(remap, to_catalog).expr
+    if isinstance(builder, Rebuildable):
+        return lambda rebuild_subexpr, remap, to_catalog: builder.rebuild(
+            tag_node, rebuild_subexpr, remap, to_catalog
         )
     return None
 

--- a/python/xorq/expr/ml/pipeline_lib.py
+++ b/python/xorq/expr/ml/pipeline_lib.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import functools
 import pickle
+from collections.abc import Callable
 
 import toolz
 from attr import (
@@ -1028,8 +1031,14 @@ class FittedPipeline:
             raise ValueError("No FittedPipeline tag found on expr")
         return cls.from_tag_node(pipeline_tags[0])
 
-    def reemit(self, tag_node, rebuild_subexpr):
-        """Re-emit *tag_node*'s subtree under current code.
+    def rebuild(
+        self,
+        tag_node: Tag,
+        rebuild_subexpr: Callable,
+        remap: dict | None = None,
+        to_catalog: object = None,
+    ) -> Expr:
+        """Re-emit *tag_node*'s subtree under current code (``Rebuildable``).
 
         Refits the pipeline on the rebuilt training subtree so the
         outer tag's ``training_hash`` and step kwargs refresh, rebuilds
@@ -1037,6 +1046,10 @@ class FittedPipeline:
         resolve to the target catalog's files), and re-stamps the outer
         pipeline tag on the rebuilt parent with fresh kwargs from the
         refitted pipeline.
+
+        ``remap``/``to_catalog`` are part of the :class:`Rebuildable`
+        contract but unused here: this builder recurses through
+        ``rebuild_subexpr``, which already carries the catalog translation.
 
         The internal transform/predict expression structure is
         preserved; we do not re-invoke the response method, since the
@@ -1046,7 +1059,7 @@ class FittedPipeline:
         tag_key = FittedPipelineTagKey(tag_node.metadata["tag"])
         if tag_key not in _FITTED_PIPELINE_REEMIT_TAGS:
             raise RuntimeError(
-                f"rebuild: FittedPipeline tag {tag_key!r} is not a reemit entry point"
+                f"rebuild: FittedPipeline tag {tag_key!r} is not a rebuild entry point"
             )
 
         # Refuse rebuild when the training subtree itself contains catalog


### PR DESCRIPTION
## Summary

- Adds a `runtime_checkable` **`Rebuildable`** protocol in `python/xorq/expr/builders/__init__.py` and collapses `get_rebuild_dispatch`'s three-way duck-typing (handler `reemit`, object `reemit`, object `with_inputs_translated`+`expr`) into one `isinstance(builder, Rebuildable)` check. The handler-level `reemit` path is unchanged.
- Implements `rebuild(tag_node, rebuild_subexpr, remap, to_catalog)` on the two existing recovered builders: `FittedPipeline.reemit` is renamed to `rebuild` (widened signature, body unchanged); `ExprComposer` gains a `rebuild` delegating to `with_inputs_translated(...).expr`.
- Documents the decision in **ADR-2103** (`docs/adr/2103-rebuildable-protocol.md`), numbered after this pull request per ADR-2210, including why the divergent "build a new expr" APIs (`predict`/`transform` vs. parameter-free recipe replay) are deliberately *not* unified.

## Context

Follow-up to ADR-0005. The recovery half (`from_tag_node -> object`) was already general; the rebuild/consumption half was duck-typed, so a third-party builder was recoverable but silently not rebuildable. This gives builders one discoverable contract to implement for `catalog replay --rebuild`. ADR-0005 is unchanged.

## Test plan

- [x] `test_replay_rebuild_builders.py` (62 passed) — dispatch now routes through `Rebuildable`; test stubs updated to implement `rebuild`.
- [x] `test_replay_rebuild.py` (24 passed) — end-to-end FittedPipeline + ExprComposer rebuild paths, handler-level `reemit` path.
- [ ] Full CI suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
