### PR TITLE
test(tee): use multi-batch sources for early-stop guarantees

### DIFF
--- a/docs/adr/0014-teenode-deferred-writes.md
+++ b/docs/adr/0014-teenode-deferred-writes.md
@@ -1,7 +1,7 @@
 # ADR-0014: TeeNode, deferred write as a side effect
 
-- **Status:** Accepted
-- **Date:** 2026-06-10
+- **Status:** Amended
+- **Date:** 2026-06-23
 - **Deciders:** Daniel Mesejo, Dan Lovell
 - **Context area:** `python/xorq/writes/` (new), `python/xorq/expr/relations.py`, `python/xorq/expr/api.py`, `python/xorq/vendor/ibis/expr/types/relations.py`
 
@@ -175,13 +175,6 @@ downstream; once downstream is done there is nothing to buffer for, so the write
 remainder freely. The lifecycle is explicit (`close()` then `join()`, no `__del__` finalizer, since
 the backend keeps the reader alive past GC), and needs no changes to the `WriteThrough` ABC or any
 implementation. See `DrainingIterator` (`write_through.py`) for the mechanics.
-
-A concurrency defect in this path is tracked in **#2105**: with a *multi-batch* parent under
-datafusion 0.2.9, the background drain thread and datafusion's in-flight terminal pull (see the
-read-ahead note in Consequences) can race on the same `write_through` generator, raising
-`ValueError('generator already executing')` so the write silently fails to publish. It is
-intermittent and 0.2.9-only (absent on the currently-pinned 0.2.7); the fix must serialize the
-drain against the engine's pull.
 
 ### Fan-out of two, chained for N
 
@@ -428,16 +421,6 @@ The first four are the footguns: cases where the write does something a caller w
   future in-engine transport (for example a Postgres data-modifying CTE) are drain-always by construction
   and cannot honor it; callers relying on early-stop suppression must not assume it holds for
   those transports.
