### PR TITLE
docs: add Claude Code plugin guide

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -49,8 +49,17 @@ website:
         text: "Concepts"
       - href: reference/index.qmd
         text: "Reference"
+      - href: claude/index.qmd
+        text: "Claude Code"
 
   sidebar:
+    - id: claude-code
+      title: "Claude Code"
+      pinned: true
+      contents:
+        - href: claude/index.qmd
+          text: "Plugin overview"
+
     - id: getting-started
       title: "Get started"
       collapse-level: 1

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -49,17 +49,8 @@ website:
         text: "Concepts"
       - href: reference/index.qmd
         text: "Reference"
-      - href: claude/index.qmd
-        text: "Claude Code"
 
   sidebar:
-    - id: claude-code
-      title: "Claude Code"
-      pinned: true
-      contents:
-        - href: claude/index.qmd
-          text: "Plugin overview"
-
     - id: getting-started
       title: "Get started"
       collapse-level: 1
@@ -71,6 +62,8 @@ website:
         - href: getting_started/switch_backends.qmd
         - href: getting_started/your_first_expression.qmd
           text: "Your first expression"
+        - href: claude/index.qmd
+          text: "Claude Code plugin"
 
     - id: how-to
       title: "How-to guides"

--- a/docs/claude/index.qmd
+++ b/docs/claude/index.qmd
@@ -22,12 +22,12 @@ A SessionStart hook loads the [essentials.md](https://github.com/xorq-labs/claud
 
 | Skill | What it does |
 |-------|--------------|
-| **ingest** | Bring data not yet catalogued (csv, parquet, or a DuckDB / SQLite / Postgres table) into a `source`. |
-| **composer** | Shape catalogued data into a new `composed` entry with inline code, reusable transforms, or both. |
-| **catalog-explore** | Read-only list, schema, row preview, and history. Also how a build is verified. |
-| **ml** | Fit an sklearn pipeline over an expression, save it as an `expr_builder`, run it on new data. |
-| **builder** | Round-trip tagged objects (semantic models, fitted pipelines, your own) through the catalog. |
-| **diagnose** | Failed, slow, or stale runs, and caching. |
+| [**ingest**](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/ingest/SKILL.md) | Bring data not yet catalogued (csv, parquet, or a DuckDB / SQLite / Postgres table) into a `source`. |
+| [**composer**](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/composer/SKILL.md) | Shape catalogued data into a new `composed` entry with inline code, reusable transforms, or both. |
+| [**catalog-explore**](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/catalog-explore/SKILL.md) | Read-only list, schema, row preview, and history. Also how a build is verified. |
+| [**ml**](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/ml/SKILL.md) | Fit an sklearn pipeline over an expression, save it as an `expr_builder`, run it on new data. |
+| [**builder**](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/builder/SKILL.md) | Round-trip tagged objects (semantic models, fitted pipelines, your own) through the catalog. |
+| [**diagnose**](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/diagnose/SKILL.md) | Failed, slow, or stale runs, and caching. |
 
 ## Example
 

--- a/docs/claude/index.qmd
+++ b/docs/claude/index.qmd
@@ -16,33 +16,78 @@ You talk to Claude in plain language. It picks the matching skill and runs the
 /plugin install xorq@xorq-plugins
 ```
 
-A SessionStart hook loads the [essentials.md](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/_shared/essentials.md) once per session, so each skill has access in context without duplicating.
-
-## A run through it
-
-Each step is what you ask Claude.
-
-| Ask | Skill | Result |
-|-----|-------|--------|
-| "Use a catalog called `demo`." | (setup) | `xorq catalog -n demo init` |
-| "Ingest `customers.csv` as `customers`." | ingest | a `source` entry |
-| "Show the catalog and preview `customers`." | catalog-explore | `list`, `schema`, `run` |
-| "From `customers`, keep `age > 30`, select name and age." | composer | a `composed` entry |
-| "Fit a classifier on `transactions` for `is_fraud`, save it." | ml | an `expr_builder` entry |
-| "That run was slow, what happened?" | diagnose | reads run logs, adds a cache |
+A SessionStart hook loads the [essentials.md](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/_shared/essentials.md) once per session, so each skill has access to the same information in context without duplication.
 
 ## Skills
 
-- **ingest**: data not catalogued yet (csv, parquet, or a DuckDB / SQLite /
-  Postgres table). Mints a `source`.
-- **composer**: shape catalogued data into a new `composed` entry with inline
-  code, reusable transforms, or both.
-- **catalog-explore**: read-only list, inspect schemas, preview rows, read
-  history. Also how a build is verified.
-- **ml**: fit an sklearn pipeline over an expression, save it as an
-  `expr_builder`, run it on new data.
-- **builder**: round-trip tagged objects (semantic models, fitted pipelines,
-  your own) through the catalog.
-- **diagnose**: failed, slow, or stale runs, and caching.
+::: {.docs-grid}
+
+::: {.doc-card}
+<i class="bi bi-box-arrow-in-down"></i>
+
+**ingest**
+
+Data not catalogued yet — csv, parquet, or a DuckDB / SQLite / Postgres table.
+Mints a `source`.
+:::
+
+::: {.doc-card}
+<i class="bi bi-diagram-3"></i>
+
+**composer**
+
+Shape catalogued data into a new `composed` entry with inline code, reusable
+transforms, or both.
+:::
+
+::: {.doc-card}
+<i class="bi bi-search"></i>
+
+**catalog-explore**
+
+Read-only: list, inspect schemas, preview rows, read history. Also how a build
+is verified.
+:::
+
+::: {.doc-card}
+<i class="bi bi-cpu"></i>
+
+**ml**
+
+Fit an sklearn pipeline over an expression, save it as an `expr_builder`, run it
+on new data.
+:::
+
+::: {.doc-card}
+<i class="bi bi-arrow-repeat"></i>
+
+**builder**
+
+Round-trip tagged objects — semantic models, fitted pipelines, your own —
+through the catalog.
+:::
+
+::: {.doc-card}
+<i class="bi bi-heart-pulse"></i>
+
+**diagnose**
+
+Failed, slow, or stale runs, and caching.
+:::
+
+:::
+
+## Example
+
+A session, one line per turn — what you say, and the skill Claude reaches for.
+
+| You ask | Skill |
+|---------|-------|
+| "Use a catalog called `demo`." | _(setup)_ |
+| "Ingest `customers.csv` as `customers`." | ingest |
+| "Show the catalog and preview `customers`." | catalog-explore |
+| "From `customers`, keep `age > 30`, select name and age." | composer |
+| "Fit a classifier on `transactions` for `is_fraud`, save it." | ml |
+| "That run was slow, what happened?" | diagnose |
 
 Full CLI and Python API index: <https://docs.xorq.dev/llms.txt>

--- a/docs/claude/index.qmd
+++ b/docs/claude/index.qmd
@@ -1,0 +1,54 @@
+---
+title: "Claude Code plugin"
+description: "Drive the xorq catalog and CLI from Claude Code in plain language"
+icon: "robot"
+headline: "Use xorq from Claude Code"
+---
+
+You talk to Claude in plain language. It picks the matching skill and runs the
+`xorq` CLI for you. No MCP server. Source and full skill docs:
+[xorq-labs/claude-plugins](https://github.com/xorq-labs/claude-plugins).
+
+## Install
+
+```
+/plugin marketplace add xorq-labs/claude-plugins
+/plugin install xorq@xorq-plugins
+```
+
+A SessionStart hook loads the shared vocabulary (CLI setup, which catalog to
+write to, the build/recover/verify idioms) once per session, so each skill
+assumes it. Entries are versioned, content-addressed build artifacts in a
+git-backed [catalog](../tutorials/core_tutorials/working_with_the_catalog.qmd).
+Kinds: `source` (raw data), `composed` (a source shaped by code or transforms),
+`unbound_expr` (a reusable transform), `expr_builder` (a tagged object like a
+fitted model that recovers into live Python).
+
+## A run through it
+
+Each step is what you ask Claude.
+
+| Ask | Skill | Result |
+|-----|-------|--------|
+| "Use a catalog called `demo`." | (setup) | `xorq catalog -n demo init` |
+| "Ingest `customers.csv` as `customers`." | ingest | a `source` entry |
+| "Show the catalog and preview `customers`." | catalog-explore | `list`, `schema`, `run` |
+| "From `customers`, keep `age > 30`, select name and age." | composer | a `composed` entry |
+| "Fit a classifier on `transactions` for `is_fraud`, save it." | ml | an `expr_builder` entry |
+| "That run was slow, what happened?" | diagnose | reads run logs, adds a cache |
+
+## Skills
+
+- **ingest**: data not catalogued yet (csv, parquet, or a DuckDB / SQLite /
+  Postgres table). Mints a `source`.
+- **composer**: shape catalogued data into a new `composed` entry with inline
+  code, reusable transforms, or both.
+- **catalog-explore**: read-only list, inspect schemas, preview rows, read
+  history. Also how a build is verified.
+- **ml**: fit an sklearn pipeline over an expression, save it as an
+  `expr_builder`, run it on new data.
+- **builder**: round-trip tagged objects (semantic models, fitted pipelines,
+  your own) through the catalog.
+- **diagnose**: failed, slow, or stale runs, and caching.
+
+Full CLI and Python API index: <https://docs.xorq.dev/llms.txt>

--- a/docs/claude/index.qmd
+++ b/docs/claude/index.qmd
@@ -1,8 +1,8 @@
 ---
 title: "Claude Code plugin"
-description: "Drive the xorq catalog and CLI from Claude Code in plain language"
+description: "Drive the Xorq catalog and command-line tool from Claude Code in plain language"
 icon: "robot"
-headline: "Use xorq from Claude Code"
+headline: "Use Xorq from Claude Code"
 ---
 
 You talk to Claude in plain language. It picks the matching skill and runs the
@@ -27,7 +27,7 @@ A SessionStart hook loads the [essentials.md](https://github.com/xorq-labs/claud
 
 **ingest**
 
-Data not catalogued yet — csv, parquet, or a DuckDB / SQLite / Postgres table.
+Data not catalogued yet—csv, parquet, or a DuckDB / SQLite / Postgres table.
 Mints a `source`.
 :::
 
@@ -63,8 +63,8 @@ on new data.
 
 **builder**
 
-Round-trip tagged objects — semantic models, fitted pipelines, your own —
-through the catalog.
+Round-trip tagged objects—semantic models, fitted pipelines, your own—through
+the catalog.
 :::
 
 ::: {.doc-card}
@@ -79,7 +79,7 @@ Failed, slow, or stale runs, and caching.
 
 ## Example
 
-A session, one line per turn — what you say, and the skill Claude reaches for.
+A session, one line per turn—what you say, and the skill Claude reaches for.
 
 | You ask | Skill |
 |---------|-------|
@@ -90,4 +90,4 @@ A session, one line per turn — what you say, and the skill Claude reaches for.
 | "Fit a classifier on `transactions` for `is_fraud`, save it." | ml |
 | "That run was slow, what happened?" | diagnose |
 
-Full CLI and Python API index: <https://docs.xorq.dev/llms.txt>
+Full command-line and Python API index: <https://docs.xorq.dev/llms.txt>

--- a/docs/claude/index.qmd
+++ b/docs/claude/index.qmd
@@ -20,62 +20,14 @@ A SessionStart hook loads the [essentials.md](https://github.com/xorq-labs/claud
 
 ## Skills
 
-::: {.docs-grid}
-
-::: {.doc-card}
-<i class="bi bi-box-arrow-in-down"></i>
-
-**ingest**
-
-Data not catalogued yet—csv, parquet, or a DuckDB / SQLite / Postgres table.
-Mints a `source`.
-:::
-
-::: {.doc-card}
-<i class="bi bi-diagram-3"></i>
-
-**composer**
-
-Shape catalogued data into a new `composed` entry with inline code, reusable
-transforms, or both.
-:::
-
-::: {.doc-card}
-<i class="bi bi-search"></i>
-
-**catalog-explore**
-
-Read-only: list, inspect schemas, preview rows, read history. Also how a build
-is verified.
-:::
-
-::: {.doc-card}
-<i class="bi bi-cpu"></i>
-
-**ml**
-
-Fit an sklearn pipeline over an expression, save it as an `expr_builder`, run it
-on new data.
-:::
-
-::: {.doc-card}
-<i class="bi bi-arrow-repeat"></i>
-
-**builder**
-
-Round-trip tagged objects—semantic models, fitted pipelines, your own—through
-the catalog.
-:::
-
-::: {.doc-card}
-<i class="bi bi-heart-pulse"></i>
-
-**diagnose**
-
-Failed, slow, or stale runs, and caching.
-:::
-
-:::
+| Skill | What it does |
+|-------|--------------|
+| **ingest** | Bring data not yet catalogued (csv, parquet, or a DuckDB / SQLite / Postgres table) into a `source`. |
+| **composer** | Shape catalogued data into a new `composed` entry with inline code, reusable transforms, or both. |
+| **catalog-explore** | Read-only list, schema, row preview, and history. Also how a build is verified. |
+| **ml** | Fit an sklearn pipeline over an expression, save it as an `expr_builder`, run it on new data. |
+| **builder** | Round-trip tagged objects (semantic models, fitted pipelines, your own) through the catalog. |
+| **diagnose** | Failed, slow, or stale runs, and caching. |
 
 ## Example
 

--- a/docs/claude/index.qmd
+++ b/docs/claude/index.qmd
@@ -6,7 +6,7 @@ headline: "Use xorq from Claude Code"
 ---
 
 You talk to Claude in plain language. It picks the matching skill and runs the
-`xorq` CLI for you. No MCP server. Source and full skill docs:
+`xorq` commands for you. Source and full skill docs:
 [xorq-labs/claude-plugins](https://github.com/xorq-labs/claude-plugins).
 
 ## Install
@@ -16,13 +16,7 @@ You talk to Claude in plain language. It picks the matching skill and runs the
 /plugin install xorq@xorq-plugins
 ```
 
-A SessionStart hook loads the shared vocabulary (CLI setup, which catalog to
-write to, the build/recover/verify idioms) once per session, so each skill
-assumes it. Entries are versioned, content-addressed build artifacts in a
-git-backed [catalog](../tutorials/core_tutorials/working_with_the_catalog.qmd).
-Kinds: `source` (raw data), `composed` (a source shaped by code or transforms),
-`unbound_expr` (a reusable transform), `expr_builder` (a tagged object like a
-fitted model that recovers into live Python).
+A SessionStart hook loads the [essentials.md](https://github.com/xorq-labs/claude-plugins/blob/main/xorq/skills/_shared/essentials.md) once per session, so each skill has access in context without duplicating.
 
 ## A run through it
 


### PR DESCRIPTION
## What

Adds a brief guide for the [xorq Claude Code plugin](https://github.com/xorq-labs/claude-plugins) to docs.xorq.dev.

The page (`docs/claude/index.qmd`) covers:
- install
- how the SessionStart hook injects shared context once per session, so each skill assumes it
- the catalog entry kinds (`source` / `composed` / `unbound_expr` / `expr_builder`)
- a short plain-language walkthrough (ask -> skill -> result)
- a six-skill overview (ingest, composer, catalog-explore, ml, builder, diagnose)

It gets its own **Claude Code** navbar item and sidebar section under `docs/claude/`, leaving room for more Claude pages later.

Brief by design, no em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)