### PR TITLE
refactor(common): derive scheme subsets from canonical REMOTE_SCHEMES

### DIFF
--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 
-REMOTE_SCHEMES = ("http://", "https://", "s3://", "gs://", "gcs://")
+HTTP_SCHEMES = ("http://", "https://")
+CLOUD_SCHEMES = ("s3://", "gs://", "gcs://")
+REMOTE_SCHEMES = HTTP_SCHEMES + CLOUD_SCHEMES
 
 READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
 

--- a/python/xorq/common/utils/dasher/_paths.py
+++ b/python/xorq/common/utils/dasher/_paths.py
@@ -17,7 +17,7 @@ import urllib.request
 
 import yaml12
 
-from xorq.common.constants import REMOTE_SCHEMES
+from xorq.common.constants import CLOUD_SCHEMES, HTTP_SCHEMES, REMOTE_SCHEMES
 from xorq.common.utils.file_utils import normalize_read_path_stat
 
 
@@ -46,7 +46,7 @@ def _canonicalize_catalog_path(s: str) -> tuple[str, bool]:
 def _normalize_path_stat(path: str, **kwargs) -> tuple:
     """Stable metadata for a path: HTTP HEAD, cloud metadata, or local stat."""
 
-    if isinstance(path, str) and path.startswith(("http://", "https://")):
+    if isinstance(path, str) and path.startswith(HTTP_SCHEMES):
         req = urllib.request.Request(
             path, method="HEAD", headers={"User-Agent": "xorq-cache"}
         )
@@ -64,7 +64,7 @@ def _normalize_path_stat(path: str, **kwargs) -> tuple:
                 for k in ("Last-Modified", "Content-Length", "Content-Type")
             ),
         )
-    if isinstance(path, str) and path.startswith(("s3://", "gs://", "gcs://")):
+    if isinstance(path, str) and path.startswith(CLOUD_SCHEMES):
         from xorq.expr import api  # noqa: PLC0415
 
         meta = api.get_object_metadata(path, **kwargs)


### PR DESCRIPTION
## What

Resolves the constant duplication flagged in #2073.

`REMOTE_SCHEMES` already lives in `xorq.common.constants` (moved there in #2070), and both `ibis_yaml/compiler.py` and `dasher/_paths.py` import it — so the main duplication and the inverted dependency are already fixed.

This finishes the remaining item (point #3): the hardcoded scheme **subsets** still inlined in `dasher/_paths._normalize_path_stat`.

## How

- Define `HTTP_SCHEMES` and `CLOUD_SCHEMES` in `constants.py` and compose `REMOTE_SCHEMES = HTTP_SCHEMES + CLOUD_SCHEMES`.
- Replace the inline `("http://", "https://")` and `("s3://", "gs://", "gcs://")` tuples in `_normalize_path_stat` with the named constants.

The two branches stay distinct (HTTP → `HEAD`, cloud → object-metadata) — they are genuine subsets, not the full tuple — but now derive from one canonical source. Adding a scheme (e.g. `abfss://`) means editing one place.

Vendored `ibis/backends/duckdb` scheme literals left untouched (third-party).

Closes #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)