-- **The `drain=False` abort is also parent-size-dependent under datafusion's read-ahead.** Even on
-  the client-side generator transport, early-stop suppression is only *observable* when the parent's
-  un-pulled tail exceeds datafusion's bounded read-ahead window (empirically ~4 batches). datafusion
-  0.2.9 added a terminal end-of-stream probe that, to detect EOF, pulls past a small parent and
-  exhausts the writer — so a sub-read-ahead parent (in the limit, a single batch) **publishes anyway
-  despite `drain=False`**. The probe is absent in 0.2.7 (the currently-pinned version, which stops at
-  the LIMIT), so this is a 0.2.9-onward behavior. A caller passing `drain=False` to suppress a write
-  on a tiny input will be surprised; the suppression is reliable only once the un-written tail is
-  larger than the read-ahead window. The same probe is what surfaces the #2105 drain race above. Tests
-  must use a multi-batch source with margin beyond the window to exercise the guarantee version-robustly.
 - The default backend consumer (`ThreadedBackendWriteThrough`) defaults to an **unbounded** queue
   (`maxsize=0`), giving up backpressure: if downstream pulls faster than the write ingests, the
   queue grows without bound. Two bounded-memory options ship: `ThreadedBackendWriteThrough(maxsize
@@ -474,5 +457,28 @@ The first four are the footguns: cases where the write does something a caller w
 - Atomic write precedent (temp file + rename): `python/xorq/caching/storage.py`
 - ADR-0013: batchcorder StreamCache for RemoteTable fan-out (forthcoming), candidate for the future buffered-tee optimization
 - Issue #2087 (build- vs. cache-hash naming): this ADR edits `get_expr_hash` (`python/xorq/common/utils/provenance_utils.py`) and relies on the build/cache hash split. A rename there (`get_expr_hash` → `compute_build_hash`) must update this ADR's references and the `include_tee_nodes` call site.
-- Issue #2105 (drain race): `drain=True` over a multi-batch parent races the background drain against datafusion 0.2.9's terminal pull (`ValueError('generator already executing')`); intermittent and 0.2.9-only. See the `drain` section and Consequences → Negative.
-- PR #1977 (`spike/add-batchcorder`): bumps `xorq-datafusion` 0.2.7 → 0.2.9, which introduces the terminal end-of-stream probe whose read-ahead behavior the drain/early-stop consequences depend on.
+
+## Amendment — 2026-06-23
+
+The decision stands; this records behavior surfaced by the forthcoming `xorq-datafusion`
+0.2.7 → 0.2.9 bump (**#1977**), which adds a terminal end-of-stream probe that, to detect EOF,
+pulls past a small parent with a bounded read-ahead window (empirically ~4 batches). Two
+consequences for the `drain` design follow. Both are 0.2.9-onward; on the currently-pinned 0.2.7
+the LIMIT stops short and neither is observable.
+
+- **`drain=False` early-stop suppression is parent-size-dependent.** On the client-side generator
+  transport, an early-stop aborts the write only when the parent's un-pulled tail exceeds the
+  read-ahead window. Under the 0.2.9 probe a sub-read-ahead parent (in the limit, a single batch)
+  is pulled to EOF and **publishes anyway despite `drain=False`**. A caller suppressing a write on a
+  tiny input will be surprised; suppression is reliable only once the un-written tail is larger than
+  the window. Tests must use a multi-batch source with margin beyond the window to exercise the
+  guarantee version-robustly.
+- **`drain=True` can race the probe (#2105).** With a *multi-batch* parent, the background drain
+  thread and datafusion's in-flight terminal pull can race on the same `write_through` generator,
+  raising `ValueError('generator already executing')` so the write silently fails to publish. It is
+  intermittent and 0.2.9-only; the fix must serialize the drain against the engine's pull.
+
+References:
+
+- Issue #2105 (drain race): `drain=True` over a multi-batch parent races the background drain against datafusion 0.2.9's terminal pull (`ValueError('generator already executing')`); intermittent and 0.2.9-only.
+- PR #1977 (`spike/add-batchcorder`): bumps `xorq-datafusion` 0.2.7 → 0.2.9, which introduces the terminal end-of-stream probe whose read-ahead behavior these consequences depend on.

--- a/docs/adr/0014-teenode-deferred-writes.md
+++ b/docs/adr/0014-teenode-deferred-writes.md
@@ -176,6 +176,13 @@ remainder freely. The lifecycle is explicit (`close()` then `join()`, no `__del_
 the backend keeps the reader alive past GC), and needs no changes to the `WriteThrough` ABC or any
 implementation. See `DrainingIterator` (`write_through.py`) for the mechanics.
 
+A concurrency defect in this path is tracked in **#2105**: with a *multi-batch* parent under
+datafusion 0.2.9, the background drain thread and datafusion's in-flight terminal pull (see the
+read-ahead note in Consequences) can race on the same `write_through` generator, raising
+`ValueError('generator already executing')` so the write silently fails to publish. It is
+intermittent and 0.2.9-only (absent on the currently-pinned 0.2.7); the fix must serialize the
+drain against the engine's pull.
+
 ### Fan-out of two, chained for N
 
 Phase 1 supports a fan-out of two: one main consumer plus one inline write. A fan-out of N
@@ -421,6 +428,16 @@ The first four are the footguns: cases where the write does something a caller w
   future in-engine transport (for example a Postgres data-modifying CTE) are drain-always by construction
   and cannot honor it; callers relying on early-stop suppression must not assume it holds for
   those transports.
