### PR TITLE
release: 0.3.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Details
 
+## [0.3.31] - 2026-06-24
+### Details
+#### Added
+- Add TeeNode for deferred sinks by @mesejo in [#2089](https://github.com/xorq-labs/xorq/pull/2089)
+- Add Claude Code plugin guide by @ghoersti in [#2104](https://github.com/xorq-labs/xorq/pull/2104)
+
+#### Changed
+- Defer pyarrow, logging_utils, and gitpython by @dlovell in [#2078](https://github.com/xorq-labs/xorq/pull/2078)
+- Phase 2a — fix misplaced pages, move reference out of concepts by @mesejo in [#2080](https://github.com/xorq-labs/xorq/pull/2080)
+- Expand explanation stubs by @mesejo in [#2084](https://github.com/xorq-labs/xorq/pull/2084)
+- Make git-annex an optional dependency by @dlovell in [#2090](https://github.com/xorq-labs/xorq/pull/2090)
+- Phase 3 polish — landing routing table, concept cross-links, orphan fix by @mesejo in [#2092](https://github.com/xorq-labs/xorq/pull/2092)
+- WAP (write-audit-publish) library by @dlovell in [#2095](https://github.com/xorq-labs/xorq/pull/2095)
+
+#### Fixed
+- Uncached strips caches nested in Flight/UDF opaque sub-exprs by @dlovell in [#2081](https://github.com/xorq-labs/xorq/pull/2081)
+- Execution pipeline descends into opaque sub-exprs by @dlovell in [#2082](https://github.com/xorq-labs/xorq/pull/2082)
+- Move cityhash to sqlite optional-dependency group by @dlovell in [#2091](https://github.com/xorq-labs/xorq/pull/2091)
+- Register dasher normalizers for sklearn param-validation types by @dlovell in [#2093](https://github.com/xorq-labs/xorq/pull/2093)
+- Single-pass lowering for asof_join by @mesejo in [#2086](https://github.com/xorq-labs/xorq/pull/2086)
+- Use multi-batch sources for early-stop guarantees by @dlovell in [#2106](https://github.com/xorq-labs/xorq/pull/2106)
+- Serialize DrainingIterator advancement to fix drain=True race by @dlovell in [#2107](https://github.com/xorq-labs/xorq/pull/2107)
+
+#### Removed
+- Remove unused hotfix_utils module by @dlovell in [#2079](https://github.com/xorq-labs/xorq/pull/2079)
+
 ## [0.3.30] - 2026-06-16
 ### Details
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ only-include = ["python"]
 
 [project]
 name = "xorq"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
     "attrs>=24.1.0; python_version >= '3.10' and python_version < '4.0'",
     "pyarrow>=13.0.0,<22; python_version >= '3.10' and python_version < '4.0'",

--- a/uv.lock
+++ b/uv.lock
@@ -6086,7 +6086,7 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.30"
+version = "0.3.31"
 source = { editable = "." }
 dependencies = [
     { name = "atpublic" },


### PR DESCRIPTION
Release **v0.3.31** (patch bump from 0.3.30), following the [Release Flow](https://github.com/xorq-labs/xorq/blob/main/CONTRIBUTING.md#release-flow).

## Changes
- Bump version `0.3.30` → `0.3.31` in `pyproject.toml` (+ `uv.lock`)
- Regenerate `CHANGELOG.md` via `git cliff`

## Changelog
### Added
- TeeNode for deferred sinks (#2089)
- Claude Code plugin guide (#2104)

### Changed
- Defer pyarrow, logging_utils, and gitpython (#2078)
- WAP (write-audit-publish) library (#2095)
- Docs IA Phase 2a / Phase 3 polish, expanded explanation stubs (#2080, #2084, #2092)
- git-annex now an optional dependency (#2090)

### Fixed
- uncached strips caches nested in Flight/UDF opaque sub-exprs (#2081)
- execution pipeline descends into opaque sub-exprs (#2082)
- cityhash moved to sqlite optional-dependency group (#2091)
- register dasher normalizers for sklearn param-validation types (#2093)
- single-pass lowering for asof_join (#2086)
- multi-batch tee early-stop guarantees (#2106)
- serialize DrainingIterator advancement to fix drain=True race (#2107)

### Removed
- unused hotfix_utils module (#2079)

## Release checklist (maintainer)
- [ ] ci-pre-release green
- [ ] Squash and merge
- [ ] Tag `v0.3.31` on main and push
- [ ] Create GitHub release to trigger PyPI publish