### PR TITLE
fix(pyiceberg): fix overwrite-mode insert for pyiceberg 0.11

### DIFF
--- a/python/xorq/backends/pyiceberg/__init__.py
+++ b/python/xorq/backends/pyiceberg/__init__.py
@@ -40,15 +40,9 @@ def parse_url(url: str) -> Dict[str, Any]:
 
 
 def _overwrite_table_data(iceberg_table: IcebergTable, data: pa.Table):
-    tx = iceberg_table.transaction()
-    tx.delete(delete_filter=ALWAYS_TRUE)
-
-    update_snapshot = tx.update_snapshot()
-    with update_snapshot.fast_append() as append_files:
-        for data_file in iceberg_table.writer().write_table(data):
-            append_files.append_data_file(data_file)
-
-    tx.commit_transaction()
+    with iceberg_table.transaction() as tx:
+        tx.delete(delete_filter=ALWAYS_TRUE)
+        tx.append(data)
 
 
 class Backend(SQLBackend):

--- a/python/xorq/backends/pyiceberg/tests/test_table_ops.py
+++ b/python/xorq/backends/pyiceberg/tests/test_table_ops.py
@@ -56,9 +56,19 @@ def test_insert_overwrite(iceberg_con, trades_df, fun):
     assert table_name in iceberg_con.list_tables()
     expected = t.execute()
 
-    iceberg_con.insert(table_name, fun(t), mode="overwrite")
-    actual = t.execute()
-    assert len(actual) == len(expected)
+    # overwrite with a differently-shaped, differently-valued dataset so the
+    # test fails on a silent no-op (data unchanged) as well as on a double-append
+    new_df = trades_df.head(5).assign(price=trades_df["price"].head(5) + 1000)
+    src_name = "trades_overwrite_src"
+    new_t = iceberg_con.create_table(src_name, new_df, overwrite=True)
+
+    iceberg_con.insert(table_name, fun(new_t), mode="overwrite")
+    actual = t.execute().sort_values("timestamp").reset_index(drop=True)
+
+    assert len(actual) == len(new_df)
+    assert len(actual) != len(expected)
+    # every price reflects the +1000 offset → data was actually replaced
+    assert (actual["price"] > 1000).all()
 
 
 def test_create_empty_raises(iceberg_con):

--- a/python/xorq/backends/pyiceberg/tests/test_table_ops.py
+++ b/python/xorq/backends/pyiceberg/tests/test_table_ops.py
@@ -71,6 +71,22 @@ def test_insert_overwrite(iceberg_con, trades_df, fun):
     assert (actual["price"] > 1000).all()
 
 
+def test_insert_overwrite_atomic_on_schema_mismatch(iceberg_con, trades_df):
+    # a failed overwrite (schema mismatch) must abort the whole delete+append
+    # transaction, leaving the original data intact rather than truncated
+    table_name = "trades_overwrite_atomic"
+
+    t = iceberg_con.create_table(table_name, trades_df, overwrite=True)
+    expected = t.execute()
+
+    bad_df = trades_df.assign(extra=1)
+    with pytest.raises(ValueError):
+        iceberg_con.insert(table_name, bad_df, mode="overwrite")
+
+    actual = t.execute()
+    assert len(actual) == len(expected)
+
+
 def test_create_empty_raises(iceberg_con):
     with pytest.raises(NotImplementedError):
         schema = Schema.from_pyarrow(

--- a/python/xorq/backends/pyiceberg/tests/test_table_ops.py
+++ b/python/xorq/backends/pyiceberg/tests/test_table_ops.py
@@ -42,6 +42,25 @@ def test_append(iceberg_con, trades_df, fun):
     assert len(actual) == len(expected) * 2
 
 
+@pytest.mark.parametrize(
+    "fun",
+    [
+        pytest.param(execute, id="pandas"),
+        pytest.param(identity, id="xorq"),
+    ],
+)
+def test_insert_overwrite(iceberg_con, trades_df, fun):
+    table_name = "trades_overwrite"
+
+    t = iceberg_con.create_table(table_name, trades_df, overwrite=True)
+    assert table_name in iceberg_con.list_tables()
+    expected = t.execute()
+
+    iceberg_con.insert(table_name, fun(t), mode="overwrite")
+    actual = t.execute()
+    assert len(actual) == len(expected)
+
+
 def test_create_empty_raises(iceberg_con):
     with pytest.raises(NotImplementedError):
         schema = Schema.from_pyarrow(


### PR DESCRIPTION
## Problem

`insert(..., mode="overwrite")` fails on the pyiceberg backend (0.11.0):

```
AttributeError: 'Table' object has no attribute 'writer'
```

`_overwrite_table_data()` called `iceberg_table.writer()`, removed in pyiceberg 0.11. Append mode was unaffected.

## Fix

Rewrite `_overwrite_table_data` to run within a single transaction:

```python
with iceberg_table.transaction() as tx:
    tx.delete(delete_filter=ALWAYS_TRUE)
    tx.append(data)
```

Atomic delete-all + append, no dead `writer()`/`fast_append`.

## Test

Added `test_insert_overwrite` (pandas + xorq variants). Verified the issue repro now works.

Closes #2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)