### PR TITLE
refactor(transform): declarative pass driver for _transform_expr (R2)

### DIFF
--- a/python/xorq/backends/duckdb/__init__.py
+++ b/python/xorq/backends/duckdb/__init__.py
@@ -36,7 +36,7 @@ class Backend(IbisDuckDBBackend):
         # duckdb registers ``source`` (typically a StreamCache) directly so it
         # can replay the stream across scans; a casting wrapper would not be
         # replayable, so casting to the logical schema happens upstream, before
-        # the StreamCache, in register_and_transform_remote_tables_into.
+        # the StreamCache, in the remote pass (REMOTE_PASS / _make_remote_replacer).
         table_name = table_name or gen_name("read_record_batches")
         self.con.register(table_name, source)
         return self.table(table_name)

--- a/python/xorq/backends/gizmosql/tests/test_read_record_batches.py
+++ b/python/xorq/backends/gizmosql/tests/test_read_record_batches.py
@@ -1,6 +1,6 @@
 """GizmoSQL read_record_batches coverage, including StreamCache inputs.
 
-register_and_transform_remote_tables_into feeds a batchcorder StreamCache straight
+The remote pass (REMOTE_PASS) feeds a batchcorder StreamCache straight
 into the target backend's read_record_batches, so these pin that gizmosql
 accepts a StreamCache (it exposes __iter__/.schema) and, in particular, that an
 empty stream still materializes the declared columns rather than raising

--- a/python/xorq/backends/xorq_datafusion/backend.py
+++ b/python/xorq/backends/xorq_datafusion/backend.py
@@ -814,7 +814,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 # bound still drives eviction. cast only retypes -- it requires
                 # matching field names -- so column projection must already have
                 # happened upstream, before the cache (the remote-table path does
-                # this; see register_and_transform_remote_tables_into). Wrapping a
+                # this; see the remote pass, REMOTE_PASS). Wrapping a
                 # second StreamCache here to drop columns would double-buffer the
                 # data and defeat eviction, so we let cast raise on a name
                 # mismatch rather than accommodate it.

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -214,7 +214,7 @@ def test_read_record_batches_stream_cache_extra_columns_raises() -> None:
     # A StreamCache must already hold the logical columns: cast only retypes,
     # it cannot drop columns, and wrapping a second cache to project would
     # double-buffer and defeat eviction. Column projection belongs upstream,
-    # before the cache (as register_and_transform_remote_tables_into does).
+    # before the cache (as the remote pass, REMOTE_PASS, does).
     con = xo.connect()
     batch = pa.record_batch({"a": [1, 2], "extra": [9, 9]})
     reader = pa.RecordBatchReader.from_batches(batch.schema, [batch])

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -364,8 +364,8 @@ def _remove_tag_nodes(expr: ir.Expr) -> ir.Expr:
 def _remove_tee_nodes(expr: ir.Expr) -> ir.Expr:
     """Strip transparent `TeeNode`s to their parent (for SQL / hashing).
 
-    Execution keeps the `TeeNode` until `register_and_transform_tee_nodes_into`
-    fires the write, so this is only used off the execution path.
+    Execution keeps the `TeeNode` until the tee pass (`TEE_PASS`) fires the
+    write, so this is only used off the execution path.
     """
 
     def replacer(node, kwargs):
@@ -483,8 +483,11 @@ _PASSES = (
         build=lambda expr, ctx: _make_cache_replacer(expr),
         after=("bind_params", "remove_tags"),
     ),
-    TEE_PASS,
-    REMOTE_PASS,
+    # TEE_PASS / REMOTE_PASS are defined with their replacers; their ``after`` is
+    # echoed here so the whole chain reads in one place (the driver still checks
+    # each record's real ``after``, so an echo that drifts raises).
+    TEE_PASS,  # BOUNDARY; after=("cache",)
+    REMOTE_PASS,  # BOUNDARY; after=("tee",)
     TransformPass(
         name="deferred_reads",
         traversal=Traversal.BOUNDARY,

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -6,7 +6,7 @@ import functools
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 import pyarrow as pa
 import toolz
@@ -28,12 +28,14 @@ from xorq.common.utils.io_utils import (
 )
 from xorq.common.utils.otel_utils import get_current_span, tracer
 from xorq.common.utils.rbr_utils import otel_instrument_reader
+from xorq.expr.enums import Traversal
 from xorq.expr.ml import (
     calc_split_column,
     train_test_splits,
 )
 from xorq.expr.operations import _MISSING, NamedScalarParameter
 from xorq.expr.relations import (
+    TEE_PASS,
     CachedNode,
     CacheTag,
     FlightExpr,
@@ -42,13 +44,13 @@ from xorq.expr.relations import (
     Read,
     Tag,
     TeeNode,
-    register_and_transform_tee_nodes_into,
 )
 from xorq.expr.remote_table_exec import (
+    REMOTE_PASS,
     RemoteTableScope,
     bind_scope_to_reader,
-    register_and_transform_remote_tables_into,
 )
+from xorq.expr.transform import TransformCtx, TransformPass, run_transform_passes
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import api
 from xorq.vendor.ibis.expr.api import *  # noqa: F403
@@ -219,9 +221,9 @@ def to_sql(expr: ir.Expr, compiler=None, pretty: bool = True) -> SQLString:
     return SQLString(_cached_with_op(unbound, pretty, compiler))
 
 
-@tracer.start_as_current_span("_register_and_transform_cache_tables")
-def _register_and_transform_cache_tables(expr):
-    """This function will sequentially execute any cache node that is not already cached"""
+def _cache_replacer(expr: "ir.Expr") -> Callable:
+    """Build the BOUNDARY replacer that sequentially executes any CachedNode that
+    is not already cached (``set_default`` materializes as a side effect)."""
     op = expr.op()
     root_is_cached = isinstance(op, CachedNode)
 
@@ -250,17 +252,18 @@ def _register_and_transform_cache_tables(expr):
             )
         return node
 
-    # op.replace, not replace_nodes (see its docstring): cache resolution has
-    # side effects (set_default executes/materializes), so it must fire only at
-    # this execution boundary. CachedNodes inside opaque sub-exprs re-enter this
-    # pass when those sub-exprs execute -- descending here would double-resolve.
-    out = op.replace(fn)
-
-    return out.to_expr()
+    return fn
 
 
-@tracer.start_as_current_span("_transform_deferred_reads")
-def _transform_deferred_reads(expr):
+@tracer.start_as_current_span("_register_and_transform_cache_tables")
+def _register_and_transform_cache_tables(expr: "ir.Expr") -> "ir.Expr":
+    """This function will sequentially execute any cache node that is not already cached"""
+    return expr.op().replace(_cache_replacer(expr)).to_expr()
+
+
+def _deferred_reads_replacer() -> Callable:
+    """Build the BOUNDARY replacer that resolves each deferred `Read` via
+    ``make_dt()`` at this execution boundary."""
     span = get_current_span()
 
     def replace_read(node, _kwargs):
@@ -285,11 +288,15 @@ def _transform_deferred_reads(expr):
                 node = node.__recreate__(_kwargs)
         return node
 
-    # op.replace, not replace_nodes (see its docstring): make_dt resolves a
-    # deferred read at this execution boundary; reads inside opaque sub-exprs
-    # are resolved when those sub-exprs execute, so descending here is wrong.
-    expr = expr.op().replace(replace_read).to_expr()
-    return expr
+    return replace_read
+
+
+@tracer.start_as_current_span("_transform_deferred_reads")
+def _transform_deferred_reads(expr: "ir.Expr") -> "ir.Expr":
+    # op.replace, not replace_nodes: make_dt resolves a deferred read at this
+    # execution boundary; reads inside opaque sub-exprs are resolved when those
+    # sub-exprs execute, so descending here is wrong.
+    return expr.op().replace(_deferred_reads_replacer()).to_expr()
 
 
 @tracer.start_as_current_span("execute")
@@ -341,8 +348,10 @@ def execute(expr: ir.Expr, **kwargs: Any):
     return expr.__pandas_result__(df)
 
 
-@tracer.start_as_current_span("_remove_tag_nodes")
-def _remove_tag_nodes(expr):
+def _remove_tag_nodes_replacer() -> Callable:
+    """Build the DESCEND replacer that strips `Tag` wrappers, re-walking the
+    unwrapped parent so nested tags collapse to their first non-Tag ancestor."""
+
     def replacer(node, kwargs):
         if isinstance(node, Tag):
             while isinstance(node, Tag):
@@ -352,7 +361,12 @@ def _remove_tag_nodes(expr):
             node = node.__recreate__(kwargs)
         return node
 
-    return replace_nodes(replacer, expr).to_expr()
+    return replacer
+
+
+@tracer.start_as_current_span("_remove_tag_nodes")
+def _remove_tag_nodes(expr: "ir.Expr") -> "ir.Expr":
+    return replace_nodes(_remove_tag_nodes_replacer(), expr).to_expr()
 
 
 @tracer.start_as_current_span("_remove_tee_nodes")
@@ -449,36 +463,73 @@ def _resolve_params(params):
     return name_values
 
 
+# The tier-1 transform as a declarative, ordered table (see xorq.expr.transform).
+# Each record fixes its own traversal kind (DESCEND vs BOUNDARY) and ``after``
+# ordering, so the driver -- not a per-call-site convention -- picks the walk and
+# asserts the dependency chain: bind -> tags -> cache -> tee -> remote -> reads.
+# ``produces_resources`` passes (tee, remote) adopt into the shared scope; cache
+# materializes persistent parquet and owns nothing scope-tracked.
+_PASSES = (
+    TransformPass(
+        name="bind_params",
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: _bind_params_replacer(
+            _resolve_bind_op_params(expr, ctx.name_values)
+        ),
+        # Skip entirely when there is nothing to bind (no values, no params).
+        when=lambda expr, ctx: (
+            bool(ctx.name_values) or bool(walk_nodes(NamedScalarParameter, expr))
+        ),
+    ),
+    TransformPass(
+        name="remove_tags",
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: _remove_tag_nodes_replacer(),
+    ),
+    TransformPass(
+        name="cache",
+        traversal=Traversal.BOUNDARY,
+        build=lambda expr, ctx: _cache_replacer(expr),
+        after=("bind_params", "remove_tags"),
+    ),
+    TEE_PASS,
+    REMOTE_PASS,
+    TransformPass(
+        name="deferred_reads",
+        traversal=Traversal.BOUNDARY,
+        build=lambda expr, ctx: _deferred_reads_replacer(),
+        after=("remote",),
+    ),
+)
+
+
 @tracer.start_as_current_span("_transform_expr")
-def _transform_expr(expr, params=None, **kwargs):
+def _transform_expr(
+    expr: "ir.Expr", params: "dict | None" = None, **kwargs: Any
+) -> "tuple[ir.Expr, RemoteTableScope]":
     """Transform an expression for execution, binding any named scalar parameters.
 
     Returns ``(expr, scope)``: the scope owns every resource the transform
     materialized (upstream readers, StreamCaches, placeholder tables) and the
     caller must close it once the transformed expr is consumed.