+- **The `drain=False` abort is also parent-size-dependent under datafusion's read-ahead.** Even on
+  the client-side generator transport, early-stop suppression is only *observable* when the parent's
+  un-pulled tail exceeds datafusion's bounded read-ahead window (empirically ~4 batches). datafusion
+  0.2.9 added a terminal end-of-stream probe that, to detect EOF, pulls past a small parent and
+  exhausts the writer — so a sub-read-ahead parent (in the limit, a single batch) **publishes anyway
+  despite `drain=False`**. The probe is absent in 0.2.7 (the currently-pinned version, which stops at
+  the LIMIT), so this is a 0.2.9-onward behavior. A caller passing `drain=False` to suppress a write
+  on a tiny input will be surprised; the suppression is reliable only once the un-written tail is
+  larger than the read-ahead window. The same probe is what surfaces the #2105 drain race above. Tests
+  must use a multi-batch source with margin beyond the window to exercise the guarantee version-robustly.
 - The default backend consumer (`ThreadedBackendWriteThrough`) defaults to an **unbounded** queue
   (`maxsize=0`), giving up backpressure: if downstream pulls faster than the write ingests, the
   queue grows without bound. Two bounded-memory options ship: `ThreadedBackendWriteThrough(maxsize
@@ -457,3 +474,5 @@ The first four are the footguns: cases where the write does something a caller w
 - Atomic write precedent (temp file + rename): `python/xorq/caching/storage.py`
 - ADR-0013: batchcorder StreamCache for RemoteTable fan-out (forthcoming), candidate for the future buffered-tee optimization
 - Issue #2087 (build- vs. cache-hash naming): this ADR edits `get_expr_hash` (`python/xorq/common/utils/provenance_utils.py`) and relies on the build/cache hash split. A rename there (`get_expr_hash` → `compute_build_hash`) must update this ADR's references and the `include_tee_nodes` call site.
+- Issue #2105 (drain race): `drain=True` over a multi-batch parent races the background drain against datafusion 0.2.9's terminal pull (`ValueError('generator already executing')`); intermittent and 0.2.9-only. See the `drain` section and Consequences → Negative.
+- PR #1977 (`spike/add-batchcorder`): bumps `xorq-datafusion` 0.2.7 → 0.2.9, which introduces the terminal end-of-stream probe whose read-ahead behavior the drain/early-stop consequences depend on.

--- a/docs/adr/0014-teenode-deferred-writes.md
+++ b/docs/adr/0014-teenode-deferred-writes.md
@@ -480,5 +480,5 @@ the LIMIT stops short and neither is observable.
 
 References:
 
-- Issue #2105 (drain race): `drain=True` over a multi-batch parent races the background drain against datafusion 0.2.9's terminal pull (`ValueError('generator already executing')`); intermittent and 0.2.9-only.
-- PR #1977 (`spike/add-batchcorder`): bumps `xorq-datafusion` 0.2.7 → 0.2.9, which introduces the terminal end-of-stream probe whose read-ahead behavior these consequences depend on.
+- Issue #2105 — the `drain=True` multi-batch race described above.
+- PR #1977 (`spike/add-batchcorder`) — the `xorq-datafusion` 0.2.7 → 0.2.9 bump that introduces the probe.

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -51,13 +51,22 @@ def t() -> Table:
 # datafusion drains a registered reader with a bounded read-ahead, so an early
 # downstream stop (LIMIT, partial read) leaves a *multi-batch* parent stream
 # un-exhausted -- the early-stop / drain guarantee is observable. A SINGLE-batch
-# source cannot express it: datafusion's terminal end-of-stream probe must pull
-# past the lone batch to detect EOF, which exhausts the writer and is
-# indistinguishable from genuine full consumption (it always publishes). The
-# early-stop tests below therefore feed a multi-batch source with margin beyond
-# the read-ahead window so the un-pulled tail is what the assertion turns on.
-# See ADR-0014.
-_MULTI_BATCH_COUNT = 8
+# source cannot express it: as of datafusion 0.2.9 a terminal end-of-stream probe
+# must pull past the lone batch to detect EOF, which exhausts the writer and is
+# indistinguishable from genuine full consumption (it always publishes). That
+# probe is absent in 0.2.7 (the version currently pinned): there the LIMIT stops
+# short and a single-batch source happens to pass -- so these tests are vacuously
+# green on 0.2.7 and only meaningfully guard once the 0.2.9 bump lands (#1977).
+# The early-stop tests below therefore feed a multi-batch source with margin
+# beyond the read-ahead window so the un-pulled tail is what the assertion turns
+# on, version-robustly. See ADR-0014.
+#
+# The count assumes datafusion's read-ahead window is ~4 batches: 8 gives margin
+# even for the thinnest case (LIMIT 2 + ~4 read-ahead leaves ~2 un-pulled). If a
+# future datafusion bump widens the window past ~6, these tests silently revert
+# to always-publishing (green for the wrong reason) -- raise this count to match.
+_DATAFUSION_READ_AHEAD = 4
+_MULTI_BATCH_COUNT = 2 * _DATAFUSION_READ_AHEAD
 
 
 def _multi_batch_source(con: Any, table_name: str) -> Table:
@@ -1499,6 +1508,14 @@ def test_draining_iterator_join_before_close_raises() -> None:
 
 
 def test_tee_drain_writes_full_on_early_stop(t: Table, tmp_path: Path) -> None:
+    # TODO(#2105): still single-batch. A multi-batch source with drain=True hits
+    # ValueError('generator already executing') (background drain vs datafusion's
+    # in-flight pull) on 0.2.9 -- a race, so it can't yet be hardened like the
+    # early-stop tests above. On 0.2.9 the further hazard is that the single batch
+    # is exhausted by the terminal EOF probe regardless of whether drain fired, so
+    # the assertion can't distinguish a genuine drain from probe exhaustion. (On
+    # 0.2.7, the pinned version, there is no probe and the drain genuinely runs.)
+    # Weakly guarded until #2105 lets this move to a multi-batch source.
     target = tmp_path / "drain_tee.parquet"
     out = t.tee(ParquetWriteThrough(path=target), drain=True).limit(2).execute()
     assert len(out) == 2

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -48,6 +48,26 @@ def t() -> Table:
     return con.register(xo.memtable(TABLE), table_name="t0")
 
 
+# datafusion drains a registered reader with a bounded read-ahead, so an early
+# downstream stop (LIMIT, partial read) leaves a *multi-batch* parent stream
+# un-exhausted -- the early-stop / drain guarantee is observable. A SINGLE-batch
+# source cannot express it: datafusion's terminal end-of-stream probe must pull
+# past the lone batch to detect EOF, which exhausts the writer and is
+# indistinguishable from genuine full consumption (it always publishes). The
+# early-stop tests below therefore feed a multi-batch source with margin beyond
+# the read-ahead window so the un-pulled tail is what the assertion turns on.
+# See ADR-0014.
+_MULTI_BATCH_COUNT = 8
+
+
+def _multi_batch_source(con: Any, table_name: str) -> Table:
+    batches = [
+        pa.record_batch({"a": [i], "b": [str(i)]}) for i in range(_MULTI_BATCH_COUNT)
+    ]
+    reader = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
+    return con.read_record_batches(reader, table_name=table_name)
+
+
 def _connect(name: str) -> Any:
     factory = {
         "datafusion": xo.connect,
@@ -757,9 +777,11 @@ def test_to_pyarrow_batches_partial_consumption_holds_resources(
 ) -> None:
     """Counterpart to the contract above: a partial read (an early break) does
     not run cleanup, so nothing is published and the table is held. This locks
-    in the leak the to_pyarrow_batches docstring warns about."""
+    in the leak the to_pyarrow_batches docstring warns about. Uses a multi-batch
+    source so datafusion's read-ahead leaves the tail un-pulled and the writer
+    un-exhausted (see _multi_batch_source)."""
     con = xo.connect()
-    tt = con.register(xo.memtable(TABLE), table_name="t0")
+    tt = _multi_batch_source(con, "partial_src")
     target = tmp_path / "out.parquet"
 
     before = _placeholder_tables(con)
@@ -1485,9 +1507,15 @@ def test_tee_drain_writes_full_on_early_stop(t: Table, tmp_path: Path) -> None:
     assert len(written) == 4
 
 
-def test_tee_drain_false_does_not_drain(t: Table, tmp_path: Path) -> None:
+def test_tee_drain_false_does_not_drain(tmp_path: Path) -> None:
+    # drain=False: an early downstream stop must NOT finish the side write. A
+    # multi-batch source is required -- datafusion's read-ahead stops short of
+    # exhausting the parent under a LIMIT, so the writer never publishes. See
+    # _multi_batch_source for why a single-batch source cannot express this.
+    con = xo.connect()
+    tt = _multi_batch_source(con, "no_drain_src")
     target = tmp_path / "no_drain.parquet"
-    t.tee(ParquetWriteThrough(path=target), drain=False).limit(2).execute()
+    tt.tee(ParquetWriteThrough(path=target), drain=False).limit(2).execute()
     assert not target.exists()
 
 

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -73,10 +73,16 @@ _DATAFUSION_READ_AHEAD = 4
 _MULTI_BATCH_COUNT = 2 * _DATAFUSION_READ_AHEAD
 
 # EOF probe lands in 0.2.9 (#1977); gates the version-sensitive markers below.
-_DATAFUSION_VERSION = tuple(
-    int(part)
-    for part in re.findall(r"\d+", importlib.metadata.version("xorq-datafusion"))[:3]
-)
+# A missing package falls back to (0, 0, 0) so collection succeeds and the
+# version-gated markers default to their pre-probe (0.2.7) behavior.
+try:
+    _raw_version = importlib.metadata.version("xorq-datafusion")
+except importlib.metadata.PackageNotFoundError:
+    _DATAFUSION_VERSION = (0, 0, 0)
+else:
+    _DATAFUSION_VERSION = tuple(
+        int(part) for part in re.findall(r"\d+", _raw_version)[:3]
+    )
 _DATAFUSION_HAS_EOF_PROBE = _DATAFUSION_VERSION >= (0, 2, 9)
 
 
@@ -1518,15 +1524,21 @@ def test_draining_iterator_join_before_close_raises() -> None:
 # ---- drain=True via .tee() --------------------------------------------------
 
 
+@pytest.mark.skipif(
+    _DATAFUSION_HAS_EOF_PROBE,
+    reason="#2105: on 0.2.9 the terminal EOF probe exhausts the single batch "
+    "regardless of whether drain fired, so the assertion passes for the wrong "
+    "reason -- skip rather than report a vacuous pass. Meaningful only on 0.2.7.",
+)
 def test_tee_drain_writes_full_on_early_stop(t: Table, tmp_path: Path) -> None:
     # TODO(#2105): still single-batch. A multi-batch source with drain=True hits
     # ValueError('generator already executing') (background drain vs datafusion's
     # in-flight pull) on 0.2.9 -- a race, so it can't yet be hardened like the
-    # early-stop tests above. On 0.2.9 the further hazard is that the single batch
-    # is exhausted by the terminal EOF probe regardless of whether drain fired, so
-    # the assertion can't distinguish a genuine drain from probe exhaustion. (On
-    # 0.2.7, the pinned version, there is no probe and the drain genuinely runs.)
-    # Weakly guarded until #2105 lets this move to a multi-batch source.
+    # early-stop tests above. The skipif above guards the 0.2.9 EOF-probe hazard:
+    # there the single batch is exhausted by the probe regardless of whether drain
+    # fired, so the assertion can't distinguish a genuine drain from probe
+    # exhaustion. On 0.2.7 (the pinned version) there is no probe and the drain
+    # genuinely runs, so the test is meaningful and not skipped.
     target = tmp_path / "drain_tee.parquet"
     out = t.tee(ParquetWriteThrough(path=target), drain=True).limit(2).execute()
     assert len(out) == 2

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -50,31 +50,16 @@ def t() -> Table:
     return con.register(xo.memtable(TABLE), table_name="t0")
 
 
-# datafusion drains a registered reader with a bounded read-ahead, so an early
-# downstream stop (LIMIT, partial read) leaves a *multi-batch* parent stream
-# un-exhausted -- the early-stop / drain guarantee is observable. A SINGLE-batch
-# source cannot express it: as of datafusion 0.2.9 a terminal end-of-stream probe
-# must pull past the lone batch to detect EOF, which exhausts the writer and is
-# indistinguishable from genuine full consumption (it always publishes). That
-# probe is absent in 0.2.7 (the version currently pinned): there the LIMIT stops
-# short and a single-batch source happens to pass -- so these tests are vacuously
-# green on 0.2.7 and only meaningfully guard once the 0.2.9 bump lands (#1977).
-# The early-stop tests below therefore feed a multi-batch source with margin
-# beyond the read-ahead window so the un-pulled tail is what the assertion turns
-# on, version-robustly. See ADR-0014.
-#
-# The count assumes datafusion's read-ahead window is ~4 batches: 8 gives margin
-# even for the thinnest case (LIMIT 2 + ~4 read-ahead leaves ~2 un-pulled). If a
-# future datafusion bump widens the window past ~6, the suppression tests would
-# silently revert to always-publishing (green for the wrong reason) -- the
-# positive control in test_tee_drain_false_does_not_drain turns that into a loud
-# failure instead; raise this count to match when it fires.
+# Early-stop tests need a multi-batch source so the parent's un-pulled tail is
+# what the drain/suppression assertions turn on; a single batch can't express it
+# (the 0.2.9 EOF probe pulls it to exhaustion). Count is 2x the ~4-batch
+# read-ahead for margin; widen if a future bump grows the window -- the positive
+# control in test_tee_drain_false_does_not_drain fails loud if it doesn't. See
+# ADR-0014 for the full read-ahead / probe rationale.
 _DATAFUSION_READ_AHEAD = 4
 _MULTI_BATCH_COUNT = 2 * _DATAFUSION_READ_AHEAD
 
-# EOF probe lands in 0.2.9 (#1977); gates the version-sensitive markers below.
-# A missing package falls back to (0, 0, 0) so collection succeeds and the
-# version-gated markers default to their pre-probe (0.2.7) behavior.
+# EOF probe lands in 0.2.9 (#1977); missing package -> pre-probe defaults.
 try:
     _raw_version = importlib.metadata.version("xorq-datafusion")
 except importlib.metadata.PackageNotFoundError:
@@ -1531,14 +1516,9 @@ def test_draining_iterator_join_before_close_raises() -> None:
     "reason -- skip rather than report a vacuous pass. Meaningful only on 0.2.7.",
 )
 def test_tee_drain_writes_full_on_early_stop(t: Table, tmp_path: Path) -> None:
-    # TODO(#2105): still single-batch. A multi-batch source with drain=True hits
-    # ValueError('generator already executing') (background drain vs datafusion's
-    # in-flight pull) on 0.2.9 -- a race, so it can't yet be hardened like the
-    # early-stop tests above. The skipif above guards the 0.2.9 EOF-probe hazard:
-    # there the single batch is exhausted by the probe regardless of whether drain
-    # fired, so the assertion can't distinguish a genuine drain from probe
-    # exhaustion. On 0.2.7 (the pinned version) there is no probe and the drain
-    # genuinely runs, so the test is meaningful and not skipped.
+    # TODO(#2105): still single-batch -- a multi-batch drain=True races
+    # datafusion's in-flight pull on 0.2.9, so it can't be hardened like the
+    # early-stop tests above. The skipif guards the 0.2.9 vacuous-pass hazard.
     target = tmp_path / "drain_tee.parquet"
     out = t.tee(ParquetWriteThrough(path=target), drain=True).limit(2).execute()
     assert len(out) == 2

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import importlib.metadata
 import os
+import re
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -63,10 +65,19 @@ def t() -> Table:
 #
 # The count assumes datafusion's read-ahead window is ~4 batches: 8 gives margin
 # even for the thinnest case (LIMIT 2 + ~4 read-ahead leaves ~2 un-pulled). If a
-# future datafusion bump widens the window past ~6, these tests silently revert
-# to always-publishing (green for the wrong reason) -- raise this count to match.
+# future datafusion bump widens the window past ~6, the suppression tests would
+# silently revert to always-publishing (green for the wrong reason) -- the
+# positive control in test_tee_drain_false_does_not_drain turns that into a loud
+# failure instead; raise this count to match when it fires.
 _DATAFUSION_READ_AHEAD = 4
 _MULTI_BATCH_COUNT = 2 * _DATAFUSION_READ_AHEAD
+
+# EOF probe lands in 0.2.9 (#1977); gates the version-sensitive markers below.
+_DATAFUSION_VERSION = tuple(
+    int(part)
+    for part in re.findall(r"\d+", importlib.metadata.version("xorq-datafusion"))[:3]
+)
+_DATAFUSION_HAS_EOF_PROBE = _DATAFUSION_VERSION >= (0, 2, 9)
 
 
 def _multi_batch_source(con: Any, table_name: str) -> Table:
@@ -1524,6 +1535,24 @@ def test_tee_drain_writes_full_on_early_stop(t: Table, tmp_path: Path) -> None:
     assert len(written) == 4
 
 
+@pytest.mark.xfail(
+    _DATAFUSION_HAS_EOF_PROBE,
+    reason="#2105: multi-batch drain=True races datafusion's in-flight terminal "
+    "pull (ValueError: generator already executing); intermittent, 0.2.9-only",
+    strict=False,
+)
+def test_tee_drain_writes_full_on_early_stop_multi_batch(tmp_path: Path) -> None:
+    # Multi-batch hardening of the single-batch test above; XPASS means #2105 is fixed -- drop the marker.
+    con = xo.connect()
+    tt = _multi_batch_source(con, "drain_multi_src")
+    target = tmp_path / "drain_tee_multi.parquet"
+    out = tt.tee(ParquetWriteThrough(path=target), drain=True).limit(2).execute()
+    assert len(out) == 2
+    assert target.exists()
+    written = pq.read_table(str(target))
+    assert len(written) == _MULTI_BATCH_COUNT
+
+
 def test_tee_drain_false_does_not_drain(tmp_path: Path) -> None:
     # drain=False: an early downstream stop must NOT finish the side write. A
     # multi-batch source is required -- datafusion's read-ahead stops short of
@@ -1534,6 +1563,13 @@ def test_tee_drain_false_does_not_drain(tmp_path: Path) -> None:
     target = tmp_path / "no_drain.parquet"
     tt.tee(ParquetWriteThrough(path=target), drain=False).limit(2).execute()
     assert not target.exists()
+
+    # Positive control: same source fully consumed must publish, else the assertion above passes for the wrong reason.
+    full_src = _multi_batch_source(con, "no_drain_full_src")
+    full_target = tmp_path / "full.parquet"
+    full_src.tee(ParquetWriteThrough(path=full_target), drain=False).execute()
+    assert full_target.exists(), "full consumption must publish despite drain=False"
+    assert len(pq.read_table(str(full_target))) == _MULTI_BATCH_COUNT
 
 
 def test_drain_build_hash_same(t: Table, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The tee early-stop tests (`test_to_pyarrow_batches_partial_consumption_holds_resources`, `test_tee_drain_false_does_not_drain`) assert the early-stop / `drain=False` guarantee using a **single-batch** source — the one input where the guarantee provably cannot hold. datafusion's terminal end-of-stream probe must pull past the lone batch to detect EOF, exhausting the writer indistinguishably from genuine full consumption (so it always publishes).

This is currently masked on `main` (`xorq-datafusion==0.2.7`, which stops at the LIMIT without the terminal probe), but breaks under `0.2.9` — the bump on `spike/add-batchcorder` (PR #1977), where the probe drives single-batch sources to `StopIteration`, turning the `core` CI job flaky/red. datafusion's read-ahead is otherwise **bounded** (~4 batches), so a multi-batch source leaves the tail un-pulled and the guarantee is observable.

Landing on `main` so the hardening is durable and pre-empts the breakage the moment the 0.2.9 bump merges; `spike/add-batchcorder` inherits it on its next merge of main.

## Changes

- Add `_multi_batch_source` test helper (+ comment explaining the read-ahead / single-batch reasoning).
- Point the two affected tests at a multi-batch source.

## Verification

Confirmed **version-robust** — full `test_write_through.py` green on both:
- `xorq-datafusion==0.2.7` (this base / `main`): 107 passed, 1 skipped (stable across repeated runs).
- `xorq-datafusion==0.2.9` (`spike/add-batchcorder`): 102 passed, 1 skipped.

The 0.2.7 single-batch probe shows `exhausted: False` (stops at LIMIT), 0.2.9 shows `exhausted: True` — exactly the divergence the fix neutralizes.

## Note

Separate **latent race** found while verifying: `drain=True` over a multi-batch source with an early stop hits `ValueError('generator already executing')` (background drain vs. datafusion's in-flight pull) and silently fails to publish. Tracked in #2105 — intentionally out of scope here.