### PR TITLE
feat(cache): freeze-time cache pinning

### DIFF
--- a/python/xorq/caching/storage.py
+++ b/python/xorq/caching/storage.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import datetime
 from abc import abstractmethod
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from attr import field, frozen
 from attr.validators import instance_of, optional
+
+
+if TYPE_CHECKING:
+    from xorq.vendor.ibis.expr.operations.core import Node
+    from xorq.vendor.ibis.expr.schema import Schema
 
 
 def _lazy_backend_validator(instance, attribute, value):
@@ -62,7 +68,7 @@ class CacheStorage:
         pass
 
     @abstractmethod
-    def get(self, key):
+    def get(self, key: str, schema: Schema | None = None) -> Node:
         pass
 
     @abstractmethod
@@ -114,11 +120,11 @@ class ParquetStorage(CacheStorage):
             self.base_path,
         )
 
-    def __attrs_post_init__(self):
+    def _ensure_dir(self) -> None:
         self.path.mkdir(exist_ok=True, parents=True)
 
     @property
-    def path(self):
+    def path(self) -> Path:
         return resolve_parquet_cache_dir(self.relative_path, self.base_path)
 
     def get_path(self, key):
@@ -127,17 +133,25 @@ class ParquetStorage(CacheStorage):
     def exists(self, key):
         return self.get_path(key).exists()
 
-    def get(self, key):
+    def get(self, key: str, schema: Schema | None = None) -> Node:
         from xorq.common.utils.defer_utils import deferred_read_parquet  # noqa: PLC0415
 
+        # When the caller already knows the schema (e.g. pinning a CachedNode
+        # whose schema is on hand), forward it so deferred_read_parquet does not
+        # open the parquet footer just to re-infer a schema we already have.
         op = deferred_read_parquet(
             path=self.get_path(key),
             con=self.source,
             table_name=key,
+            schema=schema,
         ).op()
         return op
 
-    def put(self, key, value, parquet_metadata=None):
+    def put(self, key: str, value: Node, parquet_metadata: dict | None = None) -> Node:
+        # Create the cache dir lazily, at write time only -- constructing or
+        # relocating a storage (e.g. re-pointing a pinned read at a new
+        # base_path on load) must stay free of filesystem side effects.
+        self._ensure_dir()
         path = self.get_path(key)
         # move from temp location upon success to prevent empty files on failure
         tmp_path = path.with_name(path.name + ".tmp")
@@ -179,8 +193,8 @@ class ParquetTTLStorage(ParquetStorage):
 
 @frozen
 class ParquetDummyStorage(ParquetStorage):
-    def __attrs_post_init__(self):
-        pass  # intentionally skips self.path.mkdir(…) from ParquetStorage
+    def _ensure_dir(self) -> None:
+        pass  # dummy storage never touches the filesystem, even on write
 
 
 @frozen
@@ -196,7 +210,9 @@ class SourceStorage(CacheStorage):
     def exists(self, key):
         return key in self.source.tables
 
-    def get(self, key):
+    def get(self, key: str, schema: Schema | None = None) -> Node:
+        # schema is accepted for interface parity with ParquetStorage; a live
+        # backend table already carries its schema, so there is no I/O to skip.
         return self.source.table(key).op()
 
     def put(self, key, value, parquet_metadata=None):

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
         name: str
         hash: str
 
-    from xorq.expr.relations import HashingTag, TeeNode
+    from xorq.expr.relations import CacheTag, HashingTag, TeeNode
 
     class ExprMetadata(TypedDict):
         version: Literal[4]
@@ -191,6 +191,7 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
     from xorq.expr import api  # noqa: PLC0415
     from xorq.expr.relations import (  # noqa: PLC0415
         CachedNode,
+        CacheTag,
         FlightExpr,
         FlightUDXF,
         Read,
@@ -198,6 +199,13 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
     )
 
     match node:
