### PR TITLE
feat(cli): expose cache pin/unpin for builds and catalog entries

### DIFF
--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -78,6 +78,10 @@ MAIN_GROUPS = (
         "Serve",
         ("serve-flight-udxf", "serve-unbound"),
     ),
+    (
+        "Cache",
+        ("pin", "unpin"),
+    ),
 )
 
 CATALOG_GROUPS = (
@@ -102,6 +106,10 @@ CATALOG_GROUPS = (
     (
         "Composition and execution",
         ("compose", "run", "run-cached", "serve-unbound"),
+    ),
+    (
+        "Cache",
+        ("pin", "unpin"),
     ),
     (
         "Sync, audit, replay",

--- a/examples/pin_unpin.sh
+++ b/examples/pin_unpin.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Freeze a build's caches with `xorq pin` (rewrites each cache into a direct
+# read of its file) and thaw them with `xorq unpin`. --relocate-reads bundles
+# those files into the build for a self-contained, portable artifact.
+
+script="${1:?Usage: ./pin_unpin.sh <script.py> [-e expr_name]}"
+shift || true
+
+expr_name="expr"
+cache_dir="./pin-unpin-cache"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -e) expr_name="$2"; shift 2 ;;
+        --cache-dir) cache_dir="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+echo "==> Building '${expr_name}' from ${script}"
+build_path=$(xorq build "$script" -e "$expr_name" --cache-dir "$cache_dir")
+echo "    build: ${build_path}"
+
+# Pin requires materialized caches; run once to populate them (or use `pin -e`).
+echo "==> Running build to materialize caches"
+# `head` closes the pipe early, so under `set -o pipefail` xorq's SIGPIPE (141)
+# would fail the script; `|| true` keeps the demo going. The caches are still
+# fully written -- materialization is a side effect of the run, not of how many
+# rows are read back.
+xorq run "$build_path" -f json -o - --cache-dir "$cache_dir" | head -n 5 || true
+
+echo "==> Pinning (freeze caches into direct reads, bundle them in)"
+# --relocate-reads is on by default; shown here for clarity.
+pinned_path=$(xorq pin "$build_path" --cache-dir "$cache_dir" --relocate-reads)
+echo "    pinned: ${pinned_path}"
+# Pinning intentionally changes the build hash: a distinct build, not an edit.
+
+echo "==> Unpinning (thaw frozen reads back into recomputable caches)"
+unpinned_path=$(xorq unpin "$pinned_path" --cache-dir "$cache_dir")
+echo "    unpinned: ${unpinned_path}"
+# Unpin reverses pin's cache transform. The hash only returns to the original
+# build's when reads are not relocated on either leg (relocate rewrites read
+# identity, so a relocated build is not load+rebuild hash-stable); see
+# `xorq pin/unpin --no-relocate-reads` for the hash-stable round-trip.

--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from functools import reduce
 
 from xorq.catalog.enums import CatalogTag
+from xorq.common.exceptions import UnsupportedOperationError
 from xorq.common.utils.graph_utils import replace_nodes, replace_unbound, walk_nodes
-from xorq.expr.relations import HashingTag, RemoteTable, gen_name
+from xorq.expr.relations import HashingTag, Read, RemoteTable, gen_name
 from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis.expr.schema import Schema
 
@@ -279,4 +280,22 @@ def fuse_catalog_source(expr):
 
         result = replace_nodes(replacer, expr).to_expr()
         span.set_attribute("fused", True)
+        # #2133: the fuse/bind execute path does not relocate a bundled read's
+        # base_path the way load_expr does, so a fused entry containing a
+        # relocated (bundled) read executes to a silently-empty result. Fail loud
+        # instead: catalog pin/add default to lean entries, so this only fires on
+        # an explicit --relocate-reads opt-in. Remove this guard when #2133 lands.
+        bundled = [
+            r for r in walk_nodes(Read, result) if "read_path" in dict(r.read_kwargs)
+        ]
+        if bundled:
+            span.set_attribute("fused", False)
+            span.set_attribute("reason", "relocated_read_unsupported_in_fuse")
+            raise UnsupportedOperationError(
+                "cannot fuse a catalog entry containing bundled (relocated) "
+                "reads: the fuse/bind execute path does not yet resolve a "
+                "relocated read's base_path, so the result would be empty "
+                "(#2133). Re-create the entry with --no-relocate-reads (the "
+                "default), or consume it with --no-fuse."
+            )
         return result

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -414,7 +414,9 @@ class Catalog:
 
         *relocate_reads* controls how the build is produced and so only applies
         to an ``Expr`` input; ``Path`` inputs are already-built artifacts whose
-        reads were settled at build time.
+        reads were settled at build time. Defaults to ``False`` (the CLI prefers
+        ``True``, and pin/unpin pass it explicitly) until the fuse/bind execute
+        path resolves relocated reads' base_path; see #2133.
         """
         from xorq.api import Expr  # noqa: PLC0415
 

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -13,7 +13,7 @@ from contextlib import (
 from functools import cached_property, partial
 from pathlib import Path
 from subprocess import Popen
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
 
 import attr
@@ -74,6 +74,10 @@ from xorq.catalog.s3_utils import S3_SECRET_FIELDS
 from xorq.catalog.zip_utils import BuildZip, make_zip_context, with_pure_suffix
 from xorq.common.utils.logging_utils import get_logger
 from xorq.ibis_yaml.enums import DumpFiles, ExprKind
+
+
+if TYPE_CHECKING:
+    from xorq.api import Expr
 
 
 logger = get_logger(__name__)
@@ -369,8 +373,16 @@ class Catalog:
                 zip_path, sync=sync, aliases=aliases, exist_ok=exist_ok
             )
 
-    def _add_expr(self, expr, sync=True, aliases=(), exist_ok=False, project_path=None):
-        with build_expr_context(expr) as path:
+    def _add_expr(
+        self,
+        expr: Expr,
+        sync: bool = True,
+        aliases: tuple[str, ...] = (),
+        exist_ok: bool = False,
+        project_path: Path | None = None,
+        relocate_reads: bool = False,
+    ) -> CatalogEntry:
+        with build_expr_context(expr, relocate_reads=relocate_reads) as path:
             return self._add_build_dir(
                 path,
                 sync=sync,
@@ -379,7 +391,15 @@ class Catalog:
                 project_path=project_path,
             )
 
-    def add(self, obj, sync=True, aliases=(), exist_ok=False, project_path=None):
+    def add(
+        self,
+        obj: Expr | Path,
+        sync: bool = True,
+        aliases: tuple[str, ...] = (),
+        exist_ok: bool = False,
+        project_path: Path | None = None,
+        relocate_reads: bool = False,
+    ) -> CatalogEntry:
         """Add a build to the catalog.
 
         *obj* may be a ``Path`` to a zip archive, a ``Path`` to a build
@@ -391,25 +411,41 @@ class Catalog:
         it explicitly is required when the caller's cwd is not inside the
         project (e.g. Jupyter kernels started from ``/tmp``).  Ignored for zip
         inputs, which are already complete build archives.
+
+        *relocate_reads* controls how the build is produced and so only applies
+        to an ``Expr`` input; ``Path`` inputs are already-built artifacts whose
+        reads were settled at build time.
         """
         from xorq.api import Expr  # noqa: PLC0415
 
+        if relocate_reads and not isinstance(obj, Expr):
+            raise ValueError(
+                "relocate_reads only applies to an Expr input; "
+                f"{type(obj)} is an already-built artifact"
+            )
+
         match obj:
             case Path() if obj.is_dir():
-                f = self._add_build_dir
+                return self._add_build_dir(
+                    obj,
+                    sync=sync,
+                    aliases=aliases,
+                    exist_ok=exist_ok,
+                    project_path=project_path,
+                )
             case Path() if obj.is_file():
                 return self._add_zip(obj, sync=sync, aliases=aliases, exist_ok=exist_ok)
             case Expr():
-                f = self._add_expr
+                return self._add_expr(
+                    obj,
+                    sync=sync,
+                    aliases=aliases,
+                    exist_ok=exist_ok,
+                    project_path=project_path,
+                    relocate_reads=relocate_reads,
+                )
             case _:
                 raise ValueError(f"don't know how to handle type={type(obj)}")
-        return f(
-            obj,
-            sync=sync,
-            aliases=aliases,
-            exist_ok=exist_ok,
-            project_path=project_path,
-        )
 
     def remove(self, name, sync=True):
         """Remove an entry (and its aliases) from the catalog by name."""

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -424,25 +424,18 @@ class Catalog:
                 f"{type(obj)} is an already-built artifact"
             )
 
+        shared = {"sync": sync, "aliases": aliases, "exist_ok": exist_ok}
         match obj:
             case Path() if obj.is_dir():
-                return self._add_build_dir(
-                    obj,
-                    sync=sync,
-                    aliases=aliases,
-                    exist_ok=exist_ok,
-                    project_path=project_path,
-                )
+                return self._add_build_dir(obj, project_path=project_path, **shared)
             case Path() if obj.is_file():
-                return self._add_zip(obj, sync=sync, aliases=aliases, exist_ok=exist_ok)
+                return self._add_zip(obj, **shared)
             case Expr():
                 return self._add_expr(
                     obj,
-                    sync=sync,
-                    aliases=aliases,
-                    exist_ok=exist_ok,
                     project_path=project_path,
                     relocate_reads=relocate_reads,
+                    **shared,
                 )
             case _:
                 raise ValueError(f"don't know how to handle type={type(obj)}")

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -31,6 +31,7 @@ from xorq.cli import (
 )
 from xorq.cli_options import (
     _F,
+    apply_in_help_order,
     cache_dir_option,
     cache_strategy_options,
     code_option,
@@ -500,31 +501,26 @@ def _catalog_pin_command(
 def _catalog_pin_shared_options(fn: _F) -> _F:
     """Options common to `catalog pin` and `catalog unpin`.
 
-    Applied in reverse so the resulting --help order matches the decorator stack
-    (entry, --sync, --cache-dir, --alias, --move-aliases). The command's own
-    docstring distinguishes the pinned/unpinned result, so the help text here
-    stays neutral ("the new entry").
+    The command's own docstring distinguishes the pinned/unpinned result, so the
+    help text here stays neutral ("the new entry").
     """
-    for dec in reversed(
-        (
-            click.argument("entry", shell_complete=_complete_entry_or_alias_names),
-            sync_option,
-            cache_dir_option,
-            click.option(
-                "-a",
-                "--alias",
-                default=None,
-                help="Register this alias for the new entry.",
-            ),
-            click.option(
-                "--move-aliases",
-                is_flag=True,
-                help="Move all of the source entry's aliases onto the new entry.",
-            ),
-        )
-    ):
-        fn = dec(fn)
-    return fn
+    return apply_in_help_order(
+        fn,
+        click.argument("entry", shell_complete=_complete_entry_or_alias_names),
+        sync_option,
+        cache_dir_option,
+        click.option(
+            "-a",
+            "--alias",
+            default=None,
+            help="Register this alias for the new entry.",
+        ),
+        click.option(
+            "--move-aliases",
+            is_flag=True,
+            help="Move all of the source entry's aliases onto the new entry.",
+        ),
+    )
 
 
 @cli.command("pin")

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -8,12 +8,12 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from functools import cache, partial, reduce
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import attr
 import click
@@ -457,13 +457,7 @@ def _catalog_pin_command(
         catalog = ctx.obj.make_catalog(init=False)
         catalog_entry = _get_catalog_entry(catalog, entry)
         source_aliases = (
-            tuple(
-                ca.alias
-                for ca in catalog.catalog_aliases
-                if ca.catalog_entry.name == catalog_entry.name
-            )
-            if move_aliases
-            else ()
+            tuple(ca.alias for ca in catalog_entry.aliases) if move_aliases else ()
         )
         # `load_expr` pins the entry's temp extract dir to the loaded expr's
         # lifetime (weakref.finalize in load_expr_from_zip). The pinned/unpinned
@@ -502,21 +496,41 @@ def _catalog_pin_command(
     click.echo(new_entry.name)
 
 
+_F = TypeVar("_F", bound=Callable)
+
+
+def _catalog_pin_shared_options(fn: _F) -> _F:
+    """Options common to `catalog pin` and `catalog unpin`.
+
+    Applied in reverse so the resulting --help order matches the decorator stack
+    (entry, --sync, --cache-dir, --alias, --move-aliases). The command's own
+    docstring distinguishes the pinned/unpinned result, so the help text here
+    stays neutral ("the new entry").
+    """
+    for dec in reversed(
+        (
+            click.argument("entry", shell_complete=_complete_entry_or_alias_names),
+            sync_option,
+            cache_dir_option,
+            click.option(
+                "-a",
+                "--alias",
+                default=None,
+                help="Register this alias for the new entry.",
+            ),
+            click.option(
+                "--move-aliases",
+                is_flag=True,
+                help="Move all of the source entry's aliases onto the new entry.",
+            ),
+        )
+    ):
+        fn = dec(fn)
+    return fn
+
+
 @cli.command("pin")
-@click.argument("entry", shell_complete=_complete_entry_or_alias_names)
-@sync_option
-@cache_dir_option
-@click.option(
-    "-a",
-    "--alias",
-    default=None,
-    help="Register this alias for the new pinned entry.",
-)
-@click.option(
-    "--move-aliases",
-    is_flag=True,
-    help="Move all of the source entry's aliases onto the pinned entry.",
-)
+@_catalog_pin_shared_options
 @ensure_materialized_option
 @relocate_reads_option(noun="entry", include_caches=True)
 @click.pass_context
@@ -560,20 +574,7 @@ def pin(
 
 
 @cli.command("unpin")
-@click.argument("entry", shell_complete=_complete_entry_or_alias_names)
-@sync_option
-@cache_dir_option
-@click.option(
-    "-a",
-    "--alias",
-    default=None,
-    help="Register this alias for the new unpinned entry.",
-)
-@click.option(
-    "--move-aliases",
-    is_flag=True,
-    help="Move all of the source entry's aliases onto the unpinned entry.",
-)
+@_catalog_pin_shared_options
 @relocate_reads_option(noun="entry")
 @click.pass_context
 def unpin(

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -454,7 +454,7 @@ def _catalog_pin_command(
     alias: str | None,
     move_aliases: bool,
     ensure_materialized: bool = False,
-    relocate_reads: bool = True,
+    relocate_reads: bool = False,
 ) -> None:
     # Resolve up front (like the build-level pin_command) so the load path and
     # the internal-dir classification below agree; a None default cache dir would
@@ -481,12 +481,14 @@ def _catalog_pin_command(
         )
         aliases = (alias,) if alias else ()
         if relocate_reads:
-            # Relocated entries fuse to an empty result until #2133 lands; warn
-            # here, not only in docs and an xfail test.
+            # relocate_reads is opt-in for catalog entries (default lean) because
+            # a bundled read fuses to an empty result until #2133 lands -- and
+            # fuse is the default consumption path. Warn at pin time in addition
+            # to the hard guard fuse itself now raises (see fuse_catalog_source).
             click.echo(
                 "warning: the new entry bundles relocated reads; consuming it "
-                "via fuse/bind currently returns an empty result (#2133). Use "
-                "--no-relocate-reads if you need to fuse this entry.",
+                "via fuse/bind currently raises until #2133 lands. Use the "
+                "default (--no-relocate-reads) unless you consume with --no-fuse.",
                 err=True,
             )
         with catalog.maybe_synchronizing(sync):
@@ -545,7 +547,7 @@ def _catalog_pin_shared_options(fn: _F) -> _F:
 @cli.command("pin")
 @_catalog_pin_shared_options
 @ensure_materialized_option
-@relocate_reads_option(noun="entry", include_caches=True)
+@relocate_reads_option(noun="entry", include_caches=True, default=False)
 @click.pass_context
 def pin(
     ctx: click.Context,
@@ -588,7 +590,7 @@ def pin(
 
 @cli.command("unpin")
 @_catalog_pin_shared_options
-@relocate_reads_option(noun="entry")
+@relocate_reads_option(noun="entry", default=False)
 @click.pass_context
 def unpin(
     ctx: click.Context,

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -24,11 +24,13 @@ from xorq.catalog import constants as catalog_constants
 if TYPE_CHECKING:
     from xorq.catalog.content_store import ContentStoreConfig
 
+from xorq.cli import _lazy_span
 from xorq.cli_options import (
     cache_dir_option,
     cache_strategy_options,
     code_option,
     content_store_option,
+    ensure_materialized_option,
     env_options,
     fuse_option,
     gcs_option,
@@ -36,6 +38,7 @@ from xorq.cli_options import (
     limit_option,
     output_options,
     params_option,
+    relocate_reads_option,
     rename_params_option,
     serve_options,
     sync_option,
@@ -431,6 +434,168 @@ def add_alias(ctx, name, alias, sync):
         catalog = ctx.obj.make_catalog(init=False)
         catalog_alias = catalog.add_alias(name, alias, sync=sync)
         click.echo(f"Added alias {catalog_alias.alias!r} -> {name}")
+
+
+@_lazy_span("catalog.pin_command")
+def _catalog_pin_command(
+    ctx: click.Context,
+    entry: str,
+    *,
+    do_pin: bool,
+    sync: bool,
+    cache_dir: str | None,
+    alias: str | None,
+    move_aliases: bool,
+    ensure_materialized: bool = False,
+    relocate_reads: bool = True,
+) -> None:
+    from xorq.cli import apply_pin_transform  # noqa: PLC0415
+
+    with click_context_catalog(ctx):
+        catalog = ctx.obj.make_catalog(init=False)
+        catalog_entry = _get_catalog_entry(catalog, entry)
+        source_aliases = (
+            tuple(
+                ca.alias
+                for ca in catalog.catalog_aliases
+                if ca.catalog_entry.name == catalog_entry.name
+            )
+            if move_aliases
+            else ()
+        )
+        # `load_expr` pins the entry's temp extract dir to the loaded expr's
+        # lifetime (weakref.finalize in load_expr_from_zip). The pinned/unpinned
+        # result keeps relocatable reads pointing into that dir, so we must hold
+        # `loaded` alive until the new entry is fully built -- otherwise it is
+        # GC'd, the extract dir is swept, and a relocating rebuild can't find the
+        # bundled reads.
+        loaded = catalog_entry.load_expr(cache_dir=cache_dir)
+        expr = apply_pin_transform(
+            loaded,
+            do_pin=do_pin,
+            ensure_materialized=ensure_materialized,
+            cold_cache_hint="Execute the entry first or pass --ensure-materialized/-e.",
+        )
+        aliases = (alias,) if alias else ()
+        with catalog.maybe_synchronizing(sync):
+            new_entry = catalog.add(
+                expr,
+                sync=False,
+                aliases=aliases,
+                exist_ok=True,
+                relocate_reads=relocate_reads,
+            )
+            for moved in source_aliases:
+                catalog.add_alias(new_entry.name, moved, sync=False)
+    click.echo(new_entry.name)
+
+
+@cli.command("pin")
+@click.argument("entry", shell_complete=_complete_entry_or_alias_names)
+@sync_option
+@cache_dir_option
+@click.option(
+    "-a",
+    "--alias",
+    default=None,
+    help="Register this alias for the new pinned entry.",
+)
+@click.option(
+    "--move-aliases",
+    is_flag=True,
+    help="Move all of the source entry's aliases onto the pinned entry.",
+)
+@ensure_materialized_option
+@relocate_reads_option(noun="entry", include_caches=True)
+@click.pass_context
+def pin(
+    ctx: click.Context,
+    entry: str,
+    sync: bool,
+    cache_dir: str | None,
+    alias: str | None,
+    move_aliases: bool,
+    ensure_materialized: bool,
+    relocate_reads: bool,
+) -> None:
+    """Freeze a catalog entry's caches and persist the result as a new entry.
+
+    Pinning changes the build hash, so it always yields a new content-named
+    entry rather than mutating the source. Use --alias to name it, or
+    --move-aliases to move every alias (e.g. `prod`) from the source entry onto
+    the pinned entry.
+
+    \b
+    Arguments:
+      ENTRY  An entry name or alias.
+
+    \b
+    Examples:
+      xorq catalog pin penguins-prod --alias penguins-pinned
+      xorq catalog pin penguins-prod --move-aliases
+    """
+    _catalog_pin_command(
+        ctx,
+        entry,
+        do_pin=True,
+        sync=sync,
+        cache_dir=cache_dir,
+        alias=alias,
+        move_aliases=move_aliases,
+        ensure_materialized=ensure_materialized,
+        relocate_reads=relocate_reads,
+    )
+
+
+@cli.command("unpin")
+@click.argument("entry", shell_complete=_complete_entry_or_alias_names)
+@sync_option
+@cache_dir_option
+@click.option(
+    "-a",
+    "--alias",
+    default=None,
+    help="Register this alias for the new unpinned entry.",
+)
+@click.option(
+    "--move-aliases",
+    is_flag=True,
+    help="Move all of the source entry's aliases onto the unpinned entry.",
+)
+@relocate_reads_option(noun="entry")
+@click.pass_context
+def unpin(
+    ctx: click.Context,
+    entry: str,
+    sync: bool,
+    cache_dir: str | None,
+    alias: str | None,
+    move_aliases: bool,
+    relocate_reads: bool,
+) -> None:
+    """Thaw a pinned catalog entry and persist the result as a new entry.
+
+    Inverse of `xorq catalog pin`: rebuilds frozen cache reads back into
+    recomputable caches. Like pin, this yields a new content-named entry.
+
+    \b
+    Arguments:
+      ENTRY  An entry name or alias.
+
+    \b
+    Examples:
+      xorq catalog unpin penguins-pinned --move-aliases
+    """
+    _catalog_pin_command(
+        ctx,
+        entry,
+        do_pin=False,
+        sync=sync,
+        cache_dir=cache_dir,
+        alias=alias,
+        move_aliases=move_aliases,
+        relocate_reads=relocate_reads,
+    )
 
 
 @cli.command("remove-alias")

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from xorq.catalog.content_store import ContentStoreConfig
 
 from xorq.cli import (
+    _get_cache_dir,
     _lazy_span,
     apply_pin_transform,
     raise_for_missing_relocation_source,
@@ -455,6 +456,10 @@ def _catalog_pin_command(
     ensure_materialized: bool = False,
     relocate_reads: bool = True,
 ) -> None:
+    # Resolve up front (like the build-level pin_command) so the load path and
+    # the internal-dir classification below agree; a None default cache dir would
+    # drop out of internal_dirs and mislabel a missing cache artifact as a source.
+    cache_dir = _get_cache_dir(cache_dir)
     with click_context_catalog(ctx):
         catalog = ctx.obj.make_catalog(init=False)
         catalog_entry = _get_catalog_entry(catalog, entry)
@@ -475,6 +480,15 @@ def _catalog_pin_command(
             cold_cache_hint="Execute the entry first or pass --ensure-materialized/-e.",
         )
         aliases = (alias,) if alias else ()
+        if relocate_reads:
+            # Relocated entries fuse to an empty result until #2133 lands; warn
+            # here, not only in docs and an xfail test.
+            click.echo(
+                "warning: the new entry bundles relocated reads; consuming it "
+                "via fuse/bind currently returns an empty result (#2133). Use "
+                "--no-relocate-reads if you need to fuse this entry.",
+                err=True,
+            )
         with catalog.maybe_synchronizing(sync):
             try:
                 new_entry = catalog.add(

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -8,12 +8,12 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cache, partial, reduce
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import attr
 import click
@@ -30,6 +30,7 @@ from xorq.cli import (
     raise_for_missing_relocation_source,
 )
 from xorq.cli_options import (
+    _F,
     cache_dir_option,
     cache_strategy_options,
     code_option,
@@ -494,9 +495,6 @@ def _catalog_pin_command(
             for moved in source_aliases:
                 catalog.add_alias(new_entry.name, moved, sync=False)
     click.echo(new_entry.name)
-
-
-_F = TypeVar("_F", bound=Callable)
 
 
 def _catalog_pin_shared_options(fn: _F) -> _F:

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -24,7 +24,11 @@ from xorq.catalog import constants as catalog_constants
 if TYPE_CHECKING:
     from xorq.catalog.content_store import ContentStoreConfig
 
-from xorq.cli import _lazy_span
+from xorq.cli import (
+    _lazy_span,
+    apply_pin_transform,
+    raise_for_missing_relocation_source,
+)
 from xorq.cli_options import (
     cache_dir_option,
     cache_strategy_options,
@@ -449,8 +453,6 @@ def _catalog_pin_command(
     ensure_materialized: bool = False,
     relocate_reads: bool = True,
 ) -> None:
-    from xorq.cli import apply_pin_transform  # noqa: PLC0415
-
     with click_context_catalog(ctx):
         catalog = ctx.obj.make_catalog(init=False)
         catalog_entry = _get_catalog_entry(catalog, entry)
@@ -478,13 +480,23 @@ def _catalog_pin_command(
         )
         aliases = (alias,) if alias else ()
         with catalog.maybe_synchronizing(sync):
-            new_entry = catalog.add(
-                expr,
-                sync=False,
-                aliases=aliases,
-                exist_ok=True,
-                relocate_reads=relocate_reads,
-            )
+            try:
+                new_entry = catalog.add(
+                    expr,
+                    sync=False,
+                    aliases=aliases,
+                    exist_ok=True,
+                    relocate_reads=relocate_reads,
+                )
+            except FileNotFoundError as err:
+                # a relocating rebuild bundles local reads by opening them, so a
+                # missing source surfaces the same clean hint the build-level
+                # pin/unpin gives instead of a raw traceback.
+                raise_for_missing_relocation_source(
+                    err,
+                    relocate_reads=relocate_reads,
+                    internal_dirs=(cache_dir,),
+                )
             for moved in source_aliases:
                 catalog.add_alias(new_entry.name, moved, sync=False)
     click.echo(new_entry.name)

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -487,11 +487,16 @@ def _catalog_pin_command(
             except FileNotFoundError as err:
                 # a relocating rebuild bundles local reads by opening them, so a
                 # missing source surfaces the same clean hint the build-level
-                # pin/unpin gives instead of a raw traceback.
+                # pin/unpin gives instead of a raw traceback. The loaded entry's
+                # extract dirs hold its already-bundled reads; a miss there is a
+                # vanished internal artifact, not a user source, so they join
+                # cache_dir as internal (temp is otherwise treated as source).
+                from xorq.catalog.expr_utils import _live_extract_dirs  # noqa: PLC0415
+
                 raise_for_missing_relocation_source(
                     err,
                     relocate_reads=relocate_reads,
-                    internal_dirs=(cache_dir,),
+                    internal_dirs=(cache_dir, *_live_extract_dirs),
                 )
             for moved in source_aliases:
                 catalog.add_alias(new_entry.name, moved, sync=False)

--- a/python/xorq/catalog/expr_utils.py
+++ b/python/xorq/catalog/expr_utils.py
@@ -1,13 +1,22 @@
+from __future__ import annotations
+
 import atexit
 import shutil
 import tempfile
 import weakref
+from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from xorq.catalog.zip_utils import (
     extract_build_zip_to,
     make_zip_context,
 )
+
+
+if TYPE_CHECKING:
+    from xorq.api import Expr
 
 
 # Tracks temp dirs that haven't been cleaned up yet.
@@ -29,11 +38,11 @@ atexit.register(_cleanup_all)
 
 
 @contextmanager
-def build_expr_context(expr):
+def build_expr_context(expr: Expr, relocate_reads: bool = False) -> Iterator[Path]:
     from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
 
     with tempfile.TemporaryDirectory() as td:
-        build_dir = build_expr(expr, builds_dir=td)
+        build_dir = build_expr(expr, builds_dir=td, relocate_reads=relocate_reads)
         yield build_dir
 
 

--- a/python/xorq/catalog/tests/test_bind.py
+++ b/python/xorq/catalog/tests/test_bind.py
@@ -16,6 +16,7 @@ from xorq.catalog.bind import (
 )
 from xorq.catalog.catalog import Catalog
 from xorq.catalog.composer import ExprComposer
+from xorq.common.exceptions import UnsupportedOperationError
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.relations import CacheTag, HashingTag, Read, RemoteTable
@@ -846,23 +847,19 @@ def test_fuse_preserves_non_catalog_remote_table_inside_bind(catalog):
     assert actual.reset_index(drop=True).equals(expected.reset_index(drop=True))
 
 
-@pytest.mark.xfail(
-    reason="fuse/bind execute path does not relocate bundled reads' base_path; #2133",
-    strict=True,
-)
-def test_fuse_pinned_entry_with_relocated_read(
+def test_fuse_pinned_entry_with_relocated_read_raises(
     catalog: Catalog, tmp_path: Path
 ) -> None:
-    """Fusing a pinned entry must resolve its relocated (bundled) cache read.
+    """Fusing an entry with a relocated (bundled) read raises, not silently empty.
 
-    ``xorq catalog pin`` adds the pinned expr with ``relocate_reads=True``, so
-    the frozen cache is bundled into the build under ``reads/<hash>`` as a
+    ``xorq catalog pin --relocate-reads`` (or ``catalog.add(..., relocate_reads=
+    True)``) bundles the frozen cache into the build under ``reads/<hash>`` as a
     relocated ``Read``. On the load path (``load_expr``) that read resolves
     against the build's extract dir, but the fuse/bind execute path does not
-    relocate the bundled ``read_path`` the same way -- so a fused pinned entry
-    executes to an empty/broken result. Reproduces the pin-flavored case of
-    #2133; xfail(strict) so it flips to a failure (alerting us) once fuse learns
-    the same base_path relocation ``load_expr`` does.
+    relocate the bundled ``read_path`` the same way -- so a fused entry with such
+    a read would execute to a silently-empty result (#2133). Until that lands,
+    ``fuse_catalog_source`` fails loud instead. When #2133 is fixed, this guard
+    (and this test) should flip to asserting the fused result is correct.
     """
     pq_path = tmp_path / "data.parquet"
     pq.write_table(pa.table({"x": [1, 2, 3], "y": [4, 5, 6]}), pq_path)
@@ -873,7 +870,7 @@ def test_fuse_pinned_entry_with_relocated_read(
     cached = t.filter(t.x > 1).cache(cache=cache)
     cached.execute()  # materialize the cache so it can be pinned
 
-    # mirror `xorq catalog pin`: pin, then add with relocate_reads=True
+    # explicit opt-in to relocation (no longer the catalog default)
     pinned = cached.ls.pin()
     source_entry = catalog.add(pinned, relocate_reads=True)
 
@@ -890,7 +887,43 @@ def test_fuse_pinned_entry_with_relocated_read(
     transform_entry = catalog.add(ub.limit(10))
     bound = bind(source_entry, transform_entry)
 
+    with pytest.raises(UnsupportedOperationError, match="2133"):
+        fuse_catalog_source(bound)
+
+
+def test_fuse_lean_pinned_entry_is_correct(catalog: Catalog, tmp_path: Path) -> None:
+    """A lean (default) pinned entry fuses to the correct, non-empty result.
+
+    The catalog pin/add default is ``relocate_reads=False``: the frozen cache
+    stays external and relocates via ``base_path`` at load time, which the fuse
+    path resolves correctly. This is the default consumption path (``catalog run``
+    fuses by default), so it must not hit the #2133 relocated-read guard.
+    """
+    pq_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3], "y": [4, 5, 6]}), pq_path)
+
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con, base_path=tmp_path / "cache")
+    t = deferred_read_parquet(pq_path, con, table_name="t")
+    cached = t.filter(t.x > 1).cache(cache=cache)
+    cached.execute()
+
+    pinned = cached.ls.pin()
+    source_entry = catalog.add(pinned)  # default relocate_reads=False -> lean
+
+    src_expr = _make_source_expr(source_entry)
+    assert walk_nodes((CacheTag,), src_expr)
+    assert not [
+        r for r in walk_nodes(Read, src_expr) if "read_path" in dict(r.read_kwargs)
+    ], "lean entry must not bundle reads"
+
+    schema = pinned.schema()
+    ub = ops.UnboundTable(name="ph", schema=schema).to_expr()
+    transform_entry = catalog.add(ub.limit(10))
+    bound = bind(source_entry, transform_entry)
+
     result = fuse_catalog_source(bound)
     expected = pinned.execute()
     actual = result.execute()
     assert actual.reset_index(drop=True).equals(expected.reset_index(drop=True))
