### PR TITLE
refactor(transform): unify resource-scope ownership across transform passes

### DIFF
--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -36,7 +36,7 @@ class Backend(IbisDuckDBBackend):
         # duckdb registers ``source`` (typically a StreamCache) directly so it
         # can replay the stream across scans; a casting wrapper would not be
         # replayable, so casting to the logical schema happens upstream, before
-        # the StreamCache, in register_and_transform_remote_tables.
+        # the StreamCache, in register_and_transform_remote_tables_into.
         table_name = table_name or gen_name("read_record_batches")
         self.con.register(table_name, source)
         return self.table(table_name)

--- a/python/xorq/backends/gizmosql/tests/test_read_record_batches.py
+++ b/python/xorq/backends/gizmosql/tests/test_read_record_batches.py
@@ -1,6 +1,6 @@
 """GizmoSQL read_record_batches coverage, including StreamCache inputs.
 
-register_and_transform_remote_tables feeds a batchcorder StreamCache straight
+register_and_transform_remote_tables_into feeds a batchcorder StreamCache straight
 into the target backend's read_record_batches, so these pin that gizmosql
 accepts a StreamCache (it exposes __iter__/.schema) and, in particular, that an
 empty stream still materializes the declared columns rather than raising

--- a/python/xorq/backends/xorq_datafusion/backend.py
+++ b/python/xorq/backends/xorq_datafusion/backend.py
@@ -809,7 +809,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 # bound still drives eviction. cast only retypes -- it requires
                 # matching field names -- so column projection must already have
                 # happened upstream, before the cache (the remote-table path does
-                # this; see register_and_transform_remote_tables). Wrapping a
+                # this; see register_and_transform_remote_tables_into). Wrapping a
                 # second StreamCache here to drop columns would double-buffer the
                 # data and defeat eviction, so we let cast raise on a name
                 # mismatch rather than accommodate it.

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -89,7 +89,7 @@ def test_read_record_batches_stream_cache_extra_columns_raises() -> None:
     # A StreamCache must already hold the logical columns: cast only retypes,
     # it cannot drop columns, and wrapping a second cache to project would
     # double-buffer and defeat eviction. Column projection belongs upstream,
-    # before the cache (as register_and_transform_remote_tables does).
+    # before the cache (as register_and_transform_remote_tables_into does).
     con = xo.connect()
     batch = pa.record_batch({"a": [1, 2], "extra": [9, 9]})
     reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -45,6 +45,7 @@ from xorq.expr.relations import (
     register_and_transform_tee_nodes,
 )
 from xorq.expr.remote_table_exec import (
+    RemoteTableScope,
     bind_scope_to_reader,
     register_and_transform_remote_tables,
 )
@@ -463,19 +464,23 @@ def _transform_expr(expr, params=None, **kwargs):
         else expr
     )
     expr = _remove_tag_nodes(expr)
-    expr = _register_and_transform_cache_tables(expr)
-    expr, tee_created, drains = register_and_transform_tee_nodes(expr)
-    expr, scope = register_and_transform_remote_tables(expr, **kwargs)
-    # Fold the tee-node materializations (placeholder tables + write-through
-    # drains) into the same scope so a single close() tears everything down.
-    # Drains close-then-join before any table drops (see RemoteTableScope.close).
-    for table_name, con in tee_created.items():
-        scope.adopt_table(con, table_name)
-    for drain in drains:
-        scope.adopt_drain(drain)
+    # One scope owns every resource the effectful passes materialize. It is
+    # created *before* the first effectful pass and threaded into each, so a
+    # failure in any pass tears down what *earlier* passes created -- not just
+    # its own. (Previously the scope was born inside the remote-tables pass and
+    # the tee pass's tables/drains were adopted only *after* it returned, so a
+    # remote-pass failure leaked the tee placeholder tables and drain threads.)
+    scope = RemoteTableScope()
     try:
+        expr = _register_and_transform_cache_tables(expr)
+        # tee adopts its tables/drains into the shared scope as it creates them;
+        # the returned tuple is ignored here (kept for standalone callers).
+        expr, _tee_created, _drains = register_and_transform_tee_nodes(
+            expr, scope=scope
+        )
+        expr, scope = register_and_transform_remote_tables(expr, scope=scope, **kwargs)
         expr = _transform_deferred_reads(expr)
-    except Exception:
+    except BaseException:
         scope.close()
         raise
     return (expr, scope)

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -45,9 +45,9 @@ from xorq.expr.relations import (
     register_and_transform_tee_nodes,
 )
 from xorq.expr.remote_table_exec import (
-    RemoteTableScope,
     bind_scope_to_reader,
     register_and_transform_remote_tables,
+    transform_scope,
 )
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import api
@@ -464,25 +464,24 @@ def _transform_expr(expr, params=None, **kwargs):
         else expr
     )
     expr = _remove_tag_nodes(expr)
-    # One scope owns every resource the effectful passes materialize. It is
-    # created *before* the first effectful pass and threaded into each, so a
-    # failure in any pass tears down what *earlier* passes created -- not just
-    # its own. (Previously the scope was born inside the remote-tables pass and
-    # the tee pass's tables/drains were adopted only *after* it returned, so a
-    # remote-pass failure leaked the tee placeholder tables and drain threads.)
-    scope = RemoteTableScope()
-    try:
-        expr = _register_and_transform_cache_tables(expr)
-        # tee adopts its tables/drains into the shared scope as it creates them;
-        # the returned tuple is ignored here (kept for standalone callers).
-        expr, _tee_created, _drains = register_and_transform_tee_nodes(
-            expr, scope=scope
-        )
-        expr, scope = register_and_transform_remote_tables(expr, scope=scope, **kwargs)
-        expr = _transform_deferred_reads(expr)
-    except BaseException:
-        scope.close()
-        raise
+    # One ambient scope owns every resource the effectful passes materialize.
+    # Each pass adopts what it creates into ``current_scope()`` (no scope
+    # threading), so a failure in any pass tears down what *earlier* passes
+    # created -- not just its own. (Previously the scope was born inside the
+    # remote-tables pass and the tee pass's tables/drains were adopted only
+    # *after* it returned, so a remote-pass failure leaked the tee placeholder
+    # tables and drain threads.)
+    with transform_scope() as scope:
+        try:
+            expr = _register_and_transform_cache_tables(expr)
+            # tee/remote adopt into the ambient scope as they create resources;
+            # each returns that same scope, ignored here (we already hold it).
+            expr, _ = register_and_transform_tee_nodes(expr)
+            expr, _ = register_and_transform_remote_tables(expr, **kwargs)
+            expr = _transform_deferred_reads(expr)
+        except BaseException:
+            scope.close()
+            raise
     return (expr, scope)
 
 

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -42,12 +42,12 @@ from xorq.expr.relations import (
     Read,
     Tag,
     TeeNode,
-    register_and_transform_tee_nodes,
+    register_and_transform_tee_nodes_into,
 )
 from xorq.expr.remote_table_exec import (
+    RemoteTableScope,
     bind_scope_to_reader,
-    register_and_transform_remote_tables,
-    transform_scope,
+    register_and_transform_remote_tables_into,
 )
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import api
@@ -464,24 +464,22 @@ def _transform_expr(expr, params=None, **kwargs):
         else expr
     )
     expr = _remove_tag_nodes(expr)
-    # One ambient scope owns every resource the effectful passes materialize.
-    # Each pass adopts what it creates into ``current_scope()`` (no scope
-    # threading), so a failure in any pass tears down what *earlier* passes
-    # created -- not just its own. (Previously the scope was born inside the
-    # remote-tables pass and the tee pass's tables/drains were adopted only
-    # *after* it returned, so a remote-pass failure leaked the tee placeholder
-    # tables and drain threads.)
-    with transform_scope() as scope:
-        try:
-            expr = _register_and_transform_cache_tables(expr)
-            # tee/remote adopt into the ambient scope as they create resources;
-            # each returns that same scope, ignored here (we already hold it).
-            expr, _ = register_and_transform_tee_nodes(expr)
-            expr, _ = register_and_transform_remote_tables(expr, **kwargs)
-            expr = _transform_deferred_reads(expr)
-        except BaseException:
-            scope.close()
-            raise
+    # One scope, created up front and threaded explicitly into every effectful
+    # pass, owns every resource those passes materialize. Because all passes
+    # adopt into this *same* scope as they create resources, a failure in any
+    # pass tears down what *earlier* passes created -- not just its own.
+    # (Previously the scope was born inside the remote-tables pass and the tee
+    # pass's tables/drains were adopted only *after* it returned, so a
+    # remote-pass failure leaked the tee placeholder tables and drain threads.)
+    scope = RemoteTableScope()
+    try:
+        expr = _register_and_transform_cache_tables(expr)
+        expr = register_and_transform_tee_nodes_into(expr, scope)
+        expr = register_and_transform_remote_tables_into(expr, scope, **kwargs)
+        expr = _transform_deferred_reads(expr)
+    except BaseException:
+        scope.close()
+        raise
     return (expr, scope)
 
 

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -359,7 +359,7 @@ def _remove_tag_nodes(expr):
 def _remove_tee_nodes(expr: ir.Expr) -> ir.Expr:
     """Strip transparent `TeeNode`s to their parent (for SQL / hashing).
 
