### PR TITLE
feat(catalog): multi-root join compose with same-profile backend rebind

### DIFF
--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -302,11 +302,14 @@ def compose_join(
     cache_dir: str | Path | None = None,
     rebind_backends: bool = True,
     eval_namespace: dict[str, object] | None = None,
+    binding_exprs: dict[str, Expr] | None = None,
 ) -> Expr:
     """Compose two-or-more catalog entries via inline join/union code.
 
     Each binding ``name -> entry_name`` resolves its catalog entry to a
-    SOURCE-tagged source expression exposed in *code* under ``name``.  The
+    SOURCE-tagged source expression exposed in *code* under ``name``.  Callers
+    may override individual bindings through *binding_exprs* (for example,
+    after applying positional unbound transforms to a primary binding).  The
     namespace also exposes vendored ``ibis``, an ``into_backend`` helper for
     explicit cross-backend transport (``into_backend(right, left)`` moves
     ``right`` into ``left``'s backend), and whatever *eval_namespace* the
@@ -320,13 +323,19 @@ def compose_join(
     """
     from xorq.common.utils.eval_utils import safe_eval  # noqa: PLC0415
 
-    if not bindings:
+    binding_exprs = binding_exprs or {}
+    if not bindings and not binding_exprs:
         raise ValueError("compose_join requires at least one -e/--entry binding")
     if code is None:
         raise ValueError("compose_join requires inline -c/--code")
 
     resolved = {}
+    for name, tagged_expr in binding_exprs.items():
+        con = tagged_expr._find_backend()  # xorq-style: disable=protected-access
+        resolved[name] = (tagged_expr, con)
     for name, entry_name in bindings.items():
+        if name in binding_exprs:
+            continue
         entry = catalog.get_catalog_entry(entry_name, maybe_alias=True)
         tagged_expr, con = _resolve_source(entry, None, name, cache_dir=cache_dir)
         resolved[name] = (tagged_expr, con)

--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -242,27 +242,29 @@ def _is_backend(obj: object) -> bool:
     return isinstance(obj, BaseBackend)
 
 
-def _rebind_same_profile_backends(
-    result: Expr,
-    resolved: dict[str, tuple[Expr, BaseBackend]],
-    rebind: bool = True,
-) -> Expr:
-    """Canonicalize backend sources that share a profile *config*.
+def _rebind_same_profile_backends(result: Expr, rebind: bool = True) -> Expr:
+    """Canonicalize top-level backend sources that share a profile *config*.
 
     Catalog entries hydrate as distinct backend objects even when they point
     at the same database/profile: each connection gets a fresh ``idx``
     counter, so ``_profile.hash_name`` (which is ``{config_hash}_{idx}``)
     differs per instance.  Identity here is therefore the idx-independent
     config hash (``profile.clone(idx=-1).hash_name``, the same normalization
-    ``Profile.__eq__`` uses).  Every backend source whose config matches a
-    binding's backend is rewritten to that (first-seen, binding-order)
-    backend, so a bare same-backend join stays native/fused.
+    ``Profile.__eq__`` uses).  Same-profile sources are rewritten to the
+    first-seen one so a bare same-backend join stays native/fused.
+
+    Both the canonical target and the sources to rewrite are drawn from the
+    expression's *top-level* backends (``_find_backends``) -- those it
+    actually presents as.  Sources behind an explicit ``into_backend(...)``
+    transport present as their target backend, so the moved operand is never
+    seen here and the user's transport (and its chosen target) is preserved.
+    Seeding the canonical map from binding order instead would let a binding
+    override an explicit transport target and try to relabel a top-level
+    in-connection table onto a backend it does not live on, raising under
+    ``transfer_tables=False``.
 
     When *rebind* is False this is a no-op.  Otherwise the rewrite uses
     ``transfer_tables=False`` -- a pure relabel that never moves data.