+    assert len(actual) == 2

--- a/python/xorq/catalog/tests/test_bind.py
+++ b/python/xorq/catalog/tests/test_bind.py
@@ -5,6 +5,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import xorq.api as xo
+from xorq.caching import ParquetCache
 from xorq.catalog.backend import GitBackend
 from xorq.catalog.bind import (
     CatalogTag,
@@ -17,7 +18,7 @@ from xorq.catalog.catalog import Catalog
 from xorq.catalog.composer import ExprComposer
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.graph_utils import walk_nodes
-from xorq.expr.relations import HashingTag, Read, RemoteTable
+from xorq.expr.relations import CacheTag, HashingTag, Read, RemoteTable
 from xorq.ibis_yaml.enums import ExprKind
 from xorq.vendor.ibis import Schema
 from xorq.vendor.ibis.expr import operations as ops
@@ -842,4 +843,54 @@ def test_fuse_preserves_non_catalog_remote_table_inside_bind(catalog):
     # Still produces correct results
     expected = bound.execute()
     actual = fused.execute()
+    assert actual.reset_index(drop=True).equals(expected.reset_index(drop=True))
+
+
+@pytest.mark.xfail(
+    reason="fuse/bind execute path does not relocate bundled reads' base_path; #2133",
+    strict=True,
+)
+def test_fuse_pinned_entry_with_relocated_read(
+    catalog: Catalog, tmp_path: Path
+) -> None:
+    """Fusing a pinned entry must resolve its relocated (bundled) cache read.
+
+    ``xorq catalog pin`` adds the pinned expr with ``relocate_reads=True``, so
+    the frozen cache is bundled into the build under ``reads/<hash>`` as a
+    relocated ``Read``. On the load path (``load_expr``) that read resolves
+    against the build's extract dir, but the fuse/bind execute path does not
+    relocate the bundled ``read_path`` the same way -- so a fused pinned entry
+    executes to an empty/broken result. Reproduces the pin-flavored case of
+    #2133; xfail(strict) so it flips to a failure (alerting us) once fuse learns
+    the same base_path relocation ``load_expr`` does.
+    """
+    pq_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2, 3], "y": [4, 5, 6]}), pq_path)
+
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con, base_path=tmp_path / "cache")
+    t = deferred_read_parquet(pq_path, con, table_name="t")
+    cached = t.filter(t.x > 1).cache(cache=cache)
+    cached.execute()  # materialize the cache so it can be pinned
+
+    # mirror `xorq catalog pin`: pin, then add with relocate_reads=True
+    pinned = cached.ls.pin()
+    source_entry = catalog.add(pinned, relocate_reads=True)
+
+    # the pinned cache is a relocated Read bundled into the entry's build
+    src_expr = _make_source_expr(source_entry)
+    assert walk_nodes((CacheTag,), src_expr)
+    relocated = [
+        r for r in walk_nodes(Read, src_expr) if "read_path" in dict(r.read_kwargs)
+    ]
+    assert relocated, "pinned cache read should be bundled (relocated)"
+
+    schema = pinned.schema()
+    ub = ops.UnboundTable(name="ph", schema=schema).to_expr()
+    transform_entry = catalog.add(ub.limit(10))
+    bound = bind(source_entry, transform_entry)
+
+    result = fuse_catalog_source(bound)
+    expected = pinned.execute()
+    actual = result.execute()
     assert actual.reset_index(drop=True).equals(expected.reset_index(drop=True))