-    Execution keeps the `TeeNode` until `register_and_transform_tee_nodes`
+    Execution keeps the `TeeNode` until `register_and_transform_tee_nodes_into`
     fires the write, so this is only used off the execution path.
     """
 
@@ -464,13 +464,11 @@ def _transform_expr(expr, params=None, **kwargs):
         else expr
     )
     expr = _remove_tag_nodes(expr)
-    # One scope, created up front and threaded explicitly into every effectful
-    # pass, owns every resource those passes materialize. Because all passes
-    # adopt into this *same* scope as they create resources, a failure in any
-    # pass tears down what *earlier* passes created -- not just its own.
-    # (Previously the scope was born inside the remote-tables pass and the tee
-    # pass's tables/drains were adopted only *after* it returned, so a
-    # remote-pass failure leaked the tee placeholder tables and drain threads.)
+    # One scope, created up front and threaded explicitly into the tee and
+    # remote passes, owns every teardown-able resource they materialize (the
+    # cache-table pass's tables are intentional artifacts, not scope-owned).
+    # Both passes adopt into this *same* scope, so a failure in any pass tears
+    # down what earlier passes created, not just its own.
     scope = RemoteTableScope()
     try:
         expr = _register_and_transform_cache_tables(expr)

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -30,9 +30,9 @@ from xorq.writes import DrainingIterator, WriteThrough
 
 
 if TYPE_CHECKING:
-    # imported under TYPE_CHECKING to avoid a circular import: remote_table_exec
-    # imports from this module. Used only in the register_and_transform_tee_nodes
-    # annotation.
+    # under TYPE_CHECKING only: remote_table_exec imports from this module, so a
+    # module-level import would be circular. Used for the return annotation; the
+    # runtime use is a deferred import inside register_and_transform_tee_nodes.
     from xorq.expr.remote_table_exec import RemoteTableScope
 
 
@@ -808,8 +808,7 @@ _NON_REENTRANT_TEE_BACKENDS = frozenset({"duckdb"})
 @tracer.start_as_current_span("register_and_transform_tee_nodes")
 def register_and_transform_tee_nodes(
     expr: Expr,
-    scope: RemoteTableScope | None = None,
-) -> tuple[Expr, dict[str, BaseBackend], list[DrainingIterator]]:
+) -> tuple[Expr, RemoteTableScope]:
     """Replace each surviving `TeeNode` with a backend table fed by the
     writer's ``write_through(batches)`` generator.
 