-    Deferred reads (``deferred_read_parquet`` etc.) carry their own source
-    descriptor and rebind cleanly; an in-connection ``DatabaseTable`` whose
-    data only lives on the original backend raises instead of being moved.
     """
     if not rebind:
         return result
@@ -271,27 +273,21 @@ def _rebind_same_profile_backends(
         profile = getattr(con, "_profile", None)
         return None if profile is None else profile.clone(idx=-1).hash_name
 
+    backends, _ = result._find_backends()  # xorq-style: disable=protected-access
+
     canonical = {}
-    for _name, (_expr, con) in resolved.items():
+    for con in backends:
         pid = _profile_id(con)
         if pid is not None:
             canonical.setdefault(pid, con)
 
-    # Only rebind top-level sources -- those that determine the expression's
-    # own backend(s).  Sources behind an explicit ``into_backend(...)``
-    # transport are deliberately on another backend and are moved by that
-    # transport at execution; rebinding into them would try to relabel an
-    # in-connection table to a backend it does not live on and raise under
-    # ``transfer_tables=False``.  ``_find_backends`` stops at the transport
-    # boundary, whereas ``find_all_sources`` would descend through it.
-    backends, _ = result._find_backends()  # xorq-style: disable=protected-access
     mapping = {}
     for con in backends:
         pid = _profile_id(con)
         if pid is None:
             continue
-        target = canonical.get(pid)
-        if target is not None and id(con) != id(target):
+        target = canonical[pid]
+        if id(con) != id(target):
             mapping[id(con)] = target
 
     if mapping:
@@ -351,7 +347,7 @@ def compose_join(
     }
     result = safe_eval(code, namespace)
 
-    result = _rebind_same_profile_backends(result, resolved, rebind=rebind_backends)
+    result = _rebind_same_profile_backends(result, rebind=rebind_backends)
 
     return result.hashing_tag(CatalogTag.CODE, code=code)
 

--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
 from functools import reduce
+from typing import TYPE_CHECKING
 
 from xorq.catalog.enums import CatalogTag
-from xorq.common.utils.graph_utils import replace_nodes, replace_unbound, walk_nodes
-from xorq.expr.relations import HashingTag, RemoteTable, gen_name
+from xorq.common.utils.graph_utils import (
+    replace_nodes,
+    replace_sources,
+    replace_unbound,
+    walk_nodes,
+)
+from xorq.expr.relations import HashingTag, RemoteTable, gen_name, into_backend
 from xorq.ibis_yaml.enums import ExprKind
+from xorq.vendor import ibis
 from xorq.vendor.ibis.expr.schema import Schema
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from xorq.catalog.catalog import Catalog, CatalogEntry
+    from xorq.vendor.ibis.backends import BaseBackend
+    from xorq.vendor.ibis.expr.types.core import Expr
 
 
 def _get_transform_schema_issues(
@@ -210,10 +225,135 @@ def _eval_code(code, source):
     return safe_eval(code, namespace)
 
 
-def _make_source_expr(source, con=None, alias=None, cache_dir=None):
+def _make_source_expr(
+    source: CatalogEntry | Expr,
+    con: BaseBackend | None = None,
+    alias: str | None = None,
+    cache_dir: str | Path | None = None,
+) -> Expr:
     """Wrap a CatalogEntry as a RemoteTable + HashingTag without transforms."""
     source_expr, _ = _resolve_source(source, con, alias, cache_dir=cache_dir)
     return source_expr
+
+
+def _is_backend(obj: object) -> bool:
+    from xorq.vendor.ibis.backends import BaseBackend  # noqa: PLC0415
+
+    return isinstance(obj, BaseBackend)
+
+
+def _rebind_same_profile_backends(
+    result: Expr,
+    resolved: dict[str, tuple[Expr, BaseBackend]],
+    rebind: bool = True,
+) -> Expr:
+    """Canonicalize backend sources that share a profile *config*.
+
+    Catalog entries hydrate as distinct backend objects even when they point
+    at the same database/profile: each connection gets a fresh ``idx``
+    counter, so ``_profile.hash_name`` (which is ``{config_hash}_{idx}``)
+    differs per instance.  Identity here is therefore the idx-independent
+    config hash (``profile.clone(idx=-1).hash_name``, the same normalization
+    ``Profile.__eq__`` uses).  Every backend source whose config matches a
+    binding's backend is rewritten to that (first-seen, binding-order)
+    backend, so a bare same-backend join stays native/fused.
+
+    When *rebind* is False this is a no-op.  Otherwise the rewrite uses
+    ``transfer_tables=False`` -- a pure relabel that never moves data.
+    Deferred reads (``deferred_read_parquet`` etc.) carry their own source
+    descriptor and rebind cleanly; an in-connection ``DatabaseTable`` whose
+    data only lives on the original backend raises instead of being moved.
+    """
+    if not rebind:
+        return result
+
+    def _profile_id(con):
+        profile = getattr(con, "_profile", None)
+        return None if profile is None else profile.clone(idx=-1).hash_name
+
+    canonical = {}
+    for _name, (_expr, con) in resolved.items():
+        pid = _profile_id(con)
+        if pid is not None:
+            canonical.setdefault(pid, con)
+
+    # Only rebind top-level sources -- those that determine the expression's
+    # own backend(s).  Sources behind an explicit ``into_backend(...)``
+    # transport are deliberately on another backend and are moved by that
+    # transport at execution; rebinding into them would try to relabel an
+    # in-connection table to a backend it does not live on and raise under
+    # ``transfer_tables=False``.  ``_find_backends`` stops at the transport
+    # boundary, whereas ``find_all_sources`` would descend through it.
+    backends, _ = result._find_backends()  # xorq-style: disable=protected-access
+    mapping = {}
+    for con in backends:
+        pid = _profile_id(con)
+        if pid is None:
+            continue
+        target = canonical.get(pid)
+        if target is not None and id(con) != id(target):
+            mapping[id(con)] = target
+
+    if mapping:
+        result = replace_sources(mapping, result, transfer_tables=False)
+    return result
+
+
+def compose_join(
+    catalog: Catalog,
+    bindings: dict[str, str],
+    code: str | None,
+    cache_dir: str | Path | None = None,
+    rebind_backends: bool = True,
+    eval_namespace: dict[str, object] | None = None,
+) -> Expr:
+    """Compose two-or-more catalog entries via inline join/union code.
+
+    Each binding ``name -> entry_name`` resolves its catalog entry to a
+    SOURCE-tagged source expression exposed in *code* under ``name``.  The
+    namespace also exposes vendored ``ibis``, an ``into_backend`` helper for
+    explicit cross-backend transport (``into_backend(right, left)`` moves
+    ``right`` into ``left``'s backend), and whatever *eval_namespace* the
+    caller supplies (the CLI layer passes the user-facing ``xo`` facade there;
+    library code must not import it).  Same-profile backend sources are
+    rebound to one backend (no data transfer) so native same-backend joins
+    stay fused.
+
+    Returns a CODE-tagged expression; provenance (``composed_from``) is
+    carried by each operand's SOURCE tag automatically.
+    """
+    from xorq.common.utils.eval_utils import safe_eval  # noqa: PLC0415
+
+    if not bindings:
+        raise ValueError("compose_join requires at least one -e/--entry binding")
+    if code is None:
+        raise ValueError("compose_join requires inline -c/--code")
+
+    resolved = {}
+    for name, entry_name in bindings.items():
+        entry = catalog.get_catalog_entry(entry_name, maybe_alias=True)
+        tagged_expr, con = _resolve_source(entry, None, name, cache_dir=cache_dir)
+        resolved[name] = (tagged_expr, con)
+
+    def _into_backend_helper(expr, target, name=None):
+        if _is_backend(target):
+            con = target
+        else:
+            con = target._find_backend()  # xorq-style: disable=protected-access
+        return into_backend(expr, con, name=name)
+
+    namespace = {
+        "__builtins__": {},
+        **(eval_namespace or {}),
+        "ibis": ibis,
+        "into_backend": _into_backend_helper,
+        **{name: tagged for name, (tagged, _con) in resolved.items()},
+    }
+    result = safe_eval(code, namespace)
+
+    result = _rebind_same_profile_backends(result, resolved, rebind=rebind_backends)
+
+    return result.hashing_tag(CatalogTag.CODE, code=code)
 
 
 def fuse_catalog_source(expr):

--- a/python/xorq/catalog/bind.py
+++ b/python/xorq/catalog/bind.py
@@ -295,6 +295,21 @@ def _rebind_same_profile_backends(result: Expr, rebind: bool = True) -> Expr:
     return result
 
 
+def _resolve_binding_expr(
+    catalog: Catalog,
+    entry_name: str,
+    alias: str,
+    cache_dir: str | Path | None = None,
+) -> Expr:
+    entry = catalog.get_catalog_entry(entry_name, maybe_alias=True)
+    if entry.kind is ExprKind.UnboundExpr:
+        if not entry.is_content_local:
+            entry.fetch()
+        return _make_source_tag(entry.load_expr(cache_dir=cache_dir), entry, alias)
+    expr, _ = _resolve_source(entry, None, alias, cache_dir=cache_dir)
+    return expr
+
+
 def compose_join(
     catalog: Catalog,
     bindings: dict[str, str],
@@ -329,16 +344,14 @@ def compose_join(
     if code is None:
         raise ValueError("compose_join requires inline -c/--code")
 
-    resolved = {}
-    for name, tagged_expr in binding_exprs.items():
-        con = tagged_expr._find_backend()  # xorq-style: disable=protected-access
-        resolved[name] = (tagged_expr, con)
+    def _bind_helper(source, transform):
+        return replace_unbound(transform, source.op())
+
+    resolved = dict(binding_exprs)
     for name, entry_name in bindings.items():
         if name in binding_exprs:
             continue
-        entry = catalog.get_catalog_entry(entry_name, maybe_alias=True)
-        tagged_expr, con = _resolve_source(entry, None, name, cache_dir=cache_dir)
-        resolved[name] = (tagged_expr, con)
+        resolved[name] = _resolve_binding_expr(catalog, entry_name, name, cache_dir)
 
     def _into_backend_helper(expr, target, name=None):
         if _is_backend(target):
@@ -351,8 +364,9 @@ def compose_join(
         "__builtins__": {},
         **(eval_namespace or {}),
         "ibis": ibis,
+        "bind": _bind_helper,
         "into_backend": _into_backend_helper,
-        **{name: tagged for name, (tagged, _con) in resolved.items()},
+        **resolved,
     }
     result = safe_eval(code, namespace)
 

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1195,7 +1195,7 @@ def _parse_rename_params(raw_rename_params):
     return result
 
 
-_RESERVED_BINDING_NAMES = frozenset({"xo", "ibis", "into_backend"})
+_RESERVED_BINDING_NAMES = frozenset({"bind", "xo", "ibis", "into_backend"})
 
 
 def _parse_entry_bindings(raw_entries: tuple[str, ...]) -> dict[str, str]:

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1248,16 +1248,19 @@ def _resolve_mode(
 ) -> dict[str, str]:
     """Validate and return the binding dict (empty in linear mode).
 
-    Rejects mixing ``-e`` with positional ENTRIES and requires ``-c`` in
-    multi-root mode.
+    Positional ENTRIES may be mixed with ``-e`` in two ways:
+    ``-e source=ENTRY transform...`` applies transforms to that binding, while
+    ``ENTRY transform... -e name=other`` exposes the positional chain as
+    ``source`` alongside the extra bindings.
     """
     bindings = _parse_entry_bindings(raw_entries)
     if bindings and entries:
-        raise click.UsageError(
-            "Cannot combine -e/--entry bindings with positional ENTRIES; "
-            "use one or the other."
-        )
-    if bindings and code is None:
+        if code is None and set(bindings) != {"source"}:
+            raise click.UsageError(
+                "Mixed mode with extra -e/--entry bindings "
+                "requires inline code via -c/--code."
+            )
+    if bindings and not entries and code is None:
         raise click.UsageError(
             "Multi-root mode (-e/--entry) requires inline code via -c/--code."
         )
@@ -1271,42 +1274,21 @@ def _is_cross_backend(expr: Expr) -> bool:
     return len({id(s) for s in find_all_sources(expr)}) > 1
 
 
-def _compose_expr(
+def _compose_linear_expr(
     catalog: Catalog,
     entries: tuple[str, ...],
     code: str | None,
     rename_map: dict[str, dict[str, str]] | None = None,
     cache_dir: str | Path | None = None,
-    bindings: dict[str, str] | None = None,
-    rebind_backends: bool = True,
+    source_alias: str | None = None,
 ) -> Expr:
-    """Build a composed expression from catalog entries and/or inline code."""
+    """Build a linear source + transforms expression."""
 
     from xorq.catalog.bind import (  # noqa: PLC0415
         _eval_code,
         _resolve_source,
     )
     from xorq.common.utils.graph_utils import rename_params  # noqa: PLC0415
-
-    if bindings:
-        if rename_map:
-            raise click.UsageError(
-                "--rename-params is not supported in multi-root (-e) mode."
-            )
-        import xorq.api as xo  # noqa: PLC0415
-        from xorq.catalog.bind import compose_join  # noqa: PLC0415
-
-        # The CLI is the user-facing layer, so the ``xo`` facade is supplied
-        # to the inline-code eval namespace here rather than imported inside
-        # the catalog library (compose_join).
-        return compose_join(
-            catalog,
-            bindings,
-            code,
-            cache_dir=cache_dir,
-            rebind_backends=rebind_backends,
-            eval_namespace={"xo": xo},
-        )
 
     if not entries:
         raise click.UsageError("At least one entry is required.")
@@ -1335,6 +1317,7 @@ def _compose_expr(
             source=source_entry,
             transforms=transform_entries,
             code=code,
+            alias=source_alias,
         ).expr
 
     def _load(entry):
@@ -1342,10 +1325,11 @@ def _compose_expr(
 
     if source_name in rename_map:
         source_expr = rename_params(_load(source_entry), rename_map[source_name])
+        source_tagged, resolved_con = _resolve_source(source_expr, None, source_alias)
     else:
-        source_expr = _load(source_entry)
-
-    source_tagged, resolved_con = _resolve_source(source_expr, None, None)
+        source_tagged, resolved_con = _resolve_source(
+            source_entry, None, source_alias, cache_dir=cache_dir
+        )
 
     if transform_entries:
         from xorq.catalog.bind import _ensure_remote  # noqa: PLC0415
@@ -1379,6 +1363,57 @@ def _compose_expr(
         current = _eval_code(code, current)
 
     return current
+
+
+def _compose_expr(
+    catalog: Catalog,
+    entries: tuple[str, ...],
+    code: str | None,
+    rename_map: dict[str, dict[str, str]] | None = None,
+    cache_dir: str | Path | None = None,
+    bindings: dict[str, str] | None = None,
+    rebind_backends: bool = True,
+) -> Expr:
+    """Build a composed expression from catalog entries and/or inline code."""
+
+    if bindings:
+        if rename_map:
+            raise click.UsageError(
+                "--rename-params is not supported in multi-root (-e) mode."
+            )
+        import xorq.api as xo  # noqa: PLC0415
+        from xorq.catalog.bind import compose_join  # noqa: PLC0415
+
+        binding_exprs = {}
+        if entries:
+            primary = "source"
+            linear_entries = (
+                (bindings[primary], *entries) if primary in bindings else entries
+            )
+            binding_exprs[primary] = _compose_linear_expr(
+                catalog,
+                linear_entries,
+                None,
+                cache_dir=cache_dir,
+                source_alias=primary,
+            )
+            if code is None and len(bindings) == 1:
+                return binding_exprs[primary]
+
+        # The CLI is the user-facing layer, so the ``xo`` facade is supplied
+        # to the inline-code eval namespace here rather than imported inside
+        # the catalog library (compose_join).
+        return compose_join(
+            catalog,
+            bindings,
+            code,
+            cache_dir=cache_dir,
+            rebind_backends=rebind_backends,
+            eval_namespace={"xo": xo},
+            binding_exprs=binding_exprs,
+        )
+
+    return _compose_linear_expr(catalog, entries, code, rename_map, cache_dir)
 
 
 def _assert_requirements_identical(entry_reqs):
@@ -1722,7 +1757,7 @@ def compose(  # xorq-style: disable=type-annotations
         with click_context_catalog(ctx):
             catalog = ctx.obj.make_catalog(init=False)
             bindings = _resolve_mode(entries, raw_entries, code)
-            involved_entries = tuple(bindings.values()) if bindings else entries
+            involved_entries = _involved_entries(entries, bindings)
             if not involved_entries:
                 raise click.UsageError("At least one entry is required.")
 
@@ -1835,7 +1870,18 @@ def _has_expr_modifications(ctx):
         return True
     if p.get("limit") is not None:
         return True
-    return bool(p.get("code") or p.get("raw_params") or p.get("raw_rename_params"))
+    return bool(
+        p.get("code")
+        or p.get("raw_entries")
+        or p.get("raw_params")
+        or p.get("raw_rename_params")
+    )
+
+
+def _involved_entries(
+    entries: tuple[str, ...], bindings: dict[str, str]
+) -> tuple[str, ...]:
+    return (*bindings.values(), *entries) if bindings else entries
 
 
 def _log_run_metrics(rl, span, prefix, elapsed, output_format, output_path):
@@ -1914,7 +1960,7 @@ def _resolve_and_execute(
 
     raw_entries = p.get("raw_entries", ())
     rebind_backends = p.get("rebind_backends", True)
-    bindings = _parse_entry_bindings(raw_entries)
+    bindings = _resolve_mode(entries, raw_entries, code)
 
     rename_map = _parse_rename_params(raw_rename_params) if raw_rename_params else None
 
@@ -2055,7 +2101,7 @@ def run(  # xorq-style: disable=type-annotations
         span.set_attributes({"entries": entries, "has_code": code is not None})
         with click_context_catalog(ctx):
             bindings = _resolve_mode(entries, raw_entries, code)
-            involved_entries = tuple(bindings.values()) if bindings else entries
+            involved_entries = _involved_entries(entries, bindings)
             if not involved_entries:
                 raise click.UsageError("At least one entry is required.")
 
@@ -2218,7 +2264,7 @@ def run_cached(  # xorq-style: disable=type-annotations
         span.set_attributes({"entries": entries, "has_code": code is not None})
         with click_context_catalog(ctx):
             bindings = _resolve_mode(entries, raw_entries, code)
-            involved_entries = tuple(bindings.values()) if bindings else entries
+            involved_entries = _involved_entries(entries, bindings)
             if not involved_entries:
                 raise click.UsageError("At least one entry is required.")
 

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import itertools
 import json
+import keyword
 import os
 import shutil
 import subprocess
@@ -22,13 +23,19 @@ from xorq.catalog import constants as catalog_constants
 
 
 if TYPE_CHECKING:
+    from opentelemetry.trace import Span
+
+    from xorq.catalog.catalog import Catalog
     from xorq.catalog.content_store import ContentStoreConfig
+    from xorq.common.utils.logging_utils import RunLogger
+    from xorq.vendor.ibis.expr.types.core import Expr
 
 from xorq.cli_options import (
     cache_dir_option,
     cache_strategy_options,
     code_option,
     content_store_option,
+    entry_option,
     env_options,
     fuse_option,
     gcs_option,
@@ -36,6 +43,7 @@ from xorq.cli_options import (
     limit_option,
     output_options,
     params_option,
+    rebind_backends_option,
     rename_params_option,
     serve_options,
     sync_option,
@@ -1187,7 +1195,91 @@ def _parse_rename_params(raw_rename_params):
     return result
 
 
-def _compose_expr(catalog, entries, code, rename_map=None, cache_dir=None):
+_RESERVED_BINDING_NAMES = frozenset({"xo", "ibis", "into_backend"})
+
+
+def _parse_entry_bindings(raw_entries: tuple[str, ...]) -> dict[str, str]:
+    """Parse repeatable ``-e NAME=ENTRY`` values into an ordered dict.
+
+    Returns ``{}`` when no ``-e`` was given (single-root / linear mode).
+    Insertion order is preserved so the first binding is the default
+    rebind target.
+    """
+    bindings: dict[str, str] = {}
+    for raw in raw_entries:
+        name, sep, entry = raw.partition("=")
+        if not sep or not name or not entry:
+            raise click.BadParameter(
+                f"--entry must be NAME=ENTRY, got {raw!r}",
+                param_hint="-e/--entry",
+            )
+        if not name.isidentifier():
+            raise click.BadParameter(
+                f"binding name {name!r} is not a valid Python identifier",
+                param_hint="-e/--entry",
+            )
+        if keyword.iskeyword(name):
+            raise click.BadParameter(
+                f"binding name {name!r} is a Python keyword",
+                param_hint="-e/--entry",
+            )
+        if name.startswith("__") and name.endswith("__"):
+            raise click.BadParameter(
+                f"binding name {name!r} may not be a dunder",
+                param_hint="-e/--entry",
+            )
+        if name in _RESERVED_BINDING_NAMES:
+            raise click.BadParameter(
+                f"binding name {name!r} is reserved "
+                f"(reserved: {', '.join(sorted(_RESERVED_BINDING_NAMES))})",
+                param_hint="-e/--entry",
+            )
+        if name in bindings:
+            raise click.BadParameter(
+                f"duplicate binding name {name!r}",
+                param_hint="-e/--entry",
+            )
+        bindings[name] = entry
+    return bindings
+
+
+def _resolve_mode(
+    entries: tuple[str, ...], raw_entries: tuple[str, ...], code: str | None
+) -> dict[str, str]:
+    """Validate and return the binding dict (empty in linear mode).
+
+    Rejects mixing ``-e`` with positional ENTRIES and requires ``-c`` in
+    multi-root mode.
+    """
+    bindings = _parse_entry_bindings(raw_entries)
+    if bindings and entries:
+        raise click.UsageError(
+            "Cannot combine -e/--entry bindings with positional ENTRIES; "
+            "use one or the other."
+        )
+    if bindings and code is None:
+        raise click.UsageError(
+            "Multi-root mode (-e/--entry) requires inline code via -c/--code."
+        )
+    return bindings
+
+
+def _is_cross_backend(expr: Expr) -> bool:
+    """True when *expr* reads from more than one distinct backend object."""
+    from xorq.common.utils.graph_utils import find_all_sources  # noqa: PLC0415
+
+    return len({id(s) for s in find_all_sources(expr)}) > 1
+
+
+def _compose_expr(
+    catalog: Catalog,
+    entries: tuple[str, ...],
+    code: str | None,
+    rename_map: dict[str, dict[str, str]] | None = None,
+    cache_dir: str | Path | None = None,
+    bindings: dict[str, str] | None = None,
+    rebind_backends: bool = True,
+) -> Expr:
     """Build a composed expression from catalog entries and/or inline code."""
 
     from xorq.catalog.bind import (  # noqa: PLC0415
@@ -1195,6 +1287,26 @@ def _compose_expr(catalog, entries, code, rename_map=None, cache_dir=None):
         _resolve_source,
     )
     from xorq.common.utils.graph_utils import rename_params  # noqa: PLC0415
+
+    if bindings:
+        if rename_map:
+            raise click.UsageError(
+                "--rename-params is not supported in multi-root (-e) mode."
+            )
+        import xorq.api as xo  # noqa: PLC0415
+        from xorq.catalog.bind import compose_join  # noqa: PLC0415
+
+        # The CLI is the user-facing layer, so the ``xo`` facade is supplied
+        # to the inline-code eval namespace here rather than imported inside
+        # the catalog library (compose_join).
+        return compose_join(
+            catalog,
+            bindings,
+            code,
+            cache_dir=cache_dir,
+            rebind_backends=rebind_backends,
+            eval_namespace={"xo": xo},
+        )
 
     if not entries:
         raise click.UsageError("At least one entry is required.")
@@ -1463,7 +1575,16 @@ def _forward_ctx_params(ctx, *, exclude=frozenset()):
     )
 
 
-def _compose_via_reinvoke(ctx, catalog, entries):
+def _compose_via_reinvoke(
+    ctx: click.Context,
+    catalog: Catalog,
+    entries: tuple[str, ...],
+    involved_entries: tuple[str, ...] | None = None,
+) -> Path | None:
+    # entries are the positional argv tokens (empty in multi-root mode);
+    # involved_entries are the catalog entries whose wheels to harvest.
+    if involved_entries is None:
+        involved_entries = entries
     dry_run = ctx.params.get("dry_run", False)
     forwarded = _forward_ctx_params(
         ctx, exclude={"use_this_venv", "emit_build_path_to", "alias"}
@@ -1487,7 +1608,7 @@ def _compose_via_reinvoke(ctx, catalog, entries):
         )
         try:
             with _uv_reinvoke_xorq_cli(
-                catalog, entries, *inner_cmd, capture_output=True
+                catalog, involved_entries, *inner_cmd, capture_output=True
             ) as (result, bundle):
                 if dry_run:
                     click.echo(result.stdout, nl=False)
@@ -1517,6 +1638,8 @@ def _compose_via_reinvoke(ctx, catalog, entries):
 
 @cli.command("compose")
 @click.argument("entries", nargs=-1, shell_complete=_complete_entry_or_alias_names)
+@entry_option
+@rebind_backends_option
 @sync_option
 @code_option
 @click.option(
@@ -1555,9 +1678,11 @@ def _compose_via_reinvoke(ctx, catalog, entries):
     ),
 )
 @click.pass_context
-def compose(
+def compose(  # xorq-style: disable=type-annotations
     ctx,
     entries,
+    raw_entries,
+    rebind_backends,
     sync,
     code,
     alias,
@@ -1596,12 +1721,16 @@ def compose(
         span.set_attributes({"entries": entries, "has_code": code is not None})
         with click_context_catalog(ctx):
             catalog = ctx.obj.make_catalog(init=False)
-            if not entries:
+            bindings = _resolve_mode(entries, raw_entries, code)
+            involved_entries = tuple(bindings.values()) if bindings else entries
+            if not involved_entries:
                 raise click.UsageError("At least one entry is required.")
 
             if not use_this_venv:
                 span.set_attribute("path", "uv-reinvoke")
-                build_path = _compose_via_reinvoke(ctx, catalog, entries)
+                build_path = _compose_via_reinvoke(
+                    ctx, catalog, entries, involved_entries=involved_entries
+                )
                 if build_path is None:
                     return
             else:
@@ -1611,11 +1740,25 @@ def compose(
                     if raw_rename_params
                     else None
                 )
-                expr = _compose_expr(catalog, entries, code, rename_map=rename_map)
+                expr = _compose_expr(
+                    catalog,
+                    entries,
+                    code,
+                    rename_map=rename_map,
+                    cache_dir=cache_dir if bindings else None,
+                    bindings=bindings,
+                    rebind_backends=rebind_backends,
+                )
 
                 if dry_run:
                     click.echo("Dry run — composition plan:")
-                    click.echo(f"  Entries: {' -> '.join(entries)}")
+                    if bindings:
+                        click.echo(
+                            "  Bindings: "
+                            + ", ".join(f"{k}={v}" for k, v in bindings.items())
+                        )
+                    else:
+                        click.echo(f"  Entries: {' -> '.join(entries)}")
                     if code:
                         click.echo(f"  Code: {code}")
                     sch = expr.schema()
@@ -1635,7 +1778,7 @@ def compose(
                     Path(emit_build_path_to).write_text(str(build_path))
                     return
 
-                with _entry_run_bundle(catalog, entries) as bundle:
+                with _entry_run_bundle(catalog, involved_entries) as bundle:
                     _stage_bundle_into_build(bundle, build_path)
             entry_name = build_path.name
             aliases = (alias,) if alias else ()
@@ -1708,10 +1851,21 @@ def _log_run_metrics(rl, span, prefix, elapsed, output_format, output_path):
         rl.log_span_event(span, f"{prefix}.output_written", file_metrics)
 
 
-def _reinvoke_and_log(ctx, catalog, entries, span, rl):
+def _reinvoke_and_log(
+    ctx: click.Context,
+    catalog: Catalog,
+    entries: tuple[str, ...],
+    span: Span,
+    rl: RunLogger,
+    involved_entries: tuple[str, ...] | None = None,
+) -> None:
     """Reinvoke the current Click command in the entries' pinned env and log metrics."""
     from xorq.common.utils.profile_utils import timed  # noqa: PLC0415
 
+    # entries are the positional argv tokens (empty in multi-root mode);
+    # involved_entries are the catalog entries whose wheels to harvest.
+    if involved_entries is None:
+        involved_entries = entries
     span.set_attribute("path", "uv-reinvoke")
     forwarded = _forward_ctx_params(ctx, exclude={"use_this_venv"})
     inner_cmd = (
@@ -1724,7 +1878,10 @@ def _reinvoke_and_log(ctx, catalog, entries, span, rl):
         *forwarded,
         "--use-this-venv",
     )
-    with timed() as get_elapsed, _uv_reinvoke_xorq_cli(catalog, entries, *inner_cmd):
+    with (
+        timed() as get_elapsed,
+        _uv_reinvoke_xorq_cli(catalog, involved_entries, *inner_cmd),
+    ):
         pass
 
     span_prefix = f"catalog_{ctx.info_name.replace('-', '_')}"
@@ -1755,18 +1912,38 @@ def _resolve_and_execute(
     output_path = p.get("output_path")
     output_format = p.get("output_format")
 
+    raw_entries = p.get("raw_entries", ())
+    rebind_backends = p.get("rebind_backends", True)
+    bindings = _parse_entry_bindings(raw_entries)
+
     rename_map = _parse_rename_params(raw_rename_params) if raw_rename_params else None
 
     span.set_attribute("path", "in-process")
     with timed() as get_elapsed:
-        if len(entries) > 1:
+        if bindings:
+            expr = _compose_expr(
+                catalog,
+                entries,
+                code,
+                rename_map=rename_map,
+                cache_dir=cache_dir,
+                bindings=bindings,
+                rebind_backends=rebind_backends,
+            )
+        elif len(entries) > 1:
             expr = _compose_expr(
                 catalog, entries, code, rename_map=rename_map, cache_dir=cache_dir
             )
         else:
             (entry,) = entries
             expr = _resolve_single_entry(
-                catalog, entry, code, instream, rename_map, span, cache_dir=cache_dir
+                catalog,
+                entry,
+                code,
+                instream,
+                rename_map,
+                span,
+                cache_dir=cache_dir,
             )
         rl.log_span_event(
             span,
@@ -1776,7 +1953,12 @@ def _resolve_and_execute(
 
     expr = _apply_cli_params(expr, raw_params)
 
-    if fuse:
+    # Catalog fusion strips RemoteTable wrappers for single-backend
+    # push-down, but doing so over an explicit cross-backend
+    # into_backend(...) transport collapses the transport and breaks
+    # execution. In multi-root mode, only fuse when the (post-rebind)
+    # expression lives on a single backend.
+    if fuse and not (bindings and _is_cross_backend(expr)):
         expr = expr.ls.fused
     if expr_transform is not None:
         expr = expr_transform(expr)
@@ -1791,6 +1973,8 @@ def _resolve_and_execute(
 
 @cli.command("run")
 @click.argument("entries", nargs=-1, shell_complete=_complete_entry_or_alias_names)
+@entry_option
+@rebind_backends_option
 @code_option
 @output_options
 @limit_option
@@ -1819,9 +2003,11 @@ def _resolve_and_execute(
     ),
 )
 @click.pass_context
-def run(
+def run(  # xorq-style: disable=type-annotations
     ctx,
     entries,
+    raw_entries,
+    rebind_backends,
     code,
     output_path,
     output_format,
@@ -1868,13 +2054,15 @@ def run(
     with tracer.start_as_current_span("catalog.run") as span:
         span.set_attributes({"entries": entries, "has_code": code is not None})
         with click_context_catalog(ctx):
-            if not entries:
+            bindings = _resolve_mode(entries, raw_entries, code)
+            involved_entries = tuple(bindings.values()) if bindings else entries
+            if not involved_entries:
                 raise click.UsageError("At least one entry is required.")
 
-            expr_hash = "+".join(entries)
+            expr_hash = "+".join(involved_entries)
             run_params = (
                 ("expr_hash", expr_hash),
-                ("entries", ",".join(entries)),
+                ("entries", ",".join(involved_entries)),
                 ("has_code", str(code is not None)),
                 ("output_format", str(output_format)),
                 ("output_path", str(output_path)),
@@ -1932,7 +2120,14 @@ def run(
                         return
 
                 if not use_this_venv:
-                    _reinvoke_and_log(ctx, catalog, entries, span, rl)
+                    _reinvoke_and_log(
+                        ctx,
+                        catalog,
+                        entries,
+                        span,
+                        rl,
+                        involved_entries=involved_entries,
+                    )
                     return
 
                 _resolve_and_execute(
@@ -1942,6 +2137,8 @@ def run(
 
 @cli.command("run-cached")
 @click.argument("entries", nargs=-1, shell_complete=_complete_entry_or_alias_names)
+@entry_option
+@rebind_backends_option
 @code_option
 @output_options
 @limit_option
@@ -1971,9 +2168,11 @@ def run(
     ),
 )
 @click.pass_context
-def run_cached(
+def run_cached(  # xorq-style: disable=type-annotations
     ctx,
     entries,
+    raw_entries,
+    rebind_backends,
     code,
     output_path,
     output_format,
@@ -2018,15 +2217,17 @@ def run_cached(
     with tracer.start_as_current_span("catalog.run_cached") as span:
         span.set_attributes({"entries": entries, "has_code": code is not None})
         with click_context_catalog(ctx):
-            if not entries:
+            bindings = _resolve_mode(entries, raw_entries, code)
+            involved_entries = tuple(bindings.values()) if bindings else entries
+            if not involved_entries:
                 raise click.UsageError("At least one entry is required.")
 
             resolved_cache_dir = _get_cache_dir(cache_dir)
 
-            expr_hash = "+".join(entries)
+            expr_hash = "+".join(involved_entries)
             run_params = (
                 ("expr_hash", expr_hash),
-                ("entries", ",".join(entries)),
+                ("entries", ",".join(involved_entries)),
                 ("has_code", str(code is not None)),
                 ("output_format", str(output_format)),
                 ("output_path", str(output_path)),
@@ -2045,7 +2246,14 @@ def run_cached(
                 catalog = ctx.obj.make_catalog(init=False)
 
                 if not use_this_venv:
-                    _reinvoke_and_log(ctx, catalog, entries, span, rl)
+                    _reinvoke_and_log(
+                        ctx,
+                        catalog,
+                        entries,
+                        span,
+                        rl,
+                        involved_entries=involved_entries,
+                    )
                     return
 
                 def _wrap_cache(expr):

--- a/python/xorq/catalog/composer.py
+++ b/python/xorq/catalog/composer.py
@@ -119,6 +119,11 @@ class ExprComposer:
                 "No catalog-source tag found; expression was not produced by ExprComposer"
             )
 
+        if sum(1 for n in nodes if n.metadata["tag"] == CatalogTag.SOURCE) > 1:
+            raise ValueError(
+                "multi-root join entries are not yet rebuildable via catalog replay"
+            )
+
         if nodes[-1].metadata["tag"] == CatalogTag.CODE:
             (*nodes, code_node) = nodes
             code = code_node.metadata["code"]

--- a/python/xorq/catalog/tests/test_cli_multi_root.py
+++ b/python/xorq/catalog/tests/test_cli_multi_root.py
@@ -1,0 +1,471 @@
+"""Multi-root (`-e NAME=ENTRY`) join mode for catalog run/compose/run-cached.
+
+These tests exercise the join surface added on top of the linear
+source+transforms chain: binding parsing/validation, same-backend joins
+(which stay native after same-profile rebinding), provenance capture, the
+`into_backend` transport helper, the rebuild boundary, and uv-reinvoke
+forwarding of `-e` flags.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+
+import click
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+
+import xorq.api as xo
+from xorq.catalog import cli as cli_mod
+from xorq.catalog.bind import _rebind_same_profile_backends, compose_join
+from xorq.catalog.catalog import Catalog
+from xorq.catalog.cli import (
+    _parse_entry_bindings,
+    _resolve_mode,
+    cli,
+)
+from xorq.catalog.composer import ExprComposer
+from xorq.expr.relations import into_backend
+from xorq.ibis_yaml.enums import DumpFiles
+
+
+@pytest.fixture
+def two_source_catalog(tmp_path: Path) -> Catalog:
+    """A plain-git catalog with three independent memtable source entries.
+
+    Memtable-backed entries share the process let-backend, so a bare
+    `left.join(right, ...)` resolves to a single backend (no transport).
+    """
+    cat = Catalog.from_repo_path(tmp_path / "repo", init=True, annex=False)
+    cat.add(
+        xo.memtable({"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}, name="sales"),
+        aliases=("sales",),
+    )
+    cat.add(
+        xo.memtable({"id": [1, 2, 3], "name": ["a", "b", "c"]}, name="customers"),
+        aliases=("customers",),
+    )
+    cat.add(
+        xo.memtable({"id": [1, 2, 3], "region": ["x", "y", "z"]}, name="regions"),
+        aliases=("regions",),
+    )
+    return cat
+
+
+# --- _parse_entry_bindings: pure validation ---
+
+
+def test_parse_entry_bindings_empty() -> None:
+    assert _parse_entry_bindings(()) == {}
+
+
+def test_parse_entry_bindings_basic_ordered() -> None:
+    bindings = _parse_entry_bindings(("left=sales", "right=customers"))
+    assert bindings == {"left": "sales", "right": "customers"}
+    # insertion order preserved (first binding = default target)
+    assert list(bindings) == ["left", "right"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "needle"),
+    [
+        pytest.param("no-equals", "NAME=ENTRY", id="no-equals"),
+        pytest.param("=customers", "NAME=ENTRY", id="empty-name"),
+        pytest.param("left=", "NAME=ENTRY", id="empty-entry"),
+        pytest.param("1bad=sales", "identifier", id="non-identifier-digit"),
+        pytest.param("with-dash=sales", "identifier", id="non-identifier-dash"),
+        pytest.param("class=sales", "keyword", id="keyword"),
+        pytest.param("__x__=sales", "dunder", id="dunder"),
+        pytest.param("xo=sales", "reserved", id="reserved-xo"),
+        pytest.param("ibis=sales", "reserved", id="reserved-ibis"),
+        pytest.param("into_backend=sales", "reserved", id="reserved-into-backend"),
+    ],
+)
+def test_parse_entry_bindings_rejects(raw: str, needle: str) -> None:
+    with pytest.raises(click.BadParameter, match=needle):
+        _parse_entry_bindings((raw,))
+
+
+def test_parse_entry_bindings_rejects_duplicate() -> None:
+    with pytest.raises(click.BadParameter, match="duplicate"):
+        _parse_entry_bindings(("left=sales", "left=customers"))
+
+
+# --- _resolve_mode ---
+
+
+def test_resolve_mode_linear_returns_empty() -> None:
+    assert _resolve_mode(("src", "trn"), (), None) == {}
+
+
+def test_resolve_mode_rejects_mixing() -> None:
+    with pytest.raises(click.UsageError, match="Cannot combine"):
+        _resolve_mode(("customers",), ("left=sales",), "left")
+
+
+def test_resolve_mode_requires_code() -> None:
+    with pytest.raises(click.UsageError, match="requires inline code"):
+        _resolve_mode((), ("left=sales",), None)
+
+
+# --- compose_join: same-backend semantics + provenance ---
+
+
+def test_compose_join_same_backend_executes(two_source_catalog: Catalog) -> None:
+    expr = compose_join(
+        two_source_catalog,
+        {"left": "sales", "right": "customers"},
+        "left.join(right, 'id')",
+    )
+    df = expr.ls.fused.execute().sort_values("id").reset_index(drop=True)
+    assert list(df["id"]) == [1, 2, 3]
+    assert set(df.columns) >= {"id", "amount", "name"}
+
+
+def test_compose_join_provenance_captures_all_operands(
+    two_source_catalog: Catalog,
+) -> None:
+    expr = compose_join(
+        two_source_catalog,
+        {"left": "sales", "right": "customers"},
+        "left.join(right, 'id')",
+    )
+    composed = expr.ls.metadata.composed_from
+    aliases = {c["alias"] for c in composed}
+    assert aliases == {"left", "right"}
+    # entry_name records the real catalog entry (alias resolved), not the binding
+    entry_names = {c["entry_name"] for c in composed}
+    sales_name = two_source_catalog.get_catalog_entry("sales", maybe_alias=True).name
+    assert sales_name in entry_names
+
+
+def test_compose_join_three_way(two_source_catalog: Catalog) -> None:
+    expr = compose_join(
+        two_source_catalog,
+        {"a": "sales", "b": "customers", "c": "regions"},
+        "a.join(b, 'id').join(c, 'id')",
+    )
+    composed = expr.ls.metadata.composed_from
+    assert {c["alias"] for c in composed} == {"a", "b", "c"}
+    df = expr.ls.fused.execute()
+    assert set(df.columns) >= {"id", "amount", "name", "region"}
+
+
+def test_compose_join_rebind_off_same_object(two_source_catalog: Catalog) -> None:
+    # memtable entries share one backend object, so no-rebind still resolves.
+    expr = compose_join(
+        two_source_catalog,
+        {"left": "sales", "right": "customers"},
+        "left.join(right, 'id')",
+        rebind_backends=False,
+    )
+    assert len(expr.ls.fused.execute()) == 3
+
+
+def test_rebind_preserves_explicit_into_backend_transport() -> None:
+    # Two distinct same-profile backends where each side is an in-connection
+    # table that only lives on its own connection. An explicit into_backend
+    # transport must survive automatic rebind: rebind only touches top-level
+    # sources, not the operand moved behind the RemoteTable transport, so it
+    # must NOT raise the transfer_tables=False error and must stay one backend.
+    con_a = xo.duckdb.connect()
+    con_b = xo.duckdb.connect()
+    a = con_a.create_table("a", pd.DataFrame({"id": [1, 2, 3], "x": [4, 5, 6]}))
+    b = con_b.create_table("b", pd.DataFrame({"id": [1, 2, 3], "y": [7, 8, 9]}))
+    expr = a.join(into_backend(b, con_a), "id")
+    resolved = {"a": (a, con_a), "b": (b, con_b)}
+
+    out = _rebind_same_profile_backends(expr, resolved, rebind=True)
+    assert len(out._find_backends()[0]) == 1
+
+
+def test_compose_join_into_backend_helper_accepts_bound_entry(
+    two_source_catalog: Catalog,
+) -> None:
+    # into_backend(right, left): resolves left's backend from the bound entry.
+    expr = compose_join(
+        two_source_catalog,
+        {"left": "sales", "right": "customers"},
+        "left.join(into_backend(right, left), 'id')",
+    )
+    assert len(expr.execute()) == 3
+
+
+def test_compose_join_requires_bindings(two_source_catalog: Catalog) -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        compose_join(two_source_catalog, {}, "x")
+
+
+def test_compose_join_requires_code(two_source_catalog: Catalog) -> None:
+    with pytest.raises(ValueError, match="requires inline"):
+        compose_join(two_source_catalog, {"left": "sales"}, None)
+
+
+# --- rebuild boundary: ExprComposer cannot recover a multi-source join ---
+
+
+def test_exprcomposer_from_expr_rejects_multi_source(
+    two_source_catalog: Catalog,
+) -> None:
+    expr = compose_join(
+        two_source_catalog,
+        {"left": "sales", "right": "customers"},
+        "left.join(right, 'id')",
+    )
+    with pytest.raises(ValueError, match="multi-root join"):
+        ExprComposer.from_expr(expr, two_source_catalog)
+
+
+# --- CLI: run / compose / run-cached in multi-root mode ---
+
+
+def test_cli_run_multi_root_join(
+    runner: CliRunner, two_source_catalog: Catalog
+) -> None:
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().splitlines()
+    assert len(lines) == 4  # header + 3 rows
+
+
+def test_cli_compose_multi_root_catalogs(
+    runner: CliRunner, two_source_catalog: Catalog
+) -> None:
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "compose",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+            "-a",
+            "joined",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Cataloged as 'joined'" in result.output
+    reopened = Catalog.from_kwargs(path=cp, init=False)
+    assert reopened.catalog_yaml.contains_alias("joined")
+
+
+def test_cli_compose_multi_root_dry_run(
+    runner: CliRunner, two_source_catalog: Catalog
+) -> None:
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "compose",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert "Bindings:" in result.output
+    assert "left=sales" in result.output
+    assert "Cataloged" not in result.output
+
+
+def test_cli_run_cached_multi_root(
+    runner: CliRunner, two_source_catalog: Catalog, tmp_path: Path
+) -> None:
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run-cached",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+            "--cache-dir",
+            str(tmp_path / "cache"),
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "cache").exists()
+
+
+def test_cli_run_reject_mixing(runner: CliRunner, two_source_catalog: Catalog) -> None:
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(
+        cli,
+        ["--path", cp, "run", "-e", "left=sales", "customers", "-c", "left"],
+    )
+    assert result.exit_code != 0
+    assert "Cannot combine" in result.output
+
+
+def test_cli_run_reject_no_code(runner: CliRunner, two_source_catalog: Catalog) -> None:
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(cli, ["--path", cp, "run", "-e", "left=sales"])
+    assert result.exit_code != 0
+    assert "requires inline code" in result.output
+
+
+def test_cli_run_no_rebind_backends_flag(
+    runner: CliRunner, two_source_catalog: Catalog
+) -> None:
+    # memtable entries share one backend object, so --no-rebind-backends still
+    # resolves (nothing distinct to collapse) and the join executes.
+    cp = str(two_source_catalog.repo_path)
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run",
+            "--use-this-venv",
+            "--no-rebind-backends",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(result.output.strip().splitlines()) == 4
+
+
+# --- uv-reinvoke: -e flags forwarded, wheels harvested from bound entries ---
+
+
+def _fake_uv_tool_run(captured: dict) -> Callable:
+    def fake(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return fake
+
+
+def test_cli_run_multi_root_reinvokes_with_entry_flags(
+    two_source_catalog: Catalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --use-this-venv, multi-root run must re-emit the -e bindings
+    into the inner argv and harvest wheels from the bound entries."""
+    captured: dict = {}
+    monkeypatch.setattr(
+        "xorq.ibis_yaml.packager.uv_tool_run", _fake_uv_tool_run(captured)
+    )
+    cp = str(two_source_catalog.repo_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    args = captured["args"]
+    assert "run" in args
+    assert "--entry" in args
+    assert "left=sales" in args and "right=customers" in args
+    assert "--use-this-venv" in args
+    # wheels harvested from the bound entries
+    assert any(str(w).endswith(".whl") for w in captured["kwargs"]["with_"])
+
+
+def test_cli_compose_multi_root_reinvokes(
+    two_source_catalog: Catalog,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict = {}
+
+    def fake(*args, **kwargs):
+        captured["args"] = args
+        idx = args.index("--emit-build-path-to")
+        pre_built = tmp_path / "fake-build"
+        pre_built.mkdir(exist_ok=True)
+        (pre_built / DumpFiles.requirements).write_text("")
+        pathlib.Path(args[idx + 1]).write_text(str(pre_built))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("xorq.ibis_yaml.packager.uv_tool_run", fake)
+    monkeypatch.setattr(
+        cli_mod, "_stage_bundle_into_build", lambda bundle, build_path: None
+    )
+    monkeypatch.setattr(Catalog, "add", lambda self, *a, **k: SimpleNamespace())
+
+    cp = str(two_source_catalog.repo_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "compose",
+            "-e",
+            "left=sales",
+            "-e",
+            "right=customers",
+            "-c",
+            "left.join(right, 'id')",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    args = captured["args"]
+    assert "compose" in args
+    assert "--entry" in args and "left=sales" in args
+    assert "--use-this-venv" in args

--- a/python/xorq/catalog/tests/test_cli_multi_root.py
+++ b/python/xorq/catalog/tests/test_cli_multi_root.py
@@ -80,6 +80,7 @@ def test_parse_entry_bindings_basic_ordered() -> None:
         pytest.param("with-dash=sales", "identifier", id="non-identifier-dash"),
         pytest.param("class=sales", "keyword", id="keyword"),
         pytest.param("__x__=sales", "dunder", id="dunder"),
+        pytest.param("bind=sales", "reserved", id="reserved-bind"),
         pytest.param("xo=sales", "reserved", id="reserved-xo"),
         pytest.param("ibis=sales", "reserved", id="reserved-ibis"),
         pytest.param("into_backend=sales", "reserved", id="reserved-into-backend"),
@@ -432,6 +433,34 @@ def test_cli_run_positional_chain_then_join_extra_binding(
     )
     assert result.exit_code == 0, result.output
     assert "segment" in result.output
+
+
+def test_cli_run_can_bind_unbound_entry_in_code(
+    runner: CliRunner, catalog_with_source_and_transform
+) -> None:
+    cp, _, _ = catalog_with_source_and_transform
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run",
+            "-e",
+            "source=src",
+            "-e",
+            "transform=trn",
+            "-c",
+            "bind(source, transform)",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "user_id" in result.output
+    assert "amount" in result.output
+    assert "name" not in result.output
 
 
 def test_cli_run_reject_mixed_extra_binding_without_code(

--- a/python/xorq/catalog/tests/test_cli_multi_root.py
+++ b/python/xorq/catalog/tests/test_cli_multi_root.py
@@ -177,9 +177,23 @@ def test_rebind_preserves_explicit_into_backend_transport() -> None:
     a = con_a.create_table("a", pd.DataFrame({"id": [1, 2, 3], "x": [4, 5, 6]}))
     b = con_b.create_table("b", pd.DataFrame({"id": [1, 2, 3], "y": [7, 8, 9]}))
     expr = a.join(into_backend(b, con_a), "id")
-    resolved = {"a": (a, con_a), "b": (b, con_b)}
 
-    out = _rebind_same_profile_backends(expr, resolved, rebind=True)
+    out = _rebind_same_profile_backends(expr, rebind=True)
+    assert len(out._find_backends()[0]) == 1
+
+
+def test_rebind_preserves_transport_targeting_non_first_binding() -> None:
+    # The explicit transport targets the *second* operand's backend. Binding
+    # order must not override the transport target: rebind seeds its canonical
+    # backend from top-level sources (here only con_b, the transport target),
+    # so it must NOT try to relabel the top-level table back onto con_a.
+    con_a = xo.duckdb.connect()
+    con_b = xo.duckdb.connect()
+    a = con_a.create_table("a", pd.DataFrame({"id": [1, 2, 3], "x": [4, 5, 6]}))
+    b = con_b.create_table("b", pd.DataFrame({"id": [1, 2, 3], "y": [7, 8, 9]}))
+    expr = into_backend(a, con_b).join(b, "id")
+
+    out = _rebind_same_profile_backends(expr, rebind=True)
     assert len(out._find_backends()[0]) == 1
 
 

--- a/python/xorq/catalog/tests/test_cli_multi_root.py
+++ b/python/xorq/catalog/tests/test_cli_multi_root.py
@@ -102,9 +102,19 @@ def test_resolve_mode_linear_returns_empty() -> None:
     assert _resolve_mode(("src", "trn"), (), None) == {}
 
 
-def test_resolve_mode_rejects_mixing() -> None:
-    with pytest.raises(click.UsageError, match="Cannot combine"):
-        _resolve_mode(("customers",), ("left=sales",), "left")
+def test_resolve_mode_allows_primary_binding_transforms_without_code() -> None:
+    assert _resolve_mode(("trn",), ("source=src",), None) == {"source": "src"}
+
+
+def test_resolve_mode_allows_positional_source_with_extra_bindings() -> None:
+    assert _resolve_mode(
+        ("src", "trn"), ("left=sales", "right=customers"), "source"
+    ) == {"left": "sales", "right": "customers"}
+
+
+def test_resolve_mode_requires_code_for_mixed_multi_root() -> None:
+    with pytest.raises(click.UsageError, match="requires inline code"):
+        _resolve_mode(("trn",), ("source=sales", "right=customers"), None)
 
 
 def test_resolve_mode_requires_code() -> None:
@@ -344,14 +354,109 @@ def test_cli_run_cached_multi_root(
     assert (tmp_path / "cache").exists()
 
 
-def test_cli_run_reject_mixing(runner: CliRunner, two_source_catalog: Catalog) -> None:
-    cp = str(two_source_catalog.repo_path)
+def test_cli_run_entry_source_transform_matches_linear(
+    runner: CliRunner, catalog_with_source_and_transform
+) -> None:
+    cp, _, _ = catalog_with_source_and_transform
+    linear = runner.invoke(
+        cli,
+        ["--path", cp, "run", "src", "trn", "-o", "-", "-f", "csv"],
+    )
+    mixed = runner.invoke(
+        cli,
+        ["--path", cp, "run", "-e", "source=src", "trn", "-o", "-", "-f", "csv"],
+    )
+    assert linear.exit_code == 0, linear.output
+    assert mixed.exit_code == 0, mixed.output
+    assert mixed.output == linear.output
+
+
+def test_cli_run_mixed_transform_then_join(
+    runner: CliRunner, catalog_with_source_and_transform
+) -> None:
+    cp, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=cp, init=False)
+    catalog.add(
+        xo.memtable({"user_id": [1, 2, 3], "segment": ["x", "y", "z"]}),
+        aliases=("dim",),
+    )
     result = runner.invoke(
         cli,
-        ["--path", cp, "run", "-e", "left=sales", "customers", "-c", "left"],
+        [
+            "--path",
+            cp,
+            "run",
+            "-e",
+            "source=src",
+            "trn",
+            "-e",
+            "dim=dim",
+            "-c",
+            "source.join(dim, 'user_id')",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "segment" in result.output
+
+
+def test_cli_run_positional_chain_then_join_extra_binding(
+    runner: CliRunner, catalog_with_source_and_transform
+) -> None:
+    cp, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=cp, init=False)
+    catalog.add(
+        xo.memtable({"user_id": [1, 2, 3], "segment": ["x", "y", "z"]}),
+        aliases=("dim",),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run",
+            "src",
+            "trn",
+            "-e",
+            "dim=dim",
+            "-c",
+            "source.join(dim, 'user_id')",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "segment" in result.output
+
+
+def test_cli_run_reject_mixed_extra_binding_without_code(
+    runner: CliRunner, catalog_with_source_and_transform
+) -> None:
+    cp, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=cp, init=False)
+    catalog.add(
+        xo.memtable({"user_id": [1, 2, 3], "segment": ["x", "y", "z"]}),
+        aliases=("dim",),
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            cp,
+            "run",
+            "src",
+            "trn",
+            "-e",
+            "dim=dim",
+        ],
     )
     assert result.exit_code != 0
-    assert "Cannot combine" in result.output
+    assert "requires inline code" in result.output
 
 
 def test_cli_run_reject_no_code(runner: CliRunner, two_source_catalog: Catalog) -> None:

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -175,8 +175,9 @@ entry_option = click.option(
     metavar="NAME=ENTRY",
     help=(
         "Bind a catalog entry to NAME for use in -c code (repeatable). "
-        "Any -e switches the command into multi-root/join mode, where -c "
-        "is required and positional ENTRIES are rejected."
+        "With positional ENTRIES, either bind source=ENTRY and apply ENTRIES "
+        "as transforms, or expose the positional chain as source alongside "
+        "extra bindings."
     ),
 )
 

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -167,6 +167,31 @@ code_option = click.option(
 )
 
 
+entry_option = click.option(
+    "-e",
+    "--entry",
+    "raw_entries",
+    multiple=True,
+    metavar="NAME=ENTRY",
+    help=(
+        "Bind a catalog entry to NAME for use in -c code (repeatable). "
+        "Any -e switches the command into multi-root/join mode, where -c "
+        "is required and positional ENTRIES are rejected."
+    ),
+)
+
+
+rebind_backends_option = click.option(
+    "--rebind-backends/--no-rebind-backends",
+    default=True,
+    show_default=True,
+    help=(
+        "In multi-root mode, rebind same-profile backend sources to one "
+        "backend before execution. Never transfers table data."
+    ),
+)
+
+
 sync_option = click.option(
     "--sync/--no-sync",
     default=True,


### PR DESCRIPTION
Add a multi-root/join mode to `xorq catalog run/compose/run-cached` via repeatable `-e NAME=ENTRY` bindings plus inline `-c` code. Each binding resolves a catalog entry into the eval namespace alongside vendored `ibis` and an `into_backend(...)` transport helper; the user-facing `xo` facade is injected from the CLI layer so catalog library code does not depend on `xorq.api`.

Same-profile backend sources (catalog entries hydrate as distinct backend objects even when they point at one database/profile) are canonicalized to a single backend before execution so bare same-backend joins stay native and fused. Rebinding only touches top-level sources (derived from `_find_backends`), so an explicit `into_backend(...)` transport boundary is preserved rather than rewritten through (which would otherwise raise the `transfer_tables=False` materialization error for in-connection tables).

Rebind is controlled by a boolean `--rebind-backends/--no-rebind-backends` flag (default on). Cross-backend joins without an explicit transport are left as-is.