+
+    One scope, created up front and carried in the ``TransformCtx``, owns every
+    resource the effectful passes materialize. Because all passes adopt into this
+    *same* scope, a failure in any pass tears down what *earlier* passes created
+    -- not just its own. The driver (``run_transform_passes``) selects each
+    pass's traversal from its record and asserts the ``after`` ordering.
     """
-    name_values = _resolve_params(params)
-    expr = (
-        bind_params(expr, name_values)
-        if name_values or walk_nodes(NamedScalarParameter, expr)
-        else expr
+    ctx = TransformCtx(
+        scope=RemoteTableScope(),
+        name_values=_resolve_params(params),
+        through_kwargs=kwargs,
     )
-    expr = _remove_tag_nodes(expr)
-    # One scope, created up front and threaded explicitly into the tee and
-    # remote passes, owns every teardown-able resource they materialize (the
-    # cache-table pass's tables are intentional artifacts, not scope-owned).
-    # Both passes adopt into this *same* scope, so a failure in any pass tears
-    # down what earlier passes created, not just its own.
-    scope = RemoteTableScope()
     try:
-        expr = _register_and_transform_cache_tables(expr)
-        expr = register_and_transform_tee_nodes_into(expr, scope)
-        expr = register_and_transform_remote_tables_into(expr, scope, **kwargs)
-        expr = _transform_deferred_reads(expr)
+        expr = run_transform_passes(expr, _PASSES, ctx)
     except BaseException:
-        scope.close()
+        ctx.scope.close()
         raise
-    return (expr, scope)
+    return (expr, ctx.scope)
 
 
 @contextmanager
@@ -787,6 +838,17 @@ def bind_params(expr, params: dict) -> "ir.Expr":
         If *params* contains names not found in *expr*, or values
         incompatible with the declared dtype.
     """
+    op_params = _resolve_bind_op_params(expr, params)
+    return replace_nodes(_bind_params_replacer(op_params), expr).to_expr()
+
+
+def _resolve_bind_op_params(expr: "ir.Expr", params: dict) -> dict:
+    """Validate ``params`` against ``expr``'s NamedScalarParameters and return the
+    ``{node: value}`` bindings (applying defaults for omitted ones).
+
+    Raises the same TypeError/ValueError as ``bind_params`` on extra names,
+    incompatible values, or missing required params.
+    """
     named = {node.label: node for node in walk_nodes(NamedScalarParameter, expr)}
 
     errors = []
@@ -813,11 +875,16 @@ def bind_params(expr, params: dict) -> "ir.Expr":
     if missing:
         raise ValueError(f"Missing required parameters: {', '.join(missing)}")
 
-    op_params = {
+    return {
         node: params.get(name, node.default)
         for name, node in named.items()
         if params.get(name, node.default) is not _MISSING
     }
+
+
+def _bind_params_replacer(op_params: dict) -> Callable:
+    """Build the DESCEND replacer that substitutes bound NamedScalarParameters
+    with their Literal values."""
 
     def replacer(node, kwargs):
         if kwargs:
@@ -826,4 +893,4 @@ def bind_params(expr, params: dict) -> "ir.Expr":
             return ops.Literal(value=op_params[node], dtype=node.dtype)
         return node
 
-    return replace_nodes(replacer, expr).to_expr()
+    return replacer

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -260,12 +260,6 @@ def _cache_replacer(expr: ir.Expr) -> Replacer:
     return fn
 
 
-@tracer.start_as_current_span("_register_and_transform_cache_tables")
-def _register_and_transform_cache_tables(expr: ir.Expr) -> ir.Expr:
-    """This function will sequentially execute any cache node that is not already cached"""
-    return expr.op().replace(_cache_replacer(expr)).to_expr()
-
-
 def _deferred_reads_replacer() -> Replacer:
     """Build the BOUNDARY replacer that resolves each deferred `Read` via
     ``make_dt()`` at this execution boundary."""
@@ -294,13 +288,6 @@ def _deferred_reads_replacer() -> Replacer:
         return node
 
     return replace_read
-
-
-@tracer.start_as_current_span("_transform_deferred_reads")
-def _transform_deferred_reads(expr: ir.Expr) -> ir.Expr:
-    # BOUNDARY: make_dt resolves each deferred read at this execution boundary
-    # (reads inside opaque sub-exprs resolve when those execute). See Traversal.
-    return expr.op().replace(_deferred_reads_replacer()).to_expr()
 
 
 @tracer.start_as_current_span("execute")

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -6,7 +6,7 @@ import functools
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 import pyarrow as pa
 import toolz
@@ -50,7 +50,12 @@ from xorq.expr.remote_table_exec import (
     RemoteTableScope,
     bind_scope_to_reader,
 )
-from xorq.expr.transform import TransformCtx, TransformPass, run_transform_passes
+from xorq.expr.transform import (
+    Replacer,
+    TransformCtx,
+    TransformPass,
+    run_transform_passes,
+)
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import api
 from xorq.vendor.ibis.expr.api import *  # noqa: F403
@@ -221,7 +226,7 @@ def to_sql(expr: ir.Expr, compiler=None, pretty: bool = True) -> SQLString:
     return SQLString(_cached_with_op(unbound, pretty, compiler))
 
 
-def _cache_replacer(expr: "ir.Expr") -> Callable:
+def _cache_replacer(expr: ir.Expr) -> Replacer:
     """Build the BOUNDARY replacer that sequentially executes any CachedNode that
     is not already cached (``set_default`` materializes as a side effect)."""
     op = expr.op()
@@ -256,12 +261,12 @@ def _cache_replacer(expr: "ir.Expr") -> Callable:
 
 
 @tracer.start_as_current_span("_register_and_transform_cache_tables")
-def _register_and_transform_cache_tables(expr: "ir.Expr") -> "ir.Expr":
+def _register_and_transform_cache_tables(expr: ir.Expr) -> ir.Expr:
     """This function will sequentially execute any cache node that is not already cached"""
     return expr.op().replace(_cache_replacer(expr)).to_expr()
 
 
-def _deferred_reads_replacer() -> Callable:
+def _deferred_reads_replacer() -> Replacer:
     """Build the BOUNDARY replacer that resolves each deferred `Read` via
     ``make_dt()`` at this execution boundary."""
     span = get_current_span()
@@ -292,10 +297,9 @@ def _deferred_reads_replacer() -> Callable:
 
 
 @tracer.start_as_current_span("_transform_deferred_reads")
-def _transform_deferred_reads(expr: "ir.Expr") -> "ir.Expr":
-    # op.replace, not replace_nodes: make_dt resolves a deferred read at this
-    # execution boundary; reads inside opaque sub-exprs are resolved when those
-    # sub-exprs execute, so descending here is wrong.
+def _transform_deferred_reads(expr: ir.Expr) -> ir.Expr:
+    # BOUNDARY: make_dt resolves each deferred read at this execution boundary
+    # (reads inside opaque sub-exprs resolve when those execute). See Traversal.
     return expr.op().replace(_deferred_reads_replacer()).to_expr()
 
 
@@ -348,7 +352,7 @@ def execute(expr: ir.Expr, **kwargs: Any):
     return expr.__pandas_result__(df)
 
 
-def _remove_tag_nodes_replacer() -> Callable:
+def _remove_tag_nodes_replacer() -> Replacer:
     """Build the DESCEND replacer that strips `Tag` wrappers, re-walking the
     unwrapped parent so nested tags collapse to their first non-Tag ancestor."""
 
@@ -365,7 +369,7 @@ def _remove_tag_nodes_replacer() -> Callable:
 
 
 @tracer.start_as_current_span("_remove_tag_nodes")
-def _remove_tag_nodes(expr: "ir.Expr") -> "ir.Expr":
+def _remove_tag_nodes(expr: ir.Expr) -> ir.Expr:
     return replace_nodes(_remove_tag_nodes_replacer(), expr).to_expr()
 
 
@@ -505,16 +509,14 @@ _PASSES = (
 
 @tracer.start_as_current_span("_transform_expr")
 def _transform_expr(
-    expr: "ir.Expr", params: "dict | None" = None, **kwargs: Any
-) -> "tuple[ir.Expr, RemoteTableScope]":
+    expr: ir.Expr, params: dict | None = None, **kwargs: Any
+) -> tuple[ir.Expr, RemoteTableScope]:
     """Transform an expression for execution, binding any named scalar parameters.
 
-    Returns ``(expr, scope)``: the scope owns every resource the transform
-    materialized (upstream readers, StreamCaches, placeholder tables) and the
-    caller must close it once the transformed expr is consumed.
-
-    One scope, created up front and carried in the ``TransformCtx``, owns every
-    resource the effectful passes materialize. Because all passes adopt into this
+    Returns ``(expr, scope)``. One scope, created up front and carried in the
+    ``TransformCtx``, owns every resource the effectful passes materialize
+    (upstream readers, StreamCaches, placeholder tables); the caller must close
+    it once the transformed expr is consumed. Because all passes adopt into that
     *same* scope, a failure in any pass tears down what *earlier* passes created
     -- not just its own. The driver (``run_transform_passes``) selects each
     pass's traversal from its record and asserts the ``after`` ordering.
@@ -522,7 +524,7 @@ def _transform_expr(
     ctx = TransformCtx(
         scope=RemoteTableScope(),
         name_values=_resolve_params(params),
-        through_kwargs=kwargs,
+        read_record_batches_kwargs=kwargs,
     )
     try:
         expr = run_transform_passes(expr, _PASSES, ctx)
@@ -842,7 +844,7 @@ def bind_params(expr, params: dict) -> "ir.Expr":
     return replace_nodes(_bind_params_replacer(op_params), expr).to_expr()
 
 
-def _resolve_bind_op_params(expr: "ir.Expr", params: dict) -> dict:
+def _resolve_bind_op_params(expr: ir.Expr, params: dict) -> dict:
     """Validate ``params`` against ``expr``'s NamedScalarParameters and return the
     ``{node: value}`` bindings (applying defaults for omitted ones).
 
@@ -882,7 +884,7 @@ def _resolve_bind_op_params(expr: "ir.Expr", params: dict) -> dict:
     }
 
 
