### PR TITLE
refactor(backends): standardize __all__, drop @public (#2066 phase 3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,43 @@ just up postgres # some of the tests use postgres
 python -m pytest # or pytest
 ```
 
+## Module and import conventions
+
+These rules keep the public API explicit and import time predictable across the
+package. They apply to first-party code under `python/xorq/`; vendored code
+under `python/xorq/vendor/` follows upstream conventions and is exempt.
+
+### Declaring the public API with `__all__`
+
+- Every `__init__.py` (and any module meant to be imported with `*`) declares
+  an explicit `__all__` listing the names it exports. This is the single source
+  of truth for the public surface and what IDEs and doc tooling read.
+- Do **not** use the `@public` decorator in first-party code. It mutates
+  `__all__` at runtime, which hides the public surface from static tools and
+  forces `# noqa: PLE0604`. `@public` remains only in vendored ibis.
+- Names absent from `__all__` are private: they can still be imported by their
+  fully qualified path, but they are excluded from `from module import *` and
+  are not part of the supported API.
+
+### Eager vs. lazy imports
+
+Top-level (eager, module-scope) imports are the default. Move an import into
+function scope (a "lazy" import) only for one of these reasons:
+
+- **Optional dependencies** — a backend or feature whose third-party package is
+  not a hard install requirement (e.g. `gcsfs`, `snowflake`, `pyiceberg`).
+  Deferring the import keeps `import xorq` working when the extra is absent and
+  surfaces the missing dependency only when the feature is actually used.
+- **Heavy imports** — packages with a large import cost that most code paths do
+  not touch, kept out of the base import time.
+- **Breaking an import cycle** — when a module-level import would create a
+  circular dependency.
+
+Core xorq modules and cheap standard-library imports load eagerly at module
+scope. Ruff enforces this split via `PLC0415` (import-outside-top-level): every
+deliberate lazy import must carry a `# noqa: PLC0415` comment, which makes each
+one an explicit, reviewable decision rather than an accident.
+
 ## Writing the commit
 
 xorq follows the [Conventional Commits](https://www.conventionalcommits.org/) structure.

--- a/python/xorq/backends/pandas/rewrites.py
+++ b/python/xorq/backends/pandas/rewrites.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from public import public
-
 import xorq.vendor.ibis.expr.datashape as ds
 import xorq.vendor.ibis.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
@@ -17,11 +15,23 @@ from xorq.vendor.ibis.expr.schema import Schema
 from xorq.vendor.ibis.util import gen_name
 
 
+__all__ = [
+    "PandasRename",
+    "PandasResetIndex",
+    "PandasJoin",
+    "PandasAsofJoin",
+    "PandasAggregate",
+    "PandasLimit",
+    "PandasScalarSubquery",
+    "PandasWindowFrame",
+    "PandasWindowFunction",
+]
+
+
 class PandasRelation(ops.Relation):
     pass
 
 
-@public
 class PandasRename(PandasRelation):
     parent: ops.Relation
     mapping: FrozenDict[str, str]
@@ -44,7 +54,6 @@ class PandasRename(PandasRelation):
         )
 
 
-@public
 class PandasResetIndex(PandasRelation):
     parent: ops.Relation
 
@@ -57,7 +66,6 @@ class PandasResetIndex(PandasRelation):
         return self.parent.schema
 
 
-@public
 class PandasJoin(PandasRelation):
     left: ops.Relation
     right: ops.Relation
@@ -74,14 +82,12 @@ class PandasJoin(PandasRelation):
         return self.left.schema | self.right.schema
 
 
-@public
 class PandasAsofJoin(PandasJoin):
     left_by: VarTuple[ops.Value]
     right_by: VarTuple[ops.Value]
     operator: type
 
 
-@public
 class PandasAggregate(PandasRelation):
     parent: ops.Relation
     groups: FrozenDict[str, ops.Field]
@@ -96,7 +102,6 @@ class PandasAggregate(PandasRelation):
         return Schema({k: v.dtype for k, v in self.values.items()})
 
 
-@public
 class PandasLimit(PandasRelation):
     parent: ops.Relation
     n: ops.Relation
@@ -111,7 +116,6 @@ class PandasLimit(PandasRelation):
         return self.parent.schema
 
 
-@public
 class PandasScalarSubquery(ops.Value):
     # variant with no integrity checks
     rel: ops.Relation
@@ -123,7 +127,6 @@ class PandasScalarSubquery(ops.Value):
         return self.rel.schema.types[0]
 
 
-@public
 class PandasWindowFrame(ops.Node):
     table: ops.Relation
     how: str
@@ -133,7 +136,6 @@ class PandasWindowFrame(ops.Node):
     order_by: VarTuple[ops.SortKey]
 
 
-@public
 class PandasWindowFunction(ops.Value):
     func: ops.Value
     frame: PandasWindowFrame

--- a/python/xorq/caching/__init__.py
+++ b/python/xorq/caching/__init__.py
@@ -4,7 +4,6 @@ import contextlib
 
 from attr import field, frozen
 from attr.validators import instance_of
-from public import public
 
 from xorq.caching.storage import (
     CacheStorage,
@@ -21,10 +20,11 @@ from xorq.caching.strategy import (
 from xorq.common.exceptions import XorqError
 
 
-__all__ = [  # noqa: PLE0604
+__all__ = [
     "ParquetCache",
     "ParquetSnapshotCache",
     "ParquetTTLSnapshotCache",
+    "ParquetDummySnapshotCache",
     "SourceCache",
     "SourceSnapshotCache",
     "GCSCache",
@@ -117,7 +117,6 @@ class Cache:
         return cls(strategy=strategy, storage=storage)
 
 
-@public
 @frozen
 class ParquetCache(Cache):
     """Cache expression results as Parquet files, re-hashing when source data changes.
@@ -143,7 +142,6 @@ class ParquetCache(Cache):
     storage_typ = ParquetStorage
 
 
-@public
 @frozen
 class ParquetSnapshotCache(Cache):
     """Cache expression results as Parquet files with a stable, snapshot key.
@@ -170,7 +168,6 @@ class ParquetSnapshotCache(Cache):
     storage_typ = ParquetStorage
 
 
-@public
 @frozen
 class ParquetTTLSnapshotCache(Cache):
     """Cache expression results as Parquet files with a stable key and a time-to-live.
@@ -197,13 +194,11 @@ class ParquetTTLSnapshotCache(Cache):
     storage_typ = ParquetTTLStorage
 
 
-@public
 @frozen
 class ParquetDummySnapshotCache(ParquetSnapshotCache):
     storage_typ = ParquetDummyStorage
 
 
-@public
 @frozen
 class SourceCache(Cache):
     """Cache expression results as a table in a source backend, with automatic invalidation.
@@ -223,7 +218,6 @@ class SourceCache(Cache):
     storage_typ = SourceStorage
 
 
-@public
 @frozen
 class SourceSnapshotCache(Cache):
     """Cache expression results as a table in a source backend, with a stable key.
@@ -243,7 +237,6 @@ class SourceSnapshotCache(Cache):
     storage_typ = SourceStorage
 
 
-@public
 @frozen
 class GCSCache(Cache):
     """Cache expression results as Parquet files in a Google Cloud Storage bucket.


### PR DESCRIPTION
## Summary

Phase 3 of #2066 — standardize decorator & import conventions.

First-party code used the `@public` decorator in only two modules
(`caching/__init__.py`, `backends/pandas/rewrites.py`); the rest of the package
declares its public surface with an explicit `__all__`. `@public` mutates
`__all__` at runtime, hiding the public API from static tooling and forcing
`# noqa: PLE0604`. This resolves the inconsistency in favor of explicit
`__all__`.

## Changes

- **`caching/__init__.py`** — drop `@public` (7) + `from public import public`,
  replace with explicit `__all__`. **Behavior-preserving**: `@public` had been
  adding `ParquetDummySnapshotCache` to the effective public set (which flows to
  `xorq.api` via `*caching.__all__`), so it is now listed explicitly.
- **`backends/pandas/rewrites.py`** — drop `@public` from the 9 op classes, add
  explicit `__all__`.
- **`CONTRIBUTING.md`** — new "Module and import conventions" section:
  - `__all__` is the single source of truth for the public API; no `@public` in
    first-party code.
  - eager-vs-lazy import rule (optional deps / heavy imports / cycle-breaking),
    enforced by ruff `PLC0415`.

`@public` remains only in vendored ibis (`python/xorq/vendor/`), which follows
upstream conventions and is exempt.

## Verification

- `ruff check` + `ruff format` clean (pre-commit hooks passed).
- Public surface preserved: `caching.__all__` = all 7 classes; `xorq.api`
  exposes all 7.
- Tests: 687 passed (pandas backend), 12 passed (cache).

Refs #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)