### PR TITLE
fix(relations): guard streaming generator close against concurrent advance

### DIFF
--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -623,11 +623,21 @@ def register_and_transform_tee_nodes(
                 "See ADR-0014.",
                 stacklevel=2,
             )
+        from xorq.expr.remote_table_exec import _LockedGen  # noqa: PLC0415
+
         reader = parent_expr.to_pyarrow_batches()
         write_iter = node.writer.write_through(reader)
         if node.drain:
             write_iter = DrainingIterator(write_iter)
             drains.append(write_iter)
+        else:
+            # drain=False: the raw write-through generator is registered into
+            # the backend and advanced by its read-ahead worker thread. Guard it
+            # so a GC/finalizer close() cannot race a worker mid-advance ->
+            # "generator already executing" (same race as the outer reader in
+            # bind_scope_to_reader; drain=True is already guarded by
+            # DrainingIterator's advance lock, #2107).
+            write_iter = _LockedGen(write_iter)
         wrapped = pa.RecordBatchReader.from_batches(
             reader.schema,
             write_iter,

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -603,6 +603,7 @@ def register_and_transform_tee_nodes(
     the writer can finish consuming the stream.
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
+    from xorq.expr.remote_table_exec import _LockedGen  # noqa: PLC0415
 
     drains: list[DrainingIterator] = []
     created: dict[str, BaseBackend] = {}
@@ -623,8 +624,6 @@ def register_and_transform_tee_nodes(
                 "See ADR-0014.",
                 stacklevel=2,
             )
-        from xorq.expr.remote_table_exec import _LockedGen  # noqa: PLC0415
-
         reader = parent_expr.to_pyarrow_batches()
         write_iter = node.writer.write_through(reader)
         if node.drain:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -25,7 +25,7 @@ from xorq.vendor.ibis.common.collections import (
 from xorq.vendor.ibis.expr import operations as ops
 from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node
-from xorq.writes import DrainingIterator, WriteThrough
+from xorq.writes import DrainingIterator, LockedIterator, WriteThrough
 
 
 def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
@@ -603,7 +603,6 @@ def register_and_transform_tee_nodes(
     the writer can finish consuming the stream.
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
-    from xorq.expr.remote_table_exec import _LockedGen  # noqa: PLC0415
 
     drains: list[DrainingIterator] = []
     created: dict[str, BaseBackend] = {}
@@ -636,7 +635,7 @@ def register_and_transform_tee_nodes(
             # "generator already executing" (same race as the outer reader in
             # bind_scope_to_reader; drain=True is already guarded by
             # DrainingIterator's advance lock, #2107).
-            write_iter = _LockedGen(write_iter)
+            write_iter = LockedIterator(write_iter)
         wrapped = pa.RecordBatchReader.from_batches(
             reader.schema,
             write_iter,

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import threading
 import weakref
 from collections import Counter
 from typing import Any, Callable, NamedTuple
@@ -281,6 +282,50 @@ class RemoteTableScope:
         self.close()
 
 
+class _LockedGen:
+    """Serializes advancement and close of a wrapped generator.
+
+    A datafusion scan can park the foreground ``next()`` inside an FFI pull
+    (the generator frame is in the *executing* state, not suspended) while a
+    background pull lags. If the ``weakref.finalize`` backstop then calls
+    ``close()`` on that frame, CPython raises ``ValueError: generator already
+    executing`` -- in a finalizer/daemon-thread context that escapes and aborts
+    the process. The shared lock guarantees ``close()`` only runs while the
+    generator is suspended, never mid-advance. Same race class as the
+    ``DrainingIterator`` advance lock (#2107).
+    """
+
+    def __init__(self, gen) -> None:
+        self._gen = gen
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def __iter__(self) -> "_LockedGen":
+        return self
+
+    def __next__(self):
+        with self._lock:
+            if self._closed:
+                raise StopIteration
+            return next(self._gen)
+
+    def close(self) -> None:
+        # Non-blocking acquire: closing an *executing* frame raises
+        # ``ValueError: generator already executing``, and *blocking* until the
+        # advance returns can wedge the finalizer during interpreter teardown
+        # (GIL-release fatal). So if an advance holds the lock, skip the gen
+        # close entirely -- that in-flight consumer owns the generator's
+        # teardown (its ``finally`` runs ``scope.close()``); the caller's
+        # explicit ``scope.close()`` still fires regardless.
+        if self._lock.acquire(blocking=False):
+            try:
+                if not self._closed:
+                    self._closed = True
+                    self._gen.close()
+            finally:
+                self._lock.release()
+
+
 def bind_scope_to_reader(
     scope: RemoteTableScope,
     reader: pa.RecordBatchReader,
@@ -295,6 +340,10 @@ def bind_scope_to_reader(
     never-started generator never runs its ``finally``).  Note that on
     pyarrow 21 ``reader.close()`` alone does not finalize the wrapped
     generator -- cleanup then fires when the last reference drops.
+
+    The generator is wrapped in ``_LockedGen`` so the finalizer's ``close()``
+    cannot race a foreground advance still parked inside a datafusion FFI pull
+    (see ``_LockedGen``).
     """
 
     def gen():
@@ -308,11 +357,11 @@ def bind_scope_to_reader(
             # (remote_table_scope) surface drain failures instead.
             scope.close()
 
-    g = gen()
-    out = pa.RecordBatchReader.from_batches(reader.schema, g)
+    locked = _LockedGen(gen())
+    out = pa.RecordBatchReader.from_batches(reader.schema, locked)
 
     def _cleanup() -> None:
-        g.close()
+        locked.close()
         scope.close()
 
     weakref.finalize(out, _cleanup)

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import threading
 import weakref
 from collections import Counter
 from typing import Any, Callable, NamedTuple
@@ -17,7 +16,7 @@ from xorq.expr.relations import RemoteTable, gen_name
 from xorq.vendor.ibis import Expr
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import operations as ops
-from xorq.writes import DrainingIterator
+from xorq.writes import DrainingIterator, LockedIterator
 
 
 logger = get_logger(__name__)
@@ -282,57 +281,6 @@ class RemoteTableScope:
         self.close()
 
 
-class _LockedGen:
-    """Serializes advancement and close of a wrapped generator.
-
-    A datafusion scan can park the foreground ``next()`` inside an FFI pull
-    (the generator frame is in the *executing* state, not suspended) while a
-    background pull lags. If the ``weakref.finalize`` backstop then calls
-    ``close()`` on that frame, CPython raises ``ValueError: generator already
-    executing`` -- in a finalizer/daemon-thread context that escapes and aborts
-    the process. The shared lock guarantees ``close()`` only runs while the
-    generator is suspended, never mid-advance. Same race class as the
-    ``DrainingIterator`` advance lock (#2107).
-    """
-
-    def __init__(self, gen) -> None:
-        self._gen = gen
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def __iter__(self) -> "_LockedGen":
-        return self
-
-    def __next__(self):
-        with self._lock:
-            if self._closed:
-                raise StopIteration
-            try:
-                return next(self._gen)
-            except StopIteration:
-                # natural exhaustion: mark closed so a later close() is a no-op
-                # and _closed tracks "no longer advanceable", not just explicit
-                # close calls.
-                self._closed = True
-                raise
-
-    def close(self) -> None:
-        # Non-blocking acquire: closing an *executing* frame raises
-        # ``ValueError: generator already executing``, and *blocking* until the
-        # advance returns can wedge the finalizer during interpreter teardown
-        # (GIL-release fatal). So if an advance holds the lock, skip the gen
-        # close entirely -- that in-flight consumer owns the generator's
-        # teardown (its ``finally`` runs ``scope.close()``); the caller's
-        # explicit ``scope.close()`` still fires regardless.
-        if self._lock.acquire(blocking=False):
-            try:
-                if not self._closed:
-                    self._closed = True
-                    self._gen.close()
-            finally:
-                self._lock.release()
-
-
 def bind_scope_to_reader(
     scope: RemoteTableScope,
     reader: pa.RecordBatchReader,
@@ -348,9 +296,9 @@ def bind_scope_to_reader(
     pyarrow 21 ``reader.close()`` alone does not finalize the wrapped
     generator -- cleanup then fires when the last reference drops.
 
-    The generator is wrapped in ``_LockedGen`` so the finalizer's ``close()``
+    The generator is wrapped in ``LockedIterator`` so the finalizer's ``close()``
     cannot race a foreground advance still parked inside a datafusion FFI pull
-    (see ``_LockedGen``).
+    (see ``LockedIterator``).
     """
 
     def gen():
@@ -364,7 +312,7 @@ def bind_scope_to_reader(
             # (remote_table_scope) surface drain failures instead.
             scope.close()
 
-    locked = _LockedGen(gen())
+    locked = LockedIterator(gen())
     out = pa.RecordBatchReader.from_batches(reader.schema, locked)
 
     def _cleanup() -> None:

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -307,7 +307,14 @@ class _LockedGen:
         with self._lock:
             if self._closed:
                 raise StopIteration
-            return next(self._gen)
+            try:
+                return next(self._gen)
+            except StopIteration:
+                # natural exhaustion: mark closed so a later close() is a no-op
+                # and _closed tracks "no longer advanceable", not just explicit
+                # close calls.
+                self._closed = True
+                raise
 
     def close(self) -> None:
         # Non-blocking acquire: closing an *executing* frame raises

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -22,8 +22,8 @@ import xorq.vendor.ibis.expr.types as ir
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.expr.api import get_plans, to_pyarrow_batches
 from xorq.expr.remote_table_exec import (
+    LockedIterator,
     RemoteTableScope,
-    _LockedGen,
     bind_scope_to_reader,
     drop_placeholder,
     prepare_create_table_from_expr,
@@ -405,7 +405,7 @@ def test_locked_gen_close_during_advance_does_not_raise() -> None:
     # Regression: a datafusion scan can park the foreground next() inside an
     # FFI pull (frame *executing*, not suspended). A bare gen.close() then
     # raises "ValueError: generator already executing" -- in the weakref
-    # finalizer this aborts the process. _LockedGen must make close() a no-op
+    # finalizer this aborts the process. LockedIterator must make close() a no-op
     # while an advance holds the lock. Same race class as #2107.
     in_pull = threading.Event()
     release = threading.Event()
@@ -416,7 +416,7 @@ def test_locked_gen_close_during_advance_does_not_raise() -> None:
             release.wait()  # simulate an in-flight FFI pull
             yield i
 
-    locked = _LockedGen(slow())
+    locked = LockedIterator(slow())
     errors: list[BaseException] = []
 
     def advance() -> None:
@@ -447,7 +447,7 @@ def test_locked_gen_close_when_idle_closes_generator() -> None:
         finally:
             closed.append(True)
 
-    locked = _LockedGen(gen())
+    locked = LockedIterator(gen())
     assert next(locked) == 1
     locked.close()
     assert closed == [True]

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -9,6 +9,7 @@ result readers.
 from __future__ import annotations
 
 import gc
+import threading
 from collections.abc import Callable
 
 import pandas as pd
@@ -22,6 +23,7 @@ from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.expr.api import get_plans, to_pyarrow_batches
 from xorq.expr.remote_table_exec import (
     RemoteTableScope,
+    _LockedGen,
     bind_scope_to_reader,
     drop_placeholder,
     prepare_create_table_from_expr,
@@ -397,6 +399,61 @@ def test_bind_closes_at_drain_not_gc() -> None:
     bound.read_all()
     assert closed == ["drain"], "bind must close at exhaustion, not at reader GC"
     del bound
+
+
+def test_locked_gen_close_during_advance_does_not_raise() -> None:
+    # Regression: a datafusion scan can park the foreground next() inside an
+    # FFI pull (frame *executing*, not suspended). A bare gen.close() then
+    # raises "ValueError: generator already executing" -- in the weakref
+    # finalizer this aborts the process. _LockedGen must make close() a no-op
+    # while an advance holds the lock. Same race class as #2107.
+    in_pull = threading.Event()
+    release = threading.Event()
+
+    def slow():
+        for i in range(100):
+            in_pull.set()
+            release.wait()  # simulate an in-flight FFI pull
+            yield i
+
+    locked = _LockedGen(slow())
+    errors: list[BaseException] = []
+
+    def advance() -> None:
+        try:
+            next(locked)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t = threading.Thread(target=advance)
+    t.start()
+    assert in_pull.wait(timeout=5), "advance never reached the in-flight pull"
+
+    # close() while the advance is mid-flight must not raise and must not block.
+    locked.close()  # would raise ValueError on a bare generator
+
+    release.set()
+    t.join(timeout=5)
+    assert not t.is_alive()
+    assert errors == []
+
+
+def test_locked_gen_close_when_idle_closes_generator() -> None:
+    closed: list[bool] = []
+
+    def gen():
+        try:
+            yield 1
+        finally:
+            closed.append(True)
+
+    locked = _LockedGen(gen())
+    assert next(locked) == 1
+    locked.close()
+    assert closed == [True]
+    # idempotent
+    locked.close()
+    assert closed == [True]
 
 
 def test_scope_close_closes_adopted_readers() -> None:

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -454,6 +454,9 @@ def test_locked_gen_close_when_idle_closes_generator() -> None:
     # idempotent
     locked.close()
     assert closed == [True]
+    # advancing after close raises StopIteration, not a reuse of the closed gen
+    with pytest.raises(StopIteration):
+        next(locked)
 
 
 def test_scope_close_closes_adopted_readers() -> None:

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -22,7 +22,6 @@ import xorq.vendor.ibis.expr.types as ir
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.expr.api import get_plans, to_pyarrow_batches
 from xorq.expr.remote_table_exec import (
-    LockedIterator,
     RemoteTableScope,
     bind_scope_to_reader,
     drop_placeholder,
@@ -31,6 +30,7 @@ from xorq.expr.remote_table_exec import (
 )
 from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.backends import BaseBackend
+from xorq.writes import LockedIterator
 
 
 pytest.importorskip("duckdb")
@@ -416,7 +416,9 @@ def test_locked_gen_close_during_advance_does_not_raise() -> None:
             release.wait()  # simulate an in-flight FFI pull
             yield i
 
-    locked = LockedIterator(slow())
+    gen = slow()
+
+    locked = LockedIterator(gen)
     errors: list[BaseException] = []
 
     def advance() -> None:
@@ -436,6 +438,16 @@ def test_locked_gen_close_during_advance_does_not_raise() -> None:
     t.join(timeout=5)
     assert not t.is_alive()
     assert errors == []
+
+    # The mid-advance close() was a no-op: the lock was held, so the generator
+    # was left open and _closed stays False -- it was never the owner of
+    # teardown. The generator must still be advanceable and explicitly
+    # closeable once the advance has returned the lock.
+    assert locked._closed is False
+    assert gen.gi_frame is not None  # still open, not finalized by the no-op
+    locked.close()  # idle now: this one actually closes the generator
+    assert locked._closed is True
+    assert gen.gi_frame is None  # generator finalized
 
 
 def test_locked_gen_close_when_idle_closes_generator() -> None:

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -1501,6 +1501,34 @@ def test_tee_drain_false_does_not_drain(tmp_path: Path) -> None:
     assert len(pq.read_table(str(full_target))) == _MULTI_BATCH_COUNT
 
 
+@pytest.mark.parametrize("drain", [False, True])
+def test_tee_write_iter_guard_by_drain(
+    tmp_path: Path, monkeypatch: Any, drain: bool
+) -> None:
+    # The drain=False write-through generator is registered into the backend and
+    # advanced by its read-ahead worker; it must be wrapped in _LockedGen so a
+    # GC/finalizer close() cannot race a worker mid-advance. drain=True is
+    # instead guarded by DrainingIterator, so it must NOT be _LockedGen-wrapped.
+    import xorq.expr.remote_table_exec as rte  # noqa: PLC0415
+
+    wrapped_names: list[str | None] = []
+    orig = rte._LockedGen
+
+    def spy(gen: Any) -> Any:
+        wrapped_names.append(getattr(getattr(gen, "gi_code", None), "co_name", None))
+        return orig(gen)
+
+    monkeypatch.setattr(rte, "_LockedGen", spy)
+    con = xo.connect()
+    tt = _multi_batch_source(con, f"guard_src_{drain}")
+    expr = tt.tee(ParquetWriteThrough(path=tmp_path / "o.parquet"), drain=drain)
+    register_and_transform_tee_nodes(expr)
+
+    # "write_through" identifies the ParquetWriteThrough generator; "gen" is the
+    # unrelated parent-reader wrap from bind_scope_to_reader.
+    assert ("write_through" in wrapped_names) is (drain is False)
+
+
 def test_drain_build_hash_same(t: Table, tmp_path: Path) -> None:
     writer = ParquetWriteThrough(path=tmp_path / "out.parquet")
     no_drain = t.tee(writer, drain=False)

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -1507,8 +1507,11 @@ def test_tee_write_iter_guard_by_drain(
 ) -> None:
     # The drain=False write-through generator is registered into the backend and
     # advanced by its read-ahead worker; it must be wrapped in LockedIterator so a
-    # GC/finalizer close() cannot race a worker mid-advance. drain=True is
-    # instead guarded by DrainingIterator, so it must NOT be LockedIterator-wrapped.
+    # GC/finalizer close() cannot race a worker mid-advance. drain=True instead
+    # goes through DrainingIterator, so the relations call site must NOT wrap it
+    # in LockedIterator directly. (DrainingIterator serializes advance via its own
+    # internal LockedIterator -- constructed from write_through's module global,
+    # which these spies don't patch, so it is correctly invisible here.)
     import xorq.expr.relations as rel  # noqa: PLC0415
     import xorq.expr.remote_table_exec as rte  # noqa: PLC0415
 
@@ -1539,7 +1542,8 @@ def test_tee_write_iter_guard_by_drain(
     # bypassed entirely).
     assert "gen" in wrapped_names, "spy did not observe the parent-reader wrap"
     if drain:
-        # drain=True is guarded by DrainingIterator, not LockedIterator.
+        # drain=True goes through DrainingIterator; the relations call site does
+        # not wrap the write-through gen in (a patched) LockedIterator.
         assert "write_through" not in wrapped_names
     else:
         # drain=False must wrap the raw write-through generator in LockedIterator.

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -1506,37 +1506,43 @@ def test_tee_write_iter_guard_by_drain(
     tmp_path: Path, monkeypatch: Any, drain: bool
 ) -> None:
     # The drain=False write-through generator is registered into the backend and
-    # advanced by its read-ahead worker; it must be wrapped in _LockedGen so a
+    # advanced by its read-ahead worker; it must be wrapped in LockedIterator so a
     # GC/finalizer close() cannot race a worker mid-advance. drain=True is
-    # instead guarded by DrainingIterator, so it must NOT be _LockedGen-wrapped.
+    # instead guarded by DrainingIterator, so it must NOT be LockedIterator-wrapped.
+    import xorq.expr.relations as rel  # noqa: PLC0415
     import xorq.expr.remote_table_exec as rte  # noqa: PLC0415
 
     wrapped_names: list[str | None] = []
-    orig = rte._LockedGen
+    orig = rte.LockedIterator
 
     def spy(gen: Any) -> Any:
         wrapped_names.append(getattr(getattr(gen, "gi_code", None), "co_name", None))
         return orig(gen)
 
-    monkeypatch.setattr(rte, "_LockedGen", spy)
+    # LockedIterator lives in xorq.writes; both modules bind it at import time
+    # (rte wraps the parent reader in bind_scope_to_reader -> "gen"; relations
+    # wraps the drain=False write-through generator -> "write_through"). Patch
+    # both namespaces so the spy observes each wrap site.
+    monkeypatch.setattr(rte, "LockedIterator", spy)
+    monkeypatch.setattr(rel, "LockedIterator", spy)
     con = xo.connect()
     tt = _multi_batch_source(con, f"guard_src_{drain}")
     expr = tt.tee(ParquetWriteThrough(path=tmp_path / "o.parquet"), drain=drain)
     register_and_transform_tee_nodes(expr)
 
-    # wrapped_names holds the co_name of each generator _LockedGen wraps:
+    # wrapped_names holds the co_name of each generator LockedIterator wraps:
     #   "write_through" -> the ParquetWriteThrough.write_through generator
     #   "gen"           -> the parent-reader wrap inside bind_scope_to_reader
     # bind_scope_to_reader always wraps the parent reader, so "gen" must appear
     # regardless of drain -- this proves the spy is active, so the
-    # write_through check below cannot pass vacuously (e.g. if _LockedGen were
+    # write_through check below cannot pass vacuously (e.g. if LockedIterator were
     # bypassed entirely).
     assert "gen" in wrapped_names, "spy did not observe the parent-reader wrap"
     if drain:
-        # drain=True is guarded by DrainingIterator, not _LockedGen.
+        # drain=True is guarded by DrainingIterator, not LockedIterator.
         assert "write_through" not in wrapped_names
     else:
-        # drain=False must wrap the raw write-through generator in _LockedGen.
+        # drain=False must wrap the raw write-through generator in LockedIterator.
         assert "write_through" in wrapped_names
 
 

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -1512,20 +1512,35 @@ def test_tee_write_iter_guard_by_drain(
     # in LockedIterator directly. (DrainingIterator serializes advance via its own
     # internal LockedIterator -- constructed from write_through's module global,
     # which these spies don't patch, so it is correctly invisible here.)
+    import types  # noqa: PLC0415
+
     import xorq.expr.relations as rel  # noqa: PLC0415
     import xorq.expr.remote_table_exec as rte  # noqa: PLC0415
 
-    wrapped_names: list[str | None] = []
+    # Identify the two generators we expect to be wrapped by *code object*, not
+    # by co_name string: a string match would still pass if a rename caused the
+    # wrong generator to be wrapped. The code-object references follow renames.
+    write_through_code = ParquetWriteThrough.write_through.__code__
+    # bind_scope_to_reader wraps its parent-reader closure (a nested fn "gen");
+    # extract that closure's code object. A rename of the closure surfaces as a
+    # StopIteration here (loud failure), not a silently-vacuous pass.
+    bind_gen_code = next(
+        const
+        for const in rte.bind_scope_to_reader.__code__.co_consts
+        if isinstance(const, types.CodeType) and const.co_name == "gen"
+    )
+
+    wrapped_codes: list[Any] = []
     orig = rte.LockedIterator
 
     def spy(gen: Any) -> Any:
-        wrapped_names.append(getattr(getattr(gen, "gi_code", None), "co_name", None))
+        wrapped_codes.append(getattr(gen, "gi_code", None))
         return orig(gen)
 
     # LockedIterator lives in xorq.writes; both modules bind it at import time
-    # (rte wraps the parent reader in bind_scope_to_reader -> "gen"; relations
-    # wraps the drain=False write-through generator -> "write_through"). Patch
-    # both namespaces so the spy observes each wrap site.
+    # (rte wraps the parent reader in bind_scope_to_reader; relations wraps the
+    # drain=False write-through generator). Patch both namespaces so the spy
+    # observes each wrap site.
     monkeypatch.setattr(rte, "LockedIterator", spy)
     monkeypatch.setattr(rel, "LockedIterator", spy)
     con = xo.connect()
@@ -1533,21 +1548,18 @@ def test_tee_write_iter_guard_by_drain(
     expr = tt.tee(ParquetWriteThrough(path=tmp_path / "o.parquet"), drain=drain)
     register_and_transform_tee_nodes(expr)
 
-    # wrapped_names holds the co_name of each generator LockedIterator wraps:
-    #   "write_through" -> the ParquetWriteThrough.write_through generator
-    #   "gen"           -> the parent-reader wrap inside bind_scope_to_reader
-    # bind_scope_to_reader always wraps the parent reader, so "gen" must appear
-    # regardless of drain -- this proves the spy is active, so the
-    # write_through check below cannot pass vacuously (e.g. if LockedIterator were
-    # bypassed entirely).
-    assert "gen" in wrapped_names, "spy did not observe the parent-reader wrap"
+    # bind_scope_to_reader always wraps the parent reader, so its code object
+    # must appear regardless of drain -- this proves the spy is active, so the
+    # negative drain=True check below cannot pass vacuously (e.g. if
+    # LockedIterator were bypassed entirely).
+    assert bind_gen_code in wrapped_codes, "spy did not observe the parent-reader wrap"
     if drain:
         # drain=True goes through DrainingIterator; the relations call site does
         # not wrap the write-through gen in (a patched) LockedIterator.
-        assert "write_through" not in wrapped_names
+        assert write_through_code not in wrapped_codes
     else:
         # drain=False must wrap the raw write-through generator in LockedIterator.
-        assert "write_through" in wrapped_names
+        assert write_through_code in wrapped_codes
 
 
 def test_drain_build_hash_same(t: Table, tmp_path: Path) -> None:

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -1524,9 +1524,20 @@ def test_tee_write_iter_guard_by_drain(
     expr = tt.tee(ParquetWriteThrough(path=tmp_path / "o.parquet"), drain=drain)
     register_and_transform_tee_nodes(expr)
 
-    # "write_through" identifies the ParquetWriteThrough generator; "gen" is the
-    # unrelated parent-reader wrap from bind_scope_to_reader.
-    assert ("write_through" in wrapped_names) is (drain is False)
+    # wrapped_names holds the co_name of each generator _LockedGen wraps:
+    #   "write_through" -> the ParquetWriteThrough.write_through generator
+    #   "gen"           -> the parent-reader wrap inside bind_scope_to_reader
+    # bind_scope_to_reader always wraps the parent reader, so "gen" must appear
+    # regardless of drain -- this proves the spy is active, so the
+    # write_through check below cannot pass vacuously (e.g. if _LockedGen were
+    # bypassed entirely).
+    assert "gen" in wrapped_names, "spy did not observe the parent-reader wrap"
+    if drain:
+        # drain=True is guarded by DrainingIterator, not _LockedGen.
+        assert "write_through" not in wrapped_names
+    else:
+        # drain=False must wrap the raw write-through generator in _LockedGen.
+        assert "write_through" in wrapped_names
 
 
 def test_drain_build_hash_same(t: Table, tmp_path: Path) -> None:

--- a/python/xorq/writes/__init__.py
+++ b/python/xorq/writes/__init__.py
@@ -8,6 +8,7 @@ from xorq.writes.wap import (
 from xorq.writes.write_through import (
     BackendWriteThrough,
     DrainingIterator,
+    LockedIterator,
     ParquetWriteThrough,
     ThreadedBackendWriteThrough,
     WritePrimaryWriteThrough,
@@ -18,6 +19,7 @@ from xorq.writes.write_through import (
 __all__ = [
     "BackendWriteThrough",
     "DrainingIterator",
+    "LockedIterator",
     "ParquetWriteThrough",
     "ThreadedBackendWriteThrough",
     "WriteMode",

--- a/python/xorq/writes/write_through.py
+++ b/python/xorq/writes/write_through.py
@@ -448,6 +448,15 @@ class LockedIterator:
     the process. The shared lock guarantees ``close()`` only runs while the
     generator is suspended, never mid-advance. Same race class as the
     ``DrainingIterator`` advance lock (#2107).
+
+    CPython-only: when ``close()`` finds an advance in flight it abandons the
+    explicit generator close (see ``close()``), so finalizing the still-open
+    generator frame falls to reference-counting GC -- the in-flight consumer
+    drops the last reference once its advance returns. That backstop assumes
+    CPython's deterministic refcounting; on a runtime without it (PyPy,
+    GraalPy) an abandoned-mid-advance frame could linger until the next GC
+    cycle. xorq already depends on CPython refcounting/GIL semantics throughout,
+    so this is not a new constraint.
     """
 
     def __init__(self, gen) -> None:
@@ -539,7 +548,18 @@ class DrainingIterator:
 
     def close(self) -> None:
         with self._state_lock:
-            if self._exhausted or self._drain_thread is not None:
+            # Also treat the inner iterator's own exhaustion flag as exhausted:
+            # __next__ sets _locked._closed inside the locked critical section
+            # but flips _exhausted only after releasing that lock, so there is a
+            # brief window where the generator is done yet _exhausted is still
+            # False. Checking _locked._closed here avoids spawning a drain thread
+            # that would immediately exit. (DrainingIterator never calls
+            # _locked.close(), so _closed is True only on natural exhaustion.)
+            if (
+                self._exhausted
+                or self._locked._closed
+                or self._drain_thread is not None
+            ):
                 return
             self._drain_thread = threading.Thread(target=self._drain)
             self._drain_thread.start()

--- a/python/xorq/writes/write_through.py
+++ b/python/xorq/writes/write_through.py
@@ -437,6 +437,57 @@ class WritePrimaryWriteThrough(WriteThrough):
                 raise error[0]
 
 
+class LockedIterator:
+    """Serializes advancement and close of a wrapped generator.
+
+    A datafusion scan can park the foreground ``next()`` inside an FFI pull
+    (the generator frame is in the *executing* state, not suspended) while a
+    background pull lags. If the ``weakref.finalize`` backstop then calls
+    ``close()`` on that frame, CPython raises ``ValueError: generator already
+    executing`` -- in a finalizer/daemon-thread context that escapes and aborts
+    the process. The shared lock guarantees ``close()`` only runs while the
+    generator is suspended, never mid-advance. Same race class as the
+    ``DrainingIterator`` advance lock (#2107).
+    """
+
+    def __init__(self, gen) -> None:
+        self._gen = gen
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def __iter__(self) -> "LockedIterator":
+        return self
+
+    def __next__(self):
+        with self._lock:
+            if self._closed:
+                raise StopIteration
+            try:
+                return next(self._gen)
+            except StopIteration:
+                # natural exhaustion: mark closed so a later close() is a no-op
+                # and _closed tracks "no longer advanceable", not just explicit
+                # close calls.
+                self._closed = True
+                raise
+
+    def close(self) -> None:
+        # Non-blocking acquire: closing an *executing* frame raises
+        # ``ValueError: generator already executing``, and *blocking* until the
+        # advance returns can wedge the finalizer during interpreter teardown
+        # (GIL-release fatal). So if an advance holds the lock, skip the gen
+        # close entirely -- that in-flight consumer owns the generator's
+        # teardown (its ``finally`` runs ``scope.close()``); the caller's
+        # explicit ``scope.close()`` still fires regardless.
+        if self._lock.acquire(blocking=False):
+            try:
+                if not self._closed:
+                    self._closed = True
+                    self._gen.close()
+            finally:
+                self._lock.release()
+
+
 class DrainingIterator:
     """Wraps a write-through generator; drains remaining batches on close.
 

--- a/python/xorq/writes/write_through.py
+++ b/python/xorq/writes/write_through.py
@@ -493,18 +493,21 @@ class DrainingIterator:
 
     Callers must call ``close()`` then ``join()`` — there is no ``__del__``
     finalizer; the execution pipeline (``api.py``) owns the lifecycle.
+
+    Advancement is serialized by an inner ``LockedIterator`` so the foreground
+    reader pull (datafusion read-ahead) and the background ``_drain`` loop never
+    call ``next()`` on the wrapped generator concurrently -> 'generator already
+    executing' (#2107). ``close()`` here *drains* the remainder on a worker
+    thread rather than abandoning it, so it does not use ``LockedIterator``'s
+    own (abandon-on-close) ``close()``.
     """
 
     def __init__(self, write_gen: Iterator[pa.RecordBatch]) -> None:
-        self._gen = write_gen
+        self._locked = LockedIterator(write_gen)
         self._exhausted = False
         self._drain_thread: threading.Thread | None = None
         self._error: BaseException | None = None
         self._state_lock = threading.Lock()
-        # serializes generator advancement so the foreground reader pull
-        # (datafusion read-ahead) and the background _drain loop never call
-        # next(self._gen) concurrently -> 'generator already executing'.
-        self._advance_lock = threading.Lock()
 
     @property
     def exhausted(self) -> bool:
@@ -515,24 +518,20 @@ class DrainingIterator:
         return self
 
     def __next__(self) -> pa.RecordBatch:
-        with self._advance_lock:
-            try:
-                return next(self._gen)
-            except StopIteration:
-                with self._state_lock:
-                    self._exhausted = True
-                raise
+        try:
+            return next(self._locked)
+        except StopIteration:
+            with self._state_lock:
+                self._exhausted = True
+            raise
 
     def _drain(self) -> None:
-        # acquire per-iteration, not across the whole loop, so a still-in-flight
-        # foreground __next__ can interleave instead of being starved.
+        # LockedIterator acquires its lock per-advance, so a still-in-flight
+        # foreground __next__ can interleave with this loop instead of being
+        # starved.
         try:
-            while True:
-                with self._advance_lock:
-                    try:
-                        next(self._gen)
-                    except StopIteration:
-                        break
+            for _ in self._locked:
+                pass
         except BaseException as exc:  # noqa: BLE001
             self._error = exc
         with self._state_lock:


### PR DESCRIPTION
## Problem

`test_tee_drain_false_does_not_drain` is flaky. Root cause is a concurrency bug in the streaming cleanup path, not a wrong test.

A datafusion read-ahead worker can park the foreground `next()` inside an FFI pull, leaving the generator frame in the **executing** state (not suspended). If a GC/`weakref.finalize` backstop then calls `.close()` on that frame, CPython raises:

```
ValueError: generator already executing
```

In a finalizer/daemon-thread context this escapes → `terminate called` → process abort. Under CI contention the scan lingers long enough to collide with GC/shutdown, surfacing as a flaky abort. This is the **same race class** as #2107 (`DrainingIterator._advance_lock`), which fixed the `drain=True` path; the finalizer path and the `drain=False` child were never guarded.

## Fix

Introduce `_LockedGen` — a shared lock serializes `__next__` and `close()`. `close()` uses a **non-blocking** acquire: if an advance holds the lock it skips the gen close (that in-flight consumer owns teardown via its `finally`; the explicit `scope.close()` still runs). Non-blocking avoids both the executing-frame raise and a finalizer wedge at interpreter shutdown.

Two layers guarded:

1. **`beb5e58c`** — outer result generator in `bind_scope_to_reader._cleanup` (every `to_pyarrow_batches`).
2. **`52146cc0`** — drain=False tee `write_iter`, registered into the backend and advanced by its read-ahead worker. `drain=True` stays on `DrainingIterator`.

## Tests

- `test_locked_gen_close_during_advance_does_not_raise` — close while a background thread is mid-advance; OLD bare gen raises `generator already executing`, NEW is clean.
- `test_locked_gen_close_when_idle_closes_generator` — close-when-idle closes + idempotent.
- `test_tee_write_iter_guard_by_drain` (parametrized) — write-through generator is `_LockedGen`-wrapped only when `drain=False`.

Sweep green: `test_write_through.py`, `test_transform_scope.py`, datafusion `test_into_backend`/`test_reentrancy`. Lint/format/codespell pass.

## Out of scope (follow-up)

A deeper residual remains: a datafusion read-ahead worker **parked at interpreter shutdown** can crash with `PyGILState_Release` fatal / hang. Not a generator-close race — needs Rust/binding-side scan cancellation or a worker join before finalization. Filed as #2124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)