-def _bind_params_replacer(op_params: dict) -> Callable:
+def _bind_params_replacer(op_params: dict) -> Replacer:
     """Build the DESCEND replacer that substitutes bound NamedScalarParameters
     with their Literal values."""
 

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -226,7 +226,7 @@ def to_sql(expr: ir.Expr, compiler=None, pretty: bool = True) -> SQLString:
     return SQLString(_cached_with_op(unbound, pretty, compiler))
 
 
-def _cache_replacer(expr: ir.Expr) -> Replacer:
+def _make_cache_replacer(expr: ir.Expr) -> Replacer:
     """Build the BOUNDARY replacer that sequentially executes any CachedNode that
     is not already cached (``set_default`` materializes as a side effect)."""
     op = expr.op()
@@ -260,7 +260,7 @@ def _cache_replacer(expr: ir.Expr) -> Replacer:
     return fn
 
 
-def _deferred_reads_replacer() -> Replacer:
+def _make_deferred_reads_replacer() -> Replacer:
     """Build the BOUNDARY replacer that resolves each deferred `Read` via
     ``make_dt()`` at this execution boundary."""
     span = get_current_span()
@@ -339,7 +339,7 @@ def execute(expr: ir.Expr, **kwargs: Any):
     return expr.__pandas_result__(df)
 
 
-def _remove_tag_nodes_replacer() -> Replacer:
+def _make_remove_tag_nodes_replacer() -> Replacer:
     """Build the DESCEND replacer that strips `Tag` wrappers, re-walking the
     unwrapped parent so nested tags collapse to their first non-Tag ancestor."""
 
@@ -357,7 +357,7 @@ def _remove_tag_nodes_replacer() -> Replacer:
 
 @tracer.start_as_current_span("_remove_tag_nodes")
 def _remove_tag_nodes(expr: ir.Expr) -> ir.Expr:
-    return replace_nodes(_remove_tag_nodes_replacer(), expr).to_expr()
+    return replace_nodes(_make_remove_tag_nodes_replacer(), expr).to_expr()
 
 
 @tracer.start_as_current_span("_remove_tee_nodes")