+        case CacheTag():
+            # A pinned read is a leaf: its placeholder is keyed on the cache key
+            # (the frozen read's table name), which is base_path-independent and
+            # needs no source. Returning a placeholder here also stops the
+            # rewrite from descending `parent`'s absolute path or `uncached`'s
+            # discarded upstream into the SQL. See CacheTag.__dasher_tokenize__.
+            name = _stable_opaque_name("cachetag", node.schema, node.parent.name)
         case CachedNode():
             name = _stable_opaque_name(
                 "cached",
@@ -379,10 +387,11 @@ def _decompose_expr(
     tuple[str, ...],
     tuple[HashingTag, ...],
     tuple[TeeNode, ...],
+    tuple[CacheTag, ...],
 ]:
     """Split an expression into structural SQL, data leaves, UDFs, and identity nodes.
 
-    Returns ``(sql, reads, dts, udfs, mems, param_anchors, hashing_tags, tee_nodes)``
+    Returns ``(sql, reads, dts, udfs, mems, param_anchors, hashing_tags, tee_nodes, cache_tags)``
     where *reads*/*dts*/*mems* are the data-carrying leaf ops, *udfs* are
     structural code-identity ops, *param_anchors* are stable identity
     strings for each NamedScalarParameter in graph order, *hashing_tags*
@@ -392,6 +401,7 @@ def _decompose_expr(
     from xorq.expr.api import get_compiler, to_sql  # noqa: PLC0415
     from xorq.expr.relations import (  # noqa: PLC0415
         CachedNode,
+        CacheTag,
         HashingTag,
         Read,
         TeeNode,
@@ -425,7 +435,48 @@ def _decompose_expr(
     mems = tuple(walk_nodes(InMemoryTable, op))
     hashing_tags = tuple(walk_nodes(HashingTag, op))
     tee_nodes = tuple(walk_nodes(TeeNode, op))
-    return sql, reads, dts, udfs, mems, param_anchors, hashing_tags, tee_nodes
+    # A pinned read (CacheTag) is a hash *leaf*: its identity is the cache key,
+    # folded in _hash_expr_components via __dasher_tokenize__. Prune every leaf
+    # living under a CacheTag -- both `parent` (the cache-file read, whose
+    # absolute path is base_path-dependent) and `uncached` (the discarded
+    # upstream, whose sources would be stat'd) -- so a pin hashes consistently
+    # across cache dirs and without its original sources still existing.
+    # Pruning is by node identity; a no-op when the expr has no pins.
+    cache_tags = tuple(walk_nodes(CacheTag, op))
+    if cache_tags:
+        pinned = set()
+        for ct in cache_tags:
+            pinned.update(
+                walk_nodes(
+                    (
+                        Read,
+                        DatabaseTable,
+                        InMemoryTable,
+                        AggUDF,
+                        ScalarUDF,
+                        HashingTag,
+                        TeeNode,
+                    ),
+                    ct,
+                )
+            )
+        reads = tuple(r for r in reads if r not in pinned)
+        dts = tuple(d for d in dts if d not in pinned)
+        udfs = tuple(u for u in udfs if u not in pinned)
+        mems = tuple(m for m in mems if m not in pinned)
+        hashing_tags = tuple(h for h in hashing_tags if h not in pinned)
+        tee_nodes = tuple(t for t in tee_nodes if t not in pinned)
+    return (
+        sql,
+        reads,
+        dts,
+        udfs,
+        mems,
+        param_anchors,
+        hashing_tags,
+        tee_nodes,
+        cache_tags,
+    )
 
 
 def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
@@ -440,6 +491,7 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
         param_anchors,
         hashing_tags,
         tee_nodes,
+        cache_tags,
     ) = _decompose_expr(expr, op)
     hasher = _current_hasher.get() or HASHER
 
@@ -455,6 +507,11 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
         hash_args += (tuple(hasher.tokenize(ht) for ht in hashing_tags),)
     if _include_tee_nodes.get() and tee_nodes:
         hash_args += (tuple(hasher.tokenize(tn) for tn in tee_nodes),)
+    if cache_tags:
+        # A pinned read contributes only its cache-key identity (base_path-
+        # independent, source-free) via CacheTag.__dasher_tokenize__; its
+        # subtree leaves were pruned in _decompose_expr.
+        hash_args += (tuple(hasher.tokenize(ct) for ct in cache_tags),)
     structural_hash = hasher.tokenize(*hash_args)
 
     def _read_name(r: Read) -> str:

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -206,10 +206,9 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
             # needs no source. Returning a placeholder here also stops the
             # rewrite from descending `parent`'s absolute path or `uncached`'s
             # discarded upstream into the SQL. See CacheTag.__dasher_tokenize__.
-            # Shares the identity fields with __dasher_tokenize__ via
-            # cache_tag_identity_parts; the "cachetag" prefix is this layer's
-            # own envelope and must stay distinct from the tokenize tuple's
-            # "xorq.CacheTag" tag (changing it would alter the structural SQL).
+            # Identity fields shared via cache_tag_identity_parts; the "cachetag"
+            # prefix is this layer's own (distinct from the "xorq.CacheTag" token,
+            # since it lands in the structural SQL).
             name = _stable_opaque_name("cachetag", *cache_tag_identity_parts(node))
         case CachedNode():
             name = _stable_opaque_name(

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -196,6 +196,7 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
         FlightUDXF,
         Read,
         RemoteTable,
+        cache_tag_identity_parts,
     )
 
     match node:
@@ -205,7 +206,11 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
             # needs no source. Returning a placeholder here also stops the
             # rewrite from descending `parent`'s absolute path or `uncached`'s
             # discarded upstream into the SQL. See CacheTag.__dasher_tokenize__.
-            name = _stable_opaque_name("cachetag", node.schema, node.parent.name)
+            # Shares the identity fields with __dasher_tokenize__ via
+            # cache_tag_identity_parts; the "cachetag" prefix is this layer's
+            # own envelope and must stay distinct from the tokenize tuple's
+            # "xorq.CacheTag" tag (changing it would alter the structural SQL).
+            name = _stable_opaque_name("cachetag", *cache_tag_identity_parts(node))
         case CachedNode():
             name = _stable_opaque_name(
                 "cached",

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -401,7 +401,11 @@ def _decompose_expr(
     strings for each NamedScalarParameter in graph order, *hashing_tags*
     carry user-supplied metadata, and *tee_nodes* carry writer identity.
     """
-    from xorq.common.utils.graph_utils import replace_nodes, walk_nodes  # noqa: PLC0415
+    from xorq.common.utils.graph_utils import (  # noqa: PLC0415
+        exclusively_pinned_leaves,
+        replace_nodes,
+        walk_nodes,
+    )
     from xorq.expr.api import get_compiler, to_sql  # noqa: PLC0415
     from xorq.expr.relations import (  # noqa: PLC0415
         CachedNode,
@@ -440,17 +444,11 @@ def _decompose_expr(
     hashing_tags = tuple(walk_nodes(HashingTag, op))
     tee_nodes = tuple(walk_nodes(TeeNode, op))
     # A pinned read (CacheTag) is a hash *leaf*: its identity is the cache key,
-    # folded in _hash_expr_components via __dasher_tokenize__. Prune every leaf
-    # living under a CacheTag -- both ``parent`` (the cache-file read, whose
-    # absolute path is base_path-dependent) and ``uncached`` (the discarded
-    # upstream, whose sources would be stat'd) -- so a pin hashes consistently
-    # across cache dirs and without its original sources still existing.
-    # Pruning is by node identity; a no-op when the expr has no pins.
+    # folded in _hash_expr_components via __dasher_tokenize__. Prune the leaves
+    # that token already represents -- those exclusively under a pin -- from the
+    # data/identity collections gathered above (see exclusively_pinned_leaves).
     cache_tags = tuple(walk_nodes(CacheTag, op))
     if cache_tags:
-        # The leaf types pruned here are exactly the data/identity collections
-        # gathered above; one walk per tag into a set (which dedups nodes shared
-        # by nested pins), then a single membership filter over each collection.
         pinned_leaf_types = (
             Read,
             DatabaseTable,
@@ -460,9 +458,7 @@ def _decompose_expr(
             HashingTag,
             TeeNode,
         )
-        pinned = {
-            node for ct in cache_tags for node in walk_nodes(pinned_leaf_types, ct)
-        }
+        pinned = exclusively_pinned_leaves(op, pinned_leaf_types)
         reads, dts, udfs, mems, hashing_tags, tee_nodes = (
             tuple(n for n in coll if n not in pinned)
             for coll in (reads, dts, udfs, mems, hashing_tags, tee_nodes)

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -444,28 +444,25 @@ def _decompose_expr(
     # Pruning is by node identity; a no-op when the expr has no pins.
     cache_tags = tuple(walk_nodes(CacheTag, op))
     if cache_tags:
-        pinned = set()
-        for ct in cache_tags:
-            pinned.update(
-                walk_nodes(
-                    (
-                        Read,
-                        DatabaseTable,
-                        InMemoryTable,
-                        AggUDF,
-                        ScalarUDF,
-                        HashingTag,
-                        TeeNode,
-                    ),
-                    ct,
-                )
-            )
-        reads = tuple(r for r in reads if r not in pinned)
-        dts = tuple(d for d in dts if d not in pinned)
-        udfs = tuple(u for u in udfs if u not in pinned)
-        mems = tuple(m for m in mems if m not in pinned)
-        hashing_tags = tuple(h for h in hashing_tags if h not in pinned)
-        tee_nodes = tuple(t for t in tee_nodes if t not in pinned)
+        # The leaf types pruned here are exactly the data/identity collections
+        # gathered above; one walk per tag into a set (which dedups nodes shared
+        # by nested pins), then a single membership filter over each collection.
+        pinned_leaf_types = (
+            Read,
+            DatabaseTable,
+            InMemoryTable,
+            AggUDF,
+            ScalarUDF,
+            HashingTag,
+            TeeNode,
+        )
+        pinned = {
+            node for ct in cache_tags for node in walk_nodes(pinned_leaf_types, ct)
+        }
+        reads, dts, udfs, mems, hashing_tags, tee_nodes = (
+            tuple(n for n in coll if n not in pinned)
+            for coll in (reads, dts, udfs, mems, hashing_tags, tee_nodes)
+        )
     return (
         sql,
         reads,

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -204,10 +204,10 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
             # A pinned read is a leaf: its placeholder is keyed on the cache key
             # (the frozen read's table name), which is base_path-independent and
             # needs no source. Returning a placeholder here also stops the
-            # rewrite from descending `parent`'s absolute path or `uncached`'s
+            # rewrite from descending ``parent``'s absolute path or ``uncached``'s
             # discarded upstream into the SQL. See CacheTag.__dasher_tokenize__.
             # Identity fields shared via cache_tag_identity_parts; the "cachetag"
-            # prefix is this layer's own (distinct from the "xorq.CacheTag" token,
+            # prefix is this layer's own (distinct from the "cache-tag" token,
             # since it lands in the structural SQL).
             name = _stable_opaque_name("cachetag", *cache_tag_identity_parts(node))
         case CachedNode():
@@ -441,8 +441,8 @@ def _decompose_expr(
     tee_nodes = tuple(walk_nodes(TeeNode, op))
     # A pinned read (CacheTag) is a hash *leaf*: its identity is the cache key,
     # folded in _hash_expr_components via __dasher_tokenize__. Prune every leaf
-    # living under a CacheTag -- both `parent` (the cache-file read, whose
-    # absolute path is base_path-dependent) and `uncached` (the discarded
+    # living under a CacheTag -- both ``parent`` (the cache-file read, whose
+    # absolute path is base_path-dependent) and ``uncached`` (the discarded
     # upstream, whose sources would be stat'd) -- so a pin hashes consistently
     # across cache dirs and without its original sources still existing.
     # Pruning is by node identity; a no-op when the expr has no pins.

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -14,6 +14,7 @@ from xorq.vendor.ibis.expr.operations.core import Node
 opaque_ops = (
     rel.Read,
     rel.CachedNode,
+    rel.CacheTag,
     rel.RemoteTable,
     rel.FlightUDXF,
     rel.FlightExpr,
@@ -72,7 +73,12 @@ def bfs(node):
     return Graph(dct)
 
 
-def walk_nodes(node_types, expr):
+def walk_nodes(
+    node_types: type | Tuple[type, ...],
+    expr: Expr | Node,
+    *,
+    gen_children: Callable[[Node], Any] = gen_children_of,
+) -> Tuple[Node, ...]:
     """DFS walk yielding matching nodes in parent-before-descendant order
     for tree-shaped expressions; shared (DAG) nodes may appear before a
     non-matching ancestor.
@@ -80,6 +86,10 @@ def walk_nodes(node_types, expr):
     Callers (e.g. ``_rebuild_subexpr``) depend on ancestors appearing before
     their descendants.  Changing traversal strategy (BFS, reverse, etc.) will
     break that invariant.
+
+    ``gen_children`` overrides how a node's children are enumerated (defaults
+    to ``gen_children_of``); pass a variant to prune specific opaque edges
+    (see ``find_all_sources``).
     """
     visited = set()
     to_visit = [to_node(expr)]
@@ -95,7 +105,7 @@ def walk_nodes(node_types, expr):
 
         to_visit += (
             child
-            for child in OrderedDict.fromkeys(gen_children_of(node))
+            for child in OrderedDict.fromkeys(gen_children(node))
             if child not in visited
         )
 
@@ -407,7 +417,38 @@ def get_ordered_unique_sources(nodes):
     return sources
 
 
-def find_all_sources(expr):
+def _gen_children_exec(node: Node) -> Tuple[Node, ...]:
+    """Child enumeration along the *execution* path only.
+
+    Identical to ``gen_children_of`` except at a ``CacheTag``, where it
+    descends only the frozen ``parent`` read (what actually executes) and not
+    ``uncached`` (inert reconstruction payload). Mirrors ``_decompose_expr``'s
+    pruning of pinned-leaf data so source discovery stays consistent with
+    hashing.
+    """
+    if isinstance(node, rel.CacheTag):
+        return (to_node(node.parent),)
+    return tuple(gen_children_of(node))
+
+
+def find_all_sources(
+    expr: Expr | Node, *, execution_only: bool = False
+) -> Tuple[Any, ...]:
+    """Distinct backend sources referenced in *expr*, in discovery order.
+
+    By default the full graph is walked, including a pinned read's
+    (``CacheTag``) ``uncached`` reconstruction payload -- serialization needs
+    those profiles to round-trip the discarded upstream (see
+    ``ExprDumper``/``dehydrate_cons``).
+
+    Pass ``execution_only=True`` for connection-selection consumers (e.g.
+    ``expr_to_unbound``): a pinned read executes only through its frozen
+    ``parent``, so ``uncached`` backends -- which may be transient or
+    unavailable after a roundtrip -- must not be reported as required sources.
+    This mirrors ``_decompose_expr``'s pruning of pinned-leaf data. A backend
+    shared between ``uncached`` and a live branch is still found via the live
+    branch.
+    """
     node_types = (
         ops.DatabaseTable,
         ops.SQLQueryResult,
@@ -419,6 +460,7 @@ def find_all_sources(expr):
         # ExprScalarUDF has an expr we need to get to
         # FlightOperator has a dynamically generated connection: it should be passed a Profile instead
     )
-    nodes = walk_nodes(node_types, expr)
+    gen_children = _gen_children_exec if execution_only else gen_children_of
+    nodes = walk_nodes(node_types, expr, gen_children=gen_children)
     sources = get_ordered_unique_sources(nodes)
     return sources

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -148,11 +148,14 @@ def replace_nodes(
                 parent = _replace_sub(to_node(op.parent))
                 return do_recreate(op, _kwargs, parent=parent)
             case rel.CacheTag():
-                # Do NOT forward _kwargs: the replacer already produced `op` with
-                # its native `parent` (the cache-file read) set; re-driving parent
-                # from the BFS rewrite here diverges the read's backend identity
-                # from `cache`, breaking profile resolution on load. Only the
-                # opaque `uncached` payload is descended.
+                # Do NOT forward _kwargs (the asymmetry vs the sibling branches
+                # is load-bearing, not accidental -- it is covered by
+                # test_pinned_cache_yaml_roundtrip). `parent` is the materialized
+                # cache read paired with `cache`; re-driving it from the BFS
+                # rewrite diverges the read's backend identity from `cache` and
+                # breaks profile resolution on load. The replacer has already
+                # produced `op` with the correct native `parent`; only the opaque
+                # `uncached` payload still needs descending here.
                 uncached = _replace_sub(to_node(op.uncached))
                 return do_recreate(op, None, uncached=uncached)
             case rel.FlightExpr() | rel.FlightUDXF():

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -43,6 +43,12 @@ def gen_children_of(node: Node) -> Tuple[Node, ...]:
         case rel.CachedNode():
             gen = (to_node(node.parent),)
 
+        case rel.CacheTag():
+            # parent is the direct read of the cache location; uncached is the
+            # opaque reconstruction payload (descended like CachedNode.parent so
+            # its backends/reads are discovered for serialization).
+            gen = (to_node(node.parent), to_node(node.uncached))
+
         case rel.FlightExpr() | rel.FlightUDXF():
             gen = (to_node(node.input_expr),)
 
@@ -135,6 +141,15 @@ def replace_nodes(
             case rel.CachedNode():
                 parent = _replace_sub(to_node(op.parent))
                 return do_recreate(op, _kwargs, parent=parent)
+            case rel.CacheTag():
+                # The replacer changes the node's type (CachedNode -> CacheTag), so
+                # _kwargs holds slot values keyed for the *original* class and must
+                # not be forwarded: it carries CachedNode fields (`name`, `source`)
+                # CacheTag lacks, and its `parent` is the upstream computation, which
+                # would clobber the cache-file read the replacer set as CacheTag.parent
+                # -- defeating the pin. Only `uncached` (opaque) still needs rewriting.
+                uncached = _replace_sub(to_node(op.uncached))
+                return do_recreate(op, None, uncached=uncached)
             case rel.FlightExpr() | rel.FlightUDXF():
                 input_expr = _replace_sub(op.input_expr.op())
                 return do_recreate(op, _kwargs, input_expr=input_expr)

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -122,8 +122,16 @@ def replace_nodes(
     sub_expr_memo = {}
 
     def do_recreate(op, _kwargs, **kwargs):
-        kwargs = dict(zip(op.__argnames__, op.__args__)) | (_kwargs or {}) | kwargs
-        return op.__recreate__(kwargs)
+        # ``_kwargs`` is keyed for the node as seen *before* the replacer ran. A
+        # replacer may change the node's type (e.g. CacheTag -> CachedNode on
+        # unpin), so keep only keys that are valid slots for the post-replacer
+        # ``op``; forwarding foreign keys would crash ``__recreate__``. Explicit
+        # overrides in ``kwargs`` always win.
+        argnames = op.__argnames__
+        merged = dict(zip(argnames, op.__args__))
+        if _kwargs:
+            merged |= {k: v for k, v in _kwargs.items() if k in argnames}
+        return op.__recreate__(merged | kwargs)
 
     def _replace_sub(sub_op):
         if sub_op not in sub_expr_memo:
@@ -140,12 +148,11 @@ def replace_nodes(
                 parent = _replace_sub(to_node(op.parent))
                 return do_recreate(op, _kwargs, parent=parent)
             case rel.CacheTag():
-                # The replacer changes the node's type (CachedNode -> CacheTag), so
-                # _kwargs holds slot values keyed for the *original* class and must
-                # not be forwarded: it carries CachedNode fields (`name`, `source`)
-                # CacheTag lacks, and its `parent` is the upstream computation, which
-                # would clobber the cache-file read the replacer set as CacheTag.parent
-                # -- defeating the pin.
+                # Do NOT forward _kwargs: the replacer already produced `op` with
+                # its native `parent` (the cache-file read) set; re-driving parent
+                # from the BFS rewrite here diverges the read's backend identity
+                # from `cache`, breaking profile resolution on load. Only the
+                # opaque `uncached` payload is descended.
                 uncached = _replace_sub(to_node(op.uncached))
                 return do_recreate(op, None, uncached=uncached)
             case rel.FlightExpr() | rel.FlightUDXF():

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -431,6 +431,45 @@ def _gen_children_exec(node: Node) -> Tuple[Node, ...]:
     return tuple(gen_children_of(node))
 
 
+def _gen_children_skip_pins(node: Node) -> Tuple[Node, ...]:
+    """Child enumeration that treats a ``CacheTag`` as an opaque leaf.
+
+    Descends neither ``parent`` nor ``uncached``, so a walk collects only the
+    leaves reachable *without* passing through any pin -- the "live" leaves used
+    by :func:`exclusively_pinned_leaves`.
+    """
+    if isinstance(node, rel.CacheTag):
+        return ()
+    return tuple(gen_children_of(node))
+
+
+def exclusively_pinned_leaves(
+    expr: Expr | Node, leaf_types: type | Tuple[type, ...]
+) -> frozenset:
+    """Leaves of *expr* reachable ONLY through ``CacheTag`` (pinned) subtrees.
+
+    A leaf under a pin's frozen ``parent`` or discarded ``uncached`` upstream is
+    represented in the build hash solely by the pin's cache-key token (see
+    ``CacheTag.__dasher_tokenize__``), so callers leave it out of name
+    sanitization and hash data-leaves -- otherwise hashing stat's a possibly-
+    absent upstream source. A leaf also reachable from a live (non-pinned)
+    branch is the exception: it genuinely participates there, so it stays live.
+    Returns ``under_pin - live``.
+
+    Single predicate shared by ``_sanitize_generated_names`` and
+    ``_decompose_expr`` so the two pruning sites cannot drift.
+    """
+    under_pin = {
+        n
+        for ct in walk_nodes((rel.CacheTag,), expr)
+        for n in walk_nodes(leaf_types, ct)
+    }
+    if not under_pin:
+        return frozenset()
+    live = set(walk_nodes(leaf_types, expr, gen_children=_gen_children_skip_pins))
+    return frozenset(under_pin - live)
+
+
 def find_all_sources(
     expr: Expr | Node, *, execution_only: bool = False
 ) -> Tuple[Any, ...]:

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -44,9 +44,7 @@ def gen_children_of(node: Node) -> Tuple[Node, ...]:
             gen = (to_node(node.parent),)
 
         case rel.CacheTag():
-            # parent is the direct read of the cache location; uncached is the
-            # opaque reconstruction payload (descended like CachedNode.parent so
-            # its backends/reads are discovered for serialization).
+            # descend both opaque children (see CacheTag docstring)
             gen = (to_node(node.parent), to_node(node.uncached))
 
         case rel.FlightExpr() | rel.FlightUDXF():
@@ -147,7 +145,7 @@ def replace_nodes(
                 # not be forwarded: it carries CachedNode fields (`name`, `source`)
                 # CacheTag lacks, and its `parent` is the upstream computation, which
                 # would clobber the cache-file read the replacer set as CacheTag.parent
-                # -- defeating the pin. Only `uncached` (opaque) still needs rewriting.
+                # -- defeating the pin.
                 uncached = _replace_sub(to_node(op.uncached))
                 return do_recreate(op, None, uncached=uncached)
             case rel.FlightExpr() | rel.FlightUDXF():

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -160,12 +160,12 @@ def replace_nodes(
             case rel.CacheTag():
                 # Do NOT forward _kwargs (the asymmetry vs the sibling branches
                 # is load-bearing, not accidental -- it is covered by
-                # test_pinned_cache_yaml_roundtrip). `parent` is the materialized
-                # cache read paired with `cache`; re-driving it from the BFS
-                # rewrite diverges the read's backend identity from `cache` and
+                # test_pinned_cache_yaml_roundtrip). ``parent`` is the materialized
+                # cache read paired with ``cache``; re-driving it from the BFS
+                # rewrite diverges the read's backend identity from ``cache`` and
                 # breaks profile resolution on load. The replacer has already
-                # produced `op` with the correct native `parent`; only the opaque
-                # `uncached` payload still needs descending here.
+                # produced ``op`` with the correct native ``parent``; only the opaque
+                # ``uncached`` payload still needs descending here.
                 uncached = _replace_sub(to_node(op.uncached))
                 return do_recreate(op, None, uncached=uncached)
             case rel.FlightExpr() | rel.FlightUDXF():

--- a/python/xorq/common/utils/node_utils.py
+++ b/python/xorq/common/utils/node_utils.py
@@ -172,7 +172,7 @@ def expr_to_unbound(expr, hash, tag, typs, strategy=None):
     found_expr = found.to_expr()
     to_unbind_hash = hash or compute_expr_hash(found_expr, strategy)
     found_con = None
-    # execution_only: don't let a pin's discarded `uncached` upstream drive
+    # execution_only: don't let a pin's discarded ``uncached`` upstream drive
     # connection selection -- only its frozen parent actually executes.
     match find_all_sources(found_expr, execution_only=True):
         case []:

--- a/python/xorq/common/utils/node_utils.py
+++ b/python/xorq/common/utils/node_utils.py
@@ -172,7 +172,10 @@ def expr_to_unbound(expr, hash, tag, typs, strategy=None):
     found_expr = found.to_expr()
     to_unbind_hash = hash or compute_expr_hash(found_expr, strategy)
     found_con = None
-    match find_all_sources(found_expr):
+    # execution_only: a pinned read runs through its frozen parent, so don't
+    # let the discarded `uncached` upstream's backends drive connection
+    # selection (they may be transient/unavailable here).
+    match find_all_sources(found_expr, execution_only=True):
         case []:
             match walk_nodes(ops.InMemoryTable, found_expr):
                 case []:

--- a/python/xorq/common/utils/node_utils.py
+++ b/python/xorq/common/utils/node_utils.py
@@ -172,9 +172,8 @@ def expr_to_unbound(expr, hash, tag, typs, strategy=None):
     found_expr = found.to_expr()
     to_unbind_hash = hash or compute_expr_hash(found_expr, strategy)
     found_con = None
-    # execution_only: a pinned read runs through its frozen parent, so don't
-    # let the discarded `uncached` upstream's backends drive connection
-    # selection (they may be transient/unavailable here).
+    # execution_only: don't let a pin's discarded `uncached` upstream drive
+    # connection selection -- only its frozen parent actually executes.
     match find_all_sources(found_expr, execution_only=True):
         case []:
             match walk_nodes(ops.InMemoryTable, found_expr):

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -35,6 +35,7 @@ from xorq.expr.ml import (
 from xorq.expr.operations import _MISSING, NamedScalarParameter
 from xorq.expr.relations import (
     CachedNode,
+    CacheTag,
     FlightExpr,
     FlightUDXF,
     HashingTag,
@@ -382,8 +383,21 @@ def _remove_non_hashing_tag_nodes(expr):
                 if kwargs:
                     node = node.__recreate__(kwargs)
                 return node
+            case CacheTag():
+                # Identity-bearing (a build-hash leaf via __dasher_tokenize__),
+                # not a transparent tag: like HashingTag it must survive
+                # stripping, else `untagged`-based hashes reduce a pin to its
+                # bare cache read and diverge from get_expr_hash / ls.tokenized.
+                if kwargs:
+                    node = node.__recreate__(kwargs)
+                return node
             case Tag():
-                while isinstance(node, Tag) and not isinstance(node, HashingTag):
+                # Stop at HashingTag/CacheTag: unwinding plain Tags must not
+                # strip an identity-bearing tag nested beneath them (the
+                # trailing replace_nodes preserves it via its own case).
+                while isinstance(node, Tag) and not isinstance(
+                    node, (HashingTag, CacheTag)
+                ):
                     node = node.parent
                 return replace_nodes(replacer, node)
             case TeeNode():

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -142,22 +142,20 @@ class CacheTag(Tag):
     carries the information needed to reconstruct the original ``CachedNode``.
 
     ``parent`` is the direct read of the cache file/table (what ``cache.get``
-    returns), so a pinned expression executes by reading the materialized
-    artifact directly -- it never re-derives the upstream computation.
-    ``unpin_cache`` reads ``uncached``/``cache`` back to rebuild the
-    ``CachedNode``.
+    returns), so a pinned expression reads the materialized artifact directly
+    and never re-derives the upstream computation. ``cache`` is inert
+    reconstruction payload; ``unpin_cache`` reads ``uncached``/``cache`` back
+    to rebuild the ``CachedNode``.
 
-    ``cache`` is inert reconstruction payload (read only by ``unpin_cache``).
-    ``uncached`` is the original pre-cache expr: xorq's graph machinery *does*
-    descend into it (see ``gen_children_of``) so its leaves/backends are found
-    for source normalization and serialization, but its *structure* is
-    intentionally absent from the build hash. That is safe -- not a gap --
-    because ``parent`` is the cache ``Read`` whose ``hash_path`` is the upstream
-    cache key, so the upstream identity is already folded in; ``uncached`` is
-    functionally determined by ``parent``. Do NOT add ``__dasher_tokenize__``
-    to fold ``uncached``: it carries fields the cache key strips (e.g.
-    ``RemoteTable.name``), so folding it would make logically-identical pins
-    hash differently (the ADR-0015 ``_replace_remote_table`` failure mode).
+    INVARIANT -- do NOT add ``__dasher_tokenize__`` to fold ``uncached`` into
+    the build hash. ``uncached`` (the original pre-cache expr) is descended by
+    the graph machinery (see ``gen_children_of``) only so its leaves/backends
+    are found for source normalization and serialization; its *structure* is
+    intentionally absent from the hash. That is safe, not a gap: ``parent`` is
+    the cache ``Read`` whose ``hash_path`` is the upstream cache key, so the
+    upstream identity is already folded in. ``uncached`` also carries fields the
+    cache key strips (e.g. ``RemoteTable.name``), so folding it would make
+    logically-identical pins hash differently (ADR-0015 ``_replace_remote_table``).
 
     Pinning is a freeze-time operation and is deliberately *not*
     cache-hash-neutral: the cache file read by ``parent`` participates in the

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -212,6 +212,18 @@ def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
     )
 
 
+def relocate_cache(cache: Any, base_path: Path) -> Any:
+    """Re-point a parquet cache's storage at a new ``base_path``.
+
+    Single source of truth for the storage re-pointing, shared by
+    ``relocate_cache_tag`` (pinned reads) and ``replace_base_path`` (live
+    ``CachedNode``s) so the two relocation sites cannot drift.
+    """
+    from attr import evolve  # noqa: PLC0415
+
+    return evolve(cache, storage=evolve(cache.storage, base_path=base_path))
+
+
 def relocate_cache_tag(node: CacheTag, base_path: Path) -> CacheTag:
     """Re-point a pinned cache's frozen read at a new ``base_path``.
 
@@ -221,12 +233,9 @@ def relocate_cache_tag(node: CacheTag, base_path: Path) -> CacheTag:
     does not re-materialize or re-validate; if the artifact is absent at the new
     location, execution fails like any other missing read.
     """
-    from attr import evolve  # noqa: PLC0415
-
     from xorq.common.utils.graph_utils import to_node  # noqa: PLC0415
 
-    cache = node.cache
-    new_cache = evolve(cache, storage=evolve(cache.storage, base_path=base_path))
+    new_cache = relocate_cache(node.cache, base_path)
     key = to_node(node.parent).name
     return CacheTag(
         schema=node.schema,

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -885,7 +885,30 @@ def get_cache_params(cache):
 
 
 @fmt.register(CachedNode)
-def _fmt_cache_node(op, schema, parent, source, cache, **kwargs):
+def _fmt_cache_node(
+    op: CachedNode,
+    schema: Schema,
+    parent: str,
+    source: Any,
+    cache: Any,
+    **kwargs: Any,
+) -> str:
+    strategy, parquet, backend = get_cache_params(cache)
+    name = f"{op.__class__.__name__}[{parent}, strategy={strategy}, parquet={parquet}, source={backend}]\n"
+    return name + render_schema(schema, 1)
+
+
+@fmt.register(CacheTag)
+def _fmt_cache_tag(
+    op: CacheTag,
+    schema: Schema,
+    parent: str,
+    cache: Any,
+    **kwargs: Any,
+) -> str:
+    # Render only the frozen read + cache params; the generic relation
+    # formatter chokes on `uncached` (an Ibis Expr) via its `if v` truthiness
+    # check. `parent` is already the rendered read ref.
     strategy, parquet, backend = get_cache_params(cache)
     name = f"{op.__class__.__name__}[{parent}, strategy={strategy}, parquet={parquet}, source={backend}]\n"
     return name + render_schema(schema, 1)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -176,7 +176,23 @@ class CacheTag(Tag):
         # read's absolute path; see the class docstring and ``_decompose_expr``,
         # which prunes the tag's subtree so these tokens are the only thing a
         # ``CacheTag`` contributes to the hash.
-        return ("xorq.CacheTag", self.schema, self.parent.name)
+        return ("xorq.CacheTag", *cache_tag_identity_parts(self))
+
+
+def cache_tag_identity_parts(node: "CacheTag") -> tuple:
+    """The fields that define a pinned read's identity: ``(schema, cache key)``.
+
+    Single source of truth for *which* fields identify a ``CacheTag``, shared by
+    the two layers that must agree on it -- ``CacheTag.__dasher_tokenize__`` (the
+    hash-component contribution) and the SQL placeholder in
+    ``_xorq_opaque_to_placeholder`` (the structural-``sql`` contribution). Each
+    consumer wraps these parts in its own envelope (a tokenize tuple vs. a
+    ``_stable_opaque_name`` prefix), so this returns only the shared parts, not a
+    formatted name -- adding a field here updates both consumers without
+    changing either's existing output format. ``parent.name`` is the cache key
+    (see the class docstring).
+    """
+    return (node.schema, node.parent.name)
 
 
 def cache_keyed_expr(parent: Expr) -> Expr:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -179,18 +179,14 @@ class CacheTag(Tag):
     ) -> None:
         if metadata is None:
             metadata = FrozenOrderedDict()
-        # `parent`'s Node type is enforced by the inherited ``Tag.parent``
-        # annotation, but `uncached` is ``Any`` (it holds an Expr, not a Node,
-        # so ibis cannot validate it via annotation). Guard its type here so a
-        # direct constructor that swaps `parent`/`uncached` fails loudly at
-        # construction rather than with an obscure error at execution or
-        # serialization time. ``None`` is the unset default; otherwise it must
-        # be what ``to_node`` accepts -- an Expr or a Node.
+        # `parent`'s Node type is enforced by the inherited Tag.parent
+        # annotation; `uncached` is Any, so guard it here (None, or what
+        # to_node accepts -- an Expr or Node) to catch a swapped upstream at
+        # construction rather than obscurely later.
         if uncached is not None and not isinstance(uncached, (Expr, Node)):
             raise IntegrityError(
                 f"CacheTag.uncached must be an Expr or Node, got "
-                f"{type(uncached).__name__}; it holds the original upstream "
-                f"expression (see cache_tag_identity_parts and the class docstring)."
+                f"{type(uncached).__name__}"
             )
         super().__init__(
             schema=schema,
@@ -214,14 +210,11 @@ def cache_tag_identity_parts(node: "CacheTag") -> tuple:
     """The fields that define a pinned read's identity: ``(schema, cache key)``.
 
     Single source of truth for *which* fields identify a ``CacheTag``, shared by
-    the two layers that must agree on it -- ``CacheTag.__dasher_tokenize__`` (the
-    hash-component contribution) and the SQL placeholder in
-    ``_xorq_opaque_to_placeholder`` (the structural-``sql`` contribution). Each
-    consumer wraps these parts in its own envelope (a tokenize tuple vs. a
-    ``_stable_opaque_name`` prefix), so this returns only the shared parts, not a
-    formatted name -- adding a field here updates both consumers without
-    changing either's existing output format. ``parent.name`` is the cache key
-    (see the class docstring).
+    the two layers that must agree: ``__dasher_tokenize__`` (hash component) and
+    the ``_xorq_opaque_to_placeholder`` SQL placeholder. Returns only the shared
+    parts, not a formatted name -- each consumer adds its own envelope (tokenize
+    tuple vs. ``_stable_opaque_name`` prefix), so adding a field here updates
+    both without changing either's output format. ``parent.name`` is the cache key.
     """
     return (node.schema, node.parent.name)
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -173,17 +173,16 @@ class CacheTag(Tag):
         self,
         schema: Schema,
         parent: ops.Relation,
-        uncached: Any = None,
+        uncached: Any,
         cache: Any = None,
         metadata: FrozenOrderedDict | None = None,
     ) -> None:
         if metadata is None:
             metadata = FrozenOrderedDict()
-        # ``parent``'s Node type is enforced by the inherited Tag.parent
-        # annotation; ``uncached`` is Any, so guard it here (None, or what
-        # to_node accepts -- an Expr or Node) to catch a swapped upstream at
-        # construction rather than obscurely later.
-        if uncached is not None and not isinstance(uncached, (Expr, Node)):
+        # ``uncached`` is Any but is unconditionally descended via ``to_node``
+        # (gen_children_of/replace_nodes), so require an Expr or Node -- ``None``
+        # or a swapped upstream builds an untraversable tag.
+        if not isinstance(uncached, (Expr, Node)):
             raise IntegrityError(
                 "CacheTag.uncached must be an Expr or Node, got "
                 f"{type(uncached).__name__}"
@@ -261,6 +260,13 @@ def relocate_cache(cache: Any, base_path: Path) -> Any:
     """
     from attr import evolve  # noqa: PLC0415
 
+    # only parquet storages have a base_path; on a SourceStorage evolve would
+    # raise an opaque TypeError, and the signature is Any -- fail explicitly.
+    if not hasattr(cache.storage, "base_path"):
+        raise IntegrityError(
+            "relocate_cache requires a parquet-backed cache, got "
+            f"{type(cache.storage).__name__}"
+        )
     return evolve(cache, storage=evolve(cache.storage, base_path=base_path))
 
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -190,19 +190,29 @@ def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
     )
 
 
-def _cache_tag_to_cached_node(node: CacheTag) -> CachedNode:
+def make_cached_node(schema: Schema, parent: Expr, cache: Any) -> CachedNode:
+    """Build a ``CachedNode`` from its essential parts.
+
+    Single source of truth for the node's invariant fields -- the placeholder
+    name and the ``source`` derived from the cache storage -- shared by
+    ``Expr.cache`` and ``unpin_cache`` so the two construction sites cannot
+    drift.
+    """
     from xorq.vendor.ibis.expr.types.relations import (  # noqa: PLC0415
         CACHED_NODE_NAME_PLACEHOLDER,
     )
 
-    cache = node.cache
     return CachedNode(
         name=CACHED_NODE_NAME_PLACEHOLDER,
-        schema=node.schema,
-        parent=node.uncached,
+        schema=schema,
+        parent=parent,
         source=cache.storage.source,
         cache=cache,
     )
+
+
+def _cache_tag_to_cached_node(node: CacheTag) -> CachedNode:
+    return make_cached_node(node.schema, node.uncached, node.cache)
 
 
 def _replace_op_type(

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -148,23 +148,35 @@ class CacheTag(Tag):
     reconstruction payload; ``unpin_cache`` reads ``uncached``/``cache`` back
     to rebuild the ``CachedNode``.
 
-    INVARIANT -- do NOT add ``__dasher_tokenize__`` to fold ``uncached`` into
-    the build hash. ``uncached`` (the original pre-cache expr) is descended by
-    the graph machinery (see ``gen_children_of``) only so its leaves/backends
-    are found for source normalization and serialization; its *structure* is
-    intentionally absent from the hash. That is safe, not a gap: ``parent`` is
-    the cache ``Read`` whose ``hash_path`` is the upstream cache key, so the
-    upstream identity is already folded in. ``uncached`` also carries fields the
-    cache key strips (e.g. ``RemoteTable.name``), so folding it would make
-    logically-identical pins hash differently (ADR-0015 ``_replace_remote_table``).
+    Hash identity -- a pinned read is a build-hash *leaf*: its identity is the
+    cache key (``parent``'s table name), folded in via ``__dasher_tokenize__``.
+    The cache key already encodes the upstream computation (ADR-0015), and it is
+    independent of where the artifact physically lives, so a pin hashes the same
+    wherever its cache dir is relocated to (portability) and without the original
+    sources still existing (self-containment). Crucially, the build-hash machinery
+    must NOT descend ``parent`` (its ``hash_path`` is an absolute, base_path-
+    dependent path) or ``uncached`` (the discarded upstream, whose source leaves
+    would be stat'd) when hashing a pin -- ``_decompose_expr`` treats the whole
+    ``CacheTag`` as a leaf for exactly this reason. ``uncached`` is still
+    *descended for source normalization and serialization* (see
+    ``gen_children_of``); only the hash treats the tag as a leaf.
 
     Pinning is a freeze-time operation and is deliberately *not*
-    cache-hash-neutral: the cache file read by ``parent`` participates in the
-    hash, so a pinned expression keys differently from its unpinned form.
+    cache-hash-neutral: a pinned expression keys differently from its unpinned
+    form (cache-key identity vs. the full upstream computation).
     """
 
     uncached: Any = None
     cache: Any = None
+
+    def __dasher_tokenize__(self) -> tuple:
+        # Build/cache identity of a pinned read is its cache KEY (the frozen
+        # read's table name) -- base_path-independent and computable without the
+        # upstream source. Deliberately omits ``uncached``'s structure and the
+        # read's absolute path; see the class docstring and ``_decompose_expr``,
+        # which prunes the tag's subtree so these tokens are the only thing a
+        # ``CacheTag`` contributes to the hash.
+        return ("xorq.CacheTag", self.schema, self.parent.name)
 
 
 def cache_keyed_expr(parent: Expr) -> Expr:
@@ -194,7 +206,7 @@ def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
         )
     return CacheTag(
         schema=node.schema,
-        parent=cache.storage.get(key),
+        parent=cache.storage.get(key, schema=node.schema),
         uncached=node.parent,
         cache=cache,
     )
@@ -218,7 +230,7 @@ def relocate_cache_tag(node: CacheTag, base_path: Path) -> CacheTag:
     key = to_node(node.parent).name
     return CacheTag(
         schema=node.schema,
-        parent=new_cache.storage.get(key),
+        parent=new_cache.storage.get(key, schema=node.schema),
         uncached=node.uncached,
         cache=new_cache,
     )

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -169,10 +169,13 @@ class CacheTag(Tag):
 
 
 def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
+    from xorq.common.utils.graph_utils import to_node  # noqa: PLC0415
+
     cache = node.cache
     parent = node.parent
+    parent_op = to_node(parent)
     uncached_one = (
-        parent.op().remote_expr if isinstance(parent.op(), RemoteTable) else parent
+        parent_op.remote_expr if isinstance(parent_op, RemoteTable) else parent
     )
     if not cache.exists(uncached_one):
         raise IntegrityError(
@@ -202,6 +205,25 @@ def _cache_tag_to_cached_node(node: CacheTag) -> CachedNode:
     )
 
 
+def _replace_op_type(
+    expr: Expr, op_type: type[Node], transform: Callable[[Node], Node]
+) -> Expr:
+    """Rewrite every ``op_type`` node in *expr* via *transform*, descending into
+    opaque sub-expressions. *transform* maps a node of ``op_type`` to its
+    replacement.
+    """
+    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
+
+    def replacer(node, kwargs):
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        if isinstance(node, op_type):
+            node = transform(node)
+        return node
+
+    return replace_nodes(replacer, expr).to_expr()
+
+
 def pin_cache(expr: Expr) -> Expr:
     """Freeze every ``CachedNode`` into a ``CacheTag`` reading its cache location.
 
@@ -209,16 +231,7 @@ def pin_cache(expr: Expr) -> Expr:
     cached artifacts directly without re-deriving them. Inverse of
     :func:`unpin_cache`.
     """
-    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
-
-    def replacer(node, kwargs):
-        if kwargs:
-            node = node.__recreate__(kwargs)
-        if isinstance(node, CachedNode):
-            node = _cached_node_to_cache_tag(node)
-        return node
-
-    return replace_nodes(replacer, expr).to_expr()
+    return _replace_op_type(expr, CachedNode, _cached_node_to_cache_tag)
 
 
 def unpin_cache(expr: Expr) -> Expr:
@@ -226,16 +239,7 @@ def unpin_cache(expr: Expr) -> Expr:
 
     Inverse of :func:`pin_cache`.
     """
-    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
-
-    def replacer(node, kwargs):
-        if kwargs:
-            node = node.__recreate__(kwargs)
-        if isinstance(node, CacheTag):
-            node = _cache_tag_to_cached_node(node)
-        return node
-
-    return replace_nodes(replacer, expr).to_expr()
+    return _replace_op_type(expr, CacheTag, _cache_tag_to_cached_node)
 
 
 gen_name_namespace = "rbr-placeholder"

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -169,6 +169,37 @@ class CacheTag(Tag):
     uncached: Any = None
     cache: Any = None
 
+    def __init__(
+        self,
+        schema: Schema,
+        parent: ops.Relation,
+        uncached: Any = None,
+        cache: Any = None,
+        metadata: FrozenOrderedDict | None = None,
+    ) -> None:
+        if metadata is None:
+            metadata = FrozenOrderedDict()
+        # `parent`'s Node type is enforced by the inherited ``Tag.parent``
+        # annotation, but `uncached` is ``Any`` (it holds an Expr, not a Node,
+        # so ibis cannot validate it via annotation). Guard its type here so a
+        # direct constructor that swaps `parent`/`uncached` fails loudly at
+        # construction rather than with an obscure error at execution or
+        # serialization time. ``None`` is the unset default; otherwise it must
+        # be what ``to_node`` accepts -- an Expr or a Node.
+        if uncached is not None and not isinstance(uncached, (Expr, Node)):
+            raise IntegrityError(
+                f"CacheTag.uncached must be an Expr or Node, got "
+                f"{type(uncached).__name__}; it holds the original upstream "
+                f"expression (see cache_tag_identity_parts and the class docstring)."
+            )
+        super().__init__(
+            schema=schema,
+            parent=parent,
+            uncached=uncached,
+            cache=cache,
+            metadata=metadata,
+        )
+
     def __dasher_tokenize__(self) -> tuple:
         # Build/cache identity of a pinned read is its cache KEY (the frozen
         # read's table name) -- base_path-independent and computable without the

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -137,6 +137,107 @@ class CachedNode(DatabaseTableView):
     cache: Any = None
 
 
+class CacheTag(Tag):
+    """A pinned (frozen) cache: a transparent read of the cache location that
+    carries the information needed to reconstruct the original ``CachedNode``.
+
+    ``parent`` is the direct read of the cache file/table (what ``cache.get``
+    returns), so a pinned expression executes by reading the materialized
+    artifact directly -- it never re-derives the upstream computation.
+    ``unpin_cache`` reads ``uncached``/``cache`` back to rebuild the
+    ``CachedNode``.
+
+    ``cache`` is inert reconstruction payload (read only by ``unpin_cache``).
+    ``uncached`` is the original pre-cache expr: xorq's graph machinery *does*
+    descend into it (see ``gen_children_of``) so its leaves/backends are found
+    for source normalization and serialization, but its *structure* is
+    intentionally absent from the build hash. That is safe -- not a gap --
+    because ``parent`` is the cache ``Read`` whose ``hash_path`` is the upstream
+    cache key, so the upstream identity is already folded in; ``uncached`` is
+    functionally determined by ``parent``. Do NOT add ``__dasher_tokenize__``
+    to fold ``uncached``: it carries fields the cache key strips (e.g.
+    ``RemoteTable.name``), so folding it would make logically-identical pins
+    hash differently (the ADR-0015 ``_replace_remote_table`` failure mode).
+
+    Pinning is a freeze-time operation and is deliberately *not*
+    cache-hash-neutral: the cache file read by ``parent`` participates in the
+    hash, so a pinned expression keys differently from its unpinned form.
+    """
+
+    uncached: Any = None
+    cache: Any = None
+
+
+def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
+    cache = node.cache
+    parent = node.parent
+    uncached_one = (
+        parent.op().remote_expr if isinstance(parent.op(), RemoteTable) else parent
+    )
+    if not cache.exists(uncached_one):
+        raise IntegrityError(
+            "cannot pin an unmaterialized cache; execute the expression "
+            "(or call .cache().execute()) to populate the cache first"
+        )
+    return CacheTag(
+        schema=node.schema,
+        parent=cache.get(uncached_one),
+        uncached=parent,
+        cache=cache,
+    )
+
+
+def _cache_tag_to_cached_node(node: CacheTag) -> CachedNode:
+    from xorq.vendor.ibis.expr.types.relations import (  # noqa: PLC0415
+        CACHED_NODE_NAME_PLACEHOLDER,
+    )
+
+    cache = node.cache
+    return CachedNode(
+        name=CACHED_NODE_NAME_PLACEHOLDER,
+        schema=node.schema,
+        parent=node.uncached,
+        source=cache.storage.source,
+        cache=cache,
+    )
+
+
+def pin_cache(expr: Expr) -> Expr:
+    """Freeze every ``CachedNode`` into a ``CacheTag`` reading its cache location.
+
+    Each cache must already be materialized; the resulting expression reads the
+    cached artifacts directly without re-deriving them. Inverse of
+    :func:`unpin_cache`.
+    """
+    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
+
+    def replacer(node, kwargs):
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        if isinstance(node, CachedNode):
+            node = _cached_node_to_cache_tag(node)
+        return node
+
+    return replace_nodes(replacer, expr).to_expr()
+
+
+def unpin_cache(expr: Expr) -> Expr:
+    """Rebuild every ``CacheTag`` back into its original ``CachedNode``.
+
+    Inverse of :func:`pin_cache`.
+    """
+    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
+
+    def replacer(node, kwargs):
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        if isinstance(node, CacheTag):
+            node = _cache_tag_to_cached_node(node)
+        return node
+
+    return replace_nodes(replacer, expr).to_expr()
+
+
 gen_name_namespace = "rbr-placeholder"
 gen_name = toolz.compose(
     # some engines simply truncate long names

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -179,13 +179,13 @@ class CacheTag(Tag):
     ) -> None:
         if metadata is None:
             metadata = FrozenOrderedDict()
-        # `parent`'s Node type is enforced by the inherited Tag.parent
-        # annotation; `uncached` is Any, so guard it here (None, or what
+        # ``parent``'s Node type is enforced by the inherited Tag.parent
+        # annotation; ``uncached`` is Any, so guard it here (None, or what
         # to_node accepts -- an Expr or Node) to catch a swapped upstream at
         # construction rather than obscurely later.
         if uncached is not None and not isinstance(uncached, (Expr, Node)):
             raise IntegrityError(
-                f"CacheTag.uncached must be an Expr or Node, got "
+                "CacheTag.uncached must be an Expr or Node, got "
                 f"{type(uncached).__name__}"
             )
         super().__init__(
@@ -203,10 +203,10 @@ class CacheTag(Tag):
         # read's absolute path; see the class docstring and ``_decompose_expr``,
         # which prunes the tag's subtree so these tokens are the only thing a
         # ``CacheTag`` contributes to the hash.
-        return ("xorq.CacheTag", *cache_tag_identity_parts(self))
+        return ("cache-tag", *cache_tag_identity_parts(self))
 
 
-def cache_tag_identity_parts(node: "CacheTag") -> tuple:
+def cache_tag_identity_parts(node: CacheTag) -> tuple:
     """The fields that define a pinned read's identity: ``(schema, cache key)``.
 
     Single source of truth for *which* fields identify a ``CacheTag``, shared by
@@ -884,6 +884,12 @@ def get_cache_params(cache):
     return cache_repr + (render_backend(cache.storage.source),)
 
 
+def _fmt_cache_like(op: Node, schema: Schema, parent: str, cache: Any) -> str:
+    strategy, parquet, backend = get_cache_params(cache)
+    name = f"{op.__class__.__name__}[{parent}, strategy={strategy}, parquet={parquet}, source={backend}]\n"
+    return name + render_schema(schema, 1)
+
+
 @fmt.register(CachedNode)
 def _fmt_cache_node(
     op: CachedNode,
@@ -893,9 +899,7 @@ def _fmt_cache_node(
     cache: Any,
     **kwargs: Any,
 ) -> str:
-    strategy, parquet, backend = get_cache_params(cache)
-    name = f"{op.__class__.__name__}[{parent}, strategy={strategy}, parquet={parquet}, source={backend}]\n"
-    return name + render_schema(schema, 1)
+    return _fmt_cache_like(op, schema, parent, cache)
 
 
 @fmt.register(CacheTag)
@@ -906,12 +910,11 @@ def _fmt_cache_tag(
     cache: Any,
     **kwargs: Any,
 ) -> str:
-    # Render only the frozen read + cache params; the generic relation
-    # formatter chokes on `uncached` (an Ibis Expr) via its `if v` truthiness
-    # check. `parent` is already the rendered read ref.
-    strategy, parquet, backend = get_cache_params(cache)
-    name = f"{op.__class__.__name__}[{parent}, strategy={strategy}, parquet={parquet}, source={backend}]\n"
-    return name + render_schema(schema, 1)
+    # ``CacheTag`` reuses the ``CachedNode`` rendering (frozen read + cache
+    # params only). A dedicated handler is still needed because the generic
+    # relation formatter chokes on ``uncached`` (an Ibis Expr) via its ``if v``
+    # truthiness check. ``parent`` is already the rendered read ref.
+    return _fmt_cache_like(op, schema, parent, cache)
 
 
 @fmt.register(RemoteTable)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import operator
 import warnings
+from pathlib import Path
 from typing import Any, Callable
 
 import pyarrow as pa
@@ -166,25 +167,60 @@ class CacheTag(Tag):
     cache: Any = None
 
 
-def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
+def cache_keyed_expr(parent: Expr) -> Expr:
+    """The expr a cache is keyed on for ``parent``.
+
+    A cross-engine cache's parent is a ``RemoteTable``; the cache key is keyed
+    on its ``remote_expr`` (the ``RemoteTable.name`` is stripped, see ADR-0015).
+    Otherwise the parent is keyed directly. Single source of truth for this
+    unwrap rule, shared by the ``ls.uncached_one`` accessor, pinning, and pin
+    relocation so the three sites cannot drift.
+    """
     from xorq.common.utils.graph_utils import to_node  # noqa: PLC0415
 
-    cache = node.cache
-    parent = node.parent
     parent_op = to_node(parent)
-    uncached_one = (
-        parent_op.remote_expr if isinstance(parent_op, RemoteTable) else parent
-    )
-    if not cache.exists(uncached_one):
+    return parent_op.remote_expr if isinstance(parent_op, RemoteTable) else parent
+
+
+def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
+    cache = node.cache
+    # compute the cache key once: cache.exists + cache.get would each recompute
+    # it (calc_key) and stat the artifact separately.
+    key = cache.calc_key(cache_keyed_expr(node.parent))
+    if not cache.key_exists(key):
         raise IntegrityError(
             "cannot pin an unmaterialized cache; execute the expression "
             "(or call .cache().execute()) to populate the cache first"
         )
     return CacheTag(
         schema=node.schema,
-        parent=cache.get(uncached_one),
-        uncached=parent,
+        parent=cache.storage.get(key),
+        uncached=node.parent,
         cache=cache,
+    )
+
+
+def relocate_cache_tag(node: CacheTag, base_path: Path) -> CacheTag:
+    """Re-point a pinned cache's frozen read at a new ``base_path``.
+
+    Only the directory the read resolves to changes; the read's table name *is*
+    its cache key, so it is preserved verbatim (re-deriving the key from a
+    round-tripped ``uncached`` could drift). A pinned read stays a read -- this
+    does not re-materialize or re-validate; if the artifact is absent at the new
+    location, execution fails like any other missing read.
+    """
+    from attr import evolve  # noqa: PLC0415
+
+    from xorq.common.utils.graph_utils import to_node  # noqa: PLC0415
+
+    cache = node.cache
+    new_cache = evolve(cache, storage=evolve(cache.storage, base_path=base_path))
+    key = to_node(node.parent).name
+    return CacheTag(
+        schema=node.schema,
+        parent=new_cache.storage.get(key),
+        uncached=node.uncached,
+        cache=new_cache,
     )
 
 

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -8,9 +8,12 @@ import pytest
 import xorq.api as xo
 from xorq.caching import ParquetCache
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.graph_utils import walk_nodes
+from xorq.common.utils.graph_utils import find_all_sources, walk_nodes
+from xorq.common.utils.name_utils import get_uid_prefix
 from xorq.common.utils.provenance_utils import get_expr_hash
 from xorq.expr.relations import CachedNode, CacheTag, Read, RemoteTable
+from xorq.ibis_yaml.compiler import canonicalize_expr
+from xorq.vendor.ibis.expr.operations.relations import InMemoryTable
 
 
 def make_cached(tmp_path: Path) -> tuple:
@@ -158,3 +161,61 @@ def test_pinned_expr_is_a_frozen_read_not_a_cache(tmp_path: Path) -> None:
 
     # unpin restores cache semantics
     assert pinned.ls.unpin().ls.is_cached
+
+
+def test_find_all_sources_execution_only_prunes_uncached_backend(
+    tmp_path: Path,
+) -> None:
+    # Regression: a pinned read executes only through its frozen `parent`, but
+    # its `uncached` payload still references the original upstream backend. The
+    # default walk reports both (serialization needs the uncached profiles);
+    # connection-selection consumers must pass execution_only=True to avoid
+    # reporting backends that aren't actually required to run the pinned expr.
+    con = xo.connect()
+    con2 = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path, source=con2)
+    cached = t.into_backend(con2).cache(cache)
+    # guard: the uncached payload must carry a distinct second backend
+    assert isinstance(cached.op().parent.op(), RemoteTable)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    full = find_all_sources(pinned)
+    execution = find_all_sources(pinned, execution_only=True)
+
+    # default walk descends uncached and sees both backends
+    assert len(full) == 2
+    # execution path runs only through the frozen cache read on con2
+    assert tuple(map(id, execution)) == (id(con2),)
+
+
+def test_pin_does_not_freeze_dag_shared_upstream_leaf(tmp_path: Path) -> None:
+    # Regression: a pin's `uncached` payload holds the original upstream. If a
+    # leaf there is also referenced by a live, non-pinned part of the same
+    # expression (DAG sharing), name canonicalization must NOT skip it as a
+    # pinned leaf -- otherwise the live reference keeps its session-random UID
+    # name and leaks nondeterminism into the outer expression's build hash.
+    con = xo.connect()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    # memtable (not register) so the upstream leaf is a UID-prefixed
+    # InMemoryTable -- exactly the name that must be sanitized.
+    t = xo.memtable(df, name=None)
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path, source=con)
+    cached = t.cache(cache)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    # `t` is shared: it is both the pin's uncached upstream and the live left
+    # side of the join.
+    expr = t.join(pinned, "a")[["a"]]
+    assert walk_nodes((CacheTag,), expr)
+
+    canonical = canonicalize_expr(expr)
+    # No live leaf may retain its auto-generated UID prefix after canonicalization.
+    leftover = [
+        n.name
+        for n in walk_nodes((InMemoryTable, Read), canonical)
+        if get_uid_prefix(n.name)
+    ]
+    assert leftover == [], f"unsanitized UID-prefixed leaves: {leftover}"

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -173,7 +173,7 @@ def test_cache_tag_rejects_non_expr_uncached() -> None:
     with pytest.raises(IntegrityError, match="uncached must be an Expr or Node"):
         CacheTag(schema=schema, parent=t.op(), uncached=42, cache=None)
 
-    # an Expr is accepted, a Node is accepted, and None (unset) is accepted
+    # Expr, Node, and None (unset) are all accepted
     assert CacheTag(schema=schema, parent=t.op(), uncached=t, cache=None) is not None
     assert (
         CacheTag(schema=schema, parent=t.op(), uncached=t.op(), cache=None) is not None
@@ -202,10 +202,8 @@ def test_find_all_sources_execution_only_prunes_uncached_backend(
     full = find_all_sources(pinned)
     execution = find_all_sources(pinned, execution_only=True)
 
-    # default walk descends uncached and sees both backends
-    assert len(full) == 2
-    # execution path runs only through the frozen cache read on con2
-    assert tuple(map(id, execution)) == (id(con2),)
+    assert len(full) == 2  # default walk descends uncached, sees both backends
+    assert tuple(map(id, execution)) == (id(con2),)  # only con2's frozen read
 
 
 def test_pin_does_not_freeze_dag_shared_upstream_leaf(tmp_path: Path) -> None:

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -7,9 +7,16 @@ import pytest
 
 import xorq.api as xo
 from xorq.caching import ParquetCache
+from xorq.caching.strategy import SnapshotStrategy
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.graph_utils import find_all_sources, walk_nodes
+from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.common.utils.graph_utils import (
+    exclusively_pinned_leaves,
+    find_all_sources,
+    walk_nodes,
+)
 from xorq.common.utils.name_utils import get_uid_prefix
+from xorq.common.utils.node_utils import compute_expr_hash
 from xorq.common.utils.provenance_utils import get_expr_hash
 from xorq.expr.relations import CachedNode, CacheTag, Read, RemoteTable
 from xorq.ibis_yaml.compiler import canonicalize_expr
@@ -248,3 +255,84 @@ def test_pinned_expr_is_reprable(tmp_path: Path) -> None:
 
     rendered = repr(pinned)
     assert "CacheTag" in rendered
+
+
+def test_pin_build_hash_is_source_free(tmp_path: Path) -> None:
+    # A pin reads its cache artifact directly, so hashing it must not require
+    # the discarded upstream source. Regression: get_expr_hash canonicalizes
+    # via _sanitize_generated_names, which (with a parent-only pinned-leaf set)
+    # stat-tokenized `uncached`'s own reads -- so the BUILD hash raised
+    # FileNotFoundError once the source was deleted, even though execute() and
+    # ls.tokenized did not. Pairs with
+    # test_pin_does_not_freeze_dag_shared_upstream_leaf: only both passing at
+    # once pins the `under_pin - live` predicate (whole-subtree breaks the
+    # other, parent-only breaks this).
+    con = xo.connect()
+    src = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).to_parquet(src)
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path / "cache", source=con)
+    expr = deferred_read_parquet(src, con=con).filter(xo._.a > 1).cache(cache=cache)
+    expr.execute()
+    pinned = expr.ls.pin()
+
+    before = get_expr_hash(pinned)
+    src.unlink()  # discard the upstream source entirely
+
+    # build hash AND cache hash both recompute without the source, unchanged
+    assert get_expr_hash(pinned) == before
+    assert pinned.ls.tokenized  # does not raise
+    # the pin still reads its cache artifact directly
+    assert (
+        pinned.execute()
+        .reset_index(drop=True)
+        .equals(pd.DataFrame({"a": [2, 3], "b": [5, 6]}))
+    )
+
+
+def test_exclusively_pinned_leaves_excludes_dag_shared(tmp_path: Path) -> None:
+    # The shared predicate behind both _sanitize_generated_names and
+    # _decompose_expr: a leaf living ONLY under a pin is subsumed by the pin's
+    # cache-key token, but a leaf also reachable from a live branch (DAG
+    # sharing) must stay live so its data identity reaches the build hash.
+    con = xo.connect()
+    src = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).to_parquet(src)
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path / "cache", source=con)
+    base = deferred_read_parquet(src, con=con)
+    cached = base.filter(xo._.a > 1).cache(cache=cache)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    # pin alone: both the cache-file read and the uncached upstream read are
+    # exclusively pinned.
+    assert len(exclusively_pinned_leaves(pinned.op(), (Read,))) == 2
+
+    # share `base` with a live join: the upstream read is no longer exclusive,
+    # so only the cache-file read remains pinned and `base` stays a live leaf.
+    expr = base.join(pinned, "a")[["a"]]
+    shared = exclusively_pinned_leaves(expr.op(), (Read,))
+    assert len(shared) == 1
+    live_reads = [r for r in walk_nodes((Read,), expr) if r not in shared]
+    assert any(
+        str(src) in " ".join(str(v) for v in dict(r.read_kwargs).values())
+        for r in live_reads
+    )
+
+
+def test_pin_survives_tag_stripping_for_strategy_hash(tmp_path: Path) -> None:
+    # A CacheTag is identity-bearing (a build-hash leaf keyed on its cache key),
+    # not a transparent side-effect Tag. `untagged` must keep it -- like
+    # HashingTag -- so strategy-based hashes (compute_expr_hash with a strategy,
+    # find_by_expr_hash) don't silently reduce a pin to its bare cache read.
+    cached, _ = make_cached(tmp_path)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    assert walk_nodes((CacheTag,), pinned.ls.untagged)
+
+    # the pin must hash distinctly from its raw cache-file read; before the fix
+    # tag-stripping collapsed the two.
+    bare_read = pinned.op().parent.to_expr()
+    assert compute_expr_hash(pinned, SnapshotStrategy()) != compute_expr_hash(
+        bare_read, SnapshotStrategy()
+    )

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -57,9 +57,15 @@ def test_pinned_reads_directly_and_does_not_recompute(tmp_path: Path) -> None:
 
     # remove the cache artifact: a pinned expr reads the file directly, so it
     # must fail, whereas the unpinned form would simply recompute.
+    artifact = cache.storage.get_path(pinned.op().parent.name)
+    assert artifact.exists()
     cache.drop(cached.ls.uncached_one)
+    assert not artifact.exists()  # deterministic premise, backend-independent
 
-    with pytest.raises(ValueError):
+    # failure surface is reader/backend-dependent (today a schema-mismatch
+    # ValueError, but a missing file could equally raise OSError); the premise
+    # above pins down *why* it fails.
+    with pytest.raises((ValueError, OSError)):
         pinned.execute()
 
     # unpin restores the recompute-capable form
@@ -180,12 +186,16 @@ def test_cache_tag_rejects_non_expr_uncached() -> None:
     with pytest.raises(IntegrityError, match="uncached must be an Expr or Node"):
         CacheTag(schema=schema, parent=t.op(), uncached=42, cache=None)
 
-    # Expr, Node, and None (unset) are all accepted
+    # None is rejected too: it is descended via to_node, so it would build an
+    # untraversable tag.
+    with pytest.raises(IntegrityError, match="uncached must be an Expr or Node"):
+        CacheTag(schema=schema, parent=t.op(), uncached=None, cache=None)
+
+    # Expr and Node are accepted
     assert CacheTag(schema=schema, parent=t.op(), uncached=t, cache=None) is not None
     assert (
         CacheTag(schema=schema, parent=t.op(), uncached=t.op(), cache=None) is not None
     )
-    assert CacheTag(schema=schema, parent=t.op(), uncached=None, cache=None) is not None
 
 
 def test_find_all_sources_execution_only_prunes_uncached_backend(

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -235,3 +235,16 @@ def test_pin_does_not_freeze_dag_shared_upstream_leaf(tmp_path: Path) -> None:
         if get_uid_prefix(n.name)
     ]
     assert leftover == [], f"unsanitized UID-prefixed leaves: {leftover}"
+
+
+def test_pinned_expr_is_reprable(tmp_path: Path) -> None:
+    # A CacheTag carries `uncached` (an Ibis Expr) as reconstruction payload;
+    # without a dedicated fmt the generic relation formatter's `if v`
+    # truthiness check raises "The truth value of an Ibis expression is not
+    # defined". Pinning must leave the expr printable.
+    cached, _ = make_cached(tmp_path)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    rendered = repr(pinned)
+    assert "CacheTag" in rendered

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -138,3 +138,23 @@ def test_pin_unpin_nested_caches(tmp_path: Path) -> None:
     assert len(walk_nodes((CachedNode,), unpinned)) == 2
     assert not walk_nodes((CacheTag,), unpinned)
     assert unpinned.ls.tokenized == cached.ls.tokenized
+
+
+def test_pinned_expr_is_a_frozen_read_not_a_cache(tmp_path: Path) -> None:
+    # Model A contract: a pin is a frozen read, so cache-introspection accessors
+    # deliberately do not see it. unpin() is the gate back to cache semantics.
+    cached, _ = make_cached(tmp_path)
+    cached.execute()
+    assert cached.ls.is_cached
+    assert cached.ls.has_cached
+
+    pinned = cached.ls.pin()
+
+    assert not pinned.ls.is_cached
+    assert not pinned.ls.has_cached
+    assert pinned.ls.cached_nodes == ()
+    # .ls.uncached strips live caches; a pin has none, so it is a no-op
+    assert pinned.ls.uncached.ls.tokenized == pinned.ls.tokenized
+
+    # unpin restores cache semantics
+    assert pinned.ls.unpin().ls.is_cached

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -163,6 +163,24 @@ def test_pinned_expr_is_a_frozen_read_not_a_cache(tmp_path: Path) -> None:
     assert pinned.ls.unpin().ls.is_cached
 
 
+def test_cache_tag_rejects_non_expr_uncached() -> None:
+    # `parent` is type-enforced by the inherited Tag annotation, but `uncached`
+    # is Any; the __init__ guard catches a swapped/garbage upstream at
+    # construction instead of failing obscurely later.
+    t = xo.memtable(pd.DataFrame({"a": [1]}))
+    schema = t.schema()
+
+    with pytest.raises(IntegrityError, match="uncached must be an Expr or Node"):
+        CacheTag(schema=schema, parent=t.op(), uncached=42, cache=None)
+
+    # an Expr is accepted, a Node is accepted, and None (unset) is accepted
+    assert CacheTag(schema=schema, parent=t.op(), uncached=t, cache=None) is not None
+    assert (
+        CacheTag(schema=schema, parent=t.op(), uncached=t.op(), cache=None) is not None
+    )
+    assert CacheTag(schema=schema, parent=t.op(), uncached=None, cache=None) is not None
+
+
 def test_find_all_sources_execution_only_prunes_uncached_backend(
     tmp_path: Path,
 ) -> None:

--- a/python/xorq/expr/tests/test_cache_pin.py
+++ b/python/xorq/expr/tests/test_cache_pin.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import xorq.api as xo
+from xorq.caching import ParquetCache
+from xorq.common.exceptions import IntegrityError
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.common.utils.provenance_utils import get_expr_hash
+from xorq.expr.relations import CachedNode, CacheTag, Read, RemoteTable
+
+
+def make_cached(tmp_path: Path) -> tuple:
+    con = xo.connect()
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    t = con.register(df, "tbl")
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path, source=con)
+    return t.cache(cache), cache
+
+
+def test_pin_replaces_cached_node_with_cache_tag(tmp_path: Path) -> None:
+    cached, _ = make_cached(tmp_path)
+    cached.execute()
+
+    pinned = cached.ls.pin()
+
+    assert walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    assert walk_nodes((Read,), pinned)
+    assert pinned.execute().equals(cached.execute())
+
+
+def test_pin_requires_materialized_cache(tmp_path: Path) -> None:
+    cached, _ = make_cached(tmp_path)
+
+    with pytest.raises(IntegrityError, match="unmaterialized"):
+        cached.ls.pin()
+
+
+def test_pinned_reads_directly_and_does_not_recompute(tmp_path: Path) -> None:
+    cached, cache = make_cached(tmp_path)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    # remove the cache artifact: a pinned expr reads the file directly, so it
+    # must fail, whereas the unpinned form would simply recompute.
+    cache.drop(cached.ls.uncached_one)
+
+    with pytest.raises(ValueError):
+        pinned.execute()
+
+    # unpin restores the recompute-capable form
+    assert (
+        pinned.ls.unpin()
+        .execute()
+        .equals(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    )
+
+
+def test_unpin_is_inverse_of_pin(tmp_path: Path) -> None:
+    cached, _ = make_cached(tmp_path)
+    cached.execute()
+
+    unpinned = cached.ls.pin().ls.unpin()
+
+    assert walk_nodes((CachedNode,), unpinned)
+    assert not walk_nodes((CacheTag,), unpinned)
+    # structural equivalence (CachedNode == is unreliable: it stores parent as
+    # an Any-typed Expr, so compare via tokenized + structural op equality)
+    assert unpinned.ls.tokenized == cached.ls.tokenized
+    assert unpinned.op().parent.op() == cached.op().parent.op()
+
+
+def test_pin_changes_build_hash_but_not_result(tmp_path: Path) -> None:
+    cached, _ = make_cached(tmp_path)
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    # freeze-time pinning is intentionally NOT cache-hash-neutral
+    assert get_expr_hash(pinned) != get_expr_hash(cached)
+    assert pinned.execute().equals(cached.execute())
+
+
+def test_pin_is_noop_without_cached_nodes() -> None:
+    con = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2]}), "tbl")
+    expr = t.filter(t.a > 1)
+
+    assert expr.ls.pin().ls.tokenized == expr.ls.tokenized
+
+
+def test_pin_unpin_multi_engine_remote_table(tmp_path: Path) -> None:
+    # Cache across engines: the CachedNode.parent is a RemoteTable, so pinning
+    # must take the `remote_expr` branch when locating the materialized cache.
+    con = xo.connect()
+    con2 = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path, source=con2)
+    cached = t.into_backend(con2).cache(cache)
+    # guard: this test is only meaningful if the cached parent is a RemoteTable
+    assert isinstance(cached.op().parent.op(), RemoteTable)
+    cached.execute()
+
+    pinned = cached.ls.pin()
+    assert walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    assert pinned.execute().equals(cached.execute())
+
+    unpinned = pinned.ls.unpin()
+    assert walk_nodes((CachedNode,), unpinned)
+    assert not walk_nodes((CacheTag,), unpinned)
+    # tokenized is the reliable structural comparison here: RemoteTable.__eq__
+    # is unreliable (it stores remote_expr as an Any-typed Expr), so a direct
+    # `parent.op() ==` check on a RemoteTable parent gives false negatives.
+    assert unpinned.ls.tokenized == cached.ls.tokenized
+
+
+def test_pin_unpin_nested_caches(tmp_path: Path) -> None:
+    # A cache stacked on a cache: the inner CachedNode lives under the outer's
+    # opaque `uncached` payload, so pin/unpin must descend into it.
+    con = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+    inner_cache = ParquetCache.from_kwargs(relative_path=tmp_path / "inner", source=con)
+    outer_cache = ParquetCache.from_kwargs(relative_path=tmp_path / "outer", source=con)
+    cached = t.cache(inner_cache).filter(xo._.a > 1).cache(outer_cache)
+    # executing the outer cache materializes the inner one along the way
+    cached.execute()
+
+    pinned = cached.ls.pin()
+    assert len(walk_nodes((CacheTag,), pinned)) == 2
+    assert not walk_nodes((CachedNode,), pinned)
+    assert pinned.execute().equals(cached.execute())
+
+    unpinned = pinned.ls.unpin()
+    assert len(walk_nodes((CachedNode,), unpinned)) == 2
+    assert not walk_nodes((CacheTag,), unpinned)
+    assert unpinned.ls.tokenized == cached.ls.tokenized

--- a/python/xorq/ibis_yaml/common.py
+++ b/python/xorq/ibis_yaml/common.py
@@ -17,7 +17,7 @@ import xorq.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
 from xorq.caching.strategy import SnapshotStrategy
 from xorq.common.utils.dasher import tokenize
-from xorq.expr.relations import HashingTag, Read, Tag
+from xorq.expr.relations import CacheTag, HashingTag, Read, Tag
 from xorq.ibis_yaml.config import config
 from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
 from xorq.ibis_yaml.utils import freeze
@@ -71,6 +71,10 @@ class Registry:
                 tagged_repr = node.to_expr().ls.untagged
                 with SnapshotStrategy().normalization_context(node.to_expr()):
                     node_hash = tokenize(tagged_repr)
+            case CacheTag():
+                untagged_repr = ("CacheTag", node.parent.to_expr(), node.uncached)
+                with SnapshotStrategy().normalization_context(node.to_expr()):
+                    node_hash = tokenize(untagged_repr)
             case Tag():
                 untagged_repr = ("Tag", node.parent.to_expr(), node_dict["metadata"])
                 with SnapshotStrategy().normalization_context(node.to_expr()):

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -49,6 +49,7 @@ from xorq.common.utils.graph_utils import (
     opaque_ops,
     replace_nodes,
     replace_sources,
+    to_node,
     walk_nodes,
 )
 from xorq.common.utils.name_utils import get_uid_prefix
@@ -293,9 +294,15 @@ def _sanitize_generated_names(expr, normalize_method):
     # affect the other, so a single walk collecting both is equivalent to
     # the previous two sequential walks.
     replacements = {}
+    # Only the frozen read subtree (``parent``) of a CacheTag is a hash leaf
+    # whose names must be left alone. Do NOT descend ``uncached``: its leaves
+    # never participate in execution, and a leaf shared (DAG) between
+    # ``uncached`` and a live, non-pinned part of the expression would
+    # otherwise be skipped here and keep its session-random UID name, leaking
+    # nondeterminism into the outer expression's build hash.
     pinned_leaves = set()
     for ct in walk_nodes((CacheTag,), expr):
-        pinned_leaves.update(walk_nodes((InMemoryTable, Read), ct))
+        pinned_leaves.update(walk_nodes((InMemoryTable, Read), to_node(ct.parent)))
     for node in walk_nodes((InMemoryTable, Read), expr):
         if node in pinned_leaves:
             continue

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -64,6 +64,7 @@ from xorq.expr.relations import (
     CachedNode,
     CacheTag,
     Read,
+    relocate_cache,
     relocate_cache_tag,
 )
 from xorq.ibis_yaml.common import (
@@ -837,10 +838,7 @@ class ExprLoader:
                     # that read at the new base_path (the key is base_path-
                     # independent), so a pinned build is portable across cache dirs.
                     return relocate_cache_tag(node, base_path)
-                evolved = evolve(
-                    cache,
-                    storage=evolve(cache.storage, base_path=base_path),
-                )
+                evolved = relocate_cache(cache, base_path)
                 return recreate(node, **((kwargs or {}) | {"cache": evolved}))
             return node.__recreate__(kwargs) if kwargs else node
 

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -62,7 +62,9 @@ from xorq.expr.api import deferred_read_parquet
 from xorq.expr.operations import _MISSING
 from xorq.expr.relations import (
     CachedNode,
+    CacheTag,
     Read,
+    relocate_cache_tag,
 )
 from xorq.ibis_yaml.common import (
     Registry,
@@ -821,12 +823,18 @@ class ExprLoader:
         # replace_nodes (not op.replace) so the rewrite reaches CachedNodes
         # nested inside opaque sub-exprs like RemoteTable.remote_expr.
         def replacer(node, kwargs):
-            if isinstance(node, CachedNode) and isinstance(
-                node.cache, parquet_cache_types
+            cache = getattr(node, "cache", None)
+            if isinstance(node, (CachedNode, CacheTag)) and isinstance(
+                cache, parquet_cache_types
             ):
+                if isinstance(node, CacheTag):
+                    # A pinned cache is a frozen read; relocate it by re-pointing
+                    # that read at the new base_path (the key is base_path-
+                    # independent), so a pinned build is portable across cache dirs.
+                    return relocate_cache_tag(node, base_path)
                 evolved = evolve(
-                    node.cache,
-                    storage=evolve(node.cache.storage, base_path=base_path),
+                    cache,
+                    storage=evolve(cache.storage, base_path=base_path),
                 )
                 return recreate(node, **((kwargs or {}) | {"cache": evolved}))
             return node.__recreate__(kwargs) if kwargs else node

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -292,7 +292,12 @@ def _sanitize_generated_names(expr, normalize_method):
     # affect the other, so a single walk collecting both is equivalent to
     # the previous two sequential walks.
     replacements = {}
+    pinned_leaves = set()
+    for ct in walk_nodes((CacheTag,), expr):
+        pinned_leaves.update(walk_nodes((InMemoryTable, Read), ct))
     for node in walk_nodes((InMemoryTable, Read), expr):
+        if node in pinned_leaves:
+            continue
         if isinstance(node, InMemoryTable):
             if prefix := get_uid_prefix(node.name):
                 name = f"{prefix}{tokenize(recreate(node, name='name').to_expr())}"

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -45,11 +45,11 @@ from xorq.common.utils.file_utils import (
     normalize_read_path_stat,
 )
 from xorq.common.utils.graph_utils import (
+    exclusively_pinned_leaves,
     find_all_sources,
     opaque_ops,
     replace_nodes,
     replace_sources,
-    to_node,
     walk_nodes,
 )
 from xorq.common.utils.name_utils import get_uid_prefix
@@ -294,15 +294,11 @@ def _sanitize_generated_names(expr, normalize_method):
     # affect the other, so a single walk collecting both is equivalent to
     # the previous two sequential walks.
     replacements = {}
-    # Only the frozen read subtree (``parent``) of a CacheTag is a hash leaf
-    # whose names must be left alone. Do NOT descend ``uncached``: its leaves
-    # never participate in execution, and a leaf shared (DAG) between
-    # ``uncached`` and a live, non-pinned part of the expression would
-    # otherwise be skipped here and keep its session-random UID name, leaking
-    # nondeterminism into the outer expression's build hash.
-    pinned_leaves = set()
-    for ct in walk_nodes((CacheTag,), expr):
-        pinned_leaves.update(walk_nodes((InMemoryTable, Read), to_node(ct.parent)))
+    # Leave alone the leaves a pin's cache-key token already represents (those
+    # exclusively under a CacheTag); sanitizing them would stat a possibly-
+    # absent upstream source. DAG-shared leaves stay live -- see
+    # exclusively_pinned_leaves, shared with _decompose_expr.
+    pinned_leaves = exclusively_pinned_leaves(expr, (InMemoryTable, Read))
     for node in walk_nodes((InMemoryTable, Read), expr):
         if node in pinned_leaves:
             continue

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -377,6 +377,31 @@ def test_pinned_cache_yaml_roundtrip(
     assert pinned.execute().equals(roundtrip_expr.execute())
 
 
+def test_pinned_cache_yaml_roundtrip_multi_engine(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    # Cache across engines: the CachedNode.parent is a RemoteTable, so pinning
+    # takes the `remote_expr` branch and the CacheTag's `uncached` payload
+    # carries the RemoteTable through YAML serialization (the ADR-0015
+    # _replace_remote_table failure mode the CacheTag docstring flags).
+    con = xo.connect()
+    con2 = xo.connect()
+    t = con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+    cache = ParquetCache.from_kwargs(relative_path=tmp_path, source=con2)
+    cached = t.into_backend(con2).cache(cache)
+    # guard: this test is only meaningful if the cached parent is a RemoteTable
+    assert isinstance(cached.op().parent.op(), RemoteTable)
+    # materialize the cache so the pinned expr can read it directly
+    cached.execute()
+    pinned = cached.ls.pin()
+
+    roundtrip_expr = do_roundtrip_expr(pinned, builds_dir=builds_dir)
+
+    assert walk_nodes((CacheTag,), roundtrip_expr)
+    assert not walk_nodes((CachedNode,), roundtrip_expr)
+    assert pinned.execute().equals(roundtrip_expr.execute())
+
+
 @pytest.mark.parametrize(
     "table_from_df",
     (

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -40,7 +40,7 @@ from xorq.common.utils.file_utils import normalize_read_path_md5sum
 from xorq.common.utils.graph_utils import find_all_sources, walk_nodes
 from xorq.common.utils.name_utils import get_uid_prefix
 from xorq.conftest import array_types_df
-from xorq.expr.relations import CachedNode, Read, RemoteTable
+from xorq.expr.relations import CachedNode, CacheTag, Read, RemoteTable
 from xorq.expr.udf import ExprScalarUDF
 from xorq.ibis_yaml.compiler import (
     ArtifactStore,
@@ -354,6 +354,27 @@ def test_multi_engine_with_caching_with_parquet(
     )
     assert expr.execute().equals(roundtrip_expr.execute())
     assert expected_cache_dir.exists()
+
+
+def test_pinned_cache_yaml_roundtrip(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path, parquet_dir: pathlib.Path
+) -> None:
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con, relative_path=tmp_path)
+    expr = (
+        deferred_read_parquet(parquet_dir / "awards_players.parquet", con=con)
+        .filter(xo._.playerID == "bondto01")
+        .cache(cache=cache)
+    )
+    # materialize the cache so the pinned expr can read it directly
+    expr.execute()
+    pinned = expr.ls.pin()
+
+    roundtrip_expr = do_roundtrip_expr(pinned, builds_dir=builds_dir)
+
+    assert walk_nodes((CacheTag,), roundtrip_expr)
+    assert not walk_nodes((CachedNode,), roundtrip_expr)
+    assert pinned.execute().equals(roundtrip_expr.execute())
 
 
 @pytest.mark.parametrize(

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import datetime
 import hashlib
 import itertools
 import json
 import os
 import pathlib
+import shutil
 import tempfile
 import warnings
 
@@ -400,6 +403,45 @@ def test_pinned_cache_yaml_roundtrip_multi_engine(
     assert walk_nodes((CacheTag,), roundtrip_expr)
     assert not walk_nodes((CachedNode,), roundtrip_expr)
     assert pinned.execute().equals(roundtrip_expr.execute())
+
+
+def test_pinned_cache_relocates_to_new_cache_dir(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    # A pinned build must be portable: load_expr against a different cache_dir
+    # re-points the frozen read at the relocated artifact (the key is
+    # base_path-independent). Moving the cache dir proves it reads the new
+    # location and not the original.
+    con = xo.connect()
+    src = tmp_path / "cacheA"
+    cache = ParquetCache.from_kwargs(source=con, relative_path="pins", base_path=src)
+    expr = (
+        con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+        .filter(xo._.a > 1)
+        .cache(cache=cache)
+    )
+    expr.execute()  # materialize the cache under cacheA/pins
+    pinned = expr.ls.pin()
+    expected = pinned.execute()
+
+    build_path = build_expr(pinned, builds_dir=builds_dir)
+
+    # relocate the cache files; the original directory no longer exists
+    dst = tmp_path / "cacheB"
+    shutil.move(str(src), str(dst))
+
+    relocated = load_expr(build_path, cache_dir=dst)
+
+    assert walk_nodes((CacheTag,), relocated)
+    assert not walk_nodes((CachedNode,), relocated)
+    # the frozen read now resolves under cacheB
+    read_paths = [
+        str(dict(r.read_kwargs).get("hash_path", ""))
+        for r in walk_nodes((Read,), relocated)
+    ]
+    assert any(str(dst) in p for p in read_paths)
+    assert not any(str(src) in p for p in read_paths)
+    assert relocated.execute().equals(expected)
 
 
 @pytest.mark.parametrize(

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -23,6 +23,7 @@ from xorq.common.utils.node_utils import update_read_kwargs
 from xorq.expr.operations import _MISSING, NamedScalarParameter
 from xorq.expr.relations import (
     CachedNode,
+    CacheTag,
     HashingTag,
     Read,
     RemoteTable,
@@ -1089,6 +1090,34 @@ def _tag_from_yaml(yaml_dict: dict, context: Any) -> ibis.Expr:
         schema=schema,
         parent=parent_expr.op(),
         metadata=metadata,
+    ).to_expr()
+
+
+@translate_to_yaml.register(CacheTag)
+@convert_to_node_ref
+def _cache_tag_to_yaml(op: CacheTag, context: Any) -> dict:
+    return freeze(
+        {
+            "op": "CacheTag",
+            "parent": context.translate_to_yaml(op.parent),
+            "uncached": context.translate_to_yaml(op.uncached),
+            "cache": translate_cache(op.cache, context),
+        }
+        | context.registry.register_schema(op.schema)
+    )
+
+
+@register_from_yaml_handler("CacheTag")
+def _cache_tag_from_yaml(yaml_dict: dict, context: Any) -> ibis.Expr:
+    schema = context.get_schema(yaml_dict[RefEnum.schema_ref])
+    parent_expr = context.translate_from_yaml(yaml_dict["parent"])
+    uncached_expr = context.translate_from_yaml(yaml_dict["uncached"])
+    cache = load_cache_from_yaml(yaml_dict["cache"], context)
+    return CacheTag(
+        schema=schema,
+        parent=parent_expr.op(),
+        uncached=uncached_expr,
+        cache=cache,
     ).to_expr()
 
 

--- a/python/xorq/tests/test_ls_accessor.py
+++ b/python/xorq/tests/test_ls_accessor.py
@@ -242,7 +242,8 @@ def test_exists(cached_two):
     cache = cached_two.ls.cache
 
     assert not cached_two.ls.cache_exists()
-    assert not tuple(cache.storage.path.iterdir())
+    # the cache dir is created lazily on first write, so nothing exists yet
+    assert not cache.storage.path.exists()
 
     xo.execute(cached_two)
     assert cached_two.ls.cache_exists()

--- a/python/xorq/tests/test_ls_accessor.py
+++ b/python/xorq/tests/test_ls_accessor.py
@@ -20,11 +20,16 @@ from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.relations import CachedNode, FlightExpr, FlightUDXF
 from xorq.expr.udf import ExprScalarUDF
 from xorq.vendor import ibis
+from xorq.vendor.ibis.backends import BaseBackend
 
 
 @pytest.fixture
-def cached_two(con, pg, tmp_path):
-    parquet_cache = ParquetCache.from_kwargs(source=con, relative_path=tmp_path)
+def cached_two(con: BaseBackend, pg: BaseBackend, tmp_path: Path) -> ir.Expr:
+    # use a not-yet-created subdir (not tmp_path itself, which pytest creates)
+    # so test_exists can assert the cache dir is absent until the first write
+    parquet_cache = ParquetCache.from_kwargs(
+        source=con, relative_path=tmp_path / "cache"
+    )
     return (
         pg.table("batting")[lambda t: t.yearID > 2014]
         .cache()[lambda t: t.stint == 1]

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -1071,6 +1071,12 @@ class LETSQLAccessor:
         Returns an equivalent expression that reads the materialized cache
         artifacts directly instead of re-deriving them. Each cache must already
         exist. Inverse of `unpin`.
+
+        A pinned expression is a *frozen read*, not a cache: cache-introspection
+        accessors (`is_cached`, `has_cached`, `cached_nodes`, `uncached`) by
+        design do not see it -- there is no live cache to key, materialize, or
+        recompute. Call `unpin` to restore the cache semantics before doing
+        anything cache-shaped.
         """
         from xorq.expr.relations import pin_cache
 
@@ -1250,13 +1256,9 @@ class LETSQLAccessor:
     @property
     def uncached_one(self):
         if self.is_cached:
-            from xorq.expr.relations import RemoteTable
+            from xorq.expr.relations import cache_keyed_expr
 
-            parent = self.expr.op().parent
-            if isinstance(parent.op(), RemoteTable):
-                return parent.op().remote_expr
-            else:
-                return parent
+            return cache_keyed_expr(self.expr.op().parent)
         else:
             return self.expr
 

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -1065,6 +1065,26 @@ class LETSQLAccessor:
 
         return walk_nodes((CachedNode,), self.expr)
 
+    def pin(self) -> ir.Expr:
+        """Freeze every `CachedNode` into a direct read of its cache location.
+
+        Returns an equivalent expression that reads the materialized cache
+        artifacts directly instead of re-deriving them. Each cache must already
+        exist. Inverse of `unpin`.
+        """
+        from xorq.expr.relations import pin_cache
+
+        return pin_cache(self.expr)
+
+    def unpin(self) -> ir.Expr:
+        """Rebuild every pinned cache (`CacheTag`) back into its `CachedNode`.
+
+        Inverse of `pin`.
+        """
+        from xorq.expr.relations import unpin_cache
+
+        return unpin_cache(self.expr)
+
     @property
     def tags(self):
         return self.get_tags()

--- a/python/xorq/vendor/ibis/expr/types/relations.py
+++ b/python/xorq/vendor/ibis/expr/types/relations.py
@@ -3413,7 +3413,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             SourceCache,
             maybe_prevent_cross_source_caching,
         )
-        from xorq.expr.relations import CachedNode
+        from xorq.expr.relations import make_cached_node
 
         if cache:
             expr = maybe_prevent_cross_source_caching(self, cache)
@@ -3421,13 +3421,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             expr = self
             cache = SourceCache.from_kwargs(source=expr._find_backend(use_default=True))
 
-        op = CachedNode(
-            name=CACHED_NODE_NAME_PLACEHOLDER,
-            schema=expr.schema(),
-            parent=expr,
-            source=cache.storage.source,
-            cache=cache,
-        )
+        op = make_cached_node(expr.schema(), expr, cache)
         return op.to_expr()
 
     def tee(


### PR DESCRIPTION
## Summary
- Add `expr.ls.pin()` / `expr.ls.unpin()` to toggle a `CachedNode` to/from a direct read of its materialized cache location.
- `pin()` replaces each `CachedNode` with a `CacheTag` — a transparent `Read` of the cache file that carries the `uncached` expr + `cache` object needed to reconstruct the original node. `unpin()` is its exact inverse.
- Pinning is a **freeze-time** operation and is deliberately **not** cache-hash-neutral (it changes downstream cache keys — never incorrect, just a possible redundant recompute). It survives YAML round-trips.

## Implementation notes
- `CacheTag(Tag)` carries two `Any`-typed fields: `cache` (inert; read only by `unpin`) and `uncached` (the original pre-cache expr). On the **execution/SQL** path it is stripped to its `parent` like other tags (`_remove_tag_nodes`), so a pinned expr reads the cache file directly. On the **hashing** path it is *not* stripped (`_remove_non_hashing_tag_nodes` exempts it alongside `HashingTag`) — unlike a plain tag it is identity-bearing.
- **Build-hash identity:** a `CacheTag` is a hash *leaf* keyed on its cache key via `CacheTag.__dasher_tokenize__` → `("xorq.CacheTag", schema, parent.name)`, where `parent.name` is the cache key; the absolute `hash_path` is deliberately excluded so the hash is base_path-independent. `uncached`'s *structure* is intentionally absent from the build hash — safe, not a gap: the cache key already encodes the upstream computation (ADR-0015), and the class docstring documents why folding `uncached`'s structure into the token would be wrong (the ADR-0015 `RemoteTable.name` failure mode). `uncached` is still descended as an opaque child (`gen_children_of` / `replace_nodes`) so its backends/reads participate in source normalization and serialization.
- YAML: `translate_to_yaml`/`register_from_yaml_handler` for `CacheTag`, plus a dedicated `register_node` branch.
- **Traversal fix:** in `replace_nodes`, re-applying `_kwargs` after the replacer already merged it clobbered Any-typed overrides (e.g. `cache`) whenever a native child changed. This was latent everywhere but only triggered by `CacheTag` (native `parent` + Any `cache`). Fixed by not re-passing `_kwargs` in the new branch.

## Test plan
- [x] `python/xorq/expr/tests/test_cache_pin.py` (16 tests) — pin/unpin inverse, materialization requirement, direct-read-no-recompute, build-hash change, no-op without cached nodes, **multi-engine `RemoteTable` parent**, **nested (stacked) caches**, **DAG-shared upstream leaf naming**, **`find_all_sources` execution-only pruning**, **`uncached` type guard**, reprability, and the round-3 regressions (**source-free build hash**, **exclusively-pinned-leaf predicate**, **tag-stripping survival**)
- [x] `python/xorq/ibis_yaml/tests/test_compiler.py::test_pinned_cache_yaml_roundtrip` — survives YAML round-trip in full suite (was order-dependent; now fixed)
- [x] Full `test_compiler.py` (100 pass / 1 skip), `test_graph_utils.py`, `test_relations.py`
- [x] `test_cache.py` — only pre-existing Postgres-env failures (confirmed on clean tree)

## Review follow-ups (commit a9875943)

Addressed findings from the code review of this PR:

- **Pinned build hash is now portable & source-free.** A `CacheTag` is treated as a build-hash *leaf* keyed on its cache key: `CacheTag.__dasher_tokenize__` returns `("xorq.CacheTag", schema, parent.name)`, and `_decompose_expr`/`_hash_expr_components` prune the tag's subtree and fold that token; `_xorq_opaque_to_placeholder` and `_sanitize_generated_names` skip the pinned subtree too. Fixes two review findings:
  - the pinned build hash was **base_path-dependent** (a pin built/relocated to a different cache dir got a different identity); it is now identical across cache dirs.
  - `ls.tokenized`/`get_expr_hash` **crashed with `FileNotFoundError`** once the upstream source was deleted (even though `execute()` read the cache fine), because hashing descended `uncached`'s source reads. These now compute without the sources. *(⚠️ Update: round-2's DAG-shared-leaf fix regressed the `get_expr_hash` half of this — see round 3. `ls.tokenized` stayed source-free throughout; `get_expr_hash` is source-free again as of round 3.)*
  - This **inverts** the old `CacheTag` `INVARIANT: do NOT add __dasher_tokenize__` docstring (rewritten accordingly).
- **No redundant footer read at pin time.** `ParquetStorage.get(key, schema=…)` forwards the known schema to `deferred_read_parquet`, skipping a throwaway `connect()` + parquet-footer read per cache.
- **No filesystem side effects on relocate/read.** `ParquetStorage` creates its cache dir lazily at write time (`_ensure_dir` in `put`) instead of in `__attrs_post_init__`, so relocating/reading a pin no longer `mkdir`s (and won't fail on a read-only cache dir). `ParquetDummyStorage` keeps its no-filesystem contract.
- **Clarified (not changed) the `replace_nodes` `CacheTag` branch.** Dropping `_kwargs` there is load-bearing — forwarding it re-drives the cache read's backend from the BFS rewrite and breaks profile resolution on load (covered by `test_pinned_cache_yaml_roundtrip`). The comment now documents why.

## Review follow-ups (round 2)

Second review pass, focused on the pinning traversal + identity code:

- **DAG-shared upstream leaves stay deterministic.** `_sanitize_generated_names` collected pinned leaves by walking the whole `CacheTag` (which descends `uncached`); a leaf shared between the discarded upstream and a live, non-pinned branch was then skipped and kept its session-random UID name, leaking nondeterminism into the outer expression's build hash. Now collects only from the frozen `parent` subtree (regression test added).
- **`find_all_sources` execution-vs-serialization split.** It descended `uncached` and reported the discarded upstream's backends as required sources, so connection selection (`expr_to_unbound`) could error or pick the wrong connection on a pinned expr. Added an opt-in `execution_only` flag — default keeps the full walk (serialization needs `uncached` profiles to round-trip), and `expr_to_unbound` opts in. `walk_nodes` gained a `gen_children` override so the parent-only traversal lives in one place.
- **`CacheTag` fail-loud + type guard.** Added `rel.CacheTag` to `opaque_ops` so a future regression that drops the explicit branch in `replace_nodes` raises instead of silently passing the tag through. Added a `CacheTag.__init__` guard rejecting a non-`Expr`/`Node` `uncached` (the field is `Any`, so unlike `parent` ibis can't validate it via annotation).
- **Single source for `CacheTag` identity fields.** Extracted `cache_tag_identity_parts()`, shared by `__dasher_tokenize__` and the `_xorq_opaque_to_placeholder` SQL placeholder, so the two layers can't drift on *which* fields identify a pin. Hash-neutral (verified `get_expr_hash` unchanged before/after).
- **CI: repaired `test_exists`.** The cache-dir-absent assertion could never hold — the `cached_two` fixture used `relative_path=tmp_path`, which pytest pre-creates, so `storage.path` always existed. Pointed the fixture at a lazily-created `tmp_path/"cache"` subdir (only runs in the postgres matrix, so it wasn't caught locally).

## Review follow-ups (round 3)

Third pass fixed two defects found critiquing the round-1/round-2 interaction:

- **Build hash is source-free again (regression fix).** Round-1 made hashing source-free by skipping a pin's *whole* subtree during name sanitization; round-2 narrowed that to `parent`-only to fix DAG-shared-leaf determinism — which silently re-exposed `uncached`'s own file reads to stat-tokenization in `canonicalize_expr` → `_sanitize_generated_names`. Net effect: `get_expr_hash(pinned)` raised `FileNotFoundError` once the upstream source was deleted, even though `execute()` and `ls.tokenized` did not. The two fixes were mutually exclusive as written. Resolved with a single predicate, `exclusively_pinned_leaves` (`under_pin − live`): leaves reachable *only* through a pin are subsumed by the cache-key token (skipped/pruned); leaves also reachable from a live branch stay live. Shared by `_sanitize_generated_names` and `_decompose_expr` so they cannot drift again. This also fixes the latent `_decompose_expr` gap where a live DAG-shared leaf's data identity was pruned from the build hash (previously folded into #2127).
- **`CacheTag` survives tag-stripping.** `CacheTag` is identity-bearing (a build-hash leaf via `__dasher_tokenize__`), but `_remove_non_hashing_tag_nodes` stripped it like a transparent `Tag`, so `untagged`-based hashes (`compute_expr_hash` with a strategy, `find_by_expr_hash`) silently reduced a pin to its bare cache read and diverged from `get_expr_hash`/`ls.tokenized`. Now exempted like `HashingTag`.

New regression tests: `test_pin_build_hash_is_source_free`, `test_exclusively_pinned_leaves_excludes_dag_shared`, `test_pin_survives_tag_stripping_for_strategy_hash`. The first is the missing counterpart to `test_pin_does_not_freeze_dag_shared_upstream_leaf` — together they constrain the predicate from both sides (whole-subtree fails one, parent-only the other).

### Known follow-ups (tracked separately)
- A pinned **`build_expr`** still requires the upstream source, because `uncached` is serialized in full for `unpin` — `translate_to_yaml` / `register_node` walk it and stat its reads to assign deterministic names (fails at `translate.py` `_read_to_yaml`). Hashing *and* canonicalization no longer need the source (round 3); only serialization still does. Rethinking how/whether the whole `uncached` subtree is carried is filed as #2131.
- The new op `CacheTag` is taught to several subsystems as parallel special-cases; consolidating the opaque-child *traversal* lists is filed as #2127.
- **TTL caches (intended semantics, docs-only follow-up).** `pin` locks the artifact regardless of *any* invalidation policy — exactly as pinning a `ModificationTimeStrategy` cache ignores source-mtime changes. So a pinned TTL cache reads its artifact without enforcing expiry; TTL is retained only on the inert `CacheTag.cache` (for `unpin`). The build-hash identity is the cache key (not the artifact mtime), consistent with "locked no matter what." The pin gate correctly *refuses* an expired cache: an expired TTL entry is a cache miss (`key_exists` = present-and-fresh), i.e. logically unmaterialized, so re-executing to refresh and then pinning is the intended path. pin/unpin perform no filesystem writes, so the artifact mtime — and thus the TTL clock — is untouched by the round-trip (verified). Remaining work is docs-only: state on `ls.pin` that pinning disables all invalidation (content / source-mtime / TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



