### PR TITLE
fix(writes): serialize DrainingIterator advancement to fix drain=True race

### DIFF
--- a/docs/adr/0014-teenode-deferred-writes.md
+++ b/docs/adr/0014-teenode-deferred-writes.md
@@ -446,6 +446,24 @@ The first four are the footguns: cases where the write does something a caller w
   silently escapes the build and cache hashes, risking a stale cache hit. The invariant
   ("kwargs tunes mechanics only") is a documented contract, not an enforced one.
 
+## Amendment (2026-06-23): serialize generator advancement
+
+The Decision above says that once downstream is done "the writer can consume the remainder
+freely." That assumed downstream being done meant the foreground reader had stopped pulling. It
+doesn't: `close()` can start the background drain while the foreground reader still has an in-flight
+pull. Datafusion uses a bounded read-ahead, so a multi-batch parent is typically *not* exhausted at
+cleanup time — the read-ahead thread may still be inside `DrainingIterator.__next__` when the drain
+thread enters its `for _ in self._gen` loop. Both then advance the same `write_through` generator,
+raising `ValueError('generator already executing')`; the write is silently never published,
+breaking the `drain=True` promise ([#2105](https://github.com/xorq-labs/xorq/issues/2105)). A
+single-batch parent masks this — datafusion's terminal end-of-stream probe exhausts the generator
+in the foreground, so the drain has nothing to advance and the window never opens.
+
+The fix is to serialize generator advancement: `__next__` and `_drain` acquire a shared per-batch
+lock so only one thread ever calls `next()` on the generator at a time (acquired per-iteration in
+the drain so an in-flight foreground pull can interleave rather than starve). Drain failures must
+surface, not be swallowed, or a failed publish looks like success.
+
 ## References
 
 - `Read` (deferred read precedent): `python/xorq/expr/relations.py`

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -415,11 +415,9 @@ def test_tee_drain_writes_full_on_early_stop_multibatch(tmp_path: Path) -> None:
 
 
 def test_draining_iterator_serializes_concurrent_advance() -> None:
-    # Deterministic guard for issue #2105: __next__ (foreground reader pull) and
-    # _drain (background close()) must never advance the underlying generator at
-    # once. time.sleep inside the generator body keeps its frame in the running
-    # state with the GIL released, so an overlapping next() from the other thread
-    # would raise ValueError('generator already executing') without serialization.
+    # Deterministic guard for #2105: __next__ and _drain must never advance the
+    # generator concurrently. The sleeps force the overlap that would otherwise
+    # raise 'generator already executing'.
     started = threading.Event()
 
     def slow_gen():

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -401,13 +401,9 @@ def test_tee_drops_intermediate_table_on_early_stop(tmp_path: Path) -> None:
 
 
 def test_tee_drain_writes_full_on_early_stop_multibatch(tmp_path: Path) -> None:
-    # Regression for the drain=True read-ahead race (issue #2105): with a
-    # multi-batch source, datafusion's bounded read-ahead leaves the parent
-    # un-exhausted at cleanup time, so the background drain thread and the
-    # in-flight foreground pull both advance the same write_through generator.
-    # Before serializing advancement that raced ('generator already executing')
-    # and the write was silently never published. The single-batch fixtures used
-    # by the other drain tests never open this window.
+    # Issue #2105 repro: multi-batch drain=True + early stop. Only opens the race
+    # on datafusion >=0.2.9 (bounded read-ahead); on the pinned 0.2.7 it passes
+    # even unfixed, so don't read a green run here as proof. See ADR-0014.
     con = xo.connect()
     batches = [pa.record_batch({"a": [i], "b": [str(i)]}) for i in range(8)]
     reader = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -4,6 +4,7 @@ import importlib.metadata
 import os
 import re
 import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -397,6 +398,59 @@ def test_tee_drops_intermediate_table_on_early_stop(tmp_path: Path) -> None:
     assert len(out) == 2
     assert len(pq.read_table(str(target))) == 4  # drain wrote the full parent
     assert set(con.list_tables()) == before
+
+
+def test_tee_drain_writes_full_on_early_stop_multibatch(tmp_path: Path) -> None:
+    # Regression for the drain=True read-ahead race (issue #2105): with a
+    # multi-batch source, datafusion's bounded read-ahead leaves the parent
+    # un-exhausted at cleanup time, so the background drain thread and the
+    # in-flight foreground pull both advance the same write_through generator.
+    # Before serializing advancement that raced ('generator already executing')
+    # and the write was silently never published. The single-batch fixtures used
+    # by the other drain tests never open this window.
+    con = xo.connect()
+    batches = [pa.record_batch({"a": [i], "b": [str(i)]}) for i in range(8)]
+    reader = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
+    tt = con.read_record_batches(reader, table_name="src")
+    target = tmp_path / "out.parquet"
+    out = tt.tee(ParquetWriteThrough(path=target), drain=True).limit(2).execute()
+    assert len(out) == 2
+    assert len(pq.read_table(str(target))) == 8  # drain wrote the full parent
+
+
+def test_draining_iterator_serializes_concurrent_advance() -> None:
+    # Deterministic guard for issue #2105: __next__ (foreground reader pull) and
+    # _drain (background close()) must never advance the underlying generator at
+    # once. time.sleep inside the generator body keeps its frame in the running
+    # state with the GIL released, so an overlapping next() from the other thread
+    # would raise ValueError('generator already executing') without serialization.
+    started = threading.Event()
+
+    def slow_gen():
+        for i in range(50):
+            started.set()
+            time.sleep(0.001)
+            yield pa.record_batch({"a": [i]})
+
+    di = DrainingIterator(slow_gen())
+    errors: list[BaseException] = []
+
+    def foreground():
+        try:
+            for _ in di:
+                time.sleep(0.0005)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    thread = threading.Thread(target=foreground)
+    thread.start()
+    started.wait()
+    di.close()  # start the background drain while the foreground is mid-pull
+    thread.join()
+    di.join()
+
+    assert not errors, errors
+    assert di.exhausted
 
 
 def test_tee_partial_consumption_leaks_intermediate_table(tmp_path: Path) -> None:

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -400,20 +400,6 @@ def test_tee_drops_intermediate_table_on_early_stop(tmp_path: Path) -> None:
     assert set(con.list_tables()) == before
 
 
-def test_tee_drain_writes_full_on_early_stop_multibatch(tmp_path: Path) -> None:
-    # Issue #2105 repro: multi-batch drain=True + early stop. Only opens the race
-    # on datafusion >=0.2.9 (bounded read-ahead); on the pinned 0.2.7 it passes
-    # even unfixed, so don't read a green run here as proof. See ADR-0014.
-    con = xo.connect()
-    batches = [pa.record_batch({"a": [i], "b": [str(i)]}) for i in range(8)]
-    reader = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
-    tt = con.read_record_batches(reader, table_name="src")
-    target = tmp_path / "out.parquet"
-    out = tt.tee(ParquetWriteThrough(path=target), drain=True).limit(2).execute()
-    assert len(out) == 2
-    assert len(pq.read_table(str(target))) == 8  # drain wrote the full parent
-
-
 def test_draining_iterator_serializes_concurrent_advance() -> None:
     # Deterministic guard for #2105: __next__ and _drain must never advance the
     # generator concurrently. The sleeps force the overlap that would otherwise
@@ -1575,14 +1561,12 @@ def test_tee_drain_writes_full_on_early_stop(t: Table, tmp_path: Path) -> None:
     assert len(written) == 4
 
 
-@pytest.mark.xfail(
-    _DATAFUSION_HAS_EOF_PROBE,
-    reason="#2105: multi-batch drain=True races datafusion's in-flight terminal "
-    "pull (ValueError: generator already executing); intermittent, 0.2.9-only",
-    strict=False,
-)
 def test_tee_drain_writes_full_on_early_stop_multi_batch(tmp_path: Path) -> None:
-    # Multi-batch hardening of the single-batch test above; XPASS means #2105 is fixed -- drop the marker.
+    # Issue #2105 integration repro: multi-batch drain=True + early stop must
+    # still write the full parent. Only opens the race on datafusion >=0.2.9
+    # (bounded read-ahead); on the pinned 0.2.7 it passes even unfixed, so a green
+    # run here is not proof -- test_draining_iterator_serializes_concurrent_advance
+    # is the deterministic guard. See ADR-0014.
     con = xo.connect()
     tt = _multi_batch_source(con, "drain_multi_src")
     target = tmp_path / "drain_tee_multi.parquet"

--- a/python/xorq/writes/write_through.py
+++ b/python/xorq/writes/write_through.py
@@ -449,35 +449,46 @@ class DrainingIterator:
         self._exhausted = False
         self._drain_thread: threading.Thread | None = None
         self._error: BaseException | None = None
-        self._lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        # serializes generator advancement so the foreground reader pull
+        # (datafusion read-ahead) and the background _drain loop never call
+        # next(self._gen) concurrently -> 'generator already executing'.
+        self._advance_lock = threading.Lock()
 
     @property
     def exhausted(self) -> bool:
-        with self._lock:
+        with self._state_lock:
             return self._exhausted
 
     def __iter__(self) -> DrainingIterator:  # noqa: PYI034
         return self
 
     def __next__(self) -> pa.RecordBatch:
-        try:
-            return next(self._gen)
-        except StopIteration:
-            with self._lock:
-                self._exhausted = True
-            raise
+        with self._advance_lock:
+            try:
+                return next(self._gen)
+            except StopIteration:
+                with self._state_lock:
+                    self._exhausted = True
+                raise
 
     def _drain(self) -> None:
+        # acquire per-iteration, not across the whole loop, so a still-in-flight
+        # foreground __next__ can interleave instead of being starved.
         try:
-            for _ in self._gen:
-                pass
+            while True:
+                with self._advance_lock:
+                    try:
+                        next(self._gen)
+                    except StopIteration:
+                        break
         except BaseException as exc:  # noqa: BLE001
             self._error = exc
-        with self._lock:
+        with self._state_lock:
             self._exhausted = True
 
     def close(self) -> None:
-        with self._lock:
+        with self._state_lock:
             if self._exhausted or self._drain_thread is not None:
                 return
             self._drain_thread = threading.Thread(target=self._drain)


### PR DESCRIPTION
## Ordering

> **Stacked on #2106 — merge #2106 first.** This PR's base is
> `fix/tee-drain-datafusion-eager-pull` (#2106), not `main`. #2106 hardens the
> early-stop tests to multi-batch sources and *documents* the `drain=True` race
> (deferring it to #2105); this PR *fixes* #2105 on top of that. Once #2106
> merges to `main`, retarget this PR to `main` (or it will merge automatically
> in order). The shared `_multi_batch_source` helper, version gating, and the
> ADR-0014 amendment all come from #2106.
>
> Reconciled in this PR: #2106's `xfail(strict=False)` for the #2105 race is
> dropped (this PR fixes it, so it would otherwise be a silent XPASS), and the
> two near-identical multi-batch drain tests are collapsed into one on the shared
> `_multi_batch_source` helper. `test_draining_iterator_serializes_concurrent_advance`
> remains the deterministic regression guard.

## Summary

Fixes #2105. A `tee(..., drain=True)` over a **multi-batch** parent with an early downstream stop (e.g. `.limit(n)`) could advance the same `write_through` generator from two threads at once:

- datafusion's foreground read-ahead pulling `DrainingIterator.__next__`, and
- the background `_drain()` loop started by `close()` during cleanup.

This raised `ValueError('generator already executing')` and the side-channel write was **silently never published**, breaking the `drain=True` promise.

## Fix

`python/xorq/writes/write_through.py`
- Add a dedicated `_advance_lock`, acquired **per batch** in both `__next__` and `_drain`, so only one thread advances `_gen` at a time (issue direction #2).
- `_drain` acquires per-iteration (not across the whole loop) so a still-in-flight foreground `__next__` can interleave rather than be starved. No deadlock: each `next()` is bounded by the writer thread's queue put.
- Rename the existing state lock `_lock` → `_state_lock` so the two locks are self-documenting (`_state_lock` guards `_exhausted`/`_drain_thread`; `_advance_lock` serializes advancement).

## Tests

`python/xorq/tests/test_write_through.py`
- `test_draining_iterator_serializes_concurrent_advance` — deterministic guard that overlaps a foreground pull with `close()`'s background drain. Verified it raises `ValueError: generator already executing` against the unfixed source and passes with the fix.
- `test_tee_drain_writes_full_on_early_stop_multibatch` — the issue's integration repro (multi-batch source + `.limit(2)` + `drain=True`).

Note: the integration test can't deterministically open the race in this environment — the issue cites xorq-datafusion 0.2.9's bounded ~4-batch read-ahead, but the dev env runs 0.2.7, which appears to exhaust the 8-batch parent eagerly in the foreground (passes 20/20 unfixed). The unit test is the real regression guard; the integration test documents the user-facing scenario.

The issue's direction #3 (surface the swallowed drain error) was not needed: the current `_run_cleanup` in `api.py` already surfaces drain errors via `raise_collected_errors`; the `remote_table_exec.py:268` swallow cited in the issue predates that refactor.

## Test plan

- [ ] `pytest python/xorq/tests/test_write_through.py` passes (110 passed, 1 skipped locally on the stacked branch)
- [ ] CI on a datafusion build with bounded read-ahead exercises the multi-batch integration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
