### PR TITLE
test(dasher): guard decimal precision in file-table schema component (#1973)

### DIFF
--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -206,14 +206,11 @@ def test_file_table_decimal_precision_distinguishes_schema_component(
     # schema component from the path/stat component (which differs anyway
     # because the two files live at distinct paths).
     cases = (("a", 18, 3), ("b", 9, 2))
-    schemas = []
     for name, precision, scale in cases:
         path = tmp_path / f"{name}.parquet"
         _decimal_parquet(path, precision, scale)
         schema = HASHER.normalize(make_table(path, f"t{name}").op())[1]
         assert schema == ("ibis.Schema", (("x", f"decimal({precision}, {scale})"),))
-        schemas.append(schema)
-    assert schemas[0] != schemas[1]
 
 
 # --- UDF counter independence ---------------------------------------------

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -23,6 +23,7 @@ still apply to the dasher-backed cache-key subsystem:
 
 from __future__ import annotations
 
+import decimal
 import functools
 import numbers
 import operator
@@ -66,7 +67,6 @@ from xorq.common.utils.dasher._opaque import (
     _normalize_computed_kwargs_expr,
     _parent_token,
 )
-from xorq.common.utils.dasher._relations import _databasetable_dispatcher
 from xorq.common.utils.file_utils import normalize_read_path_stat
 from xorq.common.utils.tests._test_helpers import BombHasher, MockOp, Probe
 from xorq.common.utils.toolz_utils import curry as xo_curry
@@ -176,12 +176,11 @@ def test_datafusion_parquet_different_schema_produces_different_token(tmp_path):
 
 
 def _decimal_parquet(path, precision, scale):
-    table = pa.table(
-        {"x": pa.array(["1.23", "4.56"]).cast(pa.decimal128(precision, scale))}
+    # Reuse the ``DataFrame.to_parquet`` idiom the rest of this module uses;
+    # pass an explicit pyarrow schema to pin the decimal precision/scale.
+    pd.DataFrame({"x": [decimal.Decimal("1.23"), decimal.Decimal("4.56")]}).to_parquet(
+        path, schema=pa.schema([("x", pa.decimal128(precision, scale))])
     )
-    import pyarrow.parquet as pq  # noqa: PLC0415
-
-    pq.write_table(table, path)
 
 
 @pytest.mark.parametrize(
@@ -199,12 +198,18 @@ def test_file_table_decimal_precision_distinguishes_schema_component(
     # ``str(dtype)``), not ``dt.schema.to_pandas()`` (which collapses every
     # decimal to ``dtype('O')``).  Same column name, different decimal
     # precision must produce distinct schema components in the token.
+    #
+    # ``HASHER`` is the live rule registry ``tokenize`` uses, so
+    # ``HASHER.normalize(dt)`` drives the exact same DatabaseTable normalizer
+    # under test — no private dispatcher needed.  The schema lives in element
+    # ``[1]`` of the normalized tuple; comparing it directly isolates the
+    # schema component from the path/stat component (which differs anyway
+    # because the two files live at distinct paths).
     pa_path, pb_path = tmp_path / "a.parquet", tmp_path / "b.parquet"
     _decimal_parquet(pa_path, 18, 3)
     _decimal_parquet(pb_path, 9, 2)
-    na = _databasetable_dispatcher(make_table(pa_path, "ta").op())
-    nb = _databasetable_dispatcher(make_table(pb_path, "tb").op())
-    schema_a, schema_b = na[1], nb[1]
+    schema_a = HASHER.normalize(make_table(pa_path, "ta").op())[1]
+    schema_b = HASHER.normalize(make_table(pb_path, "tb").op())[1]
     assert schema_a == ("ibis.Schema", (("x", "decimal(18, 3)"),))
     assert schema_b == ("ibis.Schema", (("x", "decimal(9, 2)"),))
     assert schema_a != schema_b

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -66,6 +66,7 @@ from xorq.common.utils.dasher._opaque import (
     _normalize_computed_kwargs_expr,
     _parent_token,
 )
+from xorq.common.utils.dasher._relations import _databasetable_dispatcher
 from xorq.common.utils.file_utils import normalize_read_path_stat
 from xorq.common.utils.tests._test_helpers import BombHasher, MockOp, Probe
 from xorq.common.utils.toolz_utils import curry as xo_curry
@@ -172,6 +173,41 @@ def test_datafusion_parquet_different_schema_produces_different_token(tmp_path):
     t_full = con.read_parquet(path, table_name="t_full")
     t_proj = t_full.select("a", "b")
     assert tokenize(t_full) != tokenize(t_proj)
+
+
+def _decimal_parquet(path, precision, scale):
+    table = pa.table(
+        {"x": pa.array(["1.23", "4.56"]).cast(pa.decimal128(precision, scale))}
+    )
+    import pyarrow.parquet as pq  # noqa: PLC0415
+
+    pq.write_table(table, path)
+
+
+@pytest.mark.parametrize(
+    "make_table",
+    (
+        pytest.param(_datafusion_table, id="datafusion"),
+        pytest.param(_duckdb_table, id="duckdb"),
+    ),
+)
+def test_file_table_decimal_precision_distinguishes_schema_component(
+    tmp_path, make_table
+):
+    # Regression guard for xorq-labs/xorq#1973: the file-table DT normalizers
+    # must route the schema through ``normalize_ibis_schema`` (which keeps
+    # ``str(dtype)``), not ``dt.schema.to_pandas()`` (which collapses every
+    # decimal to ``dtype('O')``).  Same column name, different decimal
+    # precision must produce distinct schema components in the token.
+    pa_path, pb_path = tmp_path / "a.parquet", tmp_path / "b.parquet"
+    _decimal_parquet(pa_path, 18, 3)
+    _decimal_parquet(pb_path, 9, 2)
+    na = _databasetable_dispatcher(make_table(pa_path, "ta").op())
+    nb = _databasetable_dispatcher(make_table(pb_path, "tb").op())
+    schema_a, schema_b = na[1], nb[1]
+    assert schema_a == ("ibis.Schema", (("x", "decimal(18, 3)"),))
+    assert schema_b == ("ibis.Schema", (("x", "decimal(9, 2)"),))
+    assert schema_a != schema_b
 
 
 # --- UDF counter independence ---------------------------------------------

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -205,14 +205,15 @@ def test_file_table_decimal_precision_distinguishes_schema_component(
     # ``[1]`` of the normalized tuple; comparing it directly isolates the
     # schema component from the path/stat component (which differs anyway
     # because the two files live at distinct paths).
-    pa_path, pb_path = tmp_path / "a.parquet", tmp_path / "b.parquet"
-    _decimal_parquet(pa_path, 18, 3)
-    _decimal_parquet(pb_path, 9, 2)
-    schema_a = HASHER.normalize(make_table(pa_path, "ta").op())[1]
-    schema_b = HASHER.normalize(make_table(pb_path, "tb").op())[1]
-    assert schema_a == ("ibis.Schema", (("x", "decimal(18, 3)"),))
-    assert schema_b == ("ibis.Schema", (("x", "decimal(9, 2)"),))
-    assert schema_a != schema_b
+    cases = (("a", 18, 3), ("b", 9, 2))
+    schemas = []
+    for name, precision, scale in cases:
+        path = tmp_path / f"{name}.parquet"
+        _decimal_parquet(path, precision, scale)
+        schema = HASHER.normalize(make_table(path, f"t{name}").op())[1]
+        assert schema == ("ibis.Schema", (("x", f"decimal({precision}, {scale})"),))
+        schemas.append(schema)
+    assert schemas[0] != schemas[1]
 
 
 # --- UDF counter independence ---------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1973.

**The reported bug was already fixed on `main`.** The DuckDB and DataFusion
file-table DT normalizers in `python/xorq/common/utils/dasher/_relations.py`
already return `normalize_ibis_schema(dt.schema)` (which preserves `str(dtype)`),
not `dt.schema.to_pandas()` (which collapses decimal/array/struct/map to
`dtype('O')`). The fix landed in the same commit the issue was filed against —
PR #1951 (`3d0a9807`) — so the `_relations.py:128` / `:163` line references in
the issue point at code that no longer exists.

What was **missing** was an end-to-end regression guard. The existing tests
only exercised `normalize_ibis_schema` in isolation; nothing pinned that the
file-table normalizers actually route through it. A future revert to
`to_pandas()` would pass CI silently.

## Change

Adds `test_file_table_decimal_precision_distinguishes_schema_component`,
parametrized over the DuckDB and DataFusion backends. Two parquet files with
the same column name but different decimal precision (`decimal(18,3)` vs
`decimal(9,2)`) must produce distinct schema components in the DT token. With
`to_pandas()`, both collapse to `dtype('O')` and the assertion fails.

## Notes

- Remaining `to_pandas()` calls live only in the upstream vendored
  `xorq_dasher` package, reached via `normalize_memory_databasetable`. Those
  also hash the actual data bytes per batch, so the schema-collision concern
  does not apply to memory tables.

## Test

- `pytest python/xorq/common/utils/tests/test_dasher.py` → `92 passed, 1 xfailed`
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)