@@ -464,7 +464,7 @@ _PASSES = (
     TransformPass(
         name="bind_params",
         traversal=Traversal.DESCEND,
-        build=lambda expr, ctx: _bind_params_replacer(
+        build=lambda expr, ctx: _make_bind_params_replacer(
             _resolve_bind_op_params(expr, ctx.name_values)
         ),
         # Skip entirely when there is nothing to bind (no values, no params).
@@ -475,12 +475,12 @@ _PASSES = (
     TransformPass(
         name="remove_tags",
         traversal=Traversal.DESCEND,
-        build=lambda expr, ctx: _remove_tag_nodes_replacer(),
+        build=lambda expr, ctx: _make_remove_tag_nodes_replacer(),
     ),
     TransformPass(
         name="cache",
         traversal=Traversal.BOUNDARY,
-        build=lambda expr, ctx: _cache_replacer(expr),
+        build=lambda expr, ctx: _make_cache_replacer(expr),
         after=("bind_params", "remove_tags"),
     ),
     TEE_PASS,
@@ -488,7 +488,7 @@ _PASSES = (
     TransformPass(
         name="deferred_reads",
         traversal=Traversal.BOUNDARY,
-        build=lambda expr, ctx: _deferred_reads_replacer(),
+        build=lambda expr, ctx: _make_deferred_reads_replacer(),
         after=("remote",),
     ),
 )
@@ -828,7 +828,7 @@ def bind_params(expr, params: dict) -> "ir.Expr":
         incompatible with the declared dtype.
     """
     op_params = _resolve_bind_op_params(expr, params)
-    return replace_nodes(_bind_params_replacer(op_params), expr).to_expr()
+    return replace_nodes(_make_bind_params_replacer(op_params), expr).to_expr()
 
 
 def _resolve_bind_op_params(expr: ir.Expr, params: dict) -> dict:
@@ -871,7 +871,7 @@ def _resolve_bind_op_params(expr: ir.Expr, params: dict) -> dict:
     }
 
 
-def _bind_params_replacer(op_params: dict) -> Replacer:
+def _make_bind_params_replacer(op_params: dict) -> Replacer:
     """Build the DESCEND replacer that substitutes bound NamedScalarParameters
     with their Literal values."""
 

--- a/python/xorq/expr/enums.py
+++ b/python/xorq/expr/enums.py
@@ -13,6 +13,13 @@ class Traversal(StrEnum):
     boundary) and for passes resolved at the boundary (deferred reads). Choosing
     DESCEND for an effectful pass double-materializes -- a mistake this enum
     makes impossible outside these two values.
+
+    Stopping at opaque nodes is not a coverage gap: each opaque interior
+    (RemoteTable, CachedNode, Flight*, ExprScalarUDF) re-enters the transform at
+    its own execution boundary (caching resolves and re-transforms the cached
+    parent; into_backend/flight re-pull via ``to_pyarrow_batches``), so nodes
+    nested inside it still get transformed -- exactly once. DESCEND would fire
+    them a second time.
     """
 
     DESCEND = "descend"

--- a/python/xorq/expr/enums.py
+++ b/python/xorq/expr/enums.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from xorq.common.compat import StrEnum
+
+
+class Traversal(StrEnum):
+    """How a tier-1 transform pass walks the graph -- the single source of
+    ``replace_nodes`` vs ``op.replace`` (see ``xorq.expr.transform``).
+
+    DESCEND recurses into opaque sub-exprs (``replace_nodes``); only safe for
+    pure structural rewrites. BOUNDARY stops at opaque nodes (``op.replace``);
+    required for effectful passes (so a side effect fires once, at this execution
+    boundary) and for passes resolved at the boundary (deferred reads). Choosing
+    DESCEND for an effectful pass double-materializes -- a mistake this enum
+    makes impossible outside these two values.
+    """
+
+    DESCEND = "descend"
+    BOUNDARY = "boundary"

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -16,7 +16,7 @@ from xorq.common.utils.rbr_utils import (
     instrument_reader,
 )
 from xorq.expr.enums import Traversal
-from xorq.expr.transform import Replacer, TransformCtx, TransformPass, apply_pass
+from xorq.expr.transform import Replacer, TransformPass
 from xorq.vendor import ibis
 from xorq.vendor.ibis import Expr, Schema
 from xorq.vendor.ibis.backends import BaseBackend
@@ -915,22 +915,6 @@ TEE_PASS = TransformPass(
     produces_resources=True,
     after=("cache",),
 )
-
-
-def register_and_transform_tee_nodes_into(
-    expr: Expr,
-    scope: RemoteTableScope,
-) -> Expr:
-    """Apply :data:`TEE_PASS` against the caller-owned ``scope``.
-
-    Thin adapter for callers that apply the tee pass on its own (tests, one-off
-    use): it runs the same :data:`TEE_PASS` record through the shared driver
-    that ``_transform_expr`` folds over its whole pass table, so both apply
-    identical traversal and scope discipline. The scope is threaded explicitly
-    by the caller; this never closes it -- teardown stays with the caller that
-    created it.
-    """
-    return apply_pass(TEE_PASS, expr, TransformCtx(scope=scope))
 
 
 def render_backend(con: BaseBackend) -> str:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -16,7 +16,7 @@ from xorq.common.utils.rbr_utils import (
     instrument_reader,
 )
 from xorq.expr.enums import Traversal
-from xorq.expr.transform import TransformCtx, TransformPass, apply_pass
+from xorq.expr.transform import Replacer, TransformCtx, TransformPass, apply_pass
 from xorq.vendor import ibis
 from xorq.vendor.ibis import Expr, Schema
 from xorq.vendor.ibis.backends import BaseBackend
@@ -850,7 +850,7 @@ class Read(ops.DatabaseTable):
 _NON_REENTRANT_TEE_BACKENDS = frozenset({"duckdb"})
 
 
-def _tee_replacer(scope: RemoteTableScope) -> Callable:
+def _tee_replacer(scope: RemoteTableScope) -> Replacer:
     """Build the per-node replacer that turns each surviving `TeeNode` into a
     backend table fed by the writer's ``write_through(batches)`` generator,
     adopting every resource it materializes into the caller-owned ``scope``.
@@ -905,15 +905,9 @@ def _tee_replacer(scope: RemoteTableScope) -> Callable:
     return replacer
 
 
-# BOUNDARY (op.replace), not DESCEND: this replacer has side effects (registers
-# pass-through tables, starts writers), so it must fire only at *this* execution
-# boundary. Descending into opaque sub-exprs (RemoteTable, CachedNode, Flight*,
-# ExprScalarUDF) is deliberately avoided -- not a coverage gap: each opaque
-# interior re-enters this transform at its own execution boundary (e.g.
-# caching/storage.py resolves and re-transforms the cached parent;
-# into_backend/flight re-pull via to_pyarrow_batches), so its TeeNodes still fire
-# exactly once. DESCEND would fire them twice. Runs after cache: a cache hit
-# prunes the TeeNode before its write fires.
+# BOUNDARY: this replacer has side effects (registers pass-through tables, starts
+# writers), so it must fire only at *this* execution boundary -- see Traversal.
+# Runs after cache: a cache hit prunes the TeeNode before its write fires.
 TEE_PASS = TransformPass(
     name="tee",
     traversal=Traversal.BOUNDARY,
@@ -929,10 +923,12 @@ def register_and_transform_tee_nodes_into(
 ) -> Expr:
     """Apply :data:`TEE_PASS` against the caller-owned ``scope``.
 
-    Thin adapter over the shared driver so the standalone wrapper and the
-    ``_transform_expr`` pipeline apply the tee pass identically (same traversal,
-    same scope discipline). The scope is threaded explicitly by the caller;
-    this never closes it -- teardown stays with the caller that created it.
+    Thin adapter for callers that apply the tee pass on its own (tests, one-off
+    use): it runs the same :data:`TEE_PASS` record through the shared driver
+    that ``_transform_expr`` folds over its whole pass table, so both apply
+    identical traversal and scope discipline. The scope is threaded explicitly
+    by the caller; this never closes it -- teardown stays with the caller that
+    created it.
     """
     return apply_pass(TEE_PASS, expr, TransformCtx(scope=scope))
 

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -11,11 +11,12 @@ import toolz
 
 from xorq.backends.xorq_datafusion import connect as xo_connect
 from xorq.common.exceptions import IntegrityError
-from xorq.common.utils.otel_utils import tracer
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
     instrument_reader,
 )
+from xorq.expr.enums import Traversal
+from xorq.expr.transform import TransformCtx, TransformPass, apply_pass
 from xorq.vendor import ibis
 from xorq.vendor.ibis import Expr, Schema
 from xorq.vendor.ibis.backends import BaseBackend
@@ -849,14 +850,10 @@ class Read(ops.DatabaseTable):
 _NON_REENTRANT_TEE_BACKENDS = frozenset({"duckdb"})
 
 
-@tracer.start_as_current_span("register_and_transform_tee_nodes_into")
-def register_and_transform_tee_nodes_into(
-    expr: Expr,
-    scope: RemoteTableScope,
-) -> Expr:
-    """Replace each surviving `TeeNode` with a backend table fed by the
-    writer's ``write_through(batches)`` generator, adopting every resource it
-    materializes into the caller-owned ``scope``.
+def _tee_replacer(scope: RemoteTableScope) -> Callable:
+    """Build the per-node replacer that turns each surviving `TeeNode` into a
+    backend table fed by the writer's ``write_through(batches)`` generator,
+    adopting every resource it materializes into the caller-owned ``scope``.
 
     The writer wraps the parent's batch stream: it pulls, writes as a side
     effect, and yields each batch onward. Runs after cache resolution, so a
@@ -866,7 +863,7 @@ def register_and_transform_tee_nodes_into(
     ``scope`` owns everything this pass materializes -- upstream readers, the
     pass-through tables registered on each parent backend, and the write-through
     ``DrainingIterator`` drains -- so a failure in a *later* pass still tears
-    them down. This function never closes ``scope``; teardown stays with the
+    them down. The replacer never closes ``scope``; teardown stays with the
     caller (``_transform_expr``) that created it.
     """
     from xorq.common.utils.caching_utils import find_backend  # noqa: PLC0415
@@ -905,16 +902,39 @@ def register_and_transform_tee_nodes_into(
         table = con.read_record_batches(wrapped, table_name=table_name)
         return table.op()
 
-    # op.replace, not replace_nodes: this replacer has side effects (registers
-    # pass-through tables, starts writers), so it must fire only at *this*
-    # execution boundary. Descending into opaque sub-exprs (RemoteTable,
-    # CachedNode, Flight*, ExprScalarUDF) is deliberately avoided -- that is not
-    # a coverage gap: each opaque interior re-enters this transform at its own
-    # execution boundary (e.g. caching/storage.py resolves and re-transforms the
-    # cached parent; into_backend/flight re-pull via to_pyarrow_batches), so its
-    # TeeNodes still fire exactly once. replace_nodes would fire them twice.
-    op = expr.op()
-    return op.replace(replacer).to_expr()
+    return replacer
+
+
+# BOUNDARY (op.replace), not DESCEND: this replacer has side effects (registers
+# pass-through tables, starts writers), so it must fire only at *this* execution
+# boundary. Descending into opaque sub-exprs (RemoteTable, CachedNode, Flight*,
+# ExprScalarUDF) is deliberately avoided -- not a coverage gap: each opaque
+# interior re-enters this transform at its own execution boundary (e.g.
+# caching/storage.py resolves and re-transforms the cached parent;
+# into_backend/flight re-pull via to_pyarrow_batches), so its TeeNodes still fire
+# exactly once. DESCEND would fire them twice. Runs after cache: a cache hit
+# prunes the TeeNode before its write fires.
+TEE_PASS = TransformPass(
+    name="tee",
+    traversal=Traversal.BOUNDARY,
+    build=lambda expr, ctx: _tee_replacer(ctx.scope),
+    produces_resources=True,
+    after=("cache",),
+)
+
+
+def register_and_transform_tee_nodes_into(
+    expr: Expr,
+    scope: RemoteTableScope,
+) -> Expr:
+    """Apply :data:`TEE_PASS` against the caller-owned ``scope``.
+
+    Thin adapter over the shared driver so the standalone wrapper and the
+    ``_transform_expr`` pipeline apply the tee pass identically (same traversal,
+    same scope discipline). The scope is threaded explicitly by the caller;
+    this never closes it -- teardown stays with the caller that created it.
+    """
+    return apply_pass(TEE_PASS, expr, TransformCtx(scope=scope))
 
 
 def render_backend(con: BaseBackend) -> str:

--- a/python/xorq/expr/relations.py
+++ b/python/xorq/expr/relations.py
@@ -850,7 +850,7 @@ class Read(ops.DatabaseTable):
 _NON_REENTRANT_TEE_BACKENDS = frozenset({"duckdb"})
 
 
-def _tee_replacer(scope: RemoteTableScope) -> Replacer:
+def _make_tee_replacer(scope: RemoteTableScope) -> Replacer:
     """Build the per-node replacer that turns each surviving `TeeNode` into a
     backend table fed by the writer's ``write_through(batches)`` generator,
     adopting every resource it materializes into the caller-owned ``scope``.
@@ -911,7 +911,7 @@ def _tee_replacer(scope: RemoteTableScope) -> Replacer:
 TEE_PASS = TransformPass(
     name="tee",
     traversal=Traversal.BOUNDARY,
-    build=lambda expr, ctx: _tee_replacer(ctx.scope),
+    build=lambda expr, ctx: _make_tee_replacer(ctx.scope),
     produces_resources=True,
     after=("cache",),
 )

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -12,7 +12,7 @@ from xorq.common.compat import raise_collected_errors
 from xorq.common.utils.logging_utils import get_logger
 from xorq.expr.enums import Traversal
 from xorq.expr.relations import RemoteTable, gen_name
-from xorq.expr.transform import Replacer, TransformCtx, TransformPass, apply_pass
+from xorq.expr.transform import Replacer, TransformPass
 from xorq.vendor.ibis import Expr
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import operations as ops
@@ -381,25 +381,6 @@ REMOTE_PASS = TransformPass(
     produces_resources=True,
     after=("tee",),
 )
-
-
-def register_and_transform_remote_tables_into(
-    expr: Expr, scope: RemoteTableScope, **kwargs: Any
-) -> Expr:
-    """Apply :data:`REMOTE_PASS` against the caller-owned ``scope``.
-
-    Thin adapter for callers that apply the remote pass on its own (tests,
-    one-off use): it runs the same :data:`REMOTE_PASS` record through the shared
-    driver that ``_transform_expr`` folds over its whole pass table, so both
-    apply identical traversal and scope discipline. The scope is threaded
-    explicitly by the caller; this never closes it -- ownership and teardown
-    stay with the caller that created it.
-    """
-    return apply_pass(
-        REMOTE_PASS,
-        expr,
-        TransformCtx(scope=scope, read_record_batches_kwargs=kwargs),
-    )
 
 
 def prepare_create_table_from_expr(

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -7,12 +7,12 @@ from typing import Any, Callable, NamedTuple
 
 import pyarrow as pa
 from batchcorder import StreamCache
-from opentelemetry import trace
 
 from xorq.common.compat import raise_collected_errors
 from xorq.common.utils.logging_utils import get_logger
-from xorq.common.utils.otel_utils import tracer
+from xorq.expr.enums import Traversal
 from xorq.expr.relations import RemoteTable, gen_name
+from xorq.expr.transform import TransformCtx, TransformPass, apply_pass
 from xorq.vendor.ibis import Expr
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import operations as ops
@@ -319,23 +319,17 @@ def bind_scope_to_reader(
     return out
 
 
-@tracer.start_as_current_span("register_and_transform_remote_tables_into")
-def register_and_transform_remote_tables_into(
-    expr: Expr, scope: RemoteTableScope, **kwargs: Any
-) -> Expr:
-    """Adopt every remote-table resource into the caller-owned ``scope``.
+def _remote_replacer(
+    expr: Expr, scope: RemoteTableScope, read_kwargs: dict
+) -> Callable:
+    """Build the per-node replacer that swaps each `RemoteTable` for a placeholder
+    table fed by a cached, cast stream, adopting every resource into the
+    caller-owned ``scope``.
 
-    The caller threads one shared scope through every pass (see
-    ``_transform_expr``), so a failure in a *later* pass tears down what this one
-    materialized. This function never closes ``scope``; teardown stays with the
-    caller that created it.
+    ``read_kwargs`` are the through-kwargs that must reach ``read_record_batches``
+    (e.g. Snowflake's ``database=(catalog, db)``). The replacer never closes
+    ``scope`` -- teardown stays with the caller that created it.
     """
-    # ``replacer``'s ``kwargs`` parameter (node-recreate args) shadows the
-    # outer ``**kwargs``; capture the through-kwargs here so they reach
-    # ``read_record_batches`` (e.g. Snowflake's ``database=(catalog, db)``).
-    read_kwargs = kwargs
-
-    op = expr.op()
     reader_counts = count_remote_table_readers(expr)
 
     def replacer(node, kwargs):
@@ -364,20 +358,42 @@ def register_and_transform_remote_tables_into(
             )
             return result.op()
 
+        # ``replacer``'s ``kwargs`` (node-recreate args) shadows the builder's
+        # ``read_kwargs``; those are captured above so they reach the backend.
         if kwargs:
             node = node.__recreate__(kwargs)
 
         return node
 
-    # Intentionally op.replace, not replace_nodes: mark_remote_table has side effects
-    # that must not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr).
-    # The caller owns scope teardown, so a failure here just propagates.
-    expr = op.replace(replacer).to_expr()
-    if scope.table_count:
-        trace.get_current_span().add_event(
-            "remote_table.replace", {"remote_table.count": scope.table_count}
-        )
-    return expr
+    return replacer
+
+
+# BOUNDARY (op.replace), not DESCEND: mark_remote_table has side effects that must
+# not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr).
+# Runs after tee so a tee placeholder registered earlier is torn down by the same
+# shared scope if this pass fails.
+REMOTE_PASS = TransformPass(
+    name="remote",
+    traversal=Traversal.BOUNDARY,
+    build=lambda expr, ctx: _remote_replacer(expr, ctx.scope, ctx.through_kwargs),
+    produces_resources=True,
+    after=("tee",),
+)
+
+
+def register_and_transform_remote_tables_into(
+    expr: Expr, scope: RemoteTableScope, **kwargs: Any
+) -> Expr:
+    """Apply :data:`REMOTE_PASS` against the caller-owned ``scope``.
+
+    Thin adapter over the shared driver so the standalone wrapper and the
+    ``_transform_expr`` pipeline apply the remote pass identically. The scope is
+    threaded explicitly by the caller; this never closes it -- ownership and
+    teardown stay with the caller that created it.
+    """
+    return apply_pass(
+        REMOTE_PASS, expr, TransformCtx(scope=scope, through_kwargs=kwargs)
+    )
 
 
 def prepare_create_table_from_expr(

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -319,7 +319,7 @@ def bind_scope_to_reader(
     return out
 
 
-def _remote_replacer(
+def _make_remote_replacer(
     expr: Expr, scope: RemoteTableScope, read_record_batches_kwargs: dict
 ) -> Replacer:
     """Build the per-node replacer that swaps each `RemoteTable` for a placeholder
@@ -375,7 +375,7 @@ def _remote_replacer(
 REMOTE_PASS = TransformPass(
     name="remote",
     traversal=Traversal.BOUNDARY,
-    build=lambda expr, ctx: _remote_replacer(
+    build=lambda expr, ctx: _make_remote_replacer(
         expr, ctx.scope, ctx.read_record_batches_kwargs
     ),
     produces_resources=True,

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -12,7 +12,7 @@ from xorq.common.compat import raise_collected_errors
 from xorq.common.utils.logging_utils import get_logger
 from xorq.expr.enums import Traversal
 from xorq.expr.relations import RemoteTable, gen_name
-from xorq.expr.transform import TransformCtx, TransformPass, apply_pass
+from xorq.expr.transform import Replacer, TransformCtx, TransformPass, apply_pass
 from xorq.vendor.ibis import Expr
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import operations as ops
@@ -320,13 +320,13 @@ def bind_scope_to_reader(
 
 
 def _remote_replacer(
-    expr: Expr, scope: RemoteTableScope, read_kwargs: dict
-) -> Callable:
+    expr: Expr, scope: RemoteTableScope, read_record_batches_kwargs: dict
+) -> Replacer:
     """Build the per-node replacer that swaps each `RemoteTable` for a placeholder
     table fed by a cached, cast stream, adopting every resource into the
     caller-owned ``scope``.
 
-    ``read_kwargs`` are the through-kwargs that must reach ``read_record_batches``
+    ``read_record_batches_kwargs`` are forwarded to ``read_record_batches``
     (e.g. Snowflake's ``database=(catalog, db)``). The replacer never closes
     ``scope`` -- teardown stays with the caller that created it.
     """
@@ -354,12 +354,12 @@ def _remote_replacer(
             # already declares it. Backends that genuinely use a schema
             # (xorq_datafusion, pyiceberg) default to the source's own schema.
             result = node.source.read_record_batches(
-                cache, table_name=table_name, **read_kwargs
+                cache, table_name=table_name, **read_record_batches_kwargs
             )
             return result.op()
 
         # ``replacer``'s ``kwargs`` (node-recreate args) shadows the builder's
-        # ``read_kwargs``; those are captured above so they reach the backend.
+        # ``read_record_batches_kwargs``; captured above so they reach the backend.
         if kwargs:
             node = node.__recreate__(kwargs)
 
@@ -368,14 +368,16 @@ def _remote_replacer(
     return replacer
 
 
-# BOUNDARY (op.replace), not DESCEND: mark_remote_table has side effects that must
-# not descend into opaque sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr).
-# Runs after tee so a tee placeholder registered earlier is torn down by the same
-# shared scope if this pass fails.
+# BOUNDARY: mark_remote_table has side effects, so it must not descend into opaque
+# sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr) -- see Traversal. Runs after
+# tee so a tee placeholder registered earlier is torn down by the same shared scope
+# if this pass fails.
 REMOTE_PASS = TransformPass(
     name="remote",
     traversal=Traversal.BOUNDARY,
-    build=lambda expr, ctx: _remote_replacer(expr, ctx.scope, ctx.through_kwargs),
+    build=lambda expr, ctx: _remote_replacer(
+        expr, ctx.scope, ctx.read_record_batches_kwargs
+    ),
     produces_resources=True,
     after=("tee",),
 )
@@ -386,13 +388,17 @@ def register_and_transform_remote_tables_into(
 ) -> Expr:
     """Apply :data:`REMOTE_PASS` against the caller-owned ``scope``.
 
-    Thin adapter over the shared driver so the standalone wrapper and the
-    ``_transform_expr`` pipeline apply the remote pass identically. The scope is
-    threaded explicitly by the caller; this never closes it -- ownership and
-    teardown stay with the caller that created it.
+    Thin adapter for callers that apply the remote pass on its own (tests,
+    one-off use): it runs the same :data:`REMOTE_PASS` record through the shared
+    driver that ``_transform_expr`` folds over its whole pass table, so both
+    apply identical traversal and scope discipline. The scope is threaded
+    explicitly by the caller; this never closes it -- ownership and teardown
+    stay with the caller that created it.
     """
     return apply_pass(
-        REMOTE_PASS, expr, TransformCtx(scope=scope, through_kwargs=kwargs)
+        REMOTE_PASS,
+        expr,
+        TransformCtx(scope=scope, read_record_batches_kwargs=kwargs),
     )
 
 

--- a/python/xorq/expr/tests/test_stream_cache_contract.py
+++ b/python/xorq/expr/tests/test_stream_cache_contract.py
@@ -1,6 +1,6 @@
 """Contract tests for the batchcorder ``StreamCache`` primitive xorq relies on.
 
-``register_and_transform_remote_tables_into`` builds one ``StreamCache`` per
+The remote pass (``REMOTE_PASS``) builds one ``StreamCache`` per
 RemoteTable and passes ``max_readers`` from ``count_remote_table_readers``.
 Three properties of that primitive are load-bearing for the fan-out fix and
 are pinned here directly (rather than only through a backend):

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -19,6 +19,7 @@ from typing import Callable
 import pytest
 
 import xorq.api as xo
+from xorq.common.exceptions import InternalError
 from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.enums import Traversal
 from xorq.expr.relations import RemoteTable
@@ -65,7 +66,7 @@ def test_run_transform_passes_raises_on_out_of_order() -> None:
             build=lambda expr, ctx: _identity_replacer(),
         ),
     )
-    with pytest.raises(AssertionError, match=r"must run after.*cache"):
+    with pytest.raises(InternalError, match=r"must run after.*cache"):
         run_transform_passes(t, passes, _ctx())
 
 

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -1,0 +1,170 @@
+"""Unit tests for the declarative transform driver (``xorq.expr.transform``).
+
+These pin the driver's *own* guarantees -- the ones R2 introduced -- independent
+of any concrete pass:
+
+- P3: ``run_transform_passes`` raises when a pass's ``after`` dependency is not
+  positioned earlier, instead of silently mis-transforming.
+- P2: ``apply_pass`` selects the graph walk (descend into opaque sub-exprs vs
+  stop at them) solely from the pass's ``Traversal``.
+
+The pipeline-level tests in ``test_transform_scope.py`` cover the real passes;
+this covers the mechanism they ride on.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+import xorq.api as xo
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.enums import Traversal
+from xorq.expr.relations import RemoteTable
+from xorq.expr.remote_table_exec import RemoteTableScope
+from xorq.expr.transform import (
+    TransformCtx,
+    TransformPass,
+    apply_pass,
+    run_transform_passes,
+)
+
+
+def _identity_replacer(seen: list | None = None) -> Callable:
+    """A no-op replacer that optionally records every node it is called on."""
+
+    def replacer(node, kwargs):
+        if seen is not None:
+            seen.append(node)
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        return node
+
+    return replacer
+
+
+def _ctx() -> TransformCtx:
+    # The passes below produce no resources, so the scope is never touched.
+    return TransformCtx(scope=RemoteTableScope())
+
+
+def test_run_transform_passes_raises_on_out_of_order() -> None:
+    """P3: a pass whose ``after`` dep is not positioned earlier fails loudly."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    passes = (
+        TransformPass(
+            name="needs_cache",
+            traversal=Traversal.DESCEND,
+            build=lambda expr, ctx: _identity_replacer(),
+            after=("cache",),
+        ),
+        TransformPass(
+            name="cache",
+            traversal=Traversal.DESCEND,
+            build=lambda expr, ctx: _identity_replacer(),
+        ),
+    )
+    with pytest.raises(AssertionError, match=r"must run after.*cache"):
+        run_transform_passes(t, passes, _ctx())
+
+
+def test_run_transform_passes_runs_in_order() -> None:
+    """Correctly ordered passes all run, each build invoked once, in order."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    built: list[str] = []
+
+    def build(name):
+        def _build(expr, ctx):
+            built.append(name)
+            return _identity_replacer()
+
+        return _build
+
+    passes = (
+        TransformPass(name="cache", traversal=Traversal.DESCEND, build=build("cache")),
+        TransformPass(
+            name="needs_cache",
+            traversal=Traversal.DESCEND,
+            build=build("needs_cache"),
+            after=("cache",),
+        ),
+    )
+    out = run_transform_passes(t, passes, _ctx())
+    assert built == ["cache", "needs_cache"]
+    assert out.schema() == t.schema()
+
+
+def test_skipped_pass_still_satisfies_after() -> None:
+    """A pass skipped via ``when`` is still 'positioned', so a later ``after`` on
+    it is satisfied -- ordering is by position in the table, not by execution."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    ran: list[str] = []
+
+    def _after_build(expr, ctx):
+        ran.append("after_maybe")
+        return _identity_replacer()
+
+    passes = (
+        TransformPass(
+            name="maybe",
+            traversal=Traversal.DESCEND,
+            build=lambda expr, ctx: _identity_replacer(),
+            when=lambda expr, ctx: False,  # skipped, but still positioned
+        ),
+        TransformPass(
+            name="after_maybe",
+            traversal=Traversal.DESCEND,
+            build=_after_build,
+            after=("maybe",),
+        ),
+    )
+    run_transform_passes(t, passes, _ctx())  # must not raise
+    assert ran == ["after_maybe"]
+
+
+def test_when_false_skips_the_pass() -> None:
+    """``when`` returning False skips the build/walk entirely and returns the
+    expression untouched."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    built: list[str] = []
+
+    skipped = TransformPass(
+        name="skipped",
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: built.append("built") or _identity_replacer(),
+        when=lambda expr, ctx: False,
+    )
+    out = apply_pass(skipped, t, _ctx())
+    assert built == []
+    assert out is t
+
+
+def test_apply_pass_traversal_selected_from_record() -> None:
+    """P2: ``apply_pass`` descends into opaque sub-exprs for DESCEND and stops at
+    them for BOUNDARY, chosen solely from the pass's ``traversal`` field."""
+    con = xo.connect()
+    inner = xo.memtable({"a": [1, 2, 3]})
+    expr = inner.into_backend(con, "rt")  # a RemoteTable: an opaque boundary
+    assert walk_nodes(RemoteTable, expr), "test needs an opaque sub-expr present"
+
+    descend_seen: list = []
+    boundary_seen: list = []
+    descend = TransformPass(
+        name="d",
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: _identity_replacer(descend_seen),
+    )
+    boundary = TransformPass(
+        name="b",
+        traversal=Traversal.BOUNDARY,
+        build=lambda expr, ctx: _identity_replacer(boundary_seen),
+    )
+
+    # identity replacers: neither materializes anything (no execution / no scope)
+    apply_pass(descend, expr, _ctx())
+    apply_pass(boundary, expr, _ctx())
+
+    # DESCEND recurses through RemoteTable.remote_expr, so it visits strictly more
+    # nodes than BOUNDARY, which stops at the RemoteTable.
+    assert len(descend_seen) > len(boundary_seen)

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -17,13 +17,12 @@ import pyarrow as pa
 import pytest
 
 import xorq.api as xo
-import xorq.expr.api as expr_api
 import xorq.expr.remote_table_exec as remote_table_exec
 import xorq.vendor.ibis.expr.types as ir
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.api import _transform_expr, get_plans, to_pyarrow_batches
-from xorq.expr.relations import RemoteTable
+from xorq.expr.relations import RemoteTable, register_and_transform_tee_nodes_into
 from xorq.expr.remote_table_exec import (
     RemoteTableScope,
     bind_scope_to_reader,
@@ -471,19 +470,20 @@ def test_tee_resources_released_when_remote_pass_fails(
 
     # Fail the remote pass only when a RemoteTable is actually present, so the
     # tee pass's recursion on its RemoteTable-free parent still succeeds and the
-    # failure lands at the *outer* pass 5 -- after pass 4 registered its table.
-    real_remote = expr_api.register_and_transform_remote_tables_into
+    # failure lands at the *outer* remote pass -- after the tee pass registered
+    # its table. Inject at the builder the declarative driver invokes
+    # (REMOTE_PASS.build -> _remote_replacer), so the failure rides the real
+    # pipeline path.
+    real_remote_replacer = remote_table_exec._remote_replacer
 
-    def guarded_boom(inner_expr, scope, **kwargs):
+    def guarded_boom(inner_expr, scope, read_kwargs):
         if walk_nodes(RemoteTable, inner_expr):
             raise RuntimeError("remote pass failed")
-        return real_remote(inner_expr, scope, **kwargs)
+        return real_remote_replacer(inner_expr, scope, read_kwargs)
 
     monkeypatch.setattr(RemoteTableScope, "adopt_table", spy_table)
     monkeypatch.setattr(RemoteTableScope, "adopt_drain", spy_drain)
-    monkeypatch.setattr(
-        expr_api, "register_and_transform_remote_tables_into", guarded_boom
-    )
+    monkeypatch.setattr(remote_table_exec, "_remote_replacer", guarded_boom)
 
     with pytest.raises(RuntimeError, match="remote pass failed"):
         _transform_expr(expr)
@@ -514,7 +514,7 @@ def test_tee_adopts_upstream_reader_into_scope(tmp_path: Path) -> None:
 
     # thread an explicit scope into the pass, mirroring _transform_expr
     scope = RemoteTableScope()
-    expr_api.register_and_transform_tee_nodes_into(teed, scope)
+    register_and_transform_tee_nodes_into(teed, scope)
     assert scope.reader_count >= 1, (
         "tee upstream reader must be adopted into the transform scope"
     )

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -22,14 +22,15 @@ import xorq.vendor.ibis.expr.types as ir
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.graph_utils import walk_nodes
 from xorq.expr.api import _transform_expr, get_plans, to_pyarrow_batches
-from xorq.expr.relations import RemoteTable, register_and_transform_tee_nodes_into
+from xorq.expr.relations import TEE_PASS, RemoteTable
 from xorq.expr.remote_table_exec import (
+    REMOTE_PASS,
     RemoteTableScope,
     bind_scope_to_reader,
     drop_placeholder,
     prepare_create_table_from_expr,
-    register_and_transform_remote_tables_into,
 )
+from xorq.expr.transform import TransformCtx, apply_pass
 from xorq.tests.util import assert_frame_equal
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.writes import DrainingIterator, ParquetWriteThrough
@@ -420,7 +421,7 @@ def test_replacer_adopts_reader_cache_and_table() -> None:
     target = xo.duckdb.connect()
     expr = make_remote_expr(target)
     scope = RemoteTableScope()
-    register_and_transform_remote_tables_into(expr.op().to_expr(), scope)
+    apply_pass(REMOTE_PASS, expr.op().to_expr(), TransformCtx(scope=scope))
     try:
         assert scope.reader_count == 1
         assert scope.cache_count == 1
@@ -514,7 +515,7 @@ def test_tee_adopts_upstream_reader_into_scope(tmp_path: Path) -> None:
 
     # thread an explicit scope into the pass, mirroring _transform_expr
     scope = RemoteTableScope()
-    register_and_transform_tee_nodes_into(teed, scope)
+    apply_pass(TEE_PASS, teed, TransformCtx(scope=scope))
     assert scope.reader_count >= 1, (
         "tee upstream reader must be adopted into the transform scope"
     )

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -472,9 +472,9 @@ def test_tee_resources_released_when_remote_pass_fails(
     # tee pass's recursion on its RemoteTable-free parent still succeeds and the
     # failure lands at the *outer* remote pass -- after the tee pass registered
     # its table. Inject at the builder the declarative driver invokes
-    # (REMOTE_PASS.build -> _remote_replacer), so the failure rides the real
+    # (REMOTE_PASS.build -> _make_remote_replacer), so the failure rides the real
     # pipeline path.
-    real_remote_replacer = remote_table_exec._remote_replacer
+    real_remote_replacer = remote_table_exec._make_remote_replacer
 
     def guarded_boom(inner_expr, scope, read_record_batches_kwargs):
         if walk_nodes(RemoteTable, inner_expr):
@@ -483,7 +483,7 @@ def test_tee_resources_released_when_remote_pass_fails(
 
     monkeypatch.setattr(RemoteTableScope, "adopt_table", spy_table)
     monkeypatch.setattr(RemoteTableScope, "adopt_drain", spy_drain)
-    monkeypatch.setattr(remote_table_exec, "_remote_replacer", guarded_boom)
+    monkeypatch.setattr(remote_table_exec, "_make_remote_replacer", guarded_boom)
 
     with pytest.raises(RuntimeError, match="remote pass failed"):
         _transform_expr(expr)

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -476,10 +476,10 @@ def test_tee_resources_released_when_remote_pass_fails(
     # pipeline path.
     real_remote_replacer = remote_table_exec._remote_replacer
 
-    def guarded_boom(inner_expr, scope, read_kwargs):
+    def guarded_boom(inner_expr, scope, read_record_batches_kwargs):
         if walk_nodes(RemoteTable, inner_expr):
             raise RuntimeError("remote pass failed")
-        return real_remote_replacer(inner_expr, scope, read_kwargs)
+        return real_remote_replacer(inner_expr, scope, read_record_batches_kwargs)
 
     monkeypatch.setattr(RemoteTableScope, "adopt_table", spy_table)
     monkeypatch.setattr(RemoteTableScope, "adopt_drain", spy_drain)

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -7,6 +7,7 @@ each call site:
 - **traversal kind** -- a pure structural rewrite descends into opaque sub-exprs
   (``replace_nodes``); an effectful or boundary-resolved pass must stop at opaque
   nodes (``op.replace``) so it fires exactly once, at this execution boundary.
+  The full rationale lives on :class:`~xorq.expr.enums.Traversal`.
 - **ordering** -- e.g. cache resolution must precede the tee pass (a cache hit
   prunes the ``TeeNode`` before its write fires); deferred reads resolve last.
 - **resource ownership** -- effectful passes adopt what they materialize into a
@@ -17,19 +18,27 @@ record carrying its :class:`Traversal` kind, whether it ``produces_resources``
 (and so needs the scope), and its ``after`` dependencies. :func:`apply_pass`
 selects the traversal from the record (so no call site can pick the wrong walk),
 and :func:`run_transform_passes` folds the ordered table while asserting every
-``after`` constraint holds -- a reorder now fails loudly instead of silently
+``after`` constraint holds -- a reorder now raises loudly instead of silently
 breaking correctness.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
+from attr.validators import deep_iterable, instance_of, is_callable, optional
 from attrs import field, frozen
 
+from xorq.common.exceptions import InternalError
 from xorq.common.utils.otel_utils import tracer
 from xorq.expr.enums import Traversal
 from xorq.vendor.ibis import Expr
+
+
+if TYPE_CHECKING:
+    # remote_table_exec imports this module, so a module-level import would be
+    # circular; used for annotations and the scope validator's lazy check.
+    from xorq.expr.remote_table_exec import RemoteTableScope
 
 
 # A replacer is the per-node rewrite ``(node, kwargs) -> node`` consumed by both
@@ -40,19 +49,31 @@ ReplacerBuilder = Callable[["Expr", "TransformCtx"], Replacer]
 Predicate = Callable[["Expr", "TransformCtx"], bool]
 
 
+def _validate_scope(instance: Any, attribute: Any, value: Any) -> None:
+    """Lazy ``instance_of(RemoteTableScope)``.
+
+    The class is imported inside the validator, not at module level, to keep
+    ``transform`` out of the ``remote_table_exec`` import cycle. The import is
+    cheap by the time any ``TransformCtx`` is constructed (every module is loaded).
+    """
+    from xorq.expr.remote_table_exec import RemoteTableScope  # noqa: PLC0415
+
+    instance_of(RemoteTableScope)(instance, attribute, value)
+
+
 @frozen
 class TransformCtx:
     """Per-transform context threaded to every pass builder.
 
     ``scope`` owns every resource the effectful passes materialize (created once,
-    up front, in ``_transform_expr``). ``name_values`` are the resolved
-    parameter bindings; ``through_kwargs`` are the backend read kwargs that must
+    up front, in ``_transform_expr``). ``name_values`` are the resolved parameter
+    bindings; ``read_record_batches_kwargs`` are the backend read kwargs that must
     reach ``read_record_batches`` (e.g. Snowflake's ``database=``).
     """
 
-    scope: Any
-    name_values: dict = field(factory=dict)
-    through_kwargs: dict = field(factory=dict)
+    scope: RemoteTableScope = field(validator=_validate_scope)
+    name_values: dict = field(factory=dict, validator=instance_of(dict))
+    read_record_batches_kwargs: dict = field(factory=dict, validator=instance_of(dict))
 
 
 @frozen
@@ -61,12 +82,14 @@ class TransformPass:
     (``traversal``), whether it owns resources (``produces_resources``), when it
     applies (``when``), and what must precede it (``after``)."""
 
-    name: str
-    traversal: Traversal
-    build: ReplacerBuilder
-    produces_resources: bool = False
-    when: Predicate | None = None
-    after: tuple[str, ...] = ()
+    name: str = field(validator=instance_of(str))
+    traversal: Traversal = field(validator=instance_of(Traversal))
+    build: ReplacerBuilder = field(validator=is_callable())
+    produces_resources: bool = field(default=False, validator=instance_of(bool))
+    when: Predicate | None = field(default=None, validator=optional(is_callable()))
+    after: tuple[str, ...] = field(
+        default=(), validator=deep_iterable(instance_of(str), instance_of(tuple))
+    )
 
 
 def apply_pass(p: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
@@ -100,7 +123,7 @@ def run_transform_passes(
     for p in passes:
         missing = tuple(dep for dep in p.after if dep not in done)
         if missing:
-            raise AssertionError(
+            raise InternalError(
                 f"transform pass {p.name!r} must run after {missing}, "
                 f"but they are not positioned earlier (seen: {sorted(done)})"
             )

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -1,0 +1,109 @@
+"""Declarative driver for the ``to_pyarrow_batches`` (tier-1) transform passes.
+
+Historically the six effectful/pure passes in ``_transform_expr`` were a hand-run
+sequence where three correctness rules lived only in prose comments repeated at
+each call site:
+
+- **traversal kind** -- a pure structural rewrite descends into opaque sub-exprs
+  (``replace_nodes``); an effectful or boundary-resolved pass must stop at opaque
+  nodes (``op.replace``) so it fires exactly once, at this execution boundary.
+- **ordering** -- e.g. cache resolution must precede the tee pass (a cache hit
+  prunes the ``TeeNode`` before its write fires); deferred reads resolve last.
+- **resource ownership** -- effectful passes adopt what they materialize into a
+  single shared ``RemoteTableScope`` (see ``remote_table_exec``).
+
+This module turns those rules into *data*: each pass is a :class:`TransformPass`
+record carrying its :class:`Traversal` kind, whether it ``produces_resources``
+(and so needs the scope), and its ``after`` dependencies. :func:`apply_pass`
+selects the traversal from the record (so no call site can pick the wrong walk),
+and :func:`run_transform_passes` folds the ordered table while asserting every
+``after`` constraint holds -- a reorder now fails loudly instead of silently
+breaking correctness.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from attrs import field, frozen
+
+from xorq.common.utils.otel_utils import tracer
+from xorq.expr.enums import Traversal
+from xorq.vendor.ibis import Expr
+
+
+# A replacer is the per-node rewrite ``(node, kwargs) -> node`` consumed by both
+# ``replace_nodes`` and ``op.replace``; a builder produces one from the expr +
+# context (closing over the scope, bound params, reader counts, etc.).
+Replacer = Callable[[Any, "dict | None"], Any]
+ReplacerBuilder = Callable[["Expr", "TransformCtx"], Replacer]
+Predicate = Callable[["Expr", "TransformCtx"], bool]
+
+
+@frozen
+class TransformCtx:
+    """Per-transform context threaded to every pass builder.
+
+    ``scope`` owns every resource the effectful passes materialize (created once,
+    up front, in ``_transform_expr``). ``name_values`` are the resolved
+    parameter bindings; ``through_kwargs`` are the backend read kwargs that must
+    reach ``read_record_batches`` (e.g. Snowflake's ``database=``).
+    """
+
+    scope: Any
+    name_values: dict = field(factory=dict)
+    through_kwargs: dict = field(factory=dict)
+
+
+@frozen
+class TransformPass:
+    """One tier-1 pass as data: what it does (``build``), how it walks
+    (``traversal``), whether it owns resources (``produces_resources``), when it
+    applies (``when``), and what must precede it (``after``)."""
+
+    name: str
+    traversal: Traversal
+    build: ReplacerBuilder
+    produces_resources: bool = False
+    when: Predicate | None = None
+    after: tuple[str, ...] = ()
+
+
+def apply_pass(p: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
+    """Run a single pass, selecting the traversal from ``p.traversal``.
+
+    The caller owns ``ctx.scope`` teardown; a failure here just propagates.
+    """
+    # lazy: graph_utils imports xorq.expr.relations, which imports this module at
+    # module level -- importing it here keeps that edge out of the import cycle.
+    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
+
+    if p.when is not None and not p.when(expr, ctx):
+        return expr
+    with tracer.start_as_current_span(f"transform.{p.name}"):
+        replacer = p.build(expr, ctx)
+        if p.traversal is Traversal.DESCEND:
+            return replace_nodes(replacer, expr).to_expr()
+        return expr.op().replace(replacer).to_expr()
+
+
+def run_transform_passes(
+    expr: Expr, passes: tuple[TransformPass, ...], ctx: TransformCtx
+) -> Expr:
+    """Fold the ordered ``passes`` over ``expr``, asserting ``after`` deps.
+
+    The ordering constraints are checked against passes *already positioned*
+    earlier in the tuple (whether or not they no-op'd via ``when``), so a
+    reordered table raises immediately instead of silently mis-transforming.
+    """
+    done: set[str] = set()
+    for p in passes:
+        missing = tuple(dep for dep in p.after if dep not in done)
+        if missing:
+            raise AssertionError(
+                f"transform pass {p.name!r} must run after {missing}, "
+                f"but they are not positioned earlier (seen: {sorted(done)})"
+            )
+        expr = apply_pass(p, expr, ctx)
+        done.add(p.name)
+    return expr

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -4,10 +4,9 @@ Historically the six effectful/pure passes in ``_transform_expr`` were a hand-ru
 sequence where three correctness rules lived only in prose comments repeated at
 each call site:
 
-- **traversal kind** -- a pure structural rewrite descends into opaque sub-exprs
-  (``replace_nodes``); an effectful or boundary-resolved pass must stop at opaque
-  nodes (``op.replace``) so it fires exactly once, at this execution boundary.
-  The full rationale lives on :class:`~xorq.expr.enums.Traversal`.
+- **traversal kind** -- descend into opaque sub-exprs (``replace_nodes``) vs stop
+  at them (``op.replace``); the rule and its full rationale live on
+  :class:`~xorq.expr.enums.Traversal`.
 - **ordering** -- e.g. cache resolution must precede the tee pass (a cache hit
   prunes the ``TeeNode`` before its write fires); deferred reads resolve last.
 - **resource ownership** -- effectful passes adopt what they materialize into a
@@ -33,6 +32,7 @@ from xorq.common.exceptions import InternalError
 from xorq.common.utils.otel_utils import tracer
 from xorq.expr.enums import Traversal
 from xorq.vendor.ibis import Expr
+from xorq.vendor.ibis.expr.operations import Node
 
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 # A replacer is the per-node rewrite ``(node, kwargs) -> node`` consumed by both
 # ``replace_nodes`` and ``op.replace``; a builder produces one from the expr +
 # context (closing over the scope, bound params, reader counts, etc.).
-Replacer = Callable[[Any, "dict | None"], Any]
+Replacer = Callable[[Node, "dict | None"], Node]
 ReplacerBuilder = Callable[["Expr", "TransformCtx"], Replacer]
 Predicate = Callable[["Expr", "TransformCtx"], bool]
 
@@ -66,12 +66,16 @@ class TransformCtx:
     """Per-transform context threaded to every pass builder.
 
     ``scope`` owns every resource the effectful passes materialize (created once,
-    up front, in ``_transform_expr``). ``name_values`` are the resolved parameter
-    bindings; ``read_record_batches_kwargs`` are the backend read kwargs that must
-    reach ``read_record_batches`` (e.g. Snowflake's ``database=``).
+    up front, in ``_transform_expr``); it is ``None`` only when driving a subset
+    of passes that produce nothing (e.g. a lone pure pass in a test).
+    ``name_values`` are the resolved parameter bindings;
+    ``read_record_batches_kwargs`` are the backend read kwargs that must reach
+    ``read_record_batches`` (e.g. Snowflake's ``database=``).
     """
 
-    scope: RemoteTableScope = field(validator=_validate_scope)
+    scope: RemoteTableScope | None = field(
+        default=None, validator=optional(_validate_scope)
+    )
     name_values: dict = field(factory=dict, validator=instance_of(dict))
     read_record_batches_kwargs: dict = field(factory=dict, validator=instance_of(dict))
 
@@ -92,8 +96,8 @@ class TransformPass:
     )
 
 
-def apply_pass(p: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
-    """Run a single pass, selecting the traversal from ``p.traversal``.
+def apply_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
+    """Run a single pass, selecting the traversal from ``pass_.traversal``.
 
     The caller owns ``ctx.scope`` teardown; a failure here just propagates.
     """
@@ -101,11 +105,11 @@ def apply_pass(p: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
     # module level -- importing it here keeps that edge out of the import cycle.
     from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
-    if p.when is not None and not p.when(expr, ctx):
+    if pass_.when is not None and not pass_.when(expr, ctx):
         return expr
-    with tracer.start_as_current_span(f"transform.{p.name}"):
-        replacer = p.build(expr, ctx)
-        if p.traversal is Traversal.DESCEND:
+    with tracer.start_as_current_span(f"transform.{pass_.name}"):
+        replacer = pass_.build(expr, ctx)
+        if pass_.traversal is Traversal.DESCEND:
             return replace_nodes(replacer, expr).to_expr()
         return expr.op().replace(replacer).to_expr()
 
@@ -120,13 +124,13 @@ def run_transform_passes(
     reordered table raises immediately instead of silently mis-transforming.
     """
     done: set[str] = set()
-    for p in passes:
-        missing = tuple(dep for dep in p.after if dep not in done)
+    for pass_ in passes:
+        missing = tuple(dep for dep in pass_.after if dep not in done)
         if missing:
             raise InternalError(
-                f"transform pass {p.name!r} must run after {missing}, "
+                f"transform pass {pass_.name!r} must run after {missing}, "
                 f"but they are not positioned earlier (seen: {sorted(done)})"
             )
-        expr = apply_pass(p, expr, ctx)
-        done.add(p.name)
+        expr = apply_pass(pass_, expr, ctx)
+        done.add(pass_.name)
     return expr

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1855,7 +1855,7 @@ def test_execution_handles_remote_table_in_computed_kwargs_expr(
 ) -> None:
     """RemoteTables nested inside ExprScalarUDF.computed_kwargs_expr must be
     materialized lazily when the UDF is compiled, not during the outer
-    register_and_transform_remote_tables_into pass (which intentionally skips
+    REMOTE_PASS (the remote pass, which intentionally skips
     opaque sub-expressions)."""
     cona = xo.connect()
     conb = xo.connect()

--- a/python/xorq/tests/test_into_backend.py
+++ b/python/xorq/tests/test_into_backend.py
@@ -16,10 +16,8 @@ import xorq.api as xo
 import xorq.vendor.ibis.expr.types as ir
 from xorq.caching import ParquetCache, SourceCache
 from xorq.common.exceptions import XorqError
-from xorq.expr.remote_table_exec import (
-    RemoteTableScope,
-    register_and_transform_remote_tables_into,
-)
+from xorq.expr.remote_table_exec import REMOTE_PASS, RemoteTableScope
+from xorq.expr.transform import TransformCtx, apply_pass
 from xorq.loader import load_backend
 from xorq.tests.util import assert_frame_equal, check_eq
 from xorq.vendor import ibis
@@ -265,7 +263,7 @@ def test_into_backend_duckdb(pg):
     )
 
     scope = RemoteTableScope()
-    expr = register_and_transform_remote_tables_into(expr, scope)
+    expr = apply_pass(REMOTE_PASS, expr, TransformCtx(scope=scope))
     with scope:
         query = ibis.to_sql(expr, dialect="duckdb")
         res = ddb.con.sql(query).df()
@@ -283,7 +281,7 @@ def test_into_backend_duckdb_expr(pg: BaseBackend) -> None:
     expr = t.join(t, "playerID").limit(15).select(_.playerID * 2)
 
     scope = RemoteTableScope()
-    expr = register_and_transform_remote_tables_into(expr, scope)
+    expr = apply_pass(REMOTE_PASS, expr, TransformCtx(scope=scope))
     with scope:
         query = ibis.to_sql(expr, dialect="duckdb")
         res = ddb.con.sql(query).df()
@@ -300,7 +298,7 @@ def test_into_backend_duckdb_trino(trino_table):
     expr = trino_table.head(10_000).into_backend(db_con).pipe(make_merged)
 
     scope = RemoteTableScope()
-    expr = register_and_transform_remote_tables_into(expr, scope)
+    expr = apply_pass(REMOTE_PASS, expr, TransformCtx(scope=scope))
     with scope:
         query = ibis.to_sql(expr, dialect="duckdb")
         df = db_con.con.sql(query).df()  # to bypass execute hotfix
@@ -323,7 +321,7 @@ def test_multiple_into_backend_duckdb_xorq(trino_table: ir.Table) -> None:
     )
 
     scope = RemoteTableScope()
-    expr = register_and_transform_remote_tables_into(expr, scope)
+    expr = apply_pass(REMOTE_PASS, expr, TransformCtx(scope=scope))
     with scope:
         df = expr.execute()
 

--- a/python/xorq/tests/test_write_through.py
+++ b/python/xorq/tests/test_write_through.py
@@ -22,11 +22,12 @@ from xorq.expr.api import (
     get_plans,
 )
 from xorq.expr.relations import (
+    TEE_PASS,
     HashingTag,
     TeeNode,
-    register_and_transform_tee_nodes_into,
 )
 from xorq.expr.remote_table_exec import RemoteTableScope
+from xorq.expr.transform import TransformCtx, apply_pass
 from xorq.writes import (
     BackendWriteThrough,
     DrainingIterator,
@@ -348,7 +349,7 @@ def test_tee_duckdb_warns_deadlock(tmp_path: Path) -> None:
     t = con.create_table("dd_warn", pa.table({"a": [1, 2, 3, 4]}))
     expr = t.tee(ParquetWriteThrough(path=tmp_path / "out.parquet"))
     with pytest.warns(UserWarning, match="deadlock"):
-        register_and_transform_tee_nodes_into(expr, RemoteTableScope())
+        apply_pass(TEE_PASS, expr, TransformCtx(scope=RemoteTableScope()))
 
 
 def test_write_with_cache_upstream(tmp_path: Path) -> None:
@@ -664,12 +665,12 @@ def test_to_sql_strips_nested_tee_nodes(t: Table, tmp_path: Path) -> None:
 def test_tee_transform_leaves_tee_inside_opaque_untouched(
     t: Table, tmp_path: Path
 ) -> None:
-    """register_and_transform_tee_nodes_into uses op.replace, which deliberately
-    does not descend into opaque sub-exprs (here CachedNode.parent). A TeeNode buried
-    in an opaque node must survive the outer pass untouched and its write must not
-    fire: it is handled lazily when the opaque sub-expr executes (e.g. on a cache
-    miss). Guards against a regression to replace_nodes, which would descend and
-    fire the side-effecting write at the wrong time."""
+    """TEE_PASS is BOUNDARY (op.replace), which deliberately does not descend into
+    opaque sub-exprs (here CachedNode.parent). A TeeNode buried in an opaque node
+    must survive the outer pass untouched and its write must not fire: it is
+    handled lazily when the opaque sub-expr executes (e.g. on a cache miss).
+    Guards against a regression to DESCEND, which would descend and fire the
+    side-effecting write at the wrong time."""
     target = tmp_path / "opaque.parquet"
     cached = t.tee(ParquetWriteThrough(path=target)).cache()
 
@@ -679,7 +680,7 @@ def test_tee_transform_leaves_tee_inside_opaque_untouched(
     assert len(cached.op().find(TeeNode)) == 0
 
     scope = RemoteTableScope()
-    transformed = register_and_transform_tee_nodes_into(cached, scope)
+    transformed = apply_pass(TEE_PASS, cached, TransformCtx(scope=scope))
 
     assert not target.exists(), "outer transform must not fire the buried write"
     assert scope.table_count == 0, "no pass-through table should be registered"


### PR DESCRIPTION
## Summary

Turns the hand-run tier-1 transform sequence in `_transform_expr` into a **declarative, ordered pass table** so the correctness rules that previously lived only in prose comments become *data* the driver enforces. This is **R2** of the `to_pyarrow_batches` transform-robustness plan.

- **P2 killed** — traversal kind (`replace_nodes` descend vs `op.replace` boundary) is a `Traversal` field on each pass, applied by one driver (`apply_pass`). No call site can pick the wrong walk.
- **P3 killed** — pass ordering is an `after` dependency chain (`bind → tags → cache → tee → remote → deferred_reads`) asserted by `run_transform_passes`. Reordering the table now raises immediately instead of silently mis-transforming.
- Resource ownership: the shared `RemoteTableScope` is threaded to every pass via `TransformCtx` (the R1 mechanism); the tee and remote passes (flagged `produces_resources`) are the ones that adopt resources into it.

## What changed

- New leaf module `xorq/expr/transform.py`: `TransformPass` record, `apply_pass` (selects the walk from the record), `run_transform_passes` (folds + asserts `after`). `Traversal{DESCEND|BOUNDARY}` in new `xorq/expr/enums.py`.
- Each pass is a **replacer-builder** (`_make_*_replacer`) invoked by the driver. The public entry points external callers still use are kept: `bind_params` and `_remove_tag_nodes` (used by `ibis_yaml/compiler.py` and `to_sql`). Every per-pass adapter was removed — the old tuple-returning standalone wrappers first, then (in R2 review follow-up) the tee/remote `*_into` scope-threading adapters. All callers, tests included, now apply a single pass through the driver primitive `apply_pass(PASS, expr, TransformCtx(scope=...))`, so each pass has exactly one entry point (see Observability below).
- `replace_nodes` is imported lazily inside `apply_pass` to keep `transform` out of the `graph_utils → relations` import cycle.

## Design notes

- The plan's `kind={PURE|BOUNDARY}` is split into **two orthogonal axes**: `traversal` (the walk) and `produces_resources` (needs the scope). `deferred_reads` is pure yet must be BOUNDARY; `cache` is effectful yet owns nothing scope-tracked — one field couldn't express both.
- **R2 review follow-up:** `TransformCtx.scope` is optional (pure passes skip constructing a throwaway scope), `Replacer` is typed `Callable[[Node, dict|None], Node]`, and each imported pass echoes its `after` at the `_PASSES` assembly point so the whole ordering chain reads in one place (the driver still validates each record's real `after`).

## Observability (OTel) — behavioral change

The per-pass tracing moved from decorated per-function spans to one span per pass emitted by `apply_pass`. **This renames spans** — dashboards/alerts keyed on the old names must be updated:

- `register_and_transform_remote_tables` → `transform.remote`
- `register_and_transform_tee_nodes` → `transform.tee`
- `_register_and_transform_cache_tables` → `transform.cache`
- `_remove_tag_nodes` (on the transform path) → `transform.remove_tags`
- `_transform_deferred_reads` → `transform.deferred_reads`

On the `_transform_expr` path this is a net **increase** in coverage: all six passes now get a span, whereas `bind_params` previously had none (→ `transform.bind_params`). `_transform_expr` and `to_pyarrow_batches` spans are unchanged, and the `replace_read` event still attaches to the (now renamed) deferred-reads span.

Two now-orphaned decorated functions — `_register_and_transform_cache_tables` and `_transform_deferred_reads` — were deleted: once the driver invoked their builders directly they had zero callers, so their `@tracer` spans never fired anyway.

The aggregate `remote_table.replace` OTel event was also dropped (no consumers).

## Tests

- New `test_transform_driver.py` pins the driver's own guarantees: `run_transform_passes` raises `InternalError` on a violated `after` (P3 anchor), ordered / skipped-but-positioned cases, `apply_pass` DESCEND-vs-BOUNDARY selection (P2), and `when=False` skipping.
- Green: `test_transform_scope.py`, `test_write_through.py`, `test_stream_cache_contract.py`, `test_graph_utils.py`, datafusion `test_into_backend.py`.

## Stacking

Built on **#2138** (R1 — unified resource scope), now **merged**. This branch is rebased directly onto `main`, so the diff is just the R2 declarative-pass-driver work. Behaviour-preserving refactor otherwise (aside from the observability changes noted above).

Still open in the plan: **P4** (fuse the pure DESCEND passes; the `count_remote_table_readers` extra walk) and **R3/P5** (route the Flight early-return through the driver) — both intended as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


