### PR TITLE
chore(deps): bump xorq-datafusion to 0.2.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "typing-extensions>=4.3.0",
     "py-yaml12",
     "cloudpickle>=3.1.1",
-    "xorq-datafusion==0.2.9",
+    "xorq-datafusion==0.2.10",
     "opentelemetry-sdk>=1.32.1",
     "opentelemetry-exporter-otlp>=1.32.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",

--- a/python/xorq/backends/xorq_datafusion/backend.py
+++ b/python/xorq/backends/xorq_datafusion/backend.py
@@ -487,7 +487,9 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_name
             The name of the table
         kwargs
-            Datafusion-specific keyword arguments
+            DataFusion-specific keyword arguments. Only applied to path and
+            record-batch-reader sources; ignored for expr, DataFrame, and
+            in-memory table sources.
 
         """
         import pandas as pd  # noqa: PLC0415
@@ -555,8 +557,8 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             return self.execute(source)
         backend = backends[0]
         if not isinstance(backend, Backend):
-            # Cross-backend expr: leave as ir.Expr; match arms register it via
-            # IbisTableProvider, which executes on the source's own backend.
+            # Cross-backend expr: leave as ir.Expr; the match arms register it by
+            # executing on the source's own backend.
             return source
         # Same-backend DataFusion expr: compile to a native DataFrame instead of
         # routing through IbisTableProvider. scan() would synchronously re-enter

--- a/python/xorq/backends/xorq_datafusion/backend.py
+++ b/python/xorq/backends/xorq_datafusion/backend.py
@@ -495,7 +495,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
         # Phase 1: resolve ir.Expr to a concrete type before dispatch.
         if isinstance(source, ir.Expr):
-            source = self._resolve_expr_for_register(source, **kwargs)
+            source = self._resolve_expr_for_register(source)
 
         table_name = table_name or gen_name("register")
         table_ident = str(sg.to_identifier(table_name, quoted=self.compiler.quoted))
@@ -541,7 +541,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
         return self.table(table_name)
 
-    def _resolve_expr_for_register(self, source: ir.Expr, **kwargs) -> Any:
+    def _resolve_expr_for_register(self, source: ir.Expr) -> Any:
         backends, has_unbound = source._find_backends()
         if has_unbound:
             raise ValueError(
@@ -553,16 +553,11 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         if not backends:
             # Pure in-memory expr (e.g. memtable): materialize now.
             return self.execute(source)
-        backend = backends[0]
-        if not isinstance(backend, Backend):
-            # Cross-backend expr: leave as ir.Expr; match arms handle it.
-            return source
-        # Same-backend DataFusion expr: compile to native DataFrame to avoid
-        # nested tokio runtime panic that IbisTableProvider.scan() would cause.
-        backend._register_udfs(source)
-        backend._register_in_memory_tables(source)
-        raw_sql = backend.compile(source.as_table(), **kwargs)
-        return backend.con.sql(raw_sql)
+        # Leave as ir.Expr; match arms register via IbisTableProvider. This holds
+        # for same-backend DataFusion exprs too: xorq-datafusion supports a
+        # runtime-within-runtime, so IbisTableProvider.scan() re-entering the
+        # source backend no longer panics on a nested tokio runtime.
+        return source
 
     def _register_path(self, path: str, table_name: str, **kwargs: Any) -> ir.Table:
         if path.startswith(("parquet://", "parq://")) or path.endswith(

--- a/python/xorq/backends/xorq_datafusion/backend.py
+++ b/python/xorq/backends/xorq_datafusion/backend.py
@@ -553,11 +553,19 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         if not backends:
             # Pure in-memory expr (e.g. memtable): materialize now.
             return self.execute(source)
-        # Leave as ir.Expr; match arms register via IbisTableProvider. This holds
-        # for same-backend DataFusion exprs too: xorq-datafusion supports a
-        # runtime-within-runtime, so IbisTableProvider.scan() re-entering the
-        # source backend no longer panics on a nested tokio runtime.
-        return source
+        backend = backends[0]
+        if not isinstance(backend, Backend):
+            # Cross-backend expr: leave as ir.Expr; match arms register it via
+            # IbisTableProvider, which executes on the source's own backend.
+            return source
+        # Same-backend DataFusion expr: compile to a native DataFrame instead of
+        # routing through IbisTableProvider. scan() would synchronously re-enter
+        # this connection, and a reentrant (>=3-level) expr then starves the
+        # tokio worker pool and deadlocks on core-limited runners (issue #1580).
+        backend._register_udfs(source)
+        backend._register_in_memory_tables(source)
+        raw_sql = backend.compile(source.as_table())
+        return backend.con.sql(raw_sql)
 
     def _register_path(self, path: str, table_name: str, **kwargs: Any) -> ir.Table:
         if path.startswith(("parquet://", "parq://")) or path.endswith(

--- a/python/xorq/backends/xorq_datafusion/provider.py
+++ b/python/xorq/backends/xorq_datafusion/provider.py
@@ -3,10 +3,10 @@ from xorq.internal import AbstractTableProvider
 
 
 class IbisTableProvider(AbstractTableProvider):
-    # scan() calls back into the backend synchronously, so same-connection
-    # DataFusion expressions will trigger a nested tokio runtime panic.
-    # Callers must convert those to native DataFrames before registration.
-    def __init__(self, table: ir.Table):
+    # scan() calls back into the source backend synchronously. xorq-datafusion
+    # supports a runtime-within-runtime, so this re-entry is safe even when the
+    # source is the same DataFusion connection (no nested tokio runtime panic).
+    def __init__(self, table: ir.Table) -> None:
         self.table = table
 
     def schema(self):

--- a/python/xorq/backends/xorq_datafusion/provider.py
+++ b/python/xorq/backends/xorq_datafusion/provider.py
@@ -5,8 +5,8 @@ from xorq.internal import AbstractTableProvider
 class IbisTableProvider(AbstractTableProvider):
     # scan() calls back into the source backend synchronously, so a same-backend
     # DataFusion expression re-enters the same connection and can starve the
-    # tokio worker pool (issue #1580). Callers must materialize those to native
-    # DataFrames before registration; only cross-backend tables reach here.
+    # tokio worker pool (issue #1580). register() sidesteps this by materializing
+    # same-backend exprs to native DataFrames before registration.
     def __init__(self, table: ir.Table) -> None:
         self.table = table
 

--- a/python/xorq/backends/xorq_datafusion/provider.py
+++ b/python/xorq/backends/xorq_datafusion/provider.py
@@ -3,9 +3,10 @@ from xorq.internal import AbstractTableProvider
 
 
 class IbisTableProvider(AbstractTableProvider):
-    # scan() calls back into the source backend synchronously. xorq-datafusion
-    # supports a runtime-within-runtime, so this re-entry is safe even when the
-    # source is the same DataFusion connection (no nested tokio runtime panic).
+    # scan() calls back into the source backend synchronously, so a same-backend
+    # DataFusion expression re-enters the same connection and can starve the
+    # tokio worker pool (issue #1580). Callers must materialize those to native
+    # DataFrames before registration; only cross-backend tables reach here.
     def __init__(self, table: ir.Table) -> None:
         self.table = table
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -75,7 +75,9 @@ def test_register_native_datafusion_dataframe() -> None:
     native = con.con.sql("SELECT a, a * 2 AS b FROM base")
     t = con.register(native, "from_native_df")
     assert "from_native_df" in con.list_tables()
-    assert t.execute()["b"].tolist() == [2, 4, 6]
+    # sort: DataFusion does not guarantee row order without ORDER BY
+    out = t.execute().sort_values("a").reset_index(drop=True)
+    assert out["b"].tolist() == [2, 4, 6]
 
 
 def test_register_pyarrow_dataset(tmp_path: Path) -> None:
@@ -92,7 +94,7 @@ def test_register_cross_backend_column_expr() -> None:
     src = xo.duckdb.connect().create_table("d", pa.table({"a": [1, 2, 3]}))
     con = xo.connect()
     t = con.register(src.a, "from_col")
-    assert t.execute()["a"].tolist() == [1, 2, 3]
+    assert sorted(t.execute()["a"].tolist()) == [1, 2, 3]
 
 
 def test_register_same_backend_expr_materialized() -> None:
@@ -102,9 +104,24 @@ def test_register_same_backend_expr_materialized() -> None:
     base = con.register(pa.table({"a": [1, 2, 3], "b": [10, 20, 30]}), "base")
     expr = base.filter(base.a > 1).mutate(c=base.b * 2)
     reg = con.register(expr, "derived")
-    out = reg.execute()
+    # sort: DataFusion does not guarantee row order without ORDER BY
+    out = reg.execute().sort_values("a").reset_index(drop=True)
     assert out["a"].tolist() == [2, 3]
     assert out["c"].tolist() == [40, 60]
+
+
+def test_register_same_backend_expr_with_in_memory_table() -> None:
+    # A same-backend expr that joins in an ibis.memtable exercises the
+    # materialization path's _register_in_memory_tables call: the memtable must
+    # be registered on the connection before the expr compiles to SQL.
+    con = xo.connect()
+    base = con.register(pa.table({"a": [1, 2, 3]}), "base")
+    lookup = xo.memtable({"a": [2, 3], "tag": ["x", "y"]})
+    reg = con.register(base.join(lookup, "a"), "joined_mem")
+    # sort: DataFusion does not guarantee row order without ORDER BY
+    out = reg.execute().sort_values("a").reset_index(drop=True)
+    assert out["a"].tolist() == [2, 3]
+    assert out["tag"].tolist() == ["x", "y"]
 
 
 def test_register_provider_filter_pushdown() -> None:
@@ -115,7 +132,7 @@ def test_register_provider_filter_pushdown() -> None:
     )
     con = xo.connect()
     reg = con.register(src, "prov")
-    out = reg.filter(reg.a > 2).execute()
+    out = reg.filter(reg.a > 2).execute().sort_values("a").reset_index(drop=True)
     assert out["a"].tolist() == [3, 4]
 
 

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -96,9 +96,8 @@ def test_register_cross_backend_column_expr() -> None:
 
 
 def test_register_same_backend_expr_materialized() -> None:
-    # A same-backend DataFusion expr is compiled to a native DataFrame rather
-    # than routed through IbisTableProvider, whose scan() would re-enter this
-    # connection and risk the reentrant tokio starvation of issue #1580.
+    # Same-backend exprs compile to a native DataFrame, not IbisTableProvider
+    # (see _resolve_expr_for_register / issue #1580).
     con = xo.connect()
     base = con.register(pa.table({"a": [1, 2, 3], "b": [10, 20, 30]}), "base")
     expr = base.filter(base.a > 1).mutate(c=base.b * 2)
@@ -121,18 +120,15 @@ def test_register_provider_filter_pushdown() -> None:
 
 
 def _reentrant_depth3_child(result_q: mp.Queue) -> None:
-    # Pin to two cores BEFORE the tokio runtime is built: this is the config
-    # under which a reentrant provider scan would starve the worker pool
-    # (issue #1580). Picking from the current affinity set keeps this valid
-    # inside an already-pinned container.
+    # Pin to two cores BEFORE the tokio runtime is built -- the config under
+    # which the reentrant deadlock (#1580) reproduced. Take them from the
+    # current affinity set to stay valid inside an already-pinned container.
     two_cpus = set(sorted(os.sched_getaffinity(0))[:2])
     os.sched_setaffinity(0, two_cpus)
 
     con = xo.connect()
     t = con.register(pa.table({"a": [1, 2, 3, 4, 5]}), "base")
-    # Registering a same-backend expr three levels deep is the shape that used
-    # to deadlock when it routed through IbisTableProvider (scan() re-entering
-    # the same connection); it must now complete via native materialization.
+    # Three-level same-backend registration: the shape that used to deadlock.
     for i in range(3):
         t = con.register(t.mutate(**{f"x{i}": t.a + i}), f"lvl{i}")
     result_q.put(t.execute().shape)
@@ -143,10 +139,9 @@ def _reentrant_depth3_child(result_q: mp.Queue) -> None:
     reason="needs Linux CPU-affinity control and >=2 available cores",
 )
 def test_reentrant_same_backend_register_no_deadlock_on_two_cores() -> None:
-    # Runs in a spawned, core-pinned child; a hang surfaces as timeout->failure
-    # instead of blocking the whole suite. Deterministic regardless of host core
-    # count because the child forces exactly two cores. The success path
-    # (spawn + import + connect + execute) is ~1s, so 10s is a wide margin.
+    # Spawned, core-pinned child so a hang becomes a timeout->failure instead of
+    # blocking the suite. Success path is ~1s (spawn + import + connect +
+    # execute), so 10s is a wide margin.
     timeout_s = 10
     ctx = mp.get_context("spawn")
     result_q = ctx.Queue()

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import multiprocessing as mp
+import os
+import queue
 import warnings
 from pathlib import Path
 
@@ -115,6 +118,60 @@ def test_register_provider_filter_pushdown() -> None:
     reg = con.register(src, "prov")
     out = reg.filter(reg.a > 2).execute()
     assert out["a"].tolist() == [3, 4]
+
+
+def _reentrant_depth3_child(result_q: mp.Queue) -> None:
+    # Pin to two cores BEFORE the tokio runtime is built, so the DataFusion
+    # worker pool starves under nested provider scans (issue #1580). Picking
+    # from the current affinity set keeps this valid inside a pinned container.
+    two_cpus = set(sorted(os.sched_getaffinity(0))[:2])
+    os.sched_setaffinity(0, two_cpus)
+
+    con = xo.connect()
+    t = con.register(pa.table({"a": [1, 2, 3, 4, 5]}), "base")
+    # Each register() of a same-backend expr routes through IbisTableProvider;
+    # three levels deep, scan() re-enters the same connection recursively.
+    for i in range(3):
+        t = con.register(t.mutate(**{f"x{i}": t.a + i}), f"lvl{i}")
+    result_q.put(t.execute().shape)
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "sched_setaffinity") or len(os.sched_getaffinity(0)) < 2,
+    reason="needs Linux CPU-affinity control and >=2 available cores",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "issue #1580: a >=3-level reentrant same-backend expr registers each level "
+        "via IbisTableProvider.scan(), which synchronously re-enters the same "
+        "DataFusion connection and starves the two-worker tokio pool, deadlocking. "
+        "Remove this xfail once the same-backend register path no longer hangs."
+    ),
+)
+def test_reentrant_same_backend_register_deadlocks_on_two_cores() -> None:
+    # Runs in a spawned, core-pinned child; a hang surfaces as timeout->failure
+    # instead of blocking the whole suite. Deterministic regardless of host core
+    # count because the child forces exactly two cores. The success path
+    # (spawn + import + connect + execute) is ~1s, so 10s is a wide margin.
+    timeout_s = 10
+    ctx = mp.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=_reentrant_depth3_child, args=(result_q,))
+    proc.start()
+    proc.join(timeout_s)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        pytest.fail(
+            f"reentrant same-backend register hung >{timeout_s}s "
+            "(issue #1580 tokio worker starvation)"
+        )
+    try:
+        shape = result_q.get(timeout=5)
+    except queue.Empty:
+        pytest.fail(f"child exited without a result (exitcode={proc.exitcode})")
+    assert shape == (5, 4)
 
 
 def test_register_unknown_source_type_raises() -> None:

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -95,10 +95,10 @@ def test_register_cross_backend_column_expr() -> None:
     assert t.execute()["a"].tolist() == [1, 2, 3]
 
 
-def test_register_same_backend_expr_via_provider() -> None:
-    # A same-backend DataFusion expr now registers via IbisTableProvider
-    # (xorq-datafusion runtime-within-runtime) rather than compiling to a
-    # native DataFrame; scan() re-enters the same connection without panicking.
+def test_register_same_backend_expr_materialized() -> None:
+    # A same-backend DataFusion expr is compiled to a native DataFrame rather
+    # than routed through IbisTableProvider, whose scan() would re-enter this
+    # connection and risk the reentrant tokio starvation of issue #1580.
     con = xo.connect()
     base = con.register(pa.table({"a": [1, 2, 3], "b": [10, 20, 30]}), "base")
     expr = base.filter(base.a > 1).mutate(c=base.b * 2)
@@ -121,16 +121,18 @@ def test_register_provider_filter_pushdown() -> None:
 
 
 def _reentrant_depth3_child(result_q: mp.Queue) -> None:
-    # Pin to two cores BEFORE the tokio runtime is built, so the DataFusion
-    # worker pool starves under nested provider scans (issue #1580). Picking
-    # from the current affinity set keeps this valid inside a pinned container.
+    # Pin to two cores BEFORE the tokio runtime is built: this is the config
+    # under which a reentrant provider scan would starve the worker pool
+    # (issue #1580). Picking from the current affinity set keeps this valid
+    # inside an already-pinned container.
     two_cpus = set(sorted(os.sched_getaffinity(0))[:2])
     os.sched_setaffinity(0, two_cpus)
 
     con = xo.connect()
     t = con.register(pa.table({"a": [1, 2, 3, 4, 5]}), "base")
-    # Each register() of a same-backend expr routes through IbisTableProvider;
-    # three levels deep, scan() re-enters the same connection recursively.
+    # Registering a same-backend expr three levels deep is the shape that used
+    # to deadlock when it routed through IbisTableProvider (scan() re-entering
+    # the same connection); it must now complete via native materialization.
     for i in range(3):
         t = con.register(t.mutate(**{f"x{i}": t.a + i}), f"lvl{i}")
     result_q.put(t.execute().shape)
@@ -140,16 +142,7 @@ def _reentrant_depth3_child(result_q: mp.Queue) -> None:
     not hasattr(os, "sched_setaffinity") or len(os.sched_getaffinity(0)) < 2,
     reason="needs Linux CPU-affinity control and >=2 available cores",
 )
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "issue #1580: a >=3-level reentrant same-backend expr registers each level "
-        "via IbisTableProvider.scan(), which synchronously re-enters the same "
-        "DataFusion connection and starves the two-worker tokio pool, deadlocking. "
-        "Remove this xfail once the same-backend register path no longer hangs."
-    ),
-)
-def test_reentrant_same_backend_register_deadlocks_on_two_cores() -> None:
+def test_reentrant_same_backend_register_no_deadlock_on_two_cores() -> None:
     # Runs in a spawned, core-pinned child; a hang surfaces as timeout->failure
     # instead of blocking the whole suite. Deterministic regardless of host core
     # count because the child forces exactly two cores. The success path

--- a/python/xorq/backends/xorq_datafusion/tests/test_register.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_register.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import warnings
+from pathlib import Path
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
 import pytest
 from batchcorder import StreamCache
 
@@ -58,6 +63,64 @@ def test_register_table_provider():
     # None table_name generates a name; returned table reflects it
     t = con.register_table_provider(source)
     assert t.get_name() in con.list_tables()
+
+
+def test_register_native_datafusion_dataframe() -> None:
+    # A native DataFusion DataFrame (result of con.con.sql) hits the DataFrame arm.
+    con = xo.connect()
+    con.register(pa.table({"a": [1, 2, 3]}), "base")
+    native = con.con.sql("SELECT a, a * 2 AS b FROM base")
+    t = con.register(native, "from_native_df")
+    assert "from_native_df" in con.list_tables()
+    assert t.execute()["b"].tolist() == [2, 4, 6]
+
+
+def test_register_pyarrow_dataset(tmp_path: Path) -> None:
+    # A pyarrow Dataset hits the ds.Dataset arm.
+    pq.write_table(pa.table({"a": [1, 2, 3]}), str(tmp_path / "p.parquet"))
+    con = xo.connect()
+    t = con.register(ds.dataset(str(tmp_path)), "from_dataset")
+    assert t.count().execute() == 3
+
+
+def test_register_cross_backend_column_expr() -> None:
+    # A bound non-table expr (column) hits the ir.Expr arm: materialized via
+    # the source backend's to_pyarrow_batches into a record-batch reader.
+    src = xo.duckdb.connect().create_table("d", pa.table({"a": [1, 2, 3]}))
+    con = xo.connect()
+    t = con.register(src.a, "from_col")
+    assert t.execute()["a"].tolist() == [1, 2, 3]
+
+
+def test_register_same_backend_expr_via_provider() -> None:
+    # A same-backend DataFusion expr now registers via IbisTableProvider
+    # (xorq-datafusion runtime-within-runtime) rather than compiling to a
+    # native DataFrame; scan() re-enters the same connection without panicking.
+    con = xo.connect()
+    base = con.register(pa.table({"a": [1, 2, 3], "b": [10, 20, 30]}), "base")
+    expr = base.filter(base.a > 1).mutate(c=base.b * 2)
+    reg = con.register(expr, "derived")
+    out = reg.execute()
+    assert out["a"].tolist() == [2, 3]
+    assert out["c"].tolist() == [40, 60]
+
+
+def test_register_provider_filter_pushdown() -> None:
+    # Filtering a provider-backed table pushes the predicate into
+    # IbisTableProvider.scan(filters), which re-applies it on the source side.
+    src = xo.duckdb.connect().create_table(
+        "d", pa.table({"a": [1, 2, 3, 4], "b": [10, 20, 30, 40]})
+    )
+    con = xo.connect()
+    reg = con.register(src, "prov")
+    out = reg.filter(reg.a > 2).execute()
+    assert out["a"].tolist() == [3, 4]
+
+
+def test_register_unknown_source_type_raises() -> None:
+    con = xo.connect()
+    with pytest.raises(ValueError, match="Unknown `source` type"):
+        con.register(object(), "bad")
 
 
 def test_read_record_batches_type_mismatch() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -6312,7 +6312,7 @@ requires-dist = [
     { name = "uv", specifier = ">=0.7.20" },
     { name = "xgboost", marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'examples'", specifier = ">=1.6.1" },
     { name = "xorq-dasher", specifier = ">=0.1.1" },
-    { name = "xorq-datafusion", specifier = "==0.2.9" },
+    { name = "xorq-datafusion", specifier = "==0.2.10" },
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
 ]
@@ -6377,20 +6377,20 @@ wheels = [
 
 [[package]]
 name = "xorq-datafusion"
-version = "0.2.9"
+version = "0.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/f4/43d1e410fba403778a0dc8e092478ab34031b8b885b49bda0ec3da4e7beb/xorq_datafusion-0.2.9.tar.gz", hash = "sha256:77e47ef4614544eb6ffc75629b2940da0a446ddf7afece7354b9a40232e35304", size = 20660299, upload-time = "2026-06-09T09:02:36.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/73/591a9c22f2f9b7299827e04960985f940a3040d273633447352440ee0377/xorq_datafusion-0.2.10.tar.gz", hash = "sha256:4db745babcc717440cfb4dedf8f8b973a3f5ebfe54696dd9057bc88224eef2d7", size = 20669735, upload-time = "2026-07-02T13:39:59.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/8d/d3fbcc1fc0789fc788390c36f9fddb37ac633bda1043501e617c7ff1c4a7/xorq_datafusion-0.2.9-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:206b10ee317b69644d4abd6a7c4e7ff14803bc0f0604fcd337ae5023dfac6514", size = 33154027, upload-time = "2026-06-09T09:02:09.078Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/37/c27add86a1569d1f8fdec1061e98d158b1f212c528e9291656d08aa5c2e0/xorq_datafusion-0.2.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:21446b86ed7039f719f81ae9bffc6210af6fd1cb23acc42b176782924ed48592", size = 30779807, upload-time = "2026-06-09T09:02:13.136Z" },
-    { url = "https://files.pythonhosted.org/packages/07/39/647dfd72d02f607581619b811c7b387aaaa4e15c4affddc28d784d0b995e/xorq_datafusion-0.2.9-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:480bc8747791f7dca0aacc980d23e8a70f330d33ee7d5d64e07b517b23fb5507", size = 37197416, upload-time = "2026-06-09T09:02:16.269Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/be/f7451c3cfb8d410e78b7e7ba26413425d1bd4cf91ea2a80e5a15f8398f31/xorq_datafusion-0.2.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d825533bbac509df0477e641ca0c8f8627c8116a222ff42209ad264df4becd87", size = 34614882, upload-time = "2026-06-09T09:02:19.682Z" },
-    { url = "https://files.pythonhosted.org/packages/48/bc/ecc669bf5524ec4f75a7f744f2b7c40b614ad4a8cad9af5b344dd2f54e28/xorq_datafusion-0.2.9-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48e7a904e8a1fb1d2cfb43d8a3553300ab1aa73842d54c6e03de6bc805dce946", size = 31996314, upload-time = "2026-06-09T09:02:22.555Z" },
-    { url = "https://files.pythonhosted.org/packages/48/fa/d8c71cb7bb92e0972a11dcaab79c0505b647d6353ab0b8e71b422138e48a/xorq_datafusion-0.2.9-cp38-abi3-win32.whl", hash = "sha256:7fe780e5678359a6b5a587cd9875d16e46a066cc5c1a633d8a92de50c4a83c51", size = 32922674, upload-time = "2026-06-09T09:02:25.983Z" },
-    { url = "https://files.pythonhosted.org/packages/70/e6/c50fab0701210aae471c65fed581466af3754069e2ac1011338dac59411d/xorq_datafusion-0.2.9-cp38-abi3-win_amd64.whl", hash = "sha256:ab5657ff9506d19da53eb732228461600bdc101c84b69e0ad20b7e2ebdf6ae1b", size = 36658028, upload-time = "2026-06-09T09:02:33.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1d/91641e120e268e9cb9c1fb44c76be6f097813a1bab5a86287a4db9839e8e/xorq_datafusion-0.2.10-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2b03b647c31cb6fc75f610a045dea07687c66ca552006ee60e16ecc7dc216156", size = 33036424, upload-time = "2026-07-02T13:39:38.401Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ca/bd255659b4911d006181a8c58ef1b8c3914bb70c480750f2a654773e51e6/xorq_datafusion-0.2.10-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e5ea54330ece56a4a33b7f4bbad0049dca6557e41e511e264b1dd1de53e70ac", size = 30683829, upload-time = "2026-07-02T13:39:41.608Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cc/9b095094a9d3ff76e6371ca12deb7077ad1754d3fb6a0a2258b85bf0d543/xorq_datafusion-0.2.10-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:695b1f38b8aa7be0c663562e48dd86c45f7a05204472ad5acc5107fe00bc7e4e", size = 37093852, upload-time = "2026-07-02T13:39:44.397Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/51/639565fc23acec1e5a1ee44642147a6216d7ce9251ae07c8d2f33a873fd7/xorq_datafusion-0.2.10-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d0ce82388e5dac57476552846a1e56d7186ba8bc72844e1c010764e05a471fd", size = 34508834, upload-time = "2026-07-02T13:39:47.608Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ca/1feb656c9b19ae25b5ed0b2511971f3334b910821dbd249a457efb6f5d5b/xorq_datafusion-0.2.10-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ac8c33b9b94023e3762338a8a4c230d6d9d2d5589fb4430e9425562b0eeb18a8", size = 31882824, upload-time = "2026-07-02T13:39:50.446Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8d/46911b88b041098aa1d9a636875c506d283abea293c0c2b5e0028f916d49/xorq_datafusion-0.2.10-cp38-abi3-win32.whl", hash = "sha256:85b5e1c712c6ff6d191dee2d55d5299b00cf148a27effc7775ea18d63073116a", size = 32803502, upload-time = "2026-07-02T13:39:53.671Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/64/2649ea219ce7a4e983ce685c43857825f2b5299e9d8cfd751a400a944705/xorq_datafusion-0.2.10-cp38-abi3-win_amd64.whl", hash = "sha256:a2a54517f00b3df13481c4faea9aad58e156542b7632192318cdabfdbbb740c4", size = 36489223, upload-time = "2026-07-02T13:39:56.681Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `xorq-datafusion` pin `0.2.9` → `0.2.10` (`pyproject.toml`, `uv.lock`)
- Keep same-backend DataFusion exprs compiling to a **native DataFrame** in `_resolve_expr_for_register`; only genuine cross-backend exprs register via `IbisTableProvider`. (An earlier revision of this PR routed same-backend exprs through the provider — see the note below on why that was reverted.)
- Add tests covering the `register()` dispatch arms that lacked coverage, plus a core-pinned regression test for the reentrant deadlock.

## ⚠️ Note: reverted the same-backend → `IbisTableProvider` routing (issue #1580)
An earlier revision of this PR dropped the same-backend→native-DataFrame path and routed same-backend exprs through `IbisTableProvider`, on the assumption that 0.2.10's runtime-within-runtime made `scan()` re-entering the same connection safe.

Testing showed that holds for a **single** level but not for **reentrant** exprs. `IbisTableProvider.scan()` re-enters the source connection **synchronously**, blocking the tokio worker it runs on; a ≥3-level reentrant same-backend expr then blocks workers on inner scans that themselves need workers, starving the pool and **deadlocking on core-limited (2-core CI) runners** — the exact #1580 pattern. Reproduced deterministically: pinned to 2 cores, reentrant depth ≥3 hangs (3/3); depth 1–2 and any depth at ≥48 cores pass; `main`'s native-DataFrame path never hangs at any depth. It only surfaces on 2-core runners, so it would slip through local/high-core CI.

The fix here effectively **reverts the "route same-backend exprs through `IbisTableProvider`" decision** (keeping the phase-1 signature cleanup). If that routing was intended to solve a specific problem beyond the coverage cleanup, **that goal is not addressed** — the provider path simply is not safe for same-connection reentrancy, and same-backend exprs should stay on native materialization.

## Coverage
`backend.py` improved **87.56% → ~89%** (54 → 46 missed lines locally).

New tests exercise the previously-uncovered `register()` dispatch arms:
- native DataFusion `DataFrame` arm (also the target of the same-backend materialization path)
- pyarrow `Dataset` arm
- bound non-table column `ir.Expr` arm
- unknown-source-type `ValueError`
- `IbisTableProvider.scan(filters)` via predicate push-down (cross-backend)

Plus a core-pinned, timeout-guarded regression test (`test_reentrant_same_backend_register_no_deadlock_on_two_cores`) that reproduces the #1580 shape on two cores and asserts it now completes.

Remaining uncovered lines are structural, not gaps:
- `read_delta` — requires the `deltalake` extra (absent in the test env)
- native `Table()` arm — `xorq.internal.Table` is FFI-only, no public constructor
- `provider.py` scan body — runs on a DataFusion worker thread that `coverage.py` does not trace (proven to execute via a scan trace)
- scattered validation/error branches

## Testing
- `xorq_datafusion` + `datafusion` backend suites: **all passing** (`test_register.py`: 32 passed)
- `test_into_backend` (core, non-postgres/trino): **80 passed**
- Reentrant deadlock repro/regression: verified 2-core hang on the provider route and completion on the native-DataFrame path (depths 3–6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
