### PR TITLE
fix(catalog): skip empty commits; unify commit_context

### DIFF
--- a/python/xorq/catalog/backend.py
+++ b/python/xorq/catalog/backend.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import shutil
 from collections.abc import Iterator
-from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
 from typing import Any
@@ -35,6 +34,7 @@ from xorq.catalog.content_store import (
     write_pointer,
 )
 from xorq.catalog.enums import CatalogInfix
+from xorq.catalog.git_utils import commit_context
 
 
 def _repo_has_annex_artifacts(repo: Repo) -> bool:
@@ -79,10 +79,11 @@ class CatalogBackend(abc.ABC):
     @abc.abstractmethod
     def stage_unlink(self, path: str | Path) -> None: ...
 
-    @contextmanager
     def commit_context(self, message: str) -> Iterator[IndexFile]:
-        yield self.repo.index
-        self.repo.index.commit(message)
+        # Single commit primitive lives in git_utils.commit_context (which also
+        # serves the root/submodule repo); bind it to this backend's repo. It
+        # skips empty commits, so a no-op mutation leaves no commit behind.
+        return commit_context(self.repo, message)
 
     @abc.abstractmethod
     def is_content_local(self, path: str | Path) -> bool: ...

--- a/python/xorq/catalog/backend.py
+++ b/python/xorq/catalog/backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import shutil
 from collections.abc import Iterator
+from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
 from typing import Any
@@ -79,11 +80,11 @@ class CatalogBackend(abc.ABC):
     @abc.abstractmethod
     def stage_unlink(self, path: str | Path) -> None: ...
 
+    @contextmanager
     def commit_context(self, message: str) -> Iterator[IndexFile]:
-        # Single commit primitive lives in git_utils.commit_context (which also
-        # serves the root/submodule repo); bind it to this backend's repo. It
-        # skips empty commits, so a no-op mutation leaves no commit behind.
-        return commit_context(self.repo, message)
+        # Delegates to git_utils.commit_context (skips empty commits) bound to this repo.
+        with commit_context(self.repo, message) as index:
+            yield index
 
     @abc.abstractmethod
     def is_content_local(self, path: str | Path) -> bool: ...

--- a/python/xorq/catalog/git_utils.py
+++ b/python/xorq/catalog/git_utils.py
@@ -16,13 +16,12 @@ def commit_context(repo: Repo, message: str) -> Iterator[IndexFile]:
     """Commit whatever the wrapped body stages against *repo*'s index.
 
     The single commit primitive for the catalog (``CatalogBackend.commit_context``
-    delegates here binding ``self.repo``, and the root/submodule wiring calls it
-    directly). An empty commit is skipped: a no-op mutation -- e.g. re-adding an
-    alias that already resolves to its target -- stages nothing against HEAD, and
-    committing anyway would leave an empty commit in the catalog history. Every
-    git-tracked catalog mutation funnels through ``repo.index.add``/``remove``
-    (see the backend ``stage``/``stage_content``/``stage_unlink`` methods), so
-    ``index.diff(HEAD)`` faithfully reflects whether anything changed.
+    delegates here, and the root/submodule wiring calls it directly). An empty
+    commit is skipped, since a no-op mutation would otherwise leave an empty
+    commit in the catalog history. Every git-tracked catalog mutation funnels
+    through ``repo.index.add``/``remove`` (see the backend ``stage``/
+    ``stage_content``/``stage_unlink`` methods), so ``index.diff(HEAD)``
+    faithfully reflects whether anything changed.
     """
     yield repo.index
     if not repo.head.is_valid() or repo.index.diff(repo.head.commit):

--- a/python/xorq/catalog/git_utils.py
+++ b/python/xorq/catalog/git_utils.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from git import IndexFile, Repo
 from toolz import curry
 
 from xorq.catalog.constants import DEFAULT_REMOTE
@@ -8,9 +12,21 @@ from xorq.catalog.constants import DEFAULT_REMOTE
 
 @contextmanager
 @curry
