### PR TITLE
fix(snowflake): support unencrypted keypairs (empty passphrase)

### DIFF
--- a/python/xorq/backends/conftest.py
+++ b/python/xorq/backends/conftest.py
@@ -16,8 +16,11 @@ snowflake_credentials_varnames = (
     "SNOWFLAKE_PRIVATE_KEY_PWD",
     "SNOWFLAKE_USER",
 )
+# PWD is optional: an unencrypted keypair has no passphrase, and the decrypt
+# path (maybe_decrypt_private_key) already treats an empty pwd as "unencrypted".
+# Gate only on the genuinely-required creds so unencrypted local keys can run.
 have_snowflake_credentials = all(
-    os.environ.get(varname) for varname in snowflake_credentials_varnames
+    os.environ.get(varname) for varname in ("SNOWFLAKE_PRIVATE_KEY", "SNOWFLAKE_USER")
 )
 
 KEY_PREFIX = xo.config.options.cache.key_prefix

--- a/python/xorq/backends/conftest.py
+++ b/python/xorq/backends/conftest.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import functools
 import itertools
-import os
 
 import _pytest
 import pytest
@@ -11,17 +12,28 @@ from xorq.caching import ParquetSnapshotCache, SourceSnapshotCache
 from xorq.vendor import ibis
 
 
-snowflake_credentials_varnames = (
+# PWD is optional: an unencrypted keypair has no passphrase, so gate only on
+# the genuinely-required creds
+required_snowflake_credentials_varnames = (
     "SNOWFLAKE_PRIVATE_KEY",
-    "SNOWFLAKE_PRIVATE_KEY_PWD",
     "SNOWFLAKE_USER",
 )
-# PWD is optional: an unencrypted keypair has no passphrase, and the decrypt
-# path (maybe_decrypt_private_key) already treats an empty pwd as "unencrypted".
-# Gate only on the genuinely-required creds so unencrypted local keys can run.
-have_snowflake_credentials = all(
-    os.environ.get(varname) for varname in ("SNOWFLAKE_PRIVATE_KEY", "SNOWFLAKE_USER")
+snowflake_credentials_varnames = (
+    *required_snowflake_credentials_varnames,
+    "SNOWFLAKE_PRIVATE_KEY_PWD",
 )
+
+
+@functools.cache
+def have_snowflake_credentials() -> bool:
+    # importorskip: snowflake_utils imports the backend + connector, which may
+    # not be installed; only consulted after connector is importorskip'd above
+    snowflake_utils = pytest.importorskip("xorq.common.utils.snowflake_utils")
+    return all(
+        snowflake_utils.snowflake_config.get(varname)
+        for varname in required_snowflake_credentials_varnames
+    )
+
 
 KEY_PREFIX = xo.config.options.cache.key_prefix
 
@@ -103,8 +115,9 @@ def pytest_collection_modifyitems(session, config, items):
 def maybe_snowflake_decrypt_failure():
     try:
         SKU = pytest.importorskip("xorq.common.utils.snowflake_keypair_utils")
+        SFU = pytest.importorskip("xorq.common.utils.snowflake_utils")
         kwargs = {
-            varname[len("SNOWFLAKE_") :].lower(): os.environ.get(varname)
+            varname[len("SNOWFLAKE_") :].lower(): SFU.snowflake_config.get(varname)
             for varname in snowflake_credentials_varnames
         }
         SKU.maybe_decrypt_private_key(kwargs)
@@ -115,7 +128,7 @@ def maybe_snowflake_decrypt_failure():
 def pytest_runtest_setup(item):
     if any(mark.name == "snowflake" for mark in item.iter_markers()):
         pytest.importorskip("snowflake.connector")
-        if not have_snowflake_credentials:
+        if not have_snowflake_credentials():
             pytest.skip("cannot run snowflake tests without snowflake creds")
         if e := maybe_snowflake_decrypt_failure():
             pytest.fail(f"cannot decrpyt snowflake creds '{e}'")

--- a/python/xorq/common/utils/snowflake_keypair_utils.py
+++ b/python/xorq/common/utils/snowflake_keypair_utils.py
@@ -222,8 +222,13 @@ def deassign_public_key(con, user, do_assert=True):
 
 
 def decrypt_private_key_bytes_snowflake(private_key_bytes, password_str):
-    # encrypted PEM to unencrypted DER
-    private_key = load_pem_private_key(private_key_bytes, password_str.encode("utf-8"))
+    # (encrypted) PEM to unencrypted DER. An empty/None password means the key is
+    # already unencrypted, so load with password=None — cryptography rejects a
+    # non-None password on an unencrypted key.
+    private_key = load_pem_private_key(
+        private_key_bytes,
+        password_str.encode("utf-8") if password_str else None,
+    )
     return private_key.private_bytes(
         Encoding.DER,
         PrivateFormat.PKCS8,

--- a/python/xorq/common/utils/tests/test_snowflake_keypair_utils.py
+++ b/python/xorq/common/utils/tests/test_snowflake_keypair_utils.py
@@ -1,0 +1,31 @@
+"""Credless unit tests for snowflake keypair handling.
+
+Pins that a user may choose an *unencrypted* keypair (empty passphrase) while
+an encrypted keypair + its passphrase keeps working. Pure cryptography — no
+Snowflake connection or creds, so this runs in normal CI (unlike the
+``@pytest.mark.snowflake`` round-trips).
+"""
+
+from __future__ import annotations
+
+from xorq.common.utils.snowflake_keypair_utils import (
+    SnowflakeKeypair,
+    decrypt_private_key_bytes_snowflake,
+)
+
+
+def test_decrypt_unencrypted_keypair_empty_pwd() -> None:
+    # unencrypted keypair: an empty passphrase must load (-> password=None),
+    # not be encoded to b"" (which cryptography rejects on an unencrypted key).
+    kp = SnowflakeKeypair.generate()
+    der = decrypt_private_key_bytes_snowflake(kp.get_private_bytes(encrypted=False), "")
+    assert isinstance(der, bytes) and der
+
+
+def test_decrypt_encrypted_keypair_with_pwd() -> None:
+    # encrypted keypair + its passphrase still works (no regression).
+    kp = SnowflakeKeypair.generate(password="hunter2")
+    der = decrypt_private_key_bytes_snowflake(
+        kp.get_private_bytes(encrypted=True), "hunter2"
+    )
+    assert isinstance(der, bytes) and der


### PR DESCRIPTION
## Summary

`decrypt_private_key_bytes_snowflake` encoded an empty passphrase to `b""`, which cryptography rejects when the key is unencrypted. An empty/`None` password now loads with `password=None`, so locally-generated unencrypted keypairs work.

Correspondingly, the test-credentials gate (`backends/conftest.py`) treats `SNOWFLAKE_PRIVATE_KEY_PWD` as optional — an unencrypted key has no passphrase — gating only on the genuinely required creds. CI's encrypted key + passphrase keeps working unchanged.

Includes a credless unit test (pure cryptography, runs in normal CI, no `@pytest.mark.snowflake`).

Split out of #2129, where it was enabling infra for the snowflake WAP integration tests.

## Test plan
- `pytest python/xorq/common/utils/tests/test_snowflake_keypair_utils.py` (credless, 2 tests)
- Gated snowflake round-trips unaffected (encrypted-key path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)