--- a/python/xorq/catalog/tests/test_cli_pin.py
+++ b/python/xorq/catalog/tests/test_cli_pin.py
@@ -555,3 +555,26 @@ def test_catalog_pin_no_relocate_reads_is_lean(
         build_dir = extract_build_zip_to(entry.catalog_path, td)
         reads_dir = Path(build_dir) / "reads"
         assert not reads_dir.exists() or not list(reads_dir.glob("*.parquet"))
+
+
+def test_catalog_pin_warns_about_fuse_gap_when_relocated(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    # A pin re-adds with relocate_reads=True by default, which fuses to an empty
+    # result until #2133 lands; the command must warn at pin time (not only in
+    # docs + an xfail test). --no-relocate-reads produces a fuse-safe entry, so
+    # it must NOT warn.
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cache"
+    base_args = ["--path", catalog_path, "pin", src_name, "-e", "--no-sync"]
+
+    default = runner.invoke(cli, [*base_args, "--cache-dir", str(cache_dir / "a")])
+    assert default.exit_code == 0, default.output
+    assert "#2133" in default.output
+    assert "fuse" in default.output
+
+    lean = runner.invoke(
+        cli, [*base_args, "--cache-dir", str(cache_dir / "b"), "--no-relocate-reads"]
+    )
+    assert lean.exit_code == 0, lean.output
+    assert "#2133" not in lean.output

--- a/python/xorq/catalog/tests/test_cli_pin.py
+++ b/python/xorq/catalog/tests/test_cli_pin.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from click.testing import CliRunner, Result
+
+import xorq.api as xo
+from xorq.api import Expr
+from xorq.caching import ParquetCache
+from xorq.catalog.catalog import Catalog
+from xorq.catalog.cli import cli
+from xorq.catalog.tests.conftest import alias_target_hash
+from xorq.catalog.zip_utils import extract_build_zip_to
+from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import CachedNode, CacheTag
+
+
+def _cached_expr() -> Expr:
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con)
+    t = xo.memtable({"a": [1, 2, 3], "b": [4, 5, 6]}, name="t")
+    return t.filter(t.a > 1).cache(cache=cache)
+
+
+def _add_cached_entry(catalog: Catalog, *aliases: str) -> str:
+    entry = catalog.add(_cached_expr(), sync=False, aliases=aliases)
+    return entry.name
+
+
+def _add_file_cached_entry(catalog: Catalog, parquet_path: Path) -> str:
+    pq.write_table(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}), parquet_path)
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con)
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    entry = catalog.add(t.filter(t.a > 1).cache(cache=cache), sync=False)
+    return entry.name
+
+
+def _last_line(result: Result) -> str:
+    return result.output.strip().splitlines()[-1]
+
+
+def test_catalog_pin_creates_new_pinned_entry(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cache"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_name = _last_line(result)
+    assert new_name != src_name
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    expr = reloaded.get_catalog_entry(new_name).load_expr(cache_dir=cache_dir)
+    assert walk_nodes((CacheTag,), expr)
+    assert not walk_nodes((CachedNode,), expr)
+
+
+def test_catalog_pin_with_alias(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cache"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "-a",
+            "pinned",
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_name = _last_line(result)
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    assert alias_target_hash(reloaded, "pinned") == new_name
+
+
+def test_catalog_pin_move_aliases(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_cached_entry(catalog, "prod")
+    cache_dir = tmp_path / "cache"
+    # alias points at the source entry to begin with
+    assert alias_target_hash(catalog, "prod") == src_name
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            "prod",
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--move-aliases",
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_name = _last_line(result)
+    assert new_name != src_name
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    assert alias_target_hash(reloaded, "prod") == new_name
+
+
+def test_catalog_pin_move_aliases_moves_every_alias(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_cached_entry(catalog, "prod", "latest")
+    cache_dir = tmp_path / "cache"
+    assert alias_target_hash(catalog, "prod") == src_name
+    assert alias_target_hash(catalog, "latest") == src_name
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--move-aliases",
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_name = _last_line(result)
+    assert new_name != src_name
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    assert alias_target_hash(reloaded, "prod") == new_name
+    assert alias_target_hash(reloaded, "latest") == new_name
+
+
+def test_catalog_pin_move_aliases_noop_without_aliases(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cache"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--move-aliases",
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert _last_line(result) != src_name
+
+
+def test_catalog_pin_noop_without_caches(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    entry = catalog.add(
+        xo.memtable({"a": [1, 2, 3]}, name="t").filter(xo._.a > 1), sync=False
+    )
+    cache_dir = tmp_path / "cache"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            entry.name,
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    new_name = _last_line(result)
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    pinned = reloaded.get_catalog_entry(new_name).load_expr(cache_dir=cache_dir)
+    # no caches to freeze: pin is a no-op, so the entry name is unchanged
+    assert not walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    assert new_name == entry.name
+
+
+def test_catalog_unpin_inverts_pin(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cache"
+
+    pin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert pin_result.exit_code == 0, pin_result.output
+    pinned_name = _last_line(pin_result)
+    assert pinned_name != src_name
+
+    unpin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "unpin",
+            pinned_name,
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert unpin_result.exit_code == 0, unpin_result.output
+    unpinned_name = _last_line(unpin_result)
+    # unpin restores the original unpinned build hash -> same content name
+    assert unpinned_name == src_name
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    expr = reloaded.get_catalog_entry(unpinned_name).load_expr(cache_dir=cache_dir)
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CacheTag,), expr)
+
+
+def test_catalog_pin_is_portable_across_cache_dirs(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    # A pinned entry is portable via base_path relocation, not bundling: the
+    # frozen read is a build-hash leaf keyed on its cache key, so loading the
+    # entry against a different cache dir re-points the read at the relocated
+    # artifact (see relocate_cache_tag). Moving the cache dir proves the pinned
+    # build reads the new location rather than the original.
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cacheA"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--relocate-reads",
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_name = _last_line(result)
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = reloaded.get_catalog_entry(new_name)
+
+    # baseline against the original cache dir
+    expected = entry.load_expr(cache_dir=cache_dir).execute()
+
+    # relocate the cache files; the original directory no longer exists
+    relocated_dir = tmp_path / "cacheB"
+    shutil.move(str(cache_dir), str(relocated_dir))
+
+    relocated = entry.load_expr(cache_dir=relocated_dir)
+    assert walk_nodes((CacheTag,), relocated)
+    assert not walk_nodes((CachedNode,), relocated)
+    assert relocated.execute().equals(expected)
+
+
+def test_catalog_unpin_relocate_reads_bundles_source(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    src_name = _add_file_cached_entry(catalog, tmp_path / "data.parquet")
+    cache_dir = tmp_path / "cache"
+
+    pin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert pin_result.exit_code == 0, pin_result.output
+    pinned_name = _last_line(pin_result)
+
+    unpin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "unpin",
+            pinned_name,
+            "--cache-dir",
+            str(cache_dir),
+            "--relocate-reads",
+            "--no-sync",
+        ],
+    )
+    assert unpin_result.exit_code == 0, unpin_result.output
+    unpinned_name = _last_line(unpin_result)
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = reloaded.get_catalog_entry(unpinned_name)
+    expr = entry.load_expr(cache_dir=cache_dir)
+    # unpin restores the recomputable cache form ...
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CacheTag,), expr)
+    # ... and --relocate-reads bundles the source read behind it so the
+    # recomputable form is runnable from anywhere too
+    with tempfile.TemporaryDirectory() as td:
+        build_dir = extract_build_zip_to(entry.catalog_path, td)
+        reads_dir = Path(build_dir) / "reads"
+        assert reads_dir.exists()
+        assert list(reads_dir.glob("*.parquet"))
+
+
+def test_catalog_pin_unpin_default_relocate_roundtrip_file_backed(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    # Regression: with relocate-reads defaulting on, the default pin -> unpin
+    # round-trip of a file-backed entry must succeed. The pinned/unpinned exprs
+    # keep relocatable reads pointing into the loaded entry's temp extract dir;
+    # the command must hold the loaded expr alive until the rebuild copies them,
+    # or the extract dir is swept and the relocating rebuild fails.
+    src_name = _add_file_cached_entry(catalog, tmp_path / "data.parquet")
+    cache_dir = tmp_path / "cache"
+
+    pin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert pin_result.exit_code == 0, pin_result.output
+    pinned_name = _last_line(pin_result)
+
+    unpin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "unpin",
+            pinned_name,
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert unpin_result.exit_code == 0, unpin_result.output
+    unpinned_name = _last_line(unpin_result)
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = reloaded.get_catalog_entry(unpinned_name)
+    expr = entry.load_expr(cache_dir=cache_dir)
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CacheTag,), expr)
+    # the default-relocated unpinned form bundles its source read
+    with tempfile.TemporaryDirectory() as td:
+        build_dir = extract_build_zip_to(entry.catalog_path, td)
+        assert list((Path(build_dir) / "reads").glob("*.parquet"))
+
+
+def test_catalog_pin_build_load_unpin_recomputes_from_uncached(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    # Regression for `uncached` reconstruction. 2111 prunes a pin's frozen
+    # leaves from the build hash and source scan (_decompose_expr /
+    # find_all_sources), but `uncached` must still be fully serialized so unpin
+    # rebuilds a *re-computable* CachedNode. Node-type assertions alone would
+    # miss a starved reconstruction, so this drives the full circle: pin ->
+    # build -> load -> unpin -> clear cache -> execute, and asserts the
+    # recompute-from-`uncached` result equals the cached value.
+    src_name = _add_file_cached_entry(catalog, tmp_path / "data.parquet")
+    cache_dir = tmp_path / "cache"
+
+    pin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert pin_result.exit_code == 0, pin_result.output
+
+    unpin_result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "unpin",
+            _last_line(pin_result),
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert unpin_result.exit_code == 0, unpin_result.output
+    unpinned_name = _last_line(unpin_result)
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = reloaded.get_catalog_entry(unpinned_name)
+    expr = entry.load_expr(cache_dir=cache_dir)
+    assert walk_nodes((CachedNode,), expr)
+    assert not walk_nodes((CacheTag,), expr)
+
+    from_cache = expr.execute()
+    # wipe the cache so the next execute must rebuild from `uncached` (the
+    # reconstructed upstream reading the bundled source), not the frozen cache
+    shutil.rmtree(cache_dir)
+    recomputed = entry.load_expr(cache_dir=cache_dir).execute()
+    assert recomputed.equals(from_cache)
+
+
+def test_catalog_pin_cold_cache_errors_without_ensure_materialized(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    # a freshly added cached entry has never been executed, so its cache is
+    # cold; pinning without -e must fail with the actionable hint rather than
+    # writing a silently-broken entry.
+    src_name = _add_cached_entry(catalog)
+    cache_dir = tmp_path / "cache"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "--cache-dir",
+            str(cache_dir),
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "ensure-materialized" in result.output
+
+
+def test_catalog_pin_no_relocate_reads_is_lean(
+    runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
+) -> None:
+    # --no-relocate-reads must NOT bundle the source file (nor the frozen cache):
+    # the result is a lean, machine-local entry whose reads stay absolute paths.
+    src_name = _add_file_cached_entry(catalog, tmp_path / "data.parquet")
+    cache_dir = tmp_path / "cache"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "pin",
+            src_name,
+            "-e",
+            "--cache-dir",
+            str(cache_dir),
+            "--no-relocate-reads",
+            "--no-sync",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_name = _last_line(result)
+
+    reloaded = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = reloaded.get_catalog_entry(new_name)
+    # the entry still pins (caches frozen into CacheTag reads) ...
+    expr = entry.load_expr(cache_dir=cache_dir)
+    assert walk_nodes((CacheTag,), expr)
+    assert not walk_nodes((CachedNode,), expr)
+    # ... but nothing is bundled into the build
+    with tempfile.TemporaryDirectory() as td:
+        build_dir = extract_build_zip_to(entry.catalog_path, td)
+        reads_dir = Path(build_dir) / "reads"
+        assert not reads_dir.exists() or not list(reads_dir.glob("*.parquet"))

--- a/python/xorq/catalog/tests/test_cli_pin.py
+++ b/python/xorq/catalog/tests/test_cli_pin.py
@@ -384,14 +384,15 @@ def test_catalog_unpin_relocate_reads_bundles_source(
         assert list(reads_dir.glob("*.parquet"))
 
 
-def test_catalog_pin_unpin_default_relocate_roundtrip_file_backed(
+def test_catalog_pin_unpin_relocate_roundtrip_file_backed(
     runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
 ) -> None:
-    # Regression: with relocate-reads defaulting on, the default pin -> unpin
-    # round-trip of a file-backed entry must succeed. The pinned/unpinned exprs
-    # keep relocatable reads pointing into the loaded entry's temp extract dir;
-    # the command must hold the loaded expr alive until the rebuild copies them,
-    # or the extract dir is swept and the relocating rebuild fails.
+    # Regression: an explicit --relocate-reads pin -> unpin round-trip of a
+    # file-backed entry must succeed. The pinned/unpinned exprs keep relocatable
+    # reads pointing into the loaded entry's temp extract dir; the command must
+    # hold the loaded expr alive until the rebuild copies them, or the extract
+    # dir is swept and the relocating rebuild fails. (relocate_reads is opt-in
+    # for catalog entries now -- default is lean -- so pass it explicitly here.)
     src_name = _add_file_cached_entry(catalog, tmp_path / "data.parquet")
     cache_dir = tmp_path / "cache"
 
@@ -405,6 +406,7 @@ def test_catalog_pin_unpin_default_relocate_roundtrip_file_backed(
             "-e",
             "--cache-dir",
             str(cache_dir),
+            "--relocate-reads",
             "--no-sync",
         ],
     )
@@ -420,6 +422,7 @@ def test_catalog_pin_unpin_default_relocate_roundtrip_file_backed(
             pinned_name,
             "--cache-dir",
             str(cache_dir),
+            "--relocate-reads",
             "--no-sync",
         ],
     )
@@ -431,7 +434,7 @@ def test_catalog_pin_unpin_default_relocate_roundtrip_file_backed(
     expr = entry.load_expr(cache_dir=cache_dir)
     assert walk_nodes((CachedNode,), expr)
     assert not walk_nodes((CacheTag,), expr)
-    # the default-relocated unpinned form bundles its source read
+    # the relocated unpinned form bundles its source read
     with tempfile.TemporaryDirectory() as td:
         build_dir = extract_build_zip_to(entry.catalog_path, td)
         assert list((Path(build_dir) / "reads").glob("*.parquet"))
@@ -560,21 +563,21 @@ def test_catalog_pin_no_relocate_reads_is_lean(
 def test_catalog_pin_warns_about_fuse_gap_when_relocated(
     runner: CliRunner, catalog: Catalog, catalog_path: str, tmp_path: Path
 ) -> None:
-    # A pin re-adds with relocate_reads=True by default, which fuses to an empty
-    # result until #2133 lands; the command must warn at pin time (not only in
-    # docs + an xfail test). --no-relocate-reads produces a fuse-safe entry, so
+    # relocate_reads is opt-in for catalog entries (default lean/fuse-safe). An
+    # explicit --relocate-reads entry fuses to a hard error until #2133 lands, so
+    # the command must warn at pin time. The default (lean) entry is fuse-safe, so
     # it must NOT warn.
     src_name = _add_cached_entry(catalog)
     cache_dir = tmp_path / "cache"
     base_args = ["--path", catalog_path, "pin", src_name, "-e", "--no-sync"]
 
-    default = runner.invoke(cli, [*base_args, "--cache-dir", str(cache_dir / "a")])
-    assert default.exit_code == 0, default.output
-    assert "#2133" in default.output
-    assert "fuse" in default.output
-
-    lean = runner.invoke(
-        cli, [*base_args, "--cache-dir", str(cache_dir / "b"), "--no-relocate-reads"]
+    relocated = runner.invoke(
+        cli, [*base_args, "--cache-dir", str(cache_dir / "a"), "--relocate-reads"]
     )
-    assert lean.exit_code == 0, lean.output
-    assert "#2133" not in lean.output
+    assert relocated.exit_code == 0, relocated.output
+    assert "#2133" in relocated.output
+    assert "fuse" in relocated.output
+
+    default = runner.invoke(cli, [*base_args, "--cache-dir", str(cache_dir / "b")])
+    assert default.exit_code == 0, default.output
+    assert "#2133" not in default.output

--- a/python/xorq/catalog/tests/test_cli_pin.py
+++ b/python/xorq/catalog/tests/test_cli_pin.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 from click.testing import CliRunner, Result
 
 import xorq.api as xo
@@ -17,7 +18,29 @@ from xorq.catalog.tests.conftest import alias_target_hash
 from xorq.catalog.zip_utils import extract_build_zip_to
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.graph_utils import walk_nodes
+from xorq.common.utils.process_utils import subprocess_run
 from xorq.expr.relations import CachedNode, CacheTag
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        pytest.param("pin", id="pin"),
+        pytest.param("unpin", id="unpin"),
+    ),
+)
+def test_catalog_pin_cli_help_smoke_subprocess(command: str) -> None:
+    """`xorq catalog {pin,unpin} --help` must load via a real subprocess.
+
+    The other catalog CLI tests here use the in-process CliRunner fixture, which
+    never exercises the real entrypoint and so hides an import-time cold-start
+    regression from the command's deferred imports. This spawns a real `xorq`.
+    """
+    (returncode, stdout, _stderr) = subprocess_run(
+        ["xorq", "catalog", command, "--help"], text=True
+    )
+    assert returncode == 0, _stderr
+    assert command in stdout
 
 
 def _cached_expr() -> Expr:

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -1269,12 +1269,10 @@ def pin_command(
     are materialized (by executing the expression) before pinning; caches that
     are already materialized are left untouched, so no redundant work runs.
 
-    ``relocate_reads`` bundles local-file reads into the build so it stays
-    portable. A pin does not bundle its frozen cache reads (hash leaves that
-    relocate via ``base_path``) nor the sources behind them; those sources ride
-    along only if the upstream build already bundled them (the ``xorq build``
-    default), letting a later relocated ``unpin`` recompute without the
-    originals. Pinning a ``--no-relocate-reads`` build leaves them unbundled.
+    ``relocate_reads`` bundles local-file reads — including the pinned cache
+    parquet files — into the build so it is fully self-contained. Pass
+    ``--no-relocate-reads`` for a lean build where frozen cache reads stay
+    external and relocate via ``base_path`` at load time.
 
     Relocation is one-way. Bundling a read replaces its original filesystem path
     with a content-addressed ``reads/<hash>`` entry, discarding where the source

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -1205,6 +1205,11 @@ def raise_for_missing_relocation_source(
     Shared by the build-level and catalog-level pin/unpin commands. Call it from
     inside an ``except FileNotFoundError`` block; it either raises a
     ``ClickException`` or re-raises the original ``err``.
+
+    Classification is a path-prefix heuristic: a genuine source colocated under
+    ``cache_dir``/``builds_dir`` surfaces raw rather than with the hint. That
+    bias is deliberate -- a miss inside a managed dir is likelier a bug worth a
+    full traceback than a misplaced source.
     """
     if not relocate_reads or not err.filename:
         raise err

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -232,7 +232,7 @@ def build_command(
     builds_dir="builds",
     cache_dir=None,
     debug: bool = False,
-    relocate_reads: bool = False,
+    relocate_reads: bool = True,
     emit_build_path_to=None,
 ):
     """
@@ -1180,6 +1180,38 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
         run_command(p, output_path, output_format, cache_dir, limit, raw_params)
 
 
+def raise_for_missing_relocation_source(
+    err: FileNotFoundError,
+    *,
+    relocate_reads: bool,
+    internal_dirs: tuple[str | Path | None, ...] = (),
+) -> None:
+    """Translate a missing bundle *source* into a clean CLI error, else re-raise.
+
+    Relocating a build content-hashes each local read by opening it, so a missing
+    source raises ``FileNotFoundError`` deep in the build. Only that case gets the
+    actionable message: an error with no filename, or one pointing inside a build
+    output / cache dir (a vanished artifact, an internal write), is unrelated and
+    surfaces raw rather than being mislabeled "source not found". Source files
+    themselves routinely live in a temp dir, so temp is *not* treated as internal.
+
+    Shared by the build-level and catalog-level pin/unpin commands. Call it from
+    inside an ``except FileNotFoundError`` block; it either raises a
+    ``ClickException`` or re-raises the original ``err``.
+    """
+    if not relocate_reads or not err.filename:
+        raise err
+    culprit = Path(err.filename).resolve()
+    internal = tuple(Path(d).resolve() for d in internal_dirs if d is not None)
+    if any(culprit == d or culprit.is_relative_to(d) for d in internal):
+        raise err
+    raise click.ClickException(
+        f"cannot bundle reads: source file not found ({err.filename}). "
+        "Restore it, or re-run with --no-relocate-reads for a "
+        "machine-local artifact."
+    ) from err
+
+
 def apply_pin_transform(
     expr: Expr,
     *,
@@ -1260,15 +1292,11 @@ def pin_command(
                 relocate_reads=relocate_reads,
             )
         except FileNotFoundError as err:
-            # relocating content-hashes each local read, so a missing source
-            # raises deep in the build; surface it as a clean CLI error.
-            if not relocate_reads:
-                raise
-            raise click.ClickException(
-                f"cannot bundle reads: source file not found ({err.filename}). "
-                "Restore it, or re-run with --no-relocate-reads for a "
-                "machine-local artifact."
-            ) from err
+            raise_for_missing_relocation_source(
+                err,
+                relocate_reads=relocate_reads,
+                internal_dirs=(builds_dir, cache_dir),
+            )
     click.echo(out)
     return out
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 from functools import partial, wraps
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import click
 
@@ -1268,6 +1268,15 @@ def pin_command(
     along only if the upstream build already bundled them (the ``xorq build``
     default), letting a later relocated ``unpin`` recompute without the
     originals. Pinning a ``--no-relocate-reads`` build leaves them unbundled.
+
+    Relocation is one-way. Bundling a read replaces its original filesystem path
+    with a content-addressed ``reads/<hash>`` entry, discarding where the source
+    lived; on load that read resolves into the build's own (temporary) extract
+    dir, not the original file. So ``relocate_reads=False`` here cannot *un*-bundle
+    an already-relocated input -- it only avoids bundling reads that are still
+    machine-local. Because ``xorq build`` relocates by default, pinning/unpinning
+    an ordinary build stays relocated regardless of this flag; pass
+    ``--no-relocate-reads`` at ``xorq build`` time to keep a build lean end-to-end.
     """
     from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
 
@@ -1308,11 +1317,30 @@ _PIN_BUILDS_DIR_OPTION = click.option(
     help="Directory for the resulting build artifact.",
 )
 
+_F = TypeVar("_F", bound=collections.abc.Callable)
+
+
+def _pin_shared_options(fn: _F) -> _F:
+    """Options common to `xorq pin` and `xorq unpin`.
+
+    Applied in reverse so the resulting --help order matches the decorator stack
+    (build_path, --builds-dir, --cache-dir). The differing options
+    (--ensure-materialized on pin only, and the pin/unpin flavor of
+    --relocate-reads) stay on each command.
+    """
+    for dec in reversed(
+        (
+            click.argument("build_path"),
+            _PIN_BUILDS_DIR_OPTION,
+            cache_dir_option,
+        )
+    ):
+        fn = dec(fn)
+    return fn
+
 
 @cli.command("pin")
-@click.argument("build_path")
-@_PIN_BUILDS_DIR_OPTION
-@cache_dir_option
+@_pin_shared_options
 @ensure_materialized_option
 @relocate_reads_option(include_caches=True)
 def pin(
@@ -1350,9 +1378,7 @@ def pin(
 
 
 @cli.command("unpin")
-@click.argument("build_path")
-@_PIN_BUILDS_DIR_OPTION
-@cache_dir_option
+@_pin_shared_options
 @relocate_reads_option()
 def unpin(
     build_path: str,

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -1231,9 +1231,11 @@ def pin_command(
     are already materialized are left untouched, so no redundant work runs.
 
     ``relocate_reads`` bundles local-file reads into the build so it stays
-    portable; for a pin this also bundles the source reads *behind* the cache
-    (on ``CacheTag.uncached``, never executed in the pinned form) so a later
-    ``unpin`` can recompute from them.
+    portable. A pin does not bundle its frozen cache reads (hash leaves that
+    relocate via ``base_path``) nor the sources behind them; those sources ride
+    along only if the upstream build already bundled them (the ``xorq build``
+    default), letting a later relocated ``unpin`` recompute without the
+    originals. Pinning a ``--no-relocate-reads`` build leaves them unbundled.
     """
     from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
 
@@ -1250,12 +1252,23 @@ def pin_command(
                 "or pass --ensure-materialized/-e."
             ),
         )
-        out = build_expr(
-            expr,
-            builds_dir=builds_dir,
-            cache_dir=Path(cache_dir),
-            relocate_reads=relocate_reads,
-        )
+        try:
+            out = build_expr(
+                expr,
+                builds_dir=builds_dir,
+                cache_dir=Path(cache_dir),
+                relocate_reads=relocate_reads,
+            )
+        except FileNotFoundError as err:
+            # relocating content-hashes each local read, so a missing source
+            # raises deep in the build; surface it as a clean CLI error.
+            if not relocate_reads:
+                raise
+            raise click.ClickException(
+                f"cannot bundle reads: source file not found ({err.filename}). "
+                "Restore it, or re-run with --no-relocate-reads for a "
+                "machine-local artifact."
+            ) from err
     click.echo(out)
     return out
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -9,12 +9,13 @@ import sys
 import traceback
 from functools import partial, wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import click
 
 from xorq.cli_constants import DEFAULT_CACHE_TYPE, DEFAULT_OUTPUT_FORMAT, OutputFormats
 from xorq.cli_options import (
+    _F,
     cache_dir_option,
     cache_strategy_options,
     ensure_materialized_option,
@@ -171,6 +172,7 @@ def uv_build_command(
     all_extras=True,
     debug=False,
     emit_build_path_to=None,
+    relocate_reads=True,
 ):
     if project_path and pep723:
         raise click.UsageError("--project-path and --pep723 are mutually exclusive")
@@ -187,6 +189,7 @@ def uv_build_command(
         extras=extras,
         all_extras=all_extras,
         debug=debug,
+        relocate_reads=relocate_reads,
     )
     builder.build()
     if emit_build_path_to:
@@ -866,6 +869,7 @@ def uv_group(ctx):
     is_flag=True,
     help="Output SQL files and other debug artifacts.",
 )
+@relocate_reads_option()
 @click.option(
     "--emit-build-path-to",
     type=click.Path(),
@@ -877,17 +881,18 @@ def uv_group(ctx):
     ),
 )
 def uv_build(
-    script_path,
-    expr_name,
-    builds_dir,
-    cache_dir,
-    project_path,
-    pep723,
-    extras,
-    all_extras,
-    debug,
-    emit_build_path_to,
-):
+    script_path: str,
+    expr_name: str,
+    builds_dir: str,
+    cache_dir: str | None,
+    project_path: str | None,
+    pep723: bool,
+    extras: tuple[str, ...],
+    all_extras: bool,
+    debug: bool,
+    relocate_reads: bool,
+    emit_build_path_to: str | None,
+) -> None:
     """Build an expression inside a uv-managed isolated environment.
 
     Mirrors `xorq build`, but runs inside a uv-managed environment seeded
@@ -918,6 +923,7 @@ def uv_build(
         all_extras=all_extras,
         debug=debug,
         emit_build_path_to=emit_build_path_to,
+        relocate_reads=relocate_reads,
     )
 
 
@@ -1316,8 +1322,6 @@ _PIN_BUILDS_DIR_OPTION = click.option(
     show_default=True,
     help="Directory for the resulting build artifact.",
 )
-
-_F = TypeVar("_F", bound=collections.abc.Callable)
 
 
 def _pin_shared_options(fn: _F) -> _F:

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -16,6 +16,7 @@ import click
 from xorq.cli_constants import DEFAULT_CACHE_TYPE, DEFAULT_OUTPUT_FORMAT, OutputFormats
 from xorq.cli_options import (
     _F,
+    apply_in_help_order,
     cache_dir_option,
     cache_strategy_options,
     ensure_materialized_option,
@@ -1327,20 +1328,15 @@ _PIN_BUILDS_DIR_OPTION = click.option(
 def _pin_shared_options(fn: _F) -> _F:
     """Options common to `xorq pin` and `xorq unpin`.
 
-    Applied in reverse so the resulting --help order matches the decorator stack
-    (build_path, --builds-dir, --cache-dir). The differing options
-    (--ensure-materialized on pin only, and the pin/unpin flavor of
-    --relocate-reads) stay on each command.
+    The differing options (--ensure-materialized on pin only, and the pin/unpin
+    flavor of --relocate-reads) stay on each command.
     """
-    for dec in reversed(
-        (
-            click.argument("build_path"),
-            _PIN_BUILDS_DIR_OPTION,
-            cache_dir_option,
-        )
-    ):
-        fn = dec(fn)
-    return fn
+    return apply_in_help_order(
+        fn,
+        click.argument("build_path"),
+        _PIN_BUILDS_DIR_OPTION,
+        cache_dir_option,
+    )
 
 
 @cli.command("pin")

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections.abc
 import contextlib
 import datetime
@@ -7,6 +9,7 @@ import sys
 import traceback
 from functools import partial, wraps
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
@@ -14,13 +17,19 @@ from xorq.cli_constants import DEFAULT_CACHE_TYPE, DEFAULT_OUTPUT_FORMAT, Output
 from xorq.cli_options import (
     cache_dir_option,
     cache_strategy_options,
+    ensure_materialized_option,
     limit_option,
     output_options,
     params_option,
+    relocate_reads_option,
     serve_options,
     unbind_options,
 )
 from xorq.init_templates import InitTemplates
+
+
+if TYPE_CHECKING:
+    from xorq.api import Expr
 
 
 @contextlib.contextmanager
@@ -1092,11 +1101,7 @@ def uv_run_unbound(
     is_flag=True,
     help="Output SQL files and other debug artifacts.",
 )
-@click.option(
-    "--relocate-reads",
-    is_flag=True,
-    help="Bundle all local-file Read nodes into the build artifact.",
-)
+@relocate_reads_option()
 @click.option(
     "--emit-build-path-to",
     type=click.Path(),
@@ -1173,6 +1178,167 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
     """
     with maybe_unzip(build_path) as p:
         run_command(p, output_path, output_format, cache_dir, limit, raw_params)
+
+
+def apply_pin_transform(
+    expr: Expr,
+    *,
+    do_pin: bool,
+    ensure_materialized: bool = False,
+    cold_cache_hint: str = "",
+) -> Expr:
+    """Pin or unpin ``expr``, translating a cold-cache pin into a clean CLI error.
+
+    Shared by the build-level and catalog-level pin/unpin commands. When pinning
+    without ``ensure_materialized``, an unmaterialized cache raises
+    ``IntegrityError``; we re-raise it as a ``ClickException`` with
+    ``cold_cache_hint`` appended. Under ``ensure_materialized`` materialization is
+    guaranteed, so a stray ``IntegrityError`` is a real bug and surfaces raw.
+    """
+    if ensure_materialized and not do_pin:
+        raise click.ClickException(
+            "--ensure-materialized/-e only applies when pinning."
+        )
+    if not do_pin:
+        return expr.ls.unpin()
+    if ensure_materialized:
+        return expr.ls.pin(ensure_materialized=True)
+    from xorq.common.exceptions import IntegrityError  # noqa: PLC0415
+
+    try:
+        return expr.ls.pin()
+    except IntegrityError as err:
+        raise click.ClickException(f"{err}\n{cold_cache_hint}") from err
+
+
+@_lazy_span("cli.pin_command")
+def pin_command(
+    build_path: str,
+    *,
+    do_pin: bool,
+    builds_dir: str = "builds",
+    cache_dir: str | None = None,
+    ensure_materialized: bool = False,
+    relocate_reads: bool = True,
+) -> Path:
+    """Freeze (pin) or thaw (unpin) the caches of a build artifact.
+
+    Pinning replaces each materialized ``CachedNode`` with a direct read of its
+    cache file; unpinning is the inverse.
+
+    When ``ensure_materialized`` is set, any caches that are not yet populated
+    are materialized (by executing the expression) before pinning; caches that
+    are already materialized are left untouched, so no redundant work runs.
+
+    ``relocate_reads`` bundles local-file reads into the build so it stays
+    portable; for a pin this also bundles the source reads *behind* the cache
+    (on ``CacheTag.uncached``, never executed in the pinned form) so a later
+    ``unpin`` can recompute from them.
+    """
+    from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
+
+    cache_dir = _get_cache_dir(cache_dir)
+    with maybe_unzip(build_path) as p:
+        expr = load_expr(p, cache_dir=cache_dir)
+        expr = apply_pin_transform(
+            expr,
+            do_pin=do_pin,
+            ensure_materialized=ensure_materialized,
+            cold_cache_hint=(
+                "Populate the caches first "
+                f"(xorq run {build_path} --cache-dir {cache_dir}) "
+                "or pass --ensure-materialized/-e."
+            ),
+        )
+        out = build_expr(
+            expr,
+            builds_dir=builds_dir,
+            cache_dir=Path(cache_dir),
+            relocate_reads=relocate_reads,
+        )
+    click.echo(out)
+    return out
+
+
+_PIN_BUILDS_DIR_OPTION = click.option(
+    "--builds-dir",
+    default="builds",
+    show_default=True,
+    help="Directory for the resulting build artifact.",
+)
+
+
+@cli.command("pin")
+@click.argument("build_path")
+@_PIN_BUILDS_DIR_OPTION
+@cache_dir_option
+@ensure_materialized_option
+@relocate_reads_option(include_caches=True)
+def pin(
+    build_path: str,
+    builds_dir: str,
+    cache_dir: str | None,
+    ensure_materialized: bool,
+    relocate_reads: bool,
+) -> None:
+    """Freeze a build's caches into direct reads (pin).
+
+    Each materialized cache becomes a direct read of its cache file, so the
+    pinned build executes by reading artifacts instead of re-deriving them.
+    Combine with --relocate-reads to produce a self-contained, portable build.
+
+    \b
+    Arguments:
+      BUILD_PATH  Path to the build directory produced by `xorq build`.
+
+    \b
+    Examples:
+      # Pin a build whose caches are already materialized
+      xorq pin builds/f02d28198715 --cache-dir ./cache
+      # Materialize any missing caches, then pin into a portable bundle
+      xorq pin builds/f02d28198715 --cache-dir ./cache -e --relocate-reads
+    """
+    pin_command(
+        build_path,
+        do_pin=True,
+        builds_dir=builds_dir,
+        cache_dir=cache_dir,
+        ensure_materialized=ensure_materialized,
+        relocate_reads=relocate_reads,
+    )
+
+
+@cli.command("unpin")
+@click.argument("build_path")
+@_PIN_BUILDS_DIR_OPTION
+@cache_dir_option
+@relocate_reads_option()
+def unpin(
+    build_path: str,
+    builds_dir: str,
+    cache_dir: str | None,
+    relocate_reads: bool,
+) -> None:
+    """Thaw a pinned build's frozen caches back into recomputable caches (unpin).
+
+    Inverse of `xorq pin`: each frozen cache read is rebuilt into its original
+    cache node, restoring the recompute-capable form.
+
+    \b
+    Arguments:
+      BUILD_PATH  Path to a pinned build directory.
+
+    \b
+    Examples:
+      xorq unpin builds/f02d28198715 --cache-dir ./cache
+    """
+    pin_command(
+        build_path,
+        do_pin=False,
+        builds_dir=builds_dir,
+        cache_dir=cache_dir,
+        relocate_reads=relocate_reads,
+    )
 
 
 @cli.command("run-cached")

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -11,6 +11,18 @@ from xorq.cli_constants import DEFAULT_CACHE_TYPE, DEFAULT_OUTPUT_FORMAT, Output
 
 _F = TypeVar("_F", bound=Callable)
 
+
+def apply_in_help_order(fn: _F, *decorators: Callable[[_F], _F]) -> _F:
+    """Apply option decorators so a command's --help order matches this order.
+
+    click applies stacked decorators bottom-up, so we apply the given ones in
+    reverse to make the resulting --help order match the order listed here.
+    """
+    for dec in reversed(decorators):
+        fn = dec(fn)
+    return fn
+
+
 _DEFAULT_OUTPUT_PATH_SHOW_DEFAULT = f"`{os.devnull}` (discard)"
 
 

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -93,7 +93,10 @@ def relocate_reads_option(
             f"Bundle local-file Read nodes{caches} into the {noun} so it is "
             "self-contained and runnable from anywhere. Remote reads "
             "(s3://, gs://, ...) are already location-independent and left in "
-            f"place. Pass --no-relocate-reads for a lean, machine-local {noun}."
+            f"place. Pass --no-relocate-reads for a lean, machine-local {noun}; "
+            "this only affects reads not already bundled -- relocation discards "
+            "a read's original path, so it cannot be undone by a later "
+            "--no-relocate-reads on an already-relocated input."
         ),
     )
 

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -78,6 +78,34 @@ cache_dir_option = click.option(
 )
 
 
+# Shared by `xorq build`, `xorq pin/unpin`, and `xorq catalog pin/unpin` so the
+# flag, default, and structure stay identical across all of them. Only the noun
+# (build vs catalog entry) and whether frozen caches are in play (pin only) vary.
+def relocate_reads_option(
+    noun: str = "build", *, include_caches: bool = False
+) -> Callable[[_F], _F]:
+    caches = " (including frozen caches)" if include_caches else ""
+    return click.option(
+        "--relocate-reads/--no-relocate-reads",
+        default=True,
+        show_default=True,
+        help=(
+            f"Bundle local-file Read nodes{caches} into the {noun} so it is "
+            "self-contained and runnable from anywhere. Remote reads "
+            "(s3://, gs://, ...) are already location-independent and left in "
+            f"place. Pass --no-relocate-reads for a lean, machine-local {noun}."
+        ),
+    )
+
+
+ensure_materialized_option = click.option(
+    "-e",
+    "--ensure-materialized",
+    is_flag=True,
+    help="Materialize any unpopulated caches (by executing) before pinning.",
+)
+
+
 def cache_strategy_options(fn):
     fn = click.option(
         "--ttl",

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -94,12 +94,12 @@ cache_dir_option = click.option(
 # flag, default, and structure stay identical across all of them. Only the noun
 # (build vs catalog entry) and whether frozen caches are in play (pin only) vary.
 def relocate_reads_option(
-    noun: str = "build", *, include_caches: bool = False
+    noun: str = "build", *, include_caches: bool = False, default: bool = True
 ) -> Callable[[_F], _F]:
     caches = " (including frozen caches)" if include_caches else ""
     return click.option(
         "--relocate-reads/--no-relocate-reads",
-        default=True,
+        default=default,
         show_default=True,
         help=(
             f"Bundle local-file Read nodes{caches} into the {noun} so it is "

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -77,6 +77,18 @@ def relocatable_read_path(path: str | Path) -> tuple[str, str]:
     )
 
 
+def relocatable_read_path_str(path: str | Path) -> str:
+    """Serialized ``read_path`` of a bundled relocatable read (``"reads/<hash>.ext"``).
+
+    Single source of the *joined* form of :func:`relocatable_read_path`, shared by
+    the pre-hash pass (``_ensure_relocatable_read_paths``) and the write pass
+    (``ExprDumper._prepare_relocatable_read``) so the ``read_path`` string cannot
+    drift between them -- byte-equality of the two is exactly what makes a
+    relocated build load+rebuild hash-stable.
+    """
+    return "/".join(relocatable_read_path(path))
+
+
 @toolz.curry
 def infer_csv_schema_pandas(path, chunksize=DEFAULT_CHUNKSIZE, **kwargs):
     import pandas as pd  # noqa: PLC0415

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -58,10 +58,23 @@ def make_read_kwargs(f, *args, **kwargs):
 
 
 def relocatable_read_path(path: str | Path) -> tuple[str, str]:
+    """Path parts (``(<dir>, <filename>)``) of a bundled relocatable read.
+
+    Single source of truth for the on-disk layout of a relocated read: the
+    directory comes from ``BundledSourceTypes.read`` and the filename is the
+    content hash of the source. Both the pre-hash pass
+    (``_ensure_relocatable_read_paths``) and the write pass
+    (``ExprDumper._prepare_relocatable_read``) derive the serialized
+    ``read_path`` from this, so they cannot drift.
+    """
     from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
+    from xorq.ibis_yaml.enums import BundledSourceTypes  # noqa: PLC0415
 
     path = Path(path)
-    return ("reads", f"{tokenize(normalize_read_path_md5sum(path))}{path.suffix}")
+    return (
+        BundledSourceTypes.read.value,
+        f"{tokenize(normalize_read_path_md5sum(path))}{path.suffix}",
+    )
 
 
 @toolz.curry

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -63,7 +63,7 @@ def relocatable_read_path(path: str | Path) -> tuple[str, str]:
     Single source of truth for the on-disk layout of a relocated read: the
     directory comes from ``BundledSourceTypes.read`` and the filename is the
     content hash of the source. Both the pre-hash pass
-    (``_ensure_relocatable_read_paths``) and the write pass
+    (``_prepare_relocatable_reads``) and the write pass
     (``ExprDumper._prepare_relocatable_read``) derive the serialized
     ``read_path`` from this, so they cannot drift.
     """
@@ -81,7 +81,7 @@ def relocatable_read_path_str(path: str | Path) -> str:
     """Serialized ``read_path`` of a bundled relocatable read (``"reads/<hash>.ext"``).
 
     Single source of the *joined* form of :func:`relocatable_read_path`, shared by
-    the pre-hash pass (``_ensure_relocatable_read_paths``) and the write pass
+    the pre-hash pass (``_prepare_relocatable_reads``) and the write pass
     (``ExprDumper._prepare_relocatable_read``) so the ``read_path`` string cannot
     drift between them -- byte-equality of the two is exactly what makes a
     relocated build load+rebuild hash-stable.

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -289,10 +289,23 @@ def relocate_cache_tag(node: CacheTag, base_path: Path) -> CacheTag:
     round-tripped ``uncached`` could drift). A pinned read stays a read -- this
     does not re-materialize or re-validate; if the artifact is absent at the new
     location, execution fails like any other missing read.
+
+    When the parent read has a ``read_path`` (bundled into the build by
+    ``--relocate-reads``), the read is self-contained and resolves from the
+    build directory, so ``base_path`` relocation is skipped for the parent.
+    The cache object is still relocated (for unpin round-trips).
     """
     from xorq.common.utils.graph_utils import to_node  # noqa: PLC0415
 
     new_cache = relocate_cache(node.cache, base_path)
+    parent_kw = dict(to_node(node.parent).read_kwargs)
+    if "read_path" in parent_kw:
+        return CacheTag(
+            schema=node.schema,
+            parent=node.parent,
+            uncached=node.uncached,
+            cache=new_cache,
+        )
     key = to_node(node.parent).name
     return CacheTag(
         schema=node.schema,

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -233,6 +233,17 @@ def cache_keyed_expr(parent: Expr) -> Expr:
     return parent_op.remote_expr if isinstance(parent_op, RemoteTable) else parent
 
 
+def _cached_node_materialized(node: CachedNode) -> bool:
+    """Whether ``node``'s cache is already populated.
+
+    Uses the same key derivation (``cache_keyed_expr`` + ``calc_key``/
+    ``key_exists``) as ``_cached_node_to_cache_tag`` so the pre-pin
+    materialization check and the pin itself agree on cache identity.
+    """
+    cache = node.cache
+    return cache.key_exists(cache.calc_key(cache_keyed_expr(node.parent)))
+
+
 def _cached_node_to_cache_tag(node: CachedNode) -> CacheTag:
     cache = node.cache
     # compute the cache key once: cache.exists + cache.get would each recompute
@@ -335,13 +346,33 @@ def _replace_op_type(
     return replace_nodes(replacer, expr).to_expr()
 
 
-def pin_cache(expr: Expr) -> Expr:
+def pin_cache(expr: Expr, ensure_materialized: bool = False) -> Expr:
     """Freeze every ``CachedNode`` into a ``CacheTag`` reading its cache location.
 
     Each cache must already be materialized; the resulting expression reads the
     cached artifacts directly without re-deriving them. Inverse of
     :func:`unpin_cache`.
+
+    When ``ensure_materialized`` is set, every cache that is not yet populated is
+    materialized before freezing -- already-materialized caches are skipped, and
+    operations downstream of the caches are never run. ``cached_nodes`` is
+    outermost-first, so executing an outer cold cache cascades through and warms
+    its nested caches; the per-node check then skips them. The result is one
+    ``head(0)`` execute per independent cold subtree, and -- because every cache
+    is checked -- a cache that went cold independently of its outer (TTL expiry,
+    eviction) is still re-materialized rather than silently skipped.
+
+    The materializing execute is wrapped in ``head(0)``: cache population is a
+    side effect of the execute pass (the full parent is written to storage
+    independent of any row limit, which applies only on read-back), so
+    requesting zero rows back fully writes the cache without pulling its
+    contents into client memory.
     """
+    if ensure_materialized:
+        for node in expr.ls.cached_nodes:
+            if not _cached_node_materialized(node):
+                node.to_expr().head(0).execute()
+
     return _replace_op_type(expr, CachedNode, _cached_node_to_cache_tag)
 
 

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -38,6 +38,7 @@ from xorq.common.exceptions import UnboundExpressionError
 from xorq.common.utils.caching_utils import get_xorq_cache_dir
 from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.defer_utils import (
+    relocatable_read_path,
     relocatable_read_path_str,
 )
 from xorq.common.utils.file_utils import (
@@ -156,13 +157,11 @@ def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
     pinned = exclusively_pinned_leaves(expr, (Read,))
 
     def _relocate(node, kwargs):
-        if node not in pinned:
+        if isinstance(node, Read) and node not in pinned:
+            kw = dict(node.read_kwargs)
             marking = mark and _is_relocatable_candidate(node)
-            baking = _is_relocatable_read(node) and "read_path" not in dict(
-                node.read_kwargs
-            )
+            baking = _is_relocatable_read(node) and "read_path" not in kw
             if marking or baking:
-                kw = dict(node.read_kwargs)
                 if "hash_path" not in kw:
                     raise ValueError("relocatable Read must have hash_path")
                 read_kwargs = node.read_kwargs
@@ -590,11 +589,12 @@ class ExprDumper:
         if "hash_path" not in kw:
             raise ValueError("relocatable Read must have hash_path")
         source_path = Path(kw["hash_path"])
-        # single serialized layout, identical to the pre-hash pass; split the
-        # parts back out (dir/filename never contain "/") so store path and
-        # writer can't drift from read_path.
-        read_path = relocatable_read_path_str(source_path)
-        path_parts = tuple(read_path.split("/"))
+        # relocatable_read_path is the single source of the (dir, filename)
+        # layout; read_path is its joined form -- identical byte-for-byte to the
+        # pre-hash pass's relocatable_read_path_str -- so the store path and the
+        # serialized read_path cannot drift.
+        path_parts = relocatable_read_path(source_path)
+        read_path = "/".join(path_parts)
         path = self.artifact_store.get_path(*path_parts)
         writer = functools.partial(
             self.artifact_store.copy_file,

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -38,7 +38,7 @@ from xorq.common.exceptions import UnboundExpressionError
 from xorq.common.utils.caching_utils import get_xorq_cache_dir
 from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.defer_utils import (
-    relocatable_read_path,
+    relocatable_read_path_str,
 )
 from xorq.common.utils.file_utils import (
     normalize_read_path_md5sum,
@@ -131,67 +131,51 @@ def _recreate_read(node: Any, kwargs: dict | None, **arg_overrides: Any) -> Any:
     return node.__recreate__((kwargs or {}) | args)
 
 
-def _mark_reads_relocatable(expr: ir.Expr) -> ir.Expr:
-    """Inject ``relocatable=True`` into all local-file Read nodes.
+def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
+    """Mark local-file reads relocatable and bake their bundled ``read_path`` in.
 
-    Reads reachable only through a ``CacheTag`` (pinned caches) are left alone:
-    a pinned read is a build-hash leaf keyed on its cache key, and its
-    portability comes from base_path relocation (``relocate_cache_tag``), not
-    from being bundled into the artifact here. Bundling it would stat a
-    possibly-absent frozen upstream and duplicate what the cache-key leaf
-    already represents. DAG-shared reads (also live on a non-pinned branch)
-    are not exclusively pinned, so they still get bundled.
+    One pre-hash pass (before ``canonicalize_expr``): ``read_path`` is normally
+    injected by the write phase, which is too late for the build hash, so a fresh
+    build would be named differently from every later load+rebuild. Baking the
+    content-derived ``read_path`` here -- it equals the write-phase value exactly
+    -- keeps a relocated build load+rebuild hash-stable.
+
+    ``mark`` (i.e. ``--relocate-reads``) flips local-file candidates to
+    ``relocatable=True``; reads already relocatable (e.g.
+    ``deferred_read_parquet(relocatable=True)``) get ``read_path`` baked whether
+    or not ``mark`` is set. Reads reachable only through a ``CacheTag`` are
+    skipped: a pinned read is a hash leaf keyed on its cache key, portable via
+    base_path relocation (``relocate_cache_tag``), so it never contributes a
+    ``read_path`` and must not be bundled. DAG-shared reads also live on a
+    non-pinned branch, so they are not exclusively pinned and still get marked.
     """
     pinned = exclusively_pinned_leaves(expr, (Read,))
 
     def _relocate(node, kwargs):
-        if node not in pinned and _is_relocatable_candidate(node):
-            new_kwargs = node.read_kwargs + (("relocatable", True),)
-            return _recreate_read(
-                node,
-                kwargs,
-                read_kwargs=new_kwargs,
-                normalize_method=normalize_read_path_md5sum,
+        if node not in pinned:
+            marking = mark and _is_relocatable_candidate(node)
+            baking = _is_relocatable_read(node) and "read_path" not in dict(
+                node.read_kwargs
             )
+            if marking or baking:
+                kw = dict(node.read_kwargs)
+                if "hash_path" not in kw:
+                    raise ValueError("relocatable Read must have hash_path")
+                read_kwargs = node.read_kwargs
+                overrides = {}
+                if marking:
+                    read_kwargs += (("relocatable", True),)
+                    overrides["normalize_method"] = normalize_read_path_md5sum
+                read_kwargs = update_read_kwargs(
+                    read_kwargs,
+                    (("read_path", relocatable_read_path_str(kw["hash_path"])),),
+                )
+                return _recreate_read(
+                    node, kwargs, read_kwargs=read_kwargs, **overrides
+                )
         return node.__recreate__(kwargs) if kwargs else node
 
     op = replace_nodes(_relocate, expr.op())
-    return op.to_expr()
-
-
-def _ensure_relocatable_read_paths(expr: ir.Expr) -> ir.Expr:
-    """Bake the content-stable bundled ``read_path`` into every relocatable Read.
-
-    The build hash is taken from this expr (``ExprDumper.artifact_store``), but
-    the ``read_path`` kwarg is normally injected later, by the write phase
-    (``_prepare_deferred_reads``). That is too late: a fresh build is hashed
-    before ``read_path`` exists, so it is named differently from every later
-    load+rebuild (which reloads the serialized ``read_path``). Setting it here --
-    pre-hash, and before ``canonicalize_expr`` so the read's content name folds
-    it in -- makes a relocated build load+rebuild hash-stable. ``read_path`` is
-    derived from file content, so it equals the write-phase value exactly.
-
-    Exclusively-pinned reads are skipped for the same reason as in
-    ``_mark_reads_relocatable``: a ``CacheTag`` is a hash leaf, so its frozen
-    read never contributes a ``read_path`` to the build hash.
-    """
-    pinned = exclusively_pinned_leaves(expr, (Read,))
-
-    def _set(node, kwargs):
-        if (
-            node not in pinned
-            and _is_relocatable_read(node)
-            and "read_path" not in dict(node.read_kwargs)
-        ):
-            kw = dict(node.read_kwargs)
-            read_path = "/".join(relocatable_read_path(kw["hash_path"]))
-            new_kwargs = update_read_kwargs(
-                node.read_kwargs, (("read_path", read_path),)
-            )
-            return _recreate_read(node, kwargs, read_kwargs=new_kwargs)
-        return node.__recreate__(kwargs) if kwargs else node
-
-    op = replace_nodes(_set, expr.op())
     return op.to_expr()
 
 
@@ -536,15 +520,8 @@ class ExprDumper:
         validator=is_callable(), default=normalize_read_path_stat
     )
 
-    def __attrs_post_init__(self):
-        expr = self.expr
-        if self.relocate_reads:
-            expr = _mark_reads_relocatable(expr)
-        # bake read_path in before hashing/canonicalize so a relocated build is
-        # named for what it writes (load+rebuild hash-stable); covers reads
-        # marked above and any already relocatable (e.g. deferred_read_parquet
-        # relocatable=True)
-        expr = _ensure_relocatable_read_paths(expr)
+    def __attrs_post_init__(self) -> None:
+        expr = _prepare_relocatable_reads(self.expr, mark=self.relocate_reads)
         expr = canonicalize_expr(expr, self.read_normalize_method)
         object.__setattr__(self, "expr", expr)
         attrname = "cache_dir"
@@ -609,12 +586,12 @@ class ExprDumper:
         if "hash_path" not in kw:
             raise ValueError("relocatable Read must have hash_path")
         source_path = Path(kw["hash_path"])
-        path_parts = relocatable_read_path(source_path)
+        # single serialized layout, identical to the pre-hash pass; split the
+        # parts back out (dir/filename never contain "/") so store path and
+        # writer can't drift from read_path.
+        read_path = relocatable_read_path_str(source_path)
+        path_parts = tuple(read_path.split("/"))
         path = self.artifact_store.get_path(*path_parts)
-        # serialized read_path is the same layout the pre-hash pass baked in,
-        # so a relocated build stays load+rebuild hash-stable (see
-        # _ensure_relocatable_read_paths and relocatable_read_path)
-        read_path = "/".join(path_parts)
         writer = functools.partial(
             self.artifact_store.copy_file,
             source_path,

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -119,20 +119,79 @@ def _is_relocatable_read(node: Any) -> bool:
     return any(k == "relocatable" and v for k, v in node.read_kwargs)
 
 
+def _recreate_read(node: Any, kwargs: dict | None, **arg_overrides: Any) -> Any:
+    """Rebuild a leaf ``Read`` with ``arg_overrides`` applied to its args.
+
+    ``Read`` is a graph leaf, so the ``kwargs`` ``replace_nodes`` passes in are
+    empty and ``arg_overrides`` is free to override the node's own args. Don't
+    reuse this for interior nodes -- there ``arg_overrides`` would clobber the
+    transformed children in ``kwargs``.
+    """
+    args = dict(zip(node.__argnames__, node.__args__)) | arg_overrides
+    return node.__recreate__((kwargs or {}) | args)
+
+
 def _mark_reads_relocatable(expr: ir.Expr) -> ir.Expr:
-    """Inject ``relocatable=True`` into all local-file Read nodes."""
+    """Inject ``relocatable=True`` into all local-file Read nodes.
+
+    Reads reachable only through a ``CacheTag`` (pinned caches) are left alone:
+    a pinned read is a build-hash leaf keyed on its cache key, and its
+    portability comes from base_path relocation (``relocate_cache_tag``), not
+    from being bundled into the artifact here. Bundling it would stat a
+    possibly-absent frozen upstream and duplicate what the cache-key leaf
+    already represents. DAG-shared reads (also live on a non-pinned branch)
+    are not exclusively pinned, so they still get bundled.
+    """
+    pinned = exclusively_pinned_leaves(expr, (Read,))
 
     def _relocate(node, kwargs):
-        if _is_relocatable_candidate(node):
+        if node not in pinned and _is_relocatable_candidate(node):
             new_kwargs = node.read_kwargs + (("relocatable", True),)
-            args = dict(zip(node.__argnames__, node.__args__)) | {
-                "read_kwargs": new_kwargs,
-                "normalize_method": normalize_read_path_md5sum,
-            }
-            return node.__recreate__((kwargs or {}) | args)
+            return _recreate_read(
+                node,
+                kwargs,
+                read_kwargs=new_kwargs,
+                normalize_method=normalize_read_path_md5sum,
+            )
         return node.__recreate__(kwargs) if kwargs else node
 
     op = replace_nodes(_relocate, expr.op())
+    return op.to_expr()
+
+
+def _ensure_relocatable_read_paths(expr: ir.Expr) -> ir.Expr:
+    """Bake the content-stable bundled ``read_path`` into every relocatable Read.
+
+    The build hash is taken from this expr (``ExprDumper.artifact_store``), but
+    the ``read_path`` kwarg is normally injected later, by the write phase
+    (``_prepare_deferred_reads``). That is too late: a fresh build is hashed
+    before ``read_path`` exists, so it is named differently from every later
+    load+rebuild (which reloads the serialized ``read_path``). Setting it here --
+    pre-hash, and before ``canonicalize_expr`` so the read's content name folds
+    it in -- makes a relocated build load+rebuild hash-stable. ``read_path`` is
+    derived from file content, so it equals the write-phase value exactly.
+
+    Exclusively-pinned reads are skipped for the same reason as in
+    ``_mark_reads_relocatable``: a ``CacheTag`` is a hash leaf, so its frozen
+    read never contributes a ``read_path`` to the build hash.
+    """
+    pinned = exclusively_pinned_leaves(expr, (Read,))
+
+    def _set(node, kwargs):
+        if (
+            node not in pinned
+            and _is_relocatable_read(node)
+            and "read_path" not in dict(node.read_kwargs)
+        ):
+            kw = dict(node.read_kwargs)
+            read_path = "/".join(relocatable_read_path(kw["hash_path"]))
+            new_kwargs = update_read_kwargs(
+                node.read_kwargs, (("read_path", read_path),)
+            )
+            return _recreate_read(node, kwargs, read_kwargs=new_kwargs)
+        return node.__recreate__(kwargs) if kwargs else node
+
+    op = replace_nodes(_set, expr.op())
     return op.to_expr()
 
 
@@ -203,6 +262,12 @@ class ArtifactStore:
     def copy_file(self, source: pathlib.Path, *path_parts: str) -> pathlib.Path:
         dest = self.get_path(*path_parts)
         dest.parent.mkdir(parents=True, exist_ok=True)
+        # rebuilding a relocated build into its own builds_dir can resolve a
+        # bundled read's source to the very dest it would write (e.g. a no-op
+        # pin, now that relocated builds are hash-stable); copy2 would raise
+        # SameFileError, so skip the self-copy.
+        if dest.exists() and source.resolve() == dest.resolve():
+            return dest
         shutil.copy2(source, dest)
         return dest
 
@@ -475,6 +540,11 @@ class ExprDumper:
         expr = self.expr
         if self.relocate_reads:
             expr = _mark_reads_relocatable(expr)
+        # bake read_path in before hashing/canonicalize so a relocated build is
+        # named for what it writes (load+rebuild hash-stable); covers reads
+        # marked above and any already relocatable (e.g. deferred_read_parquet
+        # relocatable=True)
+        expr = _ensure_relocatable_read_paths(expr)
         expr = canonicalize_expr(expr, self.read_normalize_method)
         object.__setattr__(self, "expr", expr)
         attrname = "cache_dir"
@@ -534,19 +604,23 @@ class ExprDumper:
 
     def _prepare_relocatable_read(
         self, read_node: Read
-    ) -> tuple[Path, functools.partial]:
+    ) -> tuple[Path, str, functools.partial]:
         kw = dict(read_node.read_kwargs)
         if "hash_path" not in kw:
             raise ValueError("relocatable Read must have hash_path")
         source_path = Path(kw["hash_path"])
         path_parts = relocatable_read_path(source_path)
         path = self.artifact_store.get_path(*path_parts)
+        # serialized read_path is the same layout the pre-hash pass baked in,
+        # so a relocated build stays load+rebuild hash-stable (see
+        # _ensure_relocatable_read_paths and relocatable_read_path)
+        read_path = "/".join(path_parts)
         writer = functools.partial(
             self.artifact_store.copy_file,
             source_path,
             *path_parts,
         )
-        return (path, writer)
+        return (path, read_path, writer)
 
     def _prepare_sql_plans(
         self,
@@ -674,9 +748,7 @@ class ExprDumper:
                 type_kwargs = {str(which): True}
                 con_kwargs = {}
             elif _is_relocatable_read(node):
-                path, writer = self._prepare_relocatable_read(node)
-                which = BundledSourceTypes.read
-                read_path = f"{which}/{path.name}"
+                path, read_path, writer = self._prepare_relocatable_read(node)
                 new_kwargs = update_read_kwargs(
                     node.read_kwargs,
                     (("hash_path", path), ("read_path", read_path)),

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -148,13 +148,14 @@ def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
     deliberately no un-marking branch, because relocation is lossy -- it replaces
     a read's original path with a content hash, so once relocated the source
     location is gone and ``mark=False`` cannot recover a lean, machine-local read.
-    Reads reachable only through a ``CacheTag`` are
-    skipped: a pinned read is a hash leaf keyed on its cache key, portable via
-    base_path relocation (``relocate_cache_tag``), so it never contributes a
-    ``read_path`` and must not be bundled. DAG-shared reads also live on a
-    non-pinned branch, so they are not exclusively pinned and still get marked.
+    When ``mark=True``, pinned cache reads (exclusively under a ``CacheTag``) are
+    bundled into the build alongside regular reads, making the pinned artifact
+    self-contained. When ``mark=False``, pinned reads are skipped and remain
+    portable via ``base_path`` relocation (``relocate_cache_tag``). DAG-shared
+    reads also live on a non-pinned branch, so they are not exclusively pinned
+    and are always marked.
     """
-    pinned = exclusively_pinned_leaves(expr, (Read,))
+    pinned = frozenset() if mark else exclusively_pinned_leaves(expr, (Read,))
 
     def _relocate(node, kwargs):
         if isinstance(node, Read) and node not in pinned:

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -593,11 +593,11 @@ class ExprDumper:
             raise ValueError("relocatable Read must have hash_path")
         source_path = Path(kw["hash_path"])
         # relocatable_read_path is the single source of the (dir, filename)
-        # layout; read_path is its joined form -- identical byte-for-byte to the
-        # pre-hash pass's relocatable_read_path_str -- so the store path and the
-        # serialized read_path cannot drift.
+        # layout; relocatable_read_path_str is its joined form -- the *same*
+        # helper the pre-hash pass uses -- so the store path and the serialized
+        # read_path cannot drift.
         path_parts = relocatable_read_path(source_path)
-        read_path = "/".join(path_parts)
+        read_path = relocatable_read_path_str(source_path)
         path = self.artifact_store.get_path(*path_parts)
         writer = functools.partial(
             self.artifact_store.copy_file,

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -120,18 +120,6 @@ def _is_relocatable_read(node: Any) -> bool:
     return any(k == "relocatable" and v for k, v in node.read_kwargs)
 
 
-def _recreate_read(node: Any, kwargs: dict | None, **arg_overrides: Any) -> Any:
-    """Rebuild a leaf ``Read`` with ``arg_overrides`` applied to its args.
-
-    ``Read`` is a graph leaf, so the ``kwargs`` ``replace_nodes`` passes in are
-    empty and ``arg_overrides`` is free to override the node's own args. Don't
-    reuse this for interior nodes -- there ``arg_overrides`` would clobber the
-    transformed children in ``kwargs``.
-    """
-    args = dict(zip(node.__argnames__, node.__args__)) | arg_overrides
-    return node.__recreate__((kwargs or {}) | args)
-
-
 def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
     """Mark local-file reads relocatable and bake their bundled ``read_path`` in.
 
@@ -155,6 +143,21 @@ def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
     reads also live on a non-pinned branch, so they are not exclusively pinned
     and are always marked.
     """
+    if not mark:
+        # mark=False never *marks* reads relocatable; it only bakes read_path into
+        # reads that are already relocatable but haven't had it baked yet. If none
+        # qualify, the pass is a structural no-op, so skip both the pinned-leaf
+        # walk and the full replace_nodes rebuild. This is the hot
+        # relocate_reads=False path -- every fuse/bind and Catalog.add build hits
+        # it, and the vast majority carry no already-relocatable reads. (The scan
+        # spans all reads, including pinned ones the rebuild would skip; that only
+        # ever makes us do a no-op rebuild we could have skipped, never skip a
+        # bake that was needed.)
+        if not any(
+            _is_relocatable_read(node) and "read_path" not in dict(node.read_kwargs)
+            for node in walk_nodes(Read, expr)
+        ):
+            return expr
     pinned = frozenset() if mark else exclusively_pinned_leaves(expr, (Read,))
 
     def _relocate(node, kwargs):
@@ -174,9 +177,9 @@ def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
                     read_kwargs,
                     (("read_path", relocatable_read_path_str(kw["hash_path"])),),
                 )
-                return _recreate_read(
-                    node, kwargs, read_kwargs=read_kwargs, **overrides
-                )
+                # Read is a graph leaf, so replace_nodes passes empty kwargs here
+                # and recreate can override the node's own args directly.
+                return recreate(node, read_kwargs=read_kwargs, **overrides)
         return node.__recreate__(kwargs) if kwargs else node
 
     op = replace_nodes(_relocate, expr.op())

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -143,7 +143,11 @@ def _prepare_relocatable_reads(expr: ir.Expr, *, mark: bool) -> ir.Expr:
     ``mark`` (i.e. ``--relocate-reads``) flips local-file candidates to
     ``relocatable=True``; reads already relocatable (e.g.
     ``deferred_read_parquet(relocatable=True)``) get ``read_path`` baked whether
-    or not ``mark`` is set. Reads reachable only through a ``CacheTag`` are
+    or not ``mark`` is set. Note this pass only ever *adds* relocation: there is
+    deliberately no un-marking branch, because relocation is lossy -- it replaces
+    a read's original path with a content hash, so once relocated the source
+    location is gone and ``mark=False`` cannot recover a lean, machine-local read.
+    Reads reachable only through a ``CacheTag`` are
     skipped: a pinned read is a hash leaf keyed on its cache key, portable via
     base_path relocation (``relocate_cache_tag``), so it never contributes a
     ``read_path`` and must not be bundled. DAG-shared reads also live on a

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -519,6 +519,8 @@ class ExprDumper:
     builds_dir = field(validator=instance_of(Path), converter=Path, default="./builds")
     cache_dir = field(validator=optional(instance_of(Path)), factory=get_xorq_cache_dir)
     debug = field(validator=instance_of(bool), default=False)
+    # Prefer True (to match the CLI), but the fuse/bind execute path doesn't yet
+    # resolve a relocated read's base_path; kept False until it does. See #2133.
     relocate_reads = field(validator=instance_of(bool), default=False)
     read_normalize_method = field(
         validator=is_callable(), default=normalize_read_path_stat

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -56,14 +56,21 @@ class UvToolRunError(subprocess.CalledProcessError):
 
 def _inner_xorq_build_help(
     python_version: str, wheel_path: Path, requirements_path: Path
-) -> str:
-    """Return the inner ``xorq build --help`` stdout (``""`` if it failed).
+) -> tuple[int, str]:
+    """Return ``(returncode, stdout)`` of the inner ``xorq build --help``.
 
     A single ~200ms warm-cache call — negligible next to the build itself —
     whose output is grepped for option support below, so we probe the inner CLI
     once rather than once per option. The inner xorq is whatever version the
     wheel + requirements resolve to (often the published PyPI release), which
     may predate options this branch passes.
+
+    The returncode is returned alongside stdout so the caller can tell a genuine
+    old-version xorq (help succeeds, option absent) from a broken probe (help
+    exits non-zero): ``xorq build --help`` exits 0 on any version that has the
+    ``build`` subcommand, so a non-zero exit means the inner env is broken, not
+    that a feature is missing -- collapsing both to ``""`` would mislabel the
+    latter and silently degrade the build.
 
     TODO(post-release): remove the option probes that consume this once the
     published xorq on PyPI ships both --emit-build-path-to and --relocate-reads.
@@ -77,7 +84,7 @@ def _inner_xorq_build_help(
         with_requirements=requirements_path,
         check=False,
     )
-    return result.stdout if result.returncode == 0 else ""
+    return result.returncode, result.stdout
 
 
 PYPROJECT_NAME = "pyproject.toml"
@@ -483,11 +490,22 @@ class PackagedBuilder:
         # requirements resolve to and may predate options we pass. Grepping its
         # --help avoids a hard "No such option" failure (exit 2) on an older
         # published xorq.
-        inner_help = _inner_xorq_build_help(
+        inner_rc, inner_help = _inner_xorq_build_help(
             self.python_version,
             self.wheel_path,
             self.requirements_path,
         )
+        # `xorq build --help` exits 0 on any version with the build subcommand,
+        # so a non-zero exit is a broken inner env (unresolvable deps, import
+        # error), not a missing feature. The real `xorq build` below would fail
+        # too -- fail loudly here rather than silently degrade to a
+        # machine-local build behind a misleading "does not support" warning.
+        if inner_rc != 0:
+            raise RuntimeError(
+                f"inner `xorq build --help` failed (exit {inner_rc}); cannot "
+                "package. Check that the wheel + requirements resolve to a "
+                "runnable xorq."
+            )
         # TODO(post-release): remove emit-path fallback once the published
         # xorq on PyPI ships --emit-build-path-to.
         used_emit_file = "--emit-build-path-to" in inner_help

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -54,15 +54,19 @@ class UvToolRunError(subprocess.CalledProcessError):
         return "\n\n".join(parts)
 
 
-def _inner_xorq_supports_emit_option(python_version, wheel_path, requirements_path):
-    """Check whether the resolved xorq CLI supports --emit-build-path-to.
+def _inner_xorq_build_help(
+    python_version: str, wheel_path: Path, requirements_path: Path
+) -> str:
+    """Return the inner ``xorq build --help`` stdout (``""`` if it failed).
 
-    Runs ``xorq build --help`` and looks for the flag in the output.
-    This is a ~200ms warm-cache call — negligible next to the build itself.
+    A single ~200ms warm-cache call — negligible next to the build itself —
+    whose output is grepped for option support below, so we probe the inner CLI
+    once rather than once per option. The inner xorq is whatever version the
+    wheel + requirements resolve to (often the published PyPI release), which
+    may predate options this branch passes.
 
-    TODO(post-release): remove once the published xorq on PyPI ships
-    --emit-build-path-to. This helper and its caller's stdout-parsing
-    branch become dead code at that point.
+    TODO(post-release): remove the option probes that consume this once the
+    published xorq on PyPI ships both --emit-build-path-to and --relocate-reads.
     """
     result = uv_tool_run(
         "xorq",
@@ -73,7 +77,7 @@ def _inner_xorq_supports_emit_option(python_version, wheel_path, requirements_pa
         with_requirements=requirements_path,
         check=False,
     )
-    return result.returncode == 0 and "--emit-build-path-to" in result.stdout
+    return result.stdout if result.returncode == 0 else ""
 
 
 PYPROJECT_NAME = "pyproject.toml"
@@ -475,6 +479,41 @@ class PackagedBuilder:
         """Run xorq build and copy wheel + requirements into the build dir."""
         from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
 
+        # Probe the inner CLI once: it is whatever version the wheel +
+        # requirements resolve to and may predate options we pass. Grepping its
+        # --help avoids a hard "No such option" failure (exit 2) on an older
+        # published xorq.
+        inner_help = _inner_xorq_build_help(
+            self.python_version,
+            self.wheel_path,
+            self.requirements_path,
+        )
+        # TODO(post-release): remove emit-path fallback once the published
+        # xorq on PyPI ships --emit-build-path-to.
+        used_emit_file = "--emit-build-path-to" in inner_help
+
+        # Match the inner `xorq build`'s relocate default explicitly so a
+        # packaged build is self-contained by default, and so
+        # `xorq uv build --no-relocate-reads` can opt out (same escape hatch as
+        # `xorq build`). Only pass the flag when the inner xorq is new enough to
+        # accept it; an older inner defaults to machine-local reads, so omitting
+        # it there is exactly the pre-relocation behavior. Passing it blindly
+        # would fail with "No such option: --relocate-reads".
+        if "--relocate-reads" in inner_help:
+            relocate_args = (
+                "--relocate-reads" if self.relocate_reads else "--no-relocate-reads",
+            )
+        else:
+            relocate_args = ()
+            if self.relocate_reads:
+                from xorq.common.utils.logging_utils import get_logger  # noqa: PLC0415
+
+                get_logger(__name__).warning(
+                    "inner xorq build does not support --relocate-reads; "
+                    "producing a machine-local build. Upgrade the packaged xorq "
+                    "to bundle reads into a portable artifact."
+                )
+
         base_args = (
             "xorq",
             "build",
@@ -485,21 +524,7 @@ class PackagedBuilder:
             self.builds_dir,
             *(("--cache-dir", self.cache_dir) if self.cache_dir else ()),
             *(("--debug",) if self.debug else ()),
-            # Match the inner `xorq build`'s relocate default explicitly so a
-            # packaged build is self-contained by default, and so
-            # `xorq uv build --no-relocate-reads` can opt out (same escape hatch
-            # as `xorq build`). NOTE: `--no-relocate-reads` requires an inner
-            # xorq new enough to accept it (same version gate as the
-            # --emit-build-path-to fallback above).
-            ("--relocate-reads" if self.relocate_reads else "--no-relocate-reads"),
-        )
-
-        # TODO(post-release): remove emit-path fallback once the published
-        # xorq on PyPI ships --emit-build-path-to.
-        used_emit_file = _inner_xorq_supports_emit_option(
-            self.python_version,
-            self.wheel_path,
-            self.requirements_path,
+            *relocate_args,
         )
 
         def get_build_path(used_emit_file, emit_path, result):

--- a/python/xorq/ibis_yaml/packager.py
+++ b/python/xorq/ibis_yaml/packager.py
@@ -456,9 +456,10 @@ class PackagedBuilder:
         default=None,
     )
     debug = field(validator=instance_of(bool), default=False)
+    relocate_reads = field(validator=instance_of(bool), default=True)
 
     @property
-    def wheel_path(self):
+    def wheel_path(self) -> Path:
         return self.bundle.wheel_path
 
     @property
@@ -484,6 +485,13 @@ class PackagedBuilder:
             self.builds_dir,
             *(("--cache-dir", self.cache_dir) if self.cache_dir else ()),
             *(("--debug",) if self.debug else ()),
+            # Match the inner `xorq build`'s relocate default explicitly so a
+            # packaged build is self-contained by default, and so
+            # `xorq uv build --no-relocate-reads` can opt out (same escape hatch
+            # as `xorq build`). NOTE: `--no-relocate-reads` requires an inner
+            # xorq new enough to accept it (same version gate as the
+            # --emit-build-path-to fallback above).
+            ("--relocate-reads" if self.relocate_reads else "--no-relocate-reads"),
         )
 
         # TODO(post-release): remove emit-path fallback once the published

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1351,6 +1351,24 @@ def test_relocate_reads_flag_changes_build_hash(
     assert default_path.name != reloc_path.name
 
 
+def test_relocate_reads_build_is_load_rebuild_hash_stable(
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
+) -> None:
+    """A relocated build must be load+rebuild hash-stable.
+
+    The fresh build's hash is taken after read_path is baked in (see
+    _ensure_relocatable_read_paths), so it equals every later load+rebuild --
+    otherwise pin/unpin (which reload+rebuild) could never restore the original
+    `xorq build` hash for a file-backed build.
+    """
+    t = deferred_read_parquet(sample_parquet)
+    fresh = build_expr(t, builds_dir=builds_dir / "fresh", relocate_reads=True)
+    rebuilt = build_expr(
+        load_expr(fresh), builds_dir=builds_dir / "rebuilt", relocate_reads=True
+    )
+    assert fresh.name == rebuilt.name
+
+
 def test_relocatable_api_and_flag_produce_same_hash(
     builds_dir: pathlib.Path, sample_parquet: pathlib.Path
 ) -> None:

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -52,7 +52,7 @@ from xorq.ibis_yaml.compiler import (
     RefEnum,
     _extract_sql_queries,
     _is_relocatable_candidate,
-    _mark_reads_relocatable,
+    _prepare_relocatable_reads,
     _sanitize_generated_names,
     build_expr,
     load_expr,
@@ -1357,7 +1357,7 @@ def test_relocate_reads_build_is_load_rebuild_hash_stable(
     """A relocated build must be load+rebuild hash-stable.
 
     The fresh build's hash is taken after read_path is baked in (see
-    _ensure_relocatable_read_paths), so it equals every later load+rebuild --
+    _prepare_relocatable_reads), so it equals every later load+rebuild --
     otherwise pin/unpin (which reload+rebuild) could never restore the original
     `xorq build` hash for a file-backed build.
     """
@@ -1438,7 +1438,7 @@ def test_relocatable_rebuild_from_loaded_expr(
 
 
 def test_mark_reads_relocatable_skips_remote(sample_parquet: pathlib.Path) -> None:
-    """_mark_reads_relocatable should not inject relocatable for remote paths."""
+    """_prepare_relocatable_reads(mark=True) should not inject relocatable for remote paths."""
     local_t = deferred_read_parquet(sample_parquet)
     local_read = list(walk_nodes(Read, local_t))[0]
 
@@ -1452,7 +1452,7 @@ def test_mark_reads_relocatable_skips_remote(sample_parquet: pathlib.Path) -> No
     )
     expr = local_t.join(remote_read.to_expr(), "x")
 
-    marked = _mark_reads_relocatable(expr)
+    marked = _prepare_relocatable_reads(expr, mark=True)
     reads = list(walk_nodes(Read, marked))
     for read in reads:
         kw = dict(read.read_kwargs)
@@ -1668,15 +1668,15 @@ def test_loaded_non_relocatable_becomes_database_table(
 
 
 # ---------------------------------------------------------------------------
-# _mark_reads_relocatable is idempotent
+# _prepare_relocatable_reads(mark=True) is idempotent
 # ---------------------------------------------------------------------------
 
 
 def test_mark_reads_relocatable_is_idempotent(sample_parquet: pathlib.Path) -> None:
-    """Calling _mark_reads_relocatable twice should not double-wrap."""
+    """Calling _prepare_relocatable_reads(mark=True) twice should not double-wrap."""
     t = deferred_read_parquet(sample_parquet)
-    once = _mark_reads_relocatable(t)
-    twice = _mark_reads_relocatable(once)
+    once = _prepare_relocatable_reads(t, mark=True)
+    twice = _prepare_relocatable_reads(once, mark=True)
 
     once_reads = list(walk_nodes(Read, once))
     twice_reads = list(walk_nodes(Read, twice))

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -444,6 +444,71 @@ def test_pinned_cache_relocates_to_new_cache_dir(
     assert relocated.execute().equals(expected)
 
 
+def test_pinned_cache_bundles_parquet_with_relocate_reads(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    con = xo.connect()
+    cache_dir = tmp_path / "cache"
+    cache = ParquetCache.from_kwargs(
+        source=con, relative_path="pins", base_path=cache_dir
+    )
+    expr = (
+        con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+        .filter(xo._.a > 1)
+        .cache(cache=cache)
+    )
+    expr.execute()
+    pinned = expr.ls.pin()
+    expected = pinned.execute()
+
+    build_path = build_expr(
+        pinned, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=True
+    )
+
+    reads_dir = build_path / "reads"
+    assert reads_dir.exists()
+    bundled = list(reads_dir.glob("*.parquet"))
+    assert bundled, "cache parquet should be bundled under reads/"
+
+    # delete the original cache dir — the build must be self-contained
+    shutil.rmtree(cache_dir)
+
+    loaded = load_expr(build_path)
+    assert walk_nodes((CacheTag,), loaded)
+    assert loaded.execute().equals(expected)
+
+
+def test_pinned_cache_not_bundled_without_relocate_reads(
+    builds_dir: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    con = xo.connect()
+    cache_dir = tmp_path / "cache"
+    cache = ParquetCache.from_kwargs(
+        source=con, relative_path="pins", base_path=cache_dir
+    )
+    expr = (
+        con.register(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}), "tbl")
+        .filter(xo._.a > 1)
+        .cache(cache=cache)
+    )
+    expr.execute()
+    pinned = expr.ls.pin()
+
+    build_path = build_expr(
+        pinned, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=False
+    )
+
+    reads_dir = build_path / "reads"
+    bundled_parquets = list(reads_dir.glob("*.parquet")) if reads_dir.exists() else []
+    assert not bundled_parquets, (
+        "cache parquet should NOT be bundled without relocate_reads"
+    )
+
+    loaded = load_expr(build_path, cache_dir=cache_dir)
+    assert walk_nodes((CacheTag,), loaded)
+    assert loaded.execute().equals(pinned.execute())
+
+
 @pytest.mark.parametrize(
     "table_from_df",
     (

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1502,7 +1502,7 @@ def test_relocatable_rebuild_from_loaded_expr(
     assert sorted(result.x.tolist()) == [1, 2, 3]
 
 
-def test_mark_reads_relocatable_skips_remote(sample_parquet: pathlib.Path) -> None:
+def test_prepare_relocatable_reads_skips_remote(sample_parquet: pathlib.Path) -> None:
     """_prepare_relocatable_reads(mark=True) should not inject relocatable for remote paths."""
     local_t = deferred_read_parquet(sample_parquet)
     local_read = list(walk_nodes(Read, local_t))[0]
@@ -1737,7 +1737,7 @@ def test_loaded_non_relocatable_becomes_database_table(
 # ---------------------------------------------------------------------------
 
 
-def test_mark_reads_relocatable_is_idempotent(sample_parquet: pathlib.Path) -> None:
+def test_prepare_relocatable_reads_is_idempotent(sample_parquet: pathlib.Path) -> None:
     """Calling _prepare_relocatable_reads(mark=True) twice should not double-wrap."""
     t = deferred_read_parquet(sample_parquet)
     once = _prepare_relocatable_reads(t, mark=True)

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1644,6 +1644,27 @@ def test_artifact_store_copy_file_missing_source(tmp_path: pathlib.Path) -> None
         store.copy_file(tmp_path / "nonexistent.txt", "out.txt")
 
 
+def test_artifact_store_copy_file_same_path_is_noop(tmp_path: pathlib.Path) -> None:
+    """copy_file must no-op (not SameFileError) when source resolves to dest.
+
+    Rebuilding a relocated build into its own builds_dir resolves a bundled
+    read's source to the very dest it would write (e.g. a no-op pin, now that
+    relocated builds are hash-stable); shutil.copy2 raises SameFileError on that
+    self-copy, so the guard skips it. Pins this branch at the copy_file layer so
+    a future get_path/resolve change that breaks the equality check goes red
+    here, not only via a high-level pin round-trip.
+    """
+    store = ArtifactStore(root_path=tmp_path / "store")
+    dest = store.get_path("reads", "same.parquet")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("frozen content")
+
+    # source IS the dest (same resolved path) -- copy2 would raise SameFileError
+    result = store.copy_file(dest, "reads", "same.parquet")
+    assert result == dest
+    assert dest.read_text() == "frozen content"
+
+
 # ---------------------------------------------------------------------------
 # warn_on_local_path changes
 # ---------------------------------------------------------------------------

--- a/python/xorq/tests/test_cli_pin.py
+++ b/python/xorq/tests/test_cli_pin.py
@@ -368,6 +368,40 @@ def test_pin_partial_materialization_errors(tmp_path: Path) -> None:
     assert result.exit_code != 0
 
 
+def test_unpin_missing_source_gives_clean_error(tmp_path: Path) -> None:
+    """Relocating with a missing source fails cleanly, not with a raw
+    FileNotFoundError.
+
+    A lean build never bundles its source; unpinning makes that read live
+    again, so relocating content-hashes a source that no longer exists.
+    """
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path, relocate_reads=False)
+    pinned = pin_command(
+        str(build_path),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+        relocate_reads=False,
+    )
+    (tmp_path / "data.parquet").unlink()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "unpin",
+            str(pinned),
+            "--cache-dir",
+            str(cache_dir),
+            "--builds-dir",
+            str(builds_dir),
+            "--relocate-reads",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "cannot bundle reads" in result.output
+    assert "--no-relocate-reads" in result.output
+
+
 def test_pin_relocate_reads_is_self_contained(tmp_path: Path) -> None:
     build_path, builds_dir, cache_dir = _cached_build(tmp_path)
 

--- a/python/xorq/tests/test_cli_pin.py
+++ b/python/xorq/tests/test_cli_pin.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import pkgutil
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+import xorq.api as xo
+import xorq.backends
+from xorq.caching import ParquetCache
+from xorq.cli import cli, pin_command, run_command
+from xorq.common.exceptions import IntegrityError
+from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import (
+    CachedNode,
+    CacheTag,
+    _cached_node_materialized,
+    pin_cache,
+)
+from xorq.ibis_yaml.compiler import build_expr, load_expr
+from xorq.vendor.ibis.expr import operations as ops
+from xorq.vendor.ibis.expr.types.core import Expr
+
+
+def caches_materialized(expr: Expr) -> bool:
+    """True if every ``CachedNode`` in ``expr`` has its cache populated."""
+    return all(map(_cached_node_materialized, expr.ls.cached_nodes))
+
+
+def _write_parquet(path: Path) -> None:
+    pq.write_table(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}), path)
+
+
+def _cached_build(
+    tmp_path: Path, materialize: bool = True, relocate_reads: bool = True
+) -> tuple[Path, Path, Path]:
+    """Build a single-cache expr; optionally materialize the cache via a run.
+
+    Defaults to ``relocate_reads=True`` to match the ``xorq build`` default, so
+    pin/unpin run in the same (default) regime they do in practice.
+    """
+    parquet_path = tmp_path / "data.parquet"
+    _write_parquet(parquet_path)
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con)
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    expr = t.filter(t.a > 1).cache(cache=cache)
+    builds_dir = tmp_path / "builds"
+    cache_dir = tmp_path / "cache"
+    build_path = build_expr(
+        expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads
+    )
+    if materialize:
+        run_command(
+            str(build_path), str(tmp_path / "out.parquet"), "parquet", str(cache_dir)
+        )
+    return build_path, builds_dir, cache_dir
+
+
+def test_pin_build_roundtrip(tmp_path: Path) -> None:
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path)
+    original = load_expr(build_path, cache_dir=cache_dir)
+
+    pinned_path = pin_command(
+        str(build_path),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+    )
+    pinned = load_expr(pinned_path, cache_dir=cache_dir)
+
+    assert walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    assert (
+        pinned.execute()
+        .reset_index(drop=True)
+        .equals(original.execute().reset_index(drop=True))
+    )
+
+
+def test_ls_pin_ensure_materialized_populates_cold_cache(tmp_path: Path) -> None:
+    build_path, _, cache_dir = _cached_build(tmp_path, materialize=False)
+    expr = load_expr(build_path, cache_dir=cache_dir)
+    assert not caches_materialized(expr)
+
+    # without the flag a cold cache cannot be pinned
+    with pytest.raises(IntegrityError):
+        expr.ls.pin()
+
+    pinned = expr.ls.pin(ensure_materialized=True)
+    assert walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+
+    # head(0) populates the *full* cache, not zero rows: the source has rows
+    # a in {1, 2, 3} and the build filters a > 1, so the pinned read yields 2.
+    assert len(pinned.execute()) == 2
+
+
+def test_pin_ensure_materialized_skips_post_cache_compute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parquet_path = tmp_path / "data.parquet"
+    _write_parquet(parquet_path)
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con)
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    # the cache is NOT the root: a filter sits downstream of it
+    expr = t.cache(cache=cache).filter(xo._.a > 1)
+    assert not caches_materialized(expr)
+
+    executed: list = []
+    original_execute = Expr.execute
+
+    def recording_execute(self, *args, **kwargs):
+        executed.append(self)
+        return original_execute(self, *args, **kwargs)
+
+    monkeypatch.setattr(Expr, "execute", recording_execute)
+
+    pinned = pin_cache(expr, ensure_materialized=True)
+
+    # exactly the cache subtree was executed -- the downstream filter never ran,
+    # and it was wrapped in head(0) so no cache rows were pulled into memory
+    assert executed
+    for e in executed:
+        assert walk_nodes((CachedNode,), e)  # the cache is materialized
+        assert not walk_nodes((ops.Filter,), e)  # post-cache compute skipped
+        assert isinstance(e.op(), ops.Limit) and e.op().n == 0  # head(0)
+    assert caches_materialized(expr)
+    assert walk_nodes((CacheTag,), pinned)
+
+
+def test_caches_materialized_predicate(tmp_path: Path) -> None:
+    build_path, _, cache_dir = _cached_build(tmp_path, materialize=False)
+    assert not caches_materialized(load_expr(build_path, cache_dir=cache_dir))
+
+    run_command(
+        str(build_path), str(tmp_path / "out.parquet"), "parquet", str(cache_dir)
+    )
+    assert caches_materialized(load_expr(build_path, cache_dir=cache_dir))
+
+
+def test_ensure_materialized_skips_execute_when_already_materialized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path, materialize=True)
+
+    calls = {"n": 0}
+    original_execute = Expr.execute
+
+    def counting_execute(self, *args, **kwargs):
+        calls["n"] += 1
+        return original_execute(self, *args, **kwargs)
+
+    monkeypatch.setattr(Expr, "execute", counting_execute)
+
+    # caches are already materialized, so ensure_materialized must not re-execute
+    pin_command(
+        str(build_path),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+        ensure_materialized=True,
+    )
+    assert calls["n"] == 0
+
+
+def test_pin_requires_materialized_cache_then_ensure_materialized(
+    tmp_path: Path,
+) -> None:
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path, materialize=False)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "pin",
+            str(build_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--builds-dir",
+            str(builds_dir),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "ensure-materialized" in result.output
+
+    result_e = CliRunner().invoke(
+        cli,
+        [
+            "pin",
+            str(build_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--builds-dir",
+            str(builds_dir),
+            "-e",
+        ],
+    )
+    assert result_e.exit_code == 0, result_e.output
+
+
+def _backend_names() -> list[str]:
+    """All backend modules, discovered from ``xorq.backends``.
+
+    Deriving the list dynamically means a newly added backend is automatically
+    swept into the contract test below -- nothing to remember to update.
+    """
+    return sorted(
+        m.name
+        for m in pkgutil.iter_modules(xorq.backends.__path__)
+        if not m.name.startswith("_") and m.name not in ("tests", "conftest")
+    )
+
+
+@pytest.mark.slow(level=1)
+@pytest.mark.parametrize("backend_name", _backend_names())
+def test_ensure_materialized_full_cache_contract(
+    backend_name: str, tmp_path: Path
+) -> None:
+    """``head(0).execute()`` must populate the FULL cache on every backend.
+
+    ``pin(ensure_materialized=True)`` relies on cache population being a side
+    effect of the execute pass, independent of the client row limit. A backend
+    that pushed the limit into cache population would write an empty cache and
+    pin a silently-wrong artifact. Backends that cannot host the flow at all
+    (need a server/creds, or cannot ingest parquet) skip via the capability
+    probe below, but any backend that *runs* the flow yet truncates the cache
+    fails on the row-count assertion -- so a newly supported backend cannot
+    regress pinning unnoticed.
+    """
+    parquet_path = tmp_path / "data.parquet"
+    _write_parquet(parquet_path)  # a in {1, 2, 3}
+    # Capability probe -- the ONLY code guarded by this try. It answers "can this
+    # backend connect and ingest+execute parquet locally", nothing more. The pin
+    # flow below is deliberately left outside the guard: a backend that clears
+    # the probe but breaks in .cache()/pin must fail loudly, not skip. Do not
+    # widen this try to cover the assertions, or a real pin regression would be
+    # silently swallowed as a skip.
+    try:
+        con = getattr(xo, backend_name).connect()
+        deferred_read_parquet(parquet_path, con, table_name="probe").execute()
+    except Exception as exc:  # noqa: BLE001 -- needs server/creds, or no parquet ingest
+        pytest.skip(f"{backend_name}: cannot host the pin flow locally ({exc!r})")
+
+    cache = ParquetCache.from_kwargs(source=con, base_path=tmp_path / "cache")
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    expr = t.cache(cache=cache).filter(xo._.a > 1)
+    assert not caches_materialized(expr)
+
+    pinned = expr.ls.pin(ensure_materialized=True)
+    assert walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    # a > 1 over {1, 2, 3} -> 2 rows; 0 would mean head(0) leaked the row limit
+    # into cache population.
+    assert len(pinned.execute()) == 2
+
+
+def test_ensure_materialized_repairs_evicted_inner_cache(tmp_path: Path) -> None:
+    """An inner cache colder than its outer is still re-materialized.
+
+    With nested caches both warm, evicting only the inner cache file leaves the
+    outer warm. ``ensure_materialized`` checks every cache, so it re-materializes
+    the cold inner directly (the warm outer is skipped) and pins cleanly --
+    nothing relies on a warm outer implying a warm inner.
+    """
+    parquet_path = tmp_path / "data.parquet"
+    _write_parquet(parquet_path)
+    con = xo.connect()
+    inner = ParquetCache.from_kwargs(source=con, base_path=tmp_path / "inner")
+    outer = ParquetCache.from_kwargs(source=con, base_path=tmp_path / "outer")
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    expr = t.cache(cache=inner).filter(xo._.a > 1).cache(cache=outer)
+    expr.execute()  # warm both caches
+
+    # evict only the inner cache file, leaving the outer warm
+    for f in Path(inner.storage.path).glob("*.parquet"):
+        f.unlink()
+    assert not caches_materialized(expr)
+
+    # the cold inner is repaired even though its outer is warm
+    pinned = pin_cache(expr, ensure_materialized=True)
+    assert caches_materialized(expr)
+    assert walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    assert len(pinned.execute()) == 2
+
+
+def test_unpin_inverts_pin(tmp_path: Path) -> None:
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path)
+
+    pinned_path = pin_command(
+        str(build_path),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+    )
+    unpinned_path = pin_command(
+        str(pinned_path),
+        do_pin=False,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+    )
+    unpinned = load_expr(unpinned_path, cache_dir=cache_dir)
+
+    assert walk_nodes((CachedNode,), unpinned)
+    assert not walk_nodes((CacheTag,), unpinned)
+
+
+def test_pin_unpin_build_hash_roundtrip(tmp_path: Path) -> None:
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path)
+
+    pinned_path = pin_command(
+        str(build_path),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+    )
+    # pinning is intentionally not build-hash-neutral
+    assert pinned_path.name != build_path.name
+
+    unpinned_path = pin_command(
+        str(pinned_path),
+        do_pin=False,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+    )
+    # unpin restores the original unpinned build hash (relocate-on round-trip is
+    # now hash-stable, so this holds in the default regime too)
+    assert unpinned_path.name == build_path.name
+
+
+def test_pin_partial_materialization_errors(tmp_path: Path) -> None:
+    parquet_path = tmp_path / "data.parquet"
+    _write_parquet(parquet_path)
+    con = xo.connect()
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    expr = (
+        t.cache(ParquetCache.from_kwargs(source=con))
+        .filter(xo._.a > 1)
+        .cache(ParquetCache.from_kwargs(source=con))
+    )
+    builds_dir = tmp_path / "builds"
+    cache_dir = tmp_path / "cache"
+    build_path = build_expr(expr, builds_dir=builds_dir, cache_dir=cache_dir)
+    run_command(
+        str(build_path), str(tmp_path / "out.parquet"), "parquet", str(cache_dir)
+    )
+
+    cache_files = list(cache_dir.rglob("*.parquet"))
+    assert len(cache_files) >= 2
+    cache_files[0].unlink()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "pin",
+            str(build_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--builds-dir",
+            str(builds_dir),
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_pin_relocate_reads_is_self_contained(tmp_path: Path) -> None:
+    build_path, builds_dir, cache_dir = _cached_build(tmp_path)
+
+    pinned_path = pin_command(
+        str(build_path),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+        relocate_reads=True,
+    )
+    reads_dir = pinned_path / "reads"
+    assert reads_dir.exists()
+    assert list(reads_dir.glob("*.parquet"))
+
+
+def test_pin_freezes_cache_against_source_change(tmp_path: Path) -> None:
+    parquet_path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}), parquet_path)
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con)
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    expr = t.filter(t.a > 1).cache(cache=cache)
+    builds_dir = tmp_path / "builds"
+    cache_dir = tmp_path / "cache"
+    raw_build = build_expr(expr, builds_dir=builds_dir, cache_dir=cache_dir)
+
+    def run(build: Path, name: str) -> list:
+        out = tmp_path / f"{name}.parquet"
+        run_command(str(build), str(out), "parquet", str(cache_dir))
+        return pq.read_table(out).to_pydict()["a"]
+
+    def caches() -> set[str]:
+        return {p.name for p in cache_dir.rglob("*.parquet")}
+
+    # materialize the cache, then freeze it
+    assert run(raw_build, "raw0") == [2, 3]
+    frozen_caches = caches()
+    assert len(frozen_caches) == 1
+
+    # stay in the non-relocate regime: this test exercises stat-based read
+    # invalidation when the source file changes, which relocating (md5 + a
+    # frozen bundled copy) would deliberately defeat.
+    pinned = pin_command(
+        str(raw_build),
+        do_pin=True,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+        relocate_reads=False,
+    )
+    assert walk_nodes((CacheTag,), load_expr(pinned, cache_dir=cache_dir))
+
+    # change the source file out from under both builds: the stat-based read key
+    # changes, so the raw cache is invalidated
+    pq.write_table(pa.table({"a": [1, 2, 3, 4, 5], "b": [4, 5, 6, 7, 8]}), parquet_path)
+
+    # raw build sees the change: recomputes and writes a new cache file
+    assert run(raw_build, "raw1") == [2, 3, 4, 5]
+    after_raw = caches()
+    live_caches = after_raw - frozen_caches
+    assert len(live_caches) == 1
+
+    # pinned build is frozen: original data, reads its frozen cache, no new file
+    assert run(pinned, "pin1") == [2, 3]
+    assert caches() == after_raw
+
+    # unpin restores a live cache that tracks the changed source again
+    unpinned = pin_command(
+        str(pinned),
+        do_pin=False,
+        builds_dir=str(builds_dir),
+        cache_dir=str(cache_dir),
+        relocate_reads=False,
+    )
+    assert walk_nodes((CachedNode,), load_expr(unpinned, cache_dir=cache_dir))
+    assert run(unpinned, "unpin1") == [2, 3, 4, 5]
+    # the unpinned form re-keys to the same live cache a fresh raw build uses,
+    # which is distinct from the frozen pin's cache
+    assert caches() == after_raw
+    assert live_caches.isdisjoint(frozen_caches)
+    assert frozen_caches <= caches()
+
+
+def test_pin_noop_without_caches(tmp_path: Path) -> None:
+    parquet_path = tmp_path / "data.parquet"
+    _write_parquet(parquet_path)
+    con = xo.connect()
+    t = deferred_read_parquet(parquet_path, con, table_name="t")
+    expr = t.filter(t.a > 1)
+    builds_dir = tmp_path / "builds"
+    cache_dir = tmp_path / "cache"
+    # build relocate-on (the `xorq build` default) so the default-relocating pin
+    # runs in the same regime; with no caches the pin is a structural no-op and,
+    # because a relocated build is load+rebuild hash-stable, the hash is unchanged.
+    build_path = build_expr(
+        expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=True
+    )
+    original = load_expr(build_path, cache_dir=cache_dir)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "pin",
+            str(build_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--builds-dir",
+            str(builds_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    pinned_path = Path(result.output.strip().splitlines()[-1])
+    pinned = load_expr(pinned_path, cache_dir=cache_dir)
+    # no caches to freeze: pin is a no-op, so the build hash is unchanged
+    assert not walk_nodes((CacheTag,), pinned)
+    assert not walk_nodes((CachedNode,), pinned)
+    assert pinned_path.name == build_path.name
+    assert (
+        pinned.execute()
+        .reset_index(drop=True)
+        .equals(original.execute().reset_index(drop=True))
+    )

--- a/python/xorq/tests/test_cli_pin.py
+++ b/python/xorq/tests/test_cli_pin.py
@@ -15,6 +15,7 @@ from xorq.cli import cli, pin_command, run_command
 from xorq.common.exceptions import IntegrityError
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.graph_utils import walk_nodes
+from xorq.common.utils.process_utils import subprocess_run
 from xorq.expr.relations import (
     CachedNode,
     CacheTag,
@@ -24,6 +25,27 @@ from xorq.expr.relations import (
 from xorq.ibis_yaml.compiler import build_expr, load_expr
 from xorq.vendor.ibis.expr import operations as ops
 from xorq.vendor.ibis.expr.types.core import Expr
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        pytest.param("pin", id="pin"),
+        pytest.param("unpin", id="unpin"),
+    ),
+)
+def test_pin_cli_help_smoke_subprocess(command: str) -> None:
+    """`xorq {pin,unpin} --help` must load via a real subprocess.
+
+    The other CLI tests here use in-process CliRunner, which never exercises
+    the real entrypoint and so hides an import-time cold-start regression from
+    the command's deferred imports. This spawns a real `xorq` to catch that.
+    """
+    (returncode, stdout, _stderr) = subprocess_run(
+        ["xorq", command, "--help"], text=True
+    )
+    assert returncode == 0, _stderr
+    assert command in stdout
 
 
 def caches_materialized(expr: Expr) -> bool:

--- a/python/xorq/vendor/ibis/expr/types/core.py
+++ b/python/xorq/vendor/ibis/expr/types/core.py
@@ -1065,12 +1065,16 @@ class LETSQLAccessor:
 
         return walk_nodes((CachedNode,), self.expr)
 
-    def pin(self) -> ir.Expr:
+    def pin(self, ensure_materialized: bool = False) -> ir.Expr:
         """Freeze every `CachedNode` into a direct read of its cache location.
 
         Returns an equivalent expression that reads the materialized cache
         artifacts directly instead of re-deriving them. Each cache must already
         exist. Inverse of `unpin`.
+
+        Set `ensure_materialized` to populate any caches that are not yet
+        materialized (by executing the expression once) before freezing;
+        already-materialized caches are left untouched.
 
         A pinned expression is a *frozen read*, not a cache: cache-introspection
         accessors (`is_cached`, `has_cached`, `cached_nodes`, `uncached`) by
@@ -1080,7 +1084,7 @@ class LETSQLAccessor:
         """
         from xorq.expr.relations import pin_cache
 
-        return pin_cache(self.expr)
+        return pin_cache(self.expr, ensure_materialized=ensure_materialized)
 
     def unpin(self) -> ir.Expr:
         """Rebuild every pinned cache (`CacheTag`) back into its `CachedNode`.


### PR DESCRIPTION
## Summary

Exposes the `expr.ls.pin()` / `expr.ls.unpin()` transforms through the CLI, for both build directories and catalog entries.

- **Build-level** (`xorq pin` / `xorq unpin <build>`): load → pin/unpin → rewrite a build artifact. Options: `--builds-dir`, `--cache-dir`, `--ensure-materialized/-e` (populate caches before pinning), `--relocate-reads` (portable self-contained bundle).
- **Catalog-level** (`xorq catalog pin` / `unpin <entry>`): re-adds the result as a new content-named entry (pinning changes the build hash, so it's never in-place). Options: `--alias`, `--move-aliases` (move every alias from the source entry), `--relocate-reads`, `--cache-dir`, `--ensure-materialized/-e`.
- Pinning a cold (unmaterialized) cache surfaces a clear, actionable CLI message instead of writing a silently-broken entry ("Populate the caches first … or pass `--ensure-materialized/-e`").
- Shared option decorators (`relocate_reads_option`, `ensure_materialized_option`) keep the flag, default, and help text consistent across `build`, `pin`/`unpin`, and `catalog pin`/`unpin` — the help noun (build vs. entry) and the frozen-caches mention (pin only) are the only differences.
- Docs CLI-reference generator updated to group the four new commands.

## Engine support

This is no longer pure CLI plumbing — a few expr/engine-level changes back the CLI:

- **Relocated builds are load+rebuild hash-stable.** A single pre-hash pass (`_prepare_relocatable_reads`) marks local-file reads relocatable and bakes in the serialized `read_path` *before* the build is hashed; the write pass (`ExprDumper._prepare_relocatable_read`) derives the same string from `relocatable_read_path_str` — the single source of the `reads/<content-hash>` layout — so a fresh build and every later load+rebuild hash identically and the two passes cannot drift.
- **`--ensure-materialized/-e` populates cold caches before pinning.** `pin_cache(ensure_materialized=True)` checks each `CachedNode` and runs a `head(0)` execute per cold subtree (already-warm caches are skipped, downstream compute never runs), so `-e` is a real guarantee rather than a best-effort hint. `head(0)` fully writes each cache — cache population is a side effect of the execute pass, independent of the read-back row limit.
- **A cold-cache pin without `-e` raises a `ClickException`** with an actionable hint (via the shared `apply_pin_transform`) instead of writing a silently-broken entry.
- **A missing bundle source raises a clean `ClickException`** (via the shared `raise_for_missing_relocation_source`) telling you to restore the file or re-run with `--no-relocate-reads`, for both `xorq pin`/`unpin` and `xorq catalog pin`/`unpin`. Only a genuinely-missing *source* is translated; unrelated `FileNotFoundError`s (e.g. inside the build/cache dirs, or a loaded catalog entry's extract dir) surface raw.
- **The inner-xorq option probe fails loudly on a broken environment.** The packager probes the bundled ("inner") xorq once via `xorq build --help` to learn which options it accepts (`--relocate-reads`, `--emit-build-path-to`) before passing them. `xorq build --help` exits 0 on any xorq that has the `build` subcommand, so a non-zero exit means a broken inner env, not a missing feature — it now raises a clear `RuntimeError` instead of silently omitting `--relocate-reads` and producing a machine-local build behind a misleading "does not support --relocate-reads" warning. The version-fallback path is reached only when help genuinely succeeds but the option is absent.

## ⚠️ Behavior change: `xorq build` now defaults to `--relocate-reads`

`xorq build` previously left local-file reads in place by default; it now bundles them into the build artifact (`--relocate-reads` defaults on). Pass `--no-relocate-reads` to restore the previous machine-local behavior.

**Rationale:** a build exists to be added to a catalog, and a catalog entry exists to run from anywhere — so a build should be self-contained by default. Remote reads (`s3://`, `gs://`, …) are already location-independent and are left in place regardless.

**Migration note:** relocation changes build content and therefore the build hash, so pipelines that pin or compare build hashes will see new hashes after this change. Add `--no-relocate-reads` to any build whose hash must stay stable.

⚠️ **`--no-relocate-reads` is not a blanket hash-preserver.** The pre-hash pass now bakes a read's bundled `read_path` in whenever the read is *already* relocatable — including reads constructed via `deferred_read_parquet(..., relocatable=True)` — regardless of the flag (this is what makes relocated builds load+rebuild hash-stable). So a pipeline that uses the relocatable read API will see its build hash change on upgrade **even with `--no-relocate-reads`**; the flag only prevents relocation of reads that are still machine-local. Pipelines that must hold a hash constant across this upgrade should re-pin/re-record against the new hash rather than assuming `--no-relocate-reads` reproduces the old one.

**Relocation is one-way.** Bundling replaces a read's original path with a content hash, so `--no-relocate-reads` only prevents *new* bundling — it cannot un-bundle an already-relocated build. To keep a build lean, pass `--no-relocate-reads` at `xorq build` time; you can't recover a machine-local build by unpinning one that was already relocated.

**API defaults:** the programmatic `build_command(...)` matches this CLI default (`relocate_reads=True`). The lower-level `build_expr(...)` and `Catalog.add(...)` intentionally keep the lean default (`False`) — relocated reads aren't yet resolved in the fuse/bind execute path, so `Catalog.add(expr, relocate_reads=True)` entries can't be fused today. Aligning those defaults with the CLI is tracked in #2133.

⚠️ **`catalog pin`/`unpin` are subject to the same gap.** They already re-add with `relocate_reads=True`, so a pinned catalog entry that contains a relocated read (e.g. its bundled cache parquet) currently returns an **empty result when consumed via fuse/bind** — the same #2133 root cause. Guarded by `test_fuse_pinned_entry_with_relocated_read` (xfail, strict), which flips to a failure the moment #2133's fuse-path fix lands and prompts us to turn it into a normal passing regression test.

## Dependency

Stacked on **#2111** (`CacheTag` + public `.pin()`/`.unpin()`). Base is `feat/cache-pinning`; retarget to `main` once #2111 merges.

Implements `plans/cli-pin-unpin.md`.

## Test plan

- [x] `python/xorq/tests/test_cli_pin.py` (16 tests) — build round-trip, cold-cache→error + `-e`, unpin inverts, build-hash round-trip invariant, partial materialization, `--relocate-reads`, full-cache contract across backends, no-op equivalence, and a real-subprocess `xorq pin`/`unpin --help` cold-start smoke test
- [x] `python/xorq/catalog/tests/test_cli_pin.py` (14 tests) — new-entry, `--alias`, `--move-aliases`, no-op, unpin inverts, default-relocate round-trip, cold-cache hint, `--no-relocate-reads` lean entry, `--relocate-reads` bundles source read, and a real-subprocess `xorq catalog pin`/`unpin --help` cold-start smoke test
- [x] `python/xorq/ibis_yaml/tests/test_compiler.py` — relocated-build load+rebuild hash stability; `ArtifactStore.copy_file` same-path no-op (self-copy skip)
- [x] `python/xorq/catalog/tests/test_bind.py::test_fuse_pinned_entry_with_relocated_read` — xfail(strict) reproducing #2133 for the pin path (fused pinned entry with a relocated read yields an empty result / `schema names don't match input data columns`)
- [x] `docs/generate_cli_reference.py` runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