-def commit_context(repo, message):
+def commit_context(repo: Repo, message: str) -> Iterator[IndexFile]:
+    """Commit whatever the wrapped body stages against *repo*'s index.
+
+    The single commit primitive for the catalog (``CatalogBackend.commit_context``
+    delegates here binding ``self.repo``, and the root/submodule wiring calls it
+    directly). An empty commit is skipped: a no-op mutation -- e.g. re-adding an
+    alias that already resolves to its target -- stages nothing against HEAD, and
+    committing anyway would leave an empty commit in the catalog history. Every
+    git-tracked catalog mutation funnels through ``repo.index.add``/``remove``
+    (see the backend ``stage``/``stage_content``/``stage_unlink`` methods), so
+    ``index.diff(HEAD)`` faithfully reflects whether anything changed.
+    """
     yield repo.index
-    repo.index.commit(message)
+    if not repo.head.is_valid() or repo.index.diff(repo.head.commit):
+        repo.index.commit(message)
 
 
 def add_as_submodule(repo, subrepo, remote=DEFAULT_REMOTE):

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -59,6 +59,7 @@ from xorq.catalog.expr_utils import (
     _live_extract_dirs,
     build_expr_context_zip,
 )
+from xorq.catalog.git_utils import commit_context
 from xorq.catalog.tests.conftest import (
     TEST_WHEEL_NAME,
     compare_repo_and_catalog,
@@ -1580,6 +1581,53 @@ def test_add_alias_real_change_still_commits(catalog_populated: Catalog) -> None
     after = _commit_count(catalog_populated)
 
     assert after == before + 2
+    catalog_populated.assert_consistency()
+
+
+def test_commit_context_unborn_head_commits(tmp_path: Path) -> None:
+    # Exercises the `not repo.head.is_valid()` branch of the empty-commit guard:
+    # on a fresh repo with no commits, `repo.head.commit` would raise, so the
+    # guard must commit unconditionally rather than diff against HEAD. No catalog
+    # path reaches commit_context with an unborn HEAD (the initial commit is made
+    # directly), so this branch is otherwise untested.
+    repo = GitRepo.init(tmp_path.joinpath("repo"), initial_branch=MAIN_BRANCH)
+    assert not repo.head.is_valid()
+    (Path(repo.working_dir) / "f.txt").write_text("hello")
+    with commit_context(repo, "first commit"):
+        repo.index.add(["f.txt"])
+    assert repo.head.is_valid()
+    assert len(list(repo.iter_commits())) == 1
+
+
+def test_add_entry_noop_leaves_no_commit(
+    catalog: Catalog, data_dict: dict[str, Path]
+) -> None:
+    # Re-adding an identical entry with exist_ok=True stages nothing
+    # (CatalogAddition._add returns early once the entry is present), so the
+    # empty-commit guard must not leave a commit behind. Runs the entry-level
+    # no-op path across git/annex/pointer, distinct from the alias no-op above.
+    path = next(iter(data_dict.values()))
+    catalog.add(path)
+
+    before = _commit_count(catalog)
+    catalog.add(path, exist_ok=True)  # identical entry -> no-op
+    after = _commit_count(catalog)
+
+    assert after == before
+    catalog.assert_consistency()
+
+
+def test_remove_still_commits(catalog_populated: Catalog) -> None:
+    # Guard sanity for the delete path: removing an entry stages real changes
+    # (yaml + unlinks) and must still produce exactly one commit, mirroring the
+    # over-skip check that test_add_alias_real_change_still_commits does for add.
+    name = catalog_populated.list()[0]
+
+    before = _commit_count(catalog_populated)
+    catalog_populated.remove(name)
+    after = _commit_count(catalog_populated)
+
+    assert after == before + 1
     catalog_populated.assert_consistency()
 
 

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -1546,6 +1546,43 @@ def test_add_alias_overwrite(catalog_populated):
     catalog_populated.assert_consistency()
 
 
+def _commit_count(catalog: Catalog) -> int:
+    return len(list(catalog.repo.iter_commits()))
+
+
+def test_add_alias_noop_leaves_no_commit(catalog_populated: Catalog) -> None:
+    # Re-adding an alias that already resolves to its target stages nothing
+    # (CatalogAlias._add returns early), so commit_context must NOT leave an
+    # empty commit behind. Runs across git/annex/pointer backends via the
+    # catalog_populated fixture.
+    name = catalog_populated.list()[0]
+    catalog_populated.add_alias(name, "my-alias")
+
+    before = _commit_count(catalog_populated)
+    catalog_populated.add_alias(name, "my-alias")  # identical -> no-op
+    after = _commit_count(catalog_populated)
+
+    assert after == before
+    catalog_populated.assert_consistency()
+
+
+def test_add_alias_real_change_still_commits(catalog_populated: Catalog) -> None:
+    # Guard sanity: a genuine alias add/retarget must still produce exactly one
+    # commit (the empty-commit guard only skips no-ops).
+    names = catalog_populated.list()
+    name_a, name_b = names[0], names[1]
+
+    catalog_populated.add_alias(name_a, "moves")
+    before = _commit_count(catalog_populated)
+    # a brand-new alias, then a retarget of it -- each a real staged change
+    catalog_populated.add_alias(name_a, "fresh")
+    catalog_populated.add_alias(name_b, "moves")
+    after = _commit_count(catalog_populated)
+
+    assert after == before + 2
+    catalog_populated.assert_consistency()
+
+
 def test_add_alias_multiple(catalog_populated):
     names = catalog_populated.list()
     aliases = [f"alias-{i}" for i in range(len(names))]


### PR DESCRIPTION
## Summary

Catalog mutations route through `commit_context`, which called `repo.index.commit` **unconditionally** — so a no-op operation left an **empty commit** in the catalog history. The most visible trigger is the pin work in #2117: `xorq catalog pin … --move-aliases` re-adds aliases that already resolve to their target, and each no-op `add_alias` leaves an empty `"add alias: X -> Y"` commit. But the bug is in shared catalog infrastructure and predates that PR — any no-op mutation hits it.

This is the follow-on cleanup discussed on #2117 (kept separate because it touches shared infra, not just pin/unpin).

## Changes

- **Collapse the two identical `commit_context` definitions.** `git_utils.commit_context(repo, message)` is now the single commit primitive. `CatalogBackend.commit_context` is a thin `@contextmanager` that delegates to it bound to `self.repo` (re-yielding the index), mirroring the sibling `Catalog.commit_context` wrapper. (The root/submodule wiring already used the git_utils one directly.)
- **Guard against empty commits.** Only commit when the index differs from HEAD (`repo.index.diff(repo.head.commit)`, with an unborn-HEAD guard for the very first commit).

### Why the index-diff signal is safe across backends

Every git-tracked catalog mutation funnels through `repo.index.add`/`remove` — verified in all three backends' `stage`/`stage_content`/`stage_unlink`:
- **git**: `index.add`/`remove` directly.
- **annex**: `annex.add(...)` **then** explicit `repo.index.add([...])`; the `git-annex` branch is managed out-of-band and was never committed by `commit_context` anyway.
- **pointer**: stages the `.pointer` file via `index.add`; the external content-store upload is addressed by the `sha256` embedded in the pointer, so identical content ⇒ identical pointer ⇒ genuinely nothing to commit (and the upload is skipped too).

So `index.diff(HEAD)` faithfully reflects whether a git-tracked mutation happened — the guard never skips a commit that should occur.

### No impact on replay

Production `replay`/`rebuild` ends in `assert_consistency` (tree/yaml agreement, not commit count), and `verify` runs against source commits at parse time. A catalog built under this change never records empty commits, so replay parity is self-preserving; `test_rebuild_preserves_commit_metadata` still passes. (Replaying a *pre-fix* catalog simply drops its empty commits — content-correct, just not a byte-for-byte history copy.)

## Test plan

New tests, all run across **git / annex / pointer** via the parametrized fixtures:

- [x] `test_add_alias_noop_leaves_no_commit` — a no-op `add_alias` leaves the commit count unchanged.
- [x] `test_add_alias_real_change_still_commits` — a fresh alias + a retarget each commit exactly once (guard doesn't over-skip).
- [x] `test_add_entry_noop_leaves_no_commit` — re-adding an identical entry (`exist_ok=True`) stages nothing and leaves no commit (entry-level no-op path).
- [x] `test_remove_still_commits` — a real removal still produces exactly one commit (over-skip check for the delete path).
- [x] `test_commit_context_unborn_head_commits` — drives `commit_context` against a fresh repo with an unborn HEAD, covering the `not repo.head.is_valid()` branch that no catalog path otherwise reaches (the initial commit is made directly).

Suites:
- [x] `python/xorq/catalog/tests/test_catalog.py` — 237 passed, 16 skipped.
- [x] `python/xorq/catalog/tests/test_replay_rebuild.py` — 24 passed (commit-metadata parity intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