@@ -818,24 +817,29 @@ def register_and_transform_tee_nodes(
     downstream cache hit prunes the `TeeNode` before this pass sees it and
     the write never fires.
 
-    Returns ``(expr, created, drains)``: the transformed expression, a
-    ``{table_name: con}`` map of the intermediate pass-through tables
-    registered on each parent backend (these persist in the backend's
-    catalog until dropped, so callers must drop them once downstream
-    consumption is done), and a list of `DrainingIterator` instances whose
-    ``close()`` must be called after downstream execution completes so that
-    the writer can finish consuming the stream.
+    Returns ``(expr, scope)`` -- consistent with
+    ``register_and_transform_remote_tables``. The ``RemoteTableScope`` is the
+    single owner of every resource this pass materializes (upstream readers, the
+    intermediate pass-through tables registered on each parent backend, and the
+    write-through ``DrainingIterator`` drains); ``scope.close()`` drops the
+    tables and closes+joins the drains after downstream execution completes.
 
-    If ``scope`` is provided, each table and drain is adopted into it *as it is
-    created*, so a later transform failure tears these resources down via the
-    shared scope. The ``created``/``drains`` tuple is still returned for
-    callers that own cleanup themselves. When ``scope`` is None the caller is
-    responsible for the returned resources (legacy behaviour).
+    When a transform is in progress the scope is the ambient ``current_scope()``,
+    so a later-pass failure tears these resources down via the shared scope.
+    Standalone callers (no active ``transform_scope()``) get a fresh scope they
+    own and must ``close()``.
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
+    from xorq.expr.remote_table_exec import (  # noqa: PLC0415
+        RemoteTableScope,
+        current_scope,
+    )
 
-    drains: list[DrainingIterator] = []
-    created: dict[str, BaseBackend] = {}
+    # Adopt into the ambient transform scope so a later-pass failure releases
+    # what this pass materialized; standalone callers (no active scope) get a
+    # fresh one they own. The scope is the single source of truth -- no parallel
+    # created/drains bookkeeping to drift out of sync with it.
+    scope = current_scope() or RemoteTableScope()
 
     def replacer(node, kwargs):
         if not isinstance(node, TeeNode):
@@ -853,13 +857,14 @@ def register_and_transform_tee_nodes(
                 "See ADR-0014.",
                 stacklevel=2,
             )
-        reader = parent_expr.to_pyarrow_batches()
+        # adopt the upstream reader too (mirrors register_and_transform_remote_tables):
+        # it holds a live backend cursor and would otherwise leak if a later pass
+        # fails before the stream is consumed.
+        reader = scope.adopt_reader(parent_expr.to_pyarrow_batches())
         write_iter = node.writer.write_through(reader)
         if node.drain:
             write_iter = DrainingIterator(write_iter)
-            drains.append(write_iter)
-            if scope is not None:
-                scope.adopt_drain(write_iter)
+            scope.adopt_drain(write_iter)
         wrapped = pa.RecordBatchReader.from_batches(
             reader.schema,
             write_iter,
@@ -868,10 +873,8 @@ def register_and_transform_tee_nodes(
         # adopt before registering (mirrors register_and_transform_remote_tables):
         # a partial failure inside read_record_batches can't strand the placeholder,
         # and drop_placeholder is a no-op if registration never landed.
-        if scope is not None:
-            scope.adopt_table(con, table_name)
+        scope.adopt_table(con, table_name)
         table = con.read_record_batches(wrapped, table_name=table_name)
-        created[table_name] = con
         return table.op()
 
     # op.replace, not replace_nodes: this replacer has side effects (registers
@@ -883,7 +886,7 @@ def register_and_transform_tee_nodes(
     # cached parent; into_backend/flight re-pull via to_pyarrow_batches), so its
     # TeeNodes still fire exactly once. replace_nodes would fire them twice.
     op = expr.op()
-    return op.replace(replacer).to_expr(), created, drains
+    return op.replace(replacer).to_expr(), scope
 
 
 def render_backend(con: BaseBackend) -> str:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -805,41 +805,30 @@ class Read(ops.DatabaseTable):
 _NON_REENTRANT_TEE_BACKENDS = frozenset({"duckdb"})
 
 
-@tracer.start_as_current_span("register_and_transform_tee_nodes")
-def register_and_transform_tee_nodes(
+@tracer.start_as_current_span("register_and_transform_tee_nodes_into")
+def register_and_transform_tee_nodes_into(
     expr: Expr,
-) -> tuple[Expr, RemoteTableScope]:
+    scope: RemoteTableScope,
+) -> Expr:
     """Replace each surviving `TeeNode` with a backend table fed by the
-    writer's ``write_through(batches)`` generator.
+    writer's ``write_through(batches)`` generator, adopting every resource it
+    materializes into the caller-owned ``scope``.
 
     The writer wraps the parent's batch stream: it pulls, writes as a side
     effect, and yields each batch onward. Runs after cache resolution, so a
     downstream cache hit prunes the `TeeNode` before this pass sees it and
     the write never fires.
 
-    Returns ``(expr, scope)`` -- consistent with
-    ``register_and_transform_remote_tables``. The ``RemoteTableScope`` is the
-    single owner of every resource this pass materializes (upstream readers, the
-    intermediate pass-through tables registered on each parent backend, and the
-    write-through ``DrainingIterator`` drains); ``scope.close()`` drops the
-    tables and closes+joins the drains after downstream execution completes.
-
-    When a transform is in progress the scope is the ambient ``current_scope()``,
-    so a later-pass failure tears these resources down via the shared scope.
-    Standalone callers (no active ``transform_scope()``) get a fresh scope they
-    own and must ``close()``.
+    ``scope`` is the single owner of every resource this pass materializes
+    (upstream readers, the intermediate pass-through tables registered on each
+    parent backend, and the write-through ``DrainingIterator`` drains);
+    ``scope.close()`` drops the tables and closes+joins the drains after
+    downstream execution completes. The scope is threaded explicitly by the
+    caller (``_transform_expr``), so a failure in a *later* pass tears these
+    resources down via the shared scope. This function never closes ``scope`` --
+    teardown stays with the caller that created it.
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
-    from xorq.expr.remote_table_exec import (  # noqa: PLC0415
-        RemoteTableScope,
-        current_scope,
-    )
-
-    # Adopt into the ambient transform scope so a later-pass failure releases
-    # what this pass materialized; standalone callers (no active scope) get a
-    # fresh one they own. The scope is the single source of truth -- no parallel
-    # created/drains bookkeeping to drift out of sync with it.
-    scope = current_scope() or RemoteTableScope()
 
     def replacer(node, kwargs):
         if not isinstance(node, TeeNode):
@@ -886,7 +875,29 @@ def register_and_transform_tee_nodes(
     # cached parent; into_backend/flight re-pull via to_pyarrow_batches), so its
     # TeeNodes still fire exactly once. replace_nodes would fire them twice.
     op = expr.op()
-    return op.replace(replacer).to_expr(), scope
+    return op.replace(replacer).to_expr()
+
+
+def register_and_transform_tee_nodes(
+    expr: Expr,
+) -> tuple[Expr, RemoteTableScope]:
+    """Standalone wrapper: transform ``expr`` into a fresh scope it returns.
+
+    For callers outside the transform pipeline (direct tests, one-off use).
+    Mirrors ``register_and_transform_remote_tables``: the returned scope owns
+    everything the pass materialized and the caller must ``close()`` it once the
+    transformed expr is consumed. Inside the pipeline, ``_transform_expr`` calls
+    ``register_and_transform_tee_nodes_into`` directly with its shared scope.
+    """
+    from xorq.expr.remote_table_exec import RemoteTableScope  # noqa: PLC0415
+
+    scope = RemoteTableScope()
+    try:
+        expr = register_and_transform_tee_nodes_into(expr, scope)
+    except BaseException:
+        scope.close()
+        raise
+    return expr, scope
 
 
 def render_backend(con: BaseBackend) -> str:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -30,9 +30,9 @@ from xorq.writes import DrainingIterator, WriteThrough
 
 
 if TYPE_CHECKING:
-    # under TYPE_CHECKING only: remote_table_exec imports from this module, so a
-    # module-level import would be circular. Used for the return annotation; the
-    # runtime use is a deferred import inside register_and_transform_tee_nodes.
+    # A module-level import would be circular (remote_table_exec imports from
+    # here); only annotations need it, and `from __future__ import annotations`
+    # defers those to strings.
     from xorq.expr.remote_table_exec import RemoteTableScope
 
 
@@ -816,17 +816,14 @@ def register_and_transform_tee_nodes_into(
 
     The writer wraps the parent's batch stream: it pulls, writes as a side
     effect, and yields each batch onward. Runs after cache resolution, so a
-    downstream cache hit prunes the `TeeNode` before this pass sees it and
-    the write never fires.
+    downstream cache hit prunes the `TeeNode` before this pass sees it and the
+    write never fires.
 
-    ``scope`` is the single owner of every resource this pass materializes
-    (upstream readers, the intermediate pass-through tables registered on each
-    parent backend, and the write-through ``DrainingIterator`` drains);
-    ``scope.close()`` drops the tables and closes+joins the drains after
-    downstream execution completes. The scope is threaded explicitly by the
-    caller (``_transform_expr``), so a failure in a *later* pass tears these
-    resources down via the shared scope. This function never closes ``scope`` --
-    teardown stays with the caller that created it.
+    ``scope`` owns everything this pass materializes -- upstream readers, the
+    pass-through tables registered on each parent backend, and the write-through
+    ``DrainingIterator`` drains -- so a failure in a *later* pass still tears
+    them down. This function never closes ``scope``; teardown stays with the
+    caller (``_transform_expr``) that created it.
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
 
@@ -846,9 +843,8 @@ def register_and_transform_tee_nodes_into(
                 "See ADR-0014.",
                 stacklevel=2,
             )
-        # adopt the upstream reader too (mirrors register_and_transform_remote_tables):
-        # it holds a live backend cursor and would otherwise leak if a later pass
-        # fails before the stream is consumed.
+        # adopt the reader (it holds a live backend cursor): a later-pass failure
+        # would otherwise leak it before the stream is consumed.
         reader = scope.adopt_reader(parent_expr.to_pyarrow_batches())
         write_iter = node.writer.write_through(reader)
         if node.drain:
@@ -859,9 +855,8 @@ def register_and_transform_tee_nodes_into(
             write_iter,
         )
         table_name = gen_name()
-        # adopt before registering (mirrors register_and_transform_remote_tables):
-        # a partial failure inside read_record_batches can't strand the placeholder,
-        # and drop_placeholder is a no-op if registration never landed.
+        # adopt before registering: a partial read_record_batches failure can't
+        # strand the placeholder (drop_placeholder no-ops if it never landed).
         scope.adopt_table(con, table_name)
         table = con.read_record_batches(wrapped, table_name=table_name)
         return table.op()
@@ -876,28 +871,6 @@ def register_and_transform_tee_nodes_into(
     # TeeNodes still fire exactly once. replace_nodes would fire them twice.
     op = expr.op()
     return op.replace(replacer).to_expr()
-
-
-def register_and_transform_tee_nodes(
-    expr: Expr,
-) -> tuple[Expr, RemoteTableScope]:
-    """Standalone wrapper: transform ``expr`` into a fresh scope it returns.
-
-    For callers outside the transform pipeline (direct tests, one-off use).
-    Mirrors ``register_and_transform_remote_tables``: the returned scope owns
-    everything the pass materialized and the caller must ``close()`` it once the
-    transformed expr is consumed. Inside the pipeline, ``_transform_expr`` calls
-    ``register_and_transform_tee_nodes_into`` directly with its shared scope.
-    """
-    from xorq.expr.remote_table_exec import RemoteTableScope  # noqa: PLC0415
-
-    scope = RemoteTableScope()
-    try:
-        expr = register_and_transform_tee_nodes_into(expr, scope)
-    except BaseException:
-        scope.close()
-        raise
-    return expr, scope
 
 
 def render_backend(con: BaseBackend) -> str:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -4,7 +4,7 @@ import functools
 import operator
 import warnings
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import pyarrow as pa
 import toolz
@@ -27,6 +27,13 @@ from xorq.vendor.ibis.expr import operations as ops
 from xorq.vendor.ibis.expr.format import fmt, render_schema
 from xorq.vendor.ibis.expr.operations import Node
 from xorq.writes import DrainingIterator, WriteThrough
+
+
+if TYPE_CHECKING:
+    # imported under TYPE_CHECKING to avoid a circular import: remote_table_exec
+    # imports from this module. Used only in the register_and_transform_tee_nodes
+    # annotation.
+    from xorq.expr.remote_table_exec import RemoteTableScope
 
 
 def replace_cache_table(node: Node, kwargs: dict[str, Any] | None) -> Node:
@@ -801,6 +808,7 @@ _NON_REENTRANT_TEE_BACKENDS = frozenset({"duckdb"})
 @tracer.start_as_current_span("register_and_transform_tee_nodes")
 def register_and_transform_tee_nodes(
     expr: Expr,
+    scope: RemoteTableScope | None = None,
 ) -> tuple[Expr, dict[str, BaseBackend], list[DrainingIterator]]:
     """Replace each surviving `TeeNode` with a backend table fed by the
     writer's ``write_through(batches)`` generator.
@@ -817,6 +825,12 @@ def register_and_transform_tee_nodes(
     consumption is done), and a list of `DrainingIterator` instances whose
     ``close()`` must be called after downstream execution completes so that
     the writer can finish consuming the stream.
+
+    If ``scope`` is provided, each table and drain is adopted into it *as it is
+    created*, so a later transform failure tears these resources down via the
+    shared scope. The ``created``/``drains`` tuple is still returned for
+    callers that own cleanup themselves. When ``scope`` is None the caller is
+    responsible for the returned resources (legacy behaviour).
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
 
@@ -844,11 +858,18 @@ def register_and_transform_tee_nodes(
         if node.drain:
             write_iter = DrainingIterator(write_iter)
             drains.append(write_iter)
+            if scope is not None:
+                scope.adopt_drain(write_iter)
         wrapped = pa.RecordBatchReader.from_batches(
             reader.schema,
             write_iter,
         )
         table_name = gen_name()
+        # adopt before registering (mirrors register_and_transform_remote_tables):
+        # a partial failure inside read_record_batches can't strand the placeholder,
+        # and drop_placeholder is a no-op if registration never landed.
+        if scope is not None:
+            scope.adopt_table(con, table_name)
         table = con.read_record_batches(wrapped, table_name=table_name)
         created[table_name] = con
         return table.op()

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -325,11 +325,10 @@ def register_and_transform_remote_tables_into(
 ) -> Expr:
     """Adopt every remote-table resource into the caller-owned ``scope``.
 
-    Threaded the shared transform scope explicitly (see ``_transform_expr``): a
-    failure in a *later* pass tears down what this pass materialized because all
-    passes share one owner. This function never closes ``scope`` -- ownership and
-    teardown stay with the caller that created it (``_transform_expr`` on the
-    pipeline path, ``register_and_transform_remote_tables`` for standalone use).
+    The caller threads one shared scope through every pass (see
+    ``_transform_expr``), so a failure in a *later* pass tears down what this one
+    materialized. This function never closes ``scope``; teardown stays with the
+    caller that created it.
     """
     # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
     # outer ``**kwargs``; capture the through-kwargs here so they reach
@@ -371,7 +370,7 @@ def register_and_transform_remote_tables_into(
         return node
 
     # Intentionally op.replace, not replace_nodes: mark_remote_table has side effects
-    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr)
+    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr).
     # The caller owns scope teardown, so a failure here just propagates.
     expr = op.replace(replacer).to_expr()
     if scope.table_count:
@@ -379,26 +378,6 @@ def register_and_transform_remote_tables_into(
             "remote_table.replace", {"remote_table.count": scope.table_count}
         )
     return expr
-
-
-def register_and_transform_remote_tables(
-    expr: Expr, **kwargs: Any
-) -> tuple[Expr, RemoteTableScope]:
-    """Standalone wrapper: transform ``expr`` into a fresh scope it returns.
-
-    For callers outside the transform pipeline (direct tests, one-off use). The
-    returned scope owns everything the pass materialized; the caller must
-    ``close()`` it once the transformed expr is consumed. Inside the pipeline,
-    ``_transform_expr`` calls ``register_and_transform_remote_tables_into``
-    directly with its shared scope instead.
-    """
-    scope = RemoteTableScope()
-    try:
-        expr = register_and_transform_remote_tables_into(expr, scope, **kwargs)
-    except BaseException:
-        scope.close()
-        raise
-    return expr, scope
 
 
 def prepare_create_table_from_expr(

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -321,9 +321,13 @@ def bind_scope_to_reader(
 
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
-    expr: Expr, **kwargs: Any
+    expr: Expr, scope: RemoteTableScope | None = None, **kwargs: Any
 ) -> tuple[Expr, RemoteTableScope]:
-    scope = RemoteTableScope()
+    # Accept a caller-owned scope so resources materialized by *earlier*
+    # transform passes (e.g. tee placeholder tables) are torn down by this same
+    # scope if this pass fails. Falls back to a fresh scope for standalone use.
+    if scope is None:
+        scope = RemoteTableScope()
     # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
     # outer ``**kwargs``; capture the through-kwargs here so they reach
     # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import contextvars
 import functools
 import weakref
 from collections import Counter
-from collections.abc import Generator
-from contextlib import contextmanager
 from typing import Any, Callable, NamedTuple
 
 import pyarrow as pa
@@ -284,42 +281,6 @@ class RemoteTableScope:
         self.close()
 
 
-_active_scope: contextvars.ContextVar[RemoteTableScope | None] = contextvars.ContextVar(
-    "xorq_active_transform_scope", default=None
-)
-
-
-def current_scope() -> RemoteTableScope | None:
-    """The ``RemoteTableScope`` owning resources for the in-progress transform.
-
-    Effectful transform passes adopt what they materialize into this ambient
-    scope (readers, caches, placeholder tables, drains) instead of threading a
-    ``scope`` argument through each one, so every pass shares a single owner and
-    a failure in *any* pass tears down what *earlier* passes created. Returns
-    ``None`` outside a ``transform_scope()`` block -- standalone callers that
-    own their own cleanup.
-    """
-    return _active_scope.get()
-
-
-@contextmanager
-def transform_scope() -> Generator[RemoteTableScope, None, None]:
-    """Bind a fresh ambient scope for the duration of a transform.
-
-    Nesting is safe: a re-entrant transform (cache resolution, ``into_backend``)
-    shadows the outer scope with its own and restores it on exit, so each
-    execution boundary owns exactly the resources it materialized. Teardown of
-    the yielded scope is the caller's: close it on failure, or hand it to the
-    result reader (``bind_scope_to_reader``) on success.
-    """
-    scope = RemoteTableScope()
-    token = _active_scope.set(scope)
-    try:
-        yield scope
-    finally:
-        _active_scope.reset(token)
-
-
 def bind_scope_to_reader(
     scope: RemoteTableScope,
     reader: pa.RecordBatchReader,
@@ -358,15 +319,18 @@ def bind_scope_to_reader(
     return out
 
 
-@tracer.start_as_current_span("register_and_transform_remote_tables")
-def register_and_transform_remote_tables(
-    expr: Expr, **kwargs: Any
-) -> tuple[Expr, RemoteTableScope]:
-    # Adopt into the ambient transform scope (see ``current_scope``) so
-    # resources materialized by *earlier* passes (e.g. tee placeholder tables)
-    # are torn down by this same scope if this pass fails. Falls back to a fresh
-    # scope for standalone callers that own their own cleanup.
-    scope = current_scope() or RemoteTableScope()
+@tracer.start_as_current_span("register_and_transform_remote_tables_into")
+def register_and_transform_remote_tables_into(
+    expr: Expr, scope: RemoteTableScope, **kwargs: Any
+) -> Expr:
+    """Adopt every remote-table resource into the caller-owned ``scope``.
+
+    Threaded the shared transform scope explicitly (see ``_transform_expr``): a
+    failure in a *later* pass tears down what this pass materialized because all
+    passes share one owner. This function never closes ``scope`` -- ownership and
+    teardown stay with the caller that created it (``_transform_expr`` on the
+    pipeline path, ``register_and_transform_remote_tables`` for standalone use).
+    """
     # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
     # outer ``**kwargs``; capture the through-kwargs here so they reach
     # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
@@ -408,15 +372,32 @@ def register_and_transform_remote_tables(
 
     # Intentionally op.replace, not replace_nodes: mark_remote_table has side effects
     # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr)
-    try:
-        expr = op.replace(replacer).to_expr()
-    except Exception:
-        scope.close()
-        raise
+    # The caller owns scope teardown, so a failure here just propagates.
+    expr = op.replace(replacer).to_expr()
     if scope.table_count:
         trace.get_current_span().add_event(
             "remote_table.replace", {"remote_table.count": scope.table_count}
         )
+    return expr
+
+
+def register_and_transform_remote_tables(
+    expr: Expr, **kwargs: Any
+) -> tuple[Expr, RemoteTableScope]:
+    """Standalone wrapper: transform ``expr`` into a fresh scope it returns.
+
+    For callers outside the transform pipeline (direct tests, one-off use). The
+    returned scope owns everything the pass materialized; the caller must
+    ``close()`` it once the transformed expr is consumed. Inside the pipeline,
+    ``_transform_expr`` calls ``register_and_transform_remote_tables_into``
+    directly with its shared scope instead.
+    """
+    scope = RemoteTableScope()
+    try:
+        expr = register_and_transform_remote_tables_into(expr, scope, **kwargs)
+    except BaseException:
+        scope.close()
+        raise
     return expr, scope
 
 

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import contextvars
 import functools
 import weakref
 from collections import Counter
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any, Callable, NamedTuple
 
 import pyarrow as pa
@@ -281,6 +284,42 @@ class RemoteTableScope:
         self.close()
 
 
+_active_scope: contextvars.ContextVar[RemoteTableScope | None] = contextvars.ContextVar(
+    "xorq_active_transform_scope", default=None
+)
+
+
+def current_scope() -> RemoteTableScope | None:
+    """The ``RemoteTableScope`` owning resources for the in-progress transform.
+
+    Effectful transform passes adopt what they materialize into this ambient
+    scope (readers, caches, placeholder tables, drains) instead of threading a
+    ``scope`` argument through each one, so every pass shares a single owner and
+    a failure in *any* pass tears down what *earlier* passes created. Returns
+    ``None`` outside a ``transform_scope()`` block -- standalone callers that
+    own their own cleanup.
+    """
+    return _active_scope.get()
+
+
+@contextmanager
+def transform_scope() -> Generator[RemoteTableScope, None, None]:
+    """Bind a fresh ambient scope for the duration of a transform.
+
+    Nesting is safe: a re-entrant transform (cache resolution, ``into_backend``)
+    shadows the outer scope with its own and restores it on exit, so each
+    execution boundary owns exactly the resources it materialized. Teardown of
+    the yielded scope is the caller's: close it on failure, or hand it to the
+    result reader (``bind_scope_to_reader``) on success.
+    """
+    scope = RemoteTableScope()
+    token = _active_scope.set(scope)
+    try:
+        yield scope
+    finally:
+        _active_scope.reset(token)
+
+
 def bind_scope_to_reader(
     scope: RemoteTableScope,
     reader: pa.RecordBatchReader,
@@ -321,13 +360,13 @@ def bind_scope_to_reader(
 
 @tracer.start_as_current_span("register_and_transform_remote_tables")
 def register_and_transform_remote_tables(
-    expr: Expr, scope: RemoteTableScope | None = None, **kwargs: Any
+    expr: Expr, **kwargs: Any
 ) -> tuple[Expr, RemoteTableScope]:
-    # Accept a caller-owned scope so resources materialized by *earlier*
-    # transform passes (e.g. tee placeholder tables) are torn down by this same
-    # scope if this pass fails. Falls back to a fresh scope for standalone use.
-    if scope is None:
-        scope = RemoteTableScope()
+    # Adopt into the ambient transform scope (see ``current_scope``) so
+    # resources materialized by *earlier* passes (e.g. tee placeholder tables)
+    # are torn down by this same scope if this pass fails. Falls back to a fresh
+    # scope for standalone callers that own their own cleanup.
+    scope = current_scope() or RemoteTableScope()
     # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
     # outer ``**kwargs``; capture the through-kwargs here so they reach
     # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).

--- a/python/xorq/expr/tests/test_stream_cache_contract.py
+++ b/python/xorq/expr/tests/test_stream_cache_contract.py
@@ -1,6 +1,6 @@
 """Contract tests for the batchcorder ``StreamCache`` primitive xorq relies on.
 
-``register_and_transform_remote_tables`` builds one ``StreamCache`` per
+``register_and_transform_remote_tables_into`` builds one ``StreamCache`` per
 RemoteTable and passes ``max_readers`` from ``count_remote_table_readers``.
 Three properties of that primitive are load-bearing for the fan-out fix and
 are pinned here directly (rather than only through a backend):

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -29,11 +29,11 @@ from xorq.expr.remote_table_exec import (
     bind_scope_to_reader,
     drop_placeholder,
     prepare_create_table_from_expr,
-    register_and_transform_remote_tables,
+    register_and_transform_remote_tables_into,
 )
 from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.backends import BaseBackend
-from xorq.writes import ParquetWriteThrough
+from xorq.writes import DrainingIterator, ParquetWriteThrough
 
 
 pytest.importorskip("duckdb")
@@ -420,7 +420,8 @@ def test_scope_close_closes_adopted_readers() -> None:
 def test_replacer_adopts_reader_cache_and_table() -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
-    _, scope = register_and_transform_remote_tables(expr.op().to_expr())
+    scope = RemoteTableScope()
+    register_and_transform_remote_tables_into(expr.op().to_expr(), scope)
     try:
         assert scope.reader_count == 1
         assert scope.cache_count == 1
@@ -434,18 +435,12 @@ def test_replacer_adopts_reader_cache_and_table() -> None:
 def test_tee_resources_released_when_remote_pass_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A tee (pass 4) registers a placeholder table + drain *before* the remote
-    pass (pass 5) runs. In ``_transform_expr`` those tee resources are adopted
-    into the scope only *after* pass 5 returns, so a pass-5 failure tears down
-    an empty scope and leaks everything pass 4 created.
-
-    Regression guard for the ownership gap: any failure during transform must
-    release resources materialized by *earlier* passes, not just the failing
-    one. ``test_planning_failure_releases_resources`` covers a remote-only expr;
-    this covers the tee+remote interaction that the after-the-fact adoption in
-    ``_transform_expr`` gets wrong. Both halves of what the tee pass creates are
-    checked: the placeholder *table* is dropped and the *drain* thread is
-    closed+joined (not left running).
+    """Any failure during transform must release resources materialized by
+    *earlier* passes, not just the failing one. The tee pass (4) registers a
+    placeholder table + drain before the remote pass (5) runs; here pass 5 fails
+    and both must still be torn down -- the table dropped and the drain thread
+    closed+joined. Complements ``test_planning_failure_releases_resources``
+    (remote-only) by exercising the tee+remote interaction.
     """
     con = xo.connect()  # datafusion: re-entrant, safe for the streaming tee
     t = con.register(
@@ -461,8 +456,8 @@ def test_tee_resources_released_when_remote_pass_fails(
     # Capture what the tee pass adopts straight from the adoption boundary
     # (RemoteTableScope.adopt_*), decoupled from the pass's return shape. The
     # tee's parent (t) has no RemoteTable, so only the outer tee registers here.
-    adopted_tables: list[tuple] = []
-    adopted_drains: list = []
+    adopted_tables: list[tuple[BaseBackend, str]] = []
+    adopted_drains: list[DrainingIterator] = []
     real_adopt_table = RemoteTableScope.adopt_table
     real_adopt_drain = RemoteTableScope.adopt_drain
 
@@ -507,12 +502,9 @@ def test_tee_resources_released_when_remote_pass_fails(
 
 def test_tee_adopts_upstream_reader_into_scope(tmp_path: Path) -> None:
     """The tee pass opens an upstream reader (``parent_expr.to_pyarrow_batches()``)
-    that holds a live backend cursor. It must be adopted into the caller-owned
-    transform scope so a later-pass failure closes it -- exactly as the remote
-    pass adopts its reader (see ``test_replacer_adopts_reader_cache_and_table``).
-
-    This is a pre-existing leak: on ``main`` (and before this fix) the tee reader
-    was never adopted, so any post-tee failure abandoned it un-closed. Composes
+    that holds a live backend cursor; it must be adopted into the caller-owned
+    scope so a later-pass failure closes it, exactly as the remote pass adopts
+    its reader (see ``test_replacer_adopts_reader_cache_and_table``). Composes
     with ``test_scope_close_closes_adopted_readers``, which proves adopted
     readers are closed on ``scope.close()``.
     """

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -431,12 +431,6 @@ def test_replacer_adopts_reader_cache_and_table() -> None:
     assert target.list_tables() == []
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P1: _transform_expr adopts tee tables/drains into the scope only "
-    "after the remote pass returns, so a remote-pass failure leaks them. Fixed "
-    "by the unified-scope refactor, which removes this marker.",
-)
 def test_tee_resources_released_when_remote_pass_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -477,16 +477,18 @@ def test_tee_resources_released_when_remote_pass_fails(
     # Fail the remote pass only when a RemoteTable is actually present, so the
     # tee pass's recursion on its RemoteTable-free parent still succeeds and the
     # failure lands at the *outer* pass 5 -- after pass 4 registered its table.
-    real_remote = expr_api.register_and_transform_remote_tables
+    real_remote = expr_api.register_and_transform_remote_tables_into
 
-    def guarded_boom(inner_expr, **kwargs):
+    def guarded_boom(inner_expr, scope, **kwargs):
         if walk_nodes(RemoteTable, inner_expr):
             raise RuntimeError("remote pass failed")
-        return real_remote(inner_expr, **kwargs)
+        return real_remote(inner_expr, scope, **kwargs)
 
     monkeypatch.setattr(RemoteTableScope, "adopt_table", spy_table)
     monkeypatch.setattr(RemoteTableScope, "adopt_drain", spy_drain)
-    monkeypatch.setattr(expr_api, "register_and_transform_remote_tables", guarded_boom)
+    monkeypatch.setattr(
+        expr_api, "register_and_transform_remote_tables_into", guarded_boom
+    )
 
     with pytest.raises(RuntimeError, match="remote pass failed"):
         _transform_expr(expr)
@@ -505,7 +507,7 @@ def test_tee_resources_released_when_remote_pass_fails(
 
 def test_tee_adopts_upstream_reader_into_scope(tmp_path: Path) -> None:
     """The tee pass opens an upstream reader (``parent_expr.to_pyarrow_batches()``)
-    that holds a live backend cursor. It must be adopted into the ambient
+    that holds a live backend cursor. It must be adopted into the caller-owned
     transform scope so a later-pass failure closes it -- exactly as the remote
     pass adopts its reader (see ``test_replacer_adopts_reader_cache_and_table``).
 
@@ -518,13 +520,14 @@ def test_tee_adopts_upstream_reader_into_scope(tmp_path: Path) -> None:
     t = con.register(xo.memtable({"a": [1, 2, 3]}), table_name="t0")
     teed = t.tee(ParquetWriteThrough(path=tmp_path / "out.parquet"))
 
-    with remote_table_exec.transform_scope() as scope:
-        expr_api.register_and_transform_tee_nodes(teed)
-        assert scope.reader_count >= 1, (
-            "tee upstream reader must be adopted into the ambient transform scope"
-        )
-        assert scope.table_count >= 1, "tee placeholder table must be adopted too"
-        placeholders = list(scope.table_names)
+    # thread an explicit scope into the pass, mirroring _transform_expr
+    scope = RemoteTableScope()
+    expr_api.register_and_transform_tee_nodes_into(teed, scope)
+    assert scope.reader_count >= 1, (
+        "tee upstream reader must be adopted into the transform scope"
+    )
+    assert scope.table_count >= 1, "tee placeholder table must be adopted too"
+    placeholders = list(scope.table_names)
     scope.close()
     # the placeholder(s) the tee pass registered are dropped (source tables t0 /
     # the memtable are not scope-owned and legitimately remain)

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -10,16 +10,20 @@ from __future__ import annotations
 
 import gc
 from collections.abc import Callable
+from pathlib import Path
 
 import pandas as pd
 import pyarrow as pa
 import pytest
 
 import xorq.api as xo
+import xorq.expr.api as expr_api
 import xorq.expr.remote_table_exec as remote_table_exec
 import xorq.vendor.ibis.expr.types as ir
 from xorq.common.utils.defer_utils import deferred_read_parquet
-from xorq.expr.api import get_plans, to_pyarrow_batches
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.api import _transform_expr, get_plans, to_pyarrow_batches
+from xorq.expr.relations import RemoteTable
 from xorq.expr.remote_table_exec import (
     RemoteTableScope,
     bind_scope_to_reader,
@@ -29,6 +33,7 @@ from xorq.expr.remote_table_exec import (
 )
 from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.backends import BaseBackend
+from xorq.writes import ParquetWriteThrough
 
 
 pytest.importorskip("duckdb")
@@ -424,6 +429,73 @@ def test_replacer_adopts_reader_cache_and_table() -> None:
     finally:
         scope.close()
     assert target.list_tables() == []
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="P1: _transform_expr adopts tee tables/drains into the scope only "
+    "after the remote pass returns, so a remote-pass failure leaks them. Fixed "
+    "by the unified-scope refactor, which removes this marker.",
+)
+def test_tee_resources_released_when_remote_pass_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tee (pass 4) registers a placeholder table + drain *before* the remote
+    pass (pass 5) runs. In ``_transform_expr`` those tee resources are adopted
+    into the scope only *after* pass 5 returns, so a pass-5 failure tears down
+    an empty scope and leaks everything pass 4 created.
+
+    Regression guard for the ownership gap: any failure during transform must
+    release resources materialized by *earlier* passes, not just the failing
+    one. ``test_planning_failure_releases_resources`` covers a remote-only expr;
+    this covers the tee+remote interaction that the after-the-fact adoption in
+    ``_transform_expr`` gets wrong.
+    """
+    con = xo.connect()  # datafusion: re-entrant, safe for the streaming tee
+    t = con.register(
+        xo.memtable({"a": [1, 2, 3], "b": ["x", "y", "z"]}), table_name="t0"
+    )
+    teed = t.tee(ParquetWriteThrough(path=tmp_path / "out.parquet"))
+    # a RemoteTable sibling so the (outer) remote pass has real work to fail on;
+    # the tee's own parent branch (t) has none, so the tee pass's internal
+    # recursion through to_pyarrow_batches stays intact.
+    rt = xo.memtable({"a": [4, 5], "b": ["p", "q"]}).into_backend(con, "rt_tbl")
+    expr = teed.union(rt)
+
+    # Accumulate every placeholder the tee pass registers across all (recursive)
+    # invocations -- the outer call registers the real one; inner recursive calls
+    # on the tee's parent register nothing.
+    created: dict = {}
+    real_tee = expr_api.register_and_transform_tee_nodes
+
+    def capturing_tee(inner_expr, **kwargs):
+        # **kwargs keeps this shim valid whether or not the pass takes a
+        # caller-owned ``scope`` (forwarded through unchanged).
+        result_expr, made, drains = real_tee(inner_expr, **kwargs)
+        created.update(made)
+        return result_expr, made, drains
+
+    # Fail the remote pass only when a RemoteTable is actually present, so the
+    # tee pass's recursion on its RemoteTable-free parent still succeeds and the
+    # failure lands at the *outer* pass 5 -- after pass 4 registered its table.
+    real_remote = expr_api.register_and_transform_remote_tables
+
+    def guarded_boom(inner_expr, **kwargs):
+        if walk_nodes(RemoteTable, inner_expr):
+            raise RuntimeError("remote pass failed")
+        return real_remote(inner_expr, **kwargs)
+
+    monkeypatch.setattr(expr_api, "register_and_transform_tee_nodes", capturing_tee)
+    monkeypatch.setattr(expr_api, "register_and_transform_remote_tables", guarded_boom)
+
+    with pytest.raises(RuntimeError, match="remote pass failed"):
+        _transform_expr(expr)
+
+    # the tee pass really did materialize a placeholder (guards against a vacuous
+    # assertion if tee handling changes)
+    assert created, "tee pass should have registered a placeholder table"
+    leaked = [name for name in created if name in con.list_tables()]
+    assert not leaked, f"tee placeholder tables leaked after pass-5 failure: {leaked}"
 
 
 def test_partial_read_record_batches_failure_drops_placeholder(

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -443,7 +443,9 @@ def test_tee_resources_released_when_remote_pass_fails(
     release resources materialized by *earlier* passes, not just the failing
     one. ``test_planning_failure_releases_resources`` covers a remote-only expr;
     this covers the tee+remote interaction that the after-the-fact adoption in
-    ``_transform_expr`` gets wrong.
+    ``_transform_expr`` gets wrong. Both halves of what the tee pass creates are
+    checked: the placeholder *table* is dropped and the *drain* thread is
+    closed+joined (not left running).
     """
     con = xo.connect()  # datafusion: re-entrant, safe for the streaming tee
     t = con.register(
@@ -456,18 +458,21 @@ def test_tee_resources_released_when_remote_pass_fails(
     rt = xo.memtable({"a": [4, 5], "b": ["p", "q"]}).into_backend(con, "rt_tbl")
     expr = teed.union(rt)
 
-    # Accumulate every placeholder the tee pass registers across all (recursive)
-    # invocations -- the outer call registers the real one; inner recursive calls
-    # on the tee's parent register nothing.
-    created: dict = {}
-    real_tee = expr_api.register_and_transform_tee_nodes
+    # Capture what the tee pass adopts straight from the adoption boundary
+    # (RemoteTableScope.adopt_*), decoupled from the pass's return shape. The
+    # tee's parent (t) has no RemoteTable, so only the outer tee registers here.
+    adopted_tables: list[tuple] = []
+    adopted_drains: list = []
+    real_adopt_table = RemoteTableScope.adopt_table
+    real_adopt_drain = RemoteTableScope.adopt_drain
 
-    def capturing_tee(inner_expr, **kwargs):
-        # **kwargs keeps this shim valid whether or not the pass takes a
-        # caller-owned ``scope`` (forwarded through unchanged).
-        result_expr, made, drains = real_tee(inner_expr, **kwargs)
-        created.update(made)
-        return result_expr, made, drains
+    def spy_table(self, con_, name):
+        adopted_tables.append((con_, name))
+        return real_adopt_table(self, con_, name)
+
+    def spy_drain(self, drain):
+        adopted_drains.append(drain)
+        return real_adopt_drain(self, drain)
 
     # Fail the remote pass only when a RemoteTable is actually present, so the
     # tee pass's recursion on its RemoteTable-free parent still succeeds and the
@@ -479,17 +484,52 @@ def test_tee_resources_released_when_remote_pass_fails(
             raise RuntimeError("remote pass failed")
         return real_remote(inner_expr, **kwargs)
 
-    monkeypatch.setattr(expr_api, "register_and_transform_tee_nodes", capturing_tee)
+    monkeypatch.setattr(RemoteTableScope, "adopt_table", spy_table)
+    monkeypatch.setattr(RemoteTableScope, "adopt_drain", spy_drain)
     monkeypatch.setattr(expr_api, "register_and_transform_remote_tables", guarded_boom)
 
     with pytest.raises(RuntimeError, match="remote pass failed"):
         _transform_expr(expr)
 
-    # the tee pass really did materialize a placeholder (guards against a vacuous
-    # assertion if tee handling changes)
-    assert created, "tee pass should have registered a placeholder table"
-    leaked = [name for name in created if name in con.list_tables()]
+    # the tee pass really did materialize a placeholder + drain (guards against a
+    # vacuous assertion if tee handling changes)
+    assert adopted_tables, "tee pass should have adopted a placeholder table"
+    assert adopted_drains, "tee pass should have adopted a drain"
+    leaked = [name for (con_, name) in adopted_tables if name in con_.list_tables()]
     assert not leaked, f"tee placeholder tables leaked after pass-5 failure: {leaked}"
+    # scope.close() must close+join the drain (it feeds the placeholder), not
+    # leave the drain thread running -- `exhausted` flips True only once it has.
+    unjoined = [d for d in adopted_drains if not d.exhausted]
+    assert not unjoined, f"tee drain threads leaked after pass-5 failure: {unjoined}"
+
+
+def test_tee_adopts_upstream_reader_into_scope(tmp_path: Path) -> None:
+    """The tee pass opens an upstream reader (``parent_expr.to_pyarrow_batches()``)
+    that holds a live backend cursor. It must be adopted into the ambient
+    transform scope so a later-pass failure closes it -- exactly as the remote
+    pass adopts its reader (see ``test_replacer_adopts_reader_cache_and_table``).
+
+    This is a pre-existing leak: on ``main`` (and before this fix) the tee reader
+    was never adopted, so any post-tee failure abandoned it un-closed. Composes
+    with ``test_scope_close_closes_adopted_readers``, which proves adopted
+    readers are closed on ``scope.close()``.
+    """
+    con = xo.connect()  # datafusion: re-entrant, safe for the streaming tee
+    t = con.register(xo.memtable({"a": [1, 2, 3]}), table_name="t0")
+    teed = t.tee(ParquetWriteThrough(path=tmp_path / "out.parquet"))
+
+    with remote_table_exec.transform_scope() as scope:
+        expr_api.register_and_transform_tee_nodes(teed)
+        assert scope.reader_count >= 1, (
+            "tee upstream reader must be adopted into the ambient transform scope"
+        )
+        assert scope.table_count >= 1, "tee placeholder table must be adopted too"
+        placeholders = list(scope.table_names)
+    scope.close()
+    # the placeholder(s) the tee pass registered are dropped (source tables t0 /
+    # the memtable are not scope-owned and legitimately remain)
+    remaining = [name for name in placeholders if name in con.list_tables()]
+    assert not remaining, f"tee placeholder tables not dropped: {remaining}"
 
 
 def test_partial_read_record_batches_failure_drops_placeholder(

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1751,7 +1751,7 @@ def test_execution_handles_remote_table_in_computed_kwargs_expr(
 ) -> None:
     """RemoteTables nested inside ExprScalarUDF.computed_kwargs_expr must be
     materialized lazily when the UDF is compiled, not during the outer
-    register_and_transform_remote_tables pass (which intentionally skips
+    register_and_transform_remote_tables_into pass (which intentionally skips
     opaque sub-expressions)."""
     cona = xo.connect()
     conb = xo.connect()

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -16,7 +16,10 @@ import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
 from xorq.caching import ParquetCache, SourceCache
 from xorq.common.exceptions import XorqError
-from xorq.expr.remote_table_exec import register_and_transform_remote_tables
+from xorq.expr.remote_table_exec import (
+    RemoteTableScope,
+    register_and_transform_remote_tables_into,
+)
 from xorq.loader import load_backend
 from xorq.tests.util import assert_frame_equal, check_eq
 from xorq.vendor import ibis
@@ -261,7 +264,8 @@ def test_into_backend_duckdb(pg):
         .select(player_id="playerID", year_id="yearID_right")
     )
 
-    expr, scope = register_and_transform_remote_tables(expr)
+    scope = RemoteTableScope()
+    expr = register_and_transform_remote_tables_into(expr, scope)
     with scope:
         query = ibis.to_sql(expr, dialect="duckdb")
         res = ddb.con.sql(query).df()
@@ -278,7 +282,8 @@ def test_into_backend_duckdb_expr(pg: BaseBackend) -> None:
     t = pg.table("batting").into_backend(ddb, "ls_batting")
     expr = t.join(t, "playerID").limit(15).select(_.playerID * 2)
 
-    expr, scope = register_and_transform_remote_tables(expr)
+    scope = RemoteTableScope()
+    expr = register_and_transform_remote_tables_into(expr, scope)
     with scope:
         query = ibis.to_sql(expr, dialect="duckdb")
         res = ddb.con.sql(query).df()
@@ -294,7 +299,8 @@ def test_into_backend_duckdb_trino(trino_table):
     db_con = xo.duckdb.connect()
     expr = trino_table.head(10_000).into_backend(db_con).pipe(make_merged)
 
-    expr, scope = register_and_transform_remote_tables(expr)
+    scope = RemoteTableScope()
+    expr = register_and_transform_remote_tables_into(expr, scope)
     with scope:
         query = ibis.to_sql(expr, dialect="duckdb")
         df = db_con.con.sql(query).df()  # to bypass execute hotfix
@@ -316,7 +322,8 @@ def test_multiple_into_backend_duckdb_xorq(trino_table: ir.Table) -> None:
         .into_backend(ls_con)[lambda t: t.orderstatus == "F"]
     )
 
-    expr, scope = register_and_transform_remote_tables(expr)
+    scope = RemoteTableScope()
+    expr = register_and_transform_remote_tables_into(expr, scope)
     with scope:
         df = expr.execute()
 

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -24,8 +24,9 @@ from xorq.expr.api import (
 from xorq.expr.relations import (
     HashingTag,
     TeeNode,
-    register_and_transform_tee_nodes,
+    register_and_transform_tee_nodes_into,
 )
+from xorq.expr.remote_table_exec import RemoteTableScope
 from xorq.writes import (
     BackendWriteThrough,
     DrainingIterator,
@@ -347,7 +348,7 @@ def test_tee_duckdb_warns_deadlock(tmp_path: Path) -> None:
     t = con.create_table("dd_warn", pa.table({"a": [1, 2, 3, 4]}))
     expr = t.tee(ParquetWriteThrough(path=tmp_path / "out.parquet"))
     with pytest.warns(UserWarning, match="deadlock"):
-        register_and_transform_tee_nodes(expr)
+        register_and_transform_tee_nodes_into(expr, RemoteTableScope())
 
 
 def test_write_with_cache_upstream(tmp_path: Path) -> None:
@@ -663,8 +664,8 @@ def test_to_sql_strips_nested_tee_nodes(t: Table, tmp_path: Path) -> None:
 def test_tee_transform_leaves_tee_inside_opaque_untouched(
     t: Table, tmp_path: Path
 ) -> None:
-    """register_and_transform_tee_nodes uses op.replace, which deliberately does
-    not descend into opaque sub-exprs (here CachedNode.parent). A TeeNode buried
+    """register_and_transform_tee_nodes_into uses op.replace, which deliberately
+    does not descend into opaque sub-exprs (here CachedNode.parent). A TeeNode buried
     in an opaque node must survive the outer pass untouched and its write must not
     fire: it is handled lazily when the opaque sub-expr executes (e.g. on a cache
     miss). Guards against a regression to replace_nodes, which would descend and
@@ -677,7 +678,8 @@ def test_tee_transform_leaves_tee_inside_opaque_untouched(
     assert len(walk_nodes((TeeNode,), cached)) == 1
     assert len(cached.op().find(TeeNode)) == 0
 
-    transformed, scope = register_and_transform_tee_nodes(cached)
+    scope = RemoteTableScope()
+    transformed = register_and_transform_tee_nodes_into(cached, scope)
 
     assert not target.exists(), "outer transform must not fire the buried write"
     assert scope.table_count == 0, "no pass-through table should be registered"

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -677,11 +677,11 @@ def test_tee_transform_leaves_tee_inside_opaque_untouched(
     assert len(walk_nodes((TeeNode,), cached)) == 1
     assert len(cached.op().find(TeeNode)) == 0
 
-    transformed, created, drains = register_and_transform_tee_nodes(cached)
+    transformed, scope = register_and_transform_tee_nodes(cached)
 
     assert not target.exists(), "outer transform must not fire the buried write"
-    assert created == {}, "no pass-through table should be registered"
-    assert drains == []
+    assert scope.table_count == 0, "no pass-through table should be registered"
+    assert scope.drain_count == 0
     assert len(walk_nodes((TeeNode,), transformed)) == 1, (
         "TeeNode inside the opaque sub-expr must survive the outer transform"
     )


### PR DESCRIPTION
## Summary

Makes a single `RemoteTableScope` own **every** resource the effectful transform passes materialize, so a failure in any pass tears down what *earlier* passes created — not just its own. Previously the scope was born inside the remote-tables pass and the tee pass's tables/drains were adopted only *after* it returned, so a remote-pass failure leaked the tee placeholder tables and drain threads.

## What changed

- **One explicitly-threaded scope.** `_transform_expr` creates a single `RemoteTableScope()` up front and threads it into both effectful passes (now `register_and_transform_tee_nodes_into` / `register_and_transform_remote_tables_into`). Each pass adopts what it materializes into that caller-owned scope instead of creating its own, so a failure in any pass — including re-entrant transforms (cache resolution, `into_backend`) — tears down what earlier passes created, not just its own.
- **Fixes a pre-existing reader leak** (present on `main`): the tee pass opened an upstream reader (`parent_expr.to_pyarrow_batches()`, a live backend cursor) but never adopted it, so any post-tee failure abandoned it un-closed. It is now adopted just like the remote pass's reader.
- **Single source of truth.** Both `_into` passes return just `expr` and adopt resources directly into the caller-owned scope; `register_and_transform_remote_tables_into` no longer creates or returns a scope, and the parallel `created`/`drains` bookkeeping is dropped, so there is no second record of the same resources to drift out of sync. Teardown stays with the caller that created the scope.
- **`except BaseException`** on the transform teardown so `KeyboardInterrupt`/`SystemExit` also release resources (previously they bypassed cleanup and leaked).

## Tests

- `test_tee_resources_released_when_remote_pass_fails` — asserts a remote-pass failure drops the tee placeholder table **and** closes+joins the drain thread (captured via `adopt_*` spies).
- `test_tee_adopts_upstream_reader_into_scope` — asserts the tee upstream reader is adopted into the threaded scope.
- Both fail without the fix.

## Behavior notes

- Given `drain=False`, a killed/failed transform abandons the tee write (verified); `drain=True` force-completes on teardown, which is its documented contract. The `except BaseException` widening only extends teardown to interrupts — it does not change drain semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
