### PR TITLE
refactor(ibis_yaml): unify ExprDumper writes into WritePlan abstraction

### DIFF
--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -520,6 +520,7 @@ def _validate_normalize_method(instance: Any, attribute: Any, value: Any) -> Non
 
     validate(value)
 
+
 @frozen
 class WritePlan:
     """A single deferred write: where, how, when, and whether duplicates are safe.
@@ -825,18 +826,19 @@ class ExprDumper:
         once with byte-identical output, so extra copies are dropped. Any other
         path collision is a bug and raises rather than silently losing a writer.
         """
-        by_path = {}
-        for plan in plans:
-            existing = by_path.get(plan.path)
-            if existing is not None:
-                if not (existing.dedupable and plan.dedupable):
-                    raise ValueError(
-                        f"conflicting non-dedupable write plans for {plan.path}: "
-                        f"{existing.phase.name} vs {plan.phase.name}"
-                    )
-                continue
-            by_path[plan.path] = plan
-        for plan in sorted(by_path.values(), key=operator.attrgetter("phase")):
+        by_path = toolz.groupby(operator.attrgetter("path"), plans)
+        conflicts = tuple(
+            f"{keeper.path}: {keeper.phase.name} vs {other.phase.name}"
+            for (keeper, *rest) in by_path.values()
+            for other in rest
+            if not (keeper.dedupable and other.dedupable)
+        )
+        if conflicts:
+            raise ValueError(
+                "conflicting non-dedupable write plans:\n" + "\n".join(conflicts)
+            )
+        keepers = (keeper for (keeper, *_) in by_path.values())
+        for plan in sorted(keepers, key=operator.attrgetter("phase")):
             plan.writer()
 
     def dump_expr(self) -> str:

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -541,13 +541,17 @@ class WritePlan:
         write_fn: Callable[..., Path],
         payload: Any,
         path_parts: str | tuple[str, ...],
-        phase: WritePhase,
+        *,
+        phase: WritePhase = WritePhase.ARTIFACT,
         dedupable: bool = False,
     ) -> "WritePlan":
         """Build a WritePlan whose path and deferred writer share one path_parts.
 
         write_fn is an ArtifactStore method taking (payload, *path_parts); binding
         both the path and the writer to the same parts keeps them from drifting.
+
+        phase defaults to ARTIFACT (order-independent metadata), the common case;
+        content files that the expr YAML tokenizes pass phase=WritePhase.DATA.
         """
         parts = path_parts if isinstance(path_parts, tuple) else (path_parts,)
         path = artifact_store.get_path(*parts)
@@ -625,7 +629,6 @@ class ExprDumper:
             self.artifact_store.write_text,
             sql,
             filename,
-            WritePhase.ARTIFACT,
             dedupable=True,
         )
 
@@ -639,7 +642,7 @@ class ExprDumper:
             self.artifact_store.write_parquet,
             table,
             (which, f"{tokenize(table)}.parquet"),
-            WritePhase.DATA,
+            phase=WritePhase.DATA,
             dedupable=True,
         )
 
@@ -653,7 +656,7 @@ class ExprDumper:
             self.artifact_store.copy_file,
             source_path,
             relocatable_read_path(source_path),
-            WritePhase.DATA,
+            phase=WritePhase.DATA,
             dedupable=True,
         )
 
@@ -680,7 +683,6 @@ class ExprDumper:
             self.artifact_store.write_yaml,
             {collection_key: items},
             dump_file,
-            WritePhase.ARTIFACT,
         )
         return (*sql_file_plans, yaml_plan)
 
@@ -705,7 +707,6 @@ class ExprDumper:
             self.artifact_store.write_text,
             self._make_build_metadata(),
             DumpFiles.build_metadata,
-            WritePhase.ARTIFACT,
         )
 
     def _make_expr_metadata(self, expr) -> Dict[str, Any]:
@@ -732,7 +733,6 @@ class ExprDumper:
             self.artifact_store.write_json,
             self._make_expr_metadata(expr),
             DumpFiles.expr_metadata,
-            WritePhase.ARTIFACT,
         )
 
     def _prepare_profiles_file(self, profiles: dict) -> WritePlan:
@@ -741,7 +741,6 @@ class ExprDumper:
             self.artifact_store.write_yaml,
             profiles,
             DumpFiles.profiles,
-            WritePhase.ARTIFACT,
         )
 
     def _prepare_debug_info(self) -> tuple[WritePlan, ...]:
@@ -827,7 +826,10 @@ class ExprDumper:
             existing = by_path.get(plan.path)
             if existing is not None:
                 if not (existing.dedupable and plan.dedupable):
-                    raise ValueError(f"conflicting write plans for {plan.path}")
+                    raise ValueError(
+                        f"conflicting non-dedupable write plans for {plan.path}: "
+                        f"{existing.phase.name} vs {plan.phase.name}"
+                    )
                 continue
             by_path[plan.path] = plan
         for plan in sorted(by_path.values(), key=operator.attrgetter("phase")):

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -772,8 +772,12 @@ class ExprDumper:
                 con_kwargs = {}
             elif _is_relocatable_read(node):
                 plan = self._prepare_relocatable_read(node)
-                which = BundledSourceTypes.read
-                read_path = f"{which}/{plan.path.name}"
+                # read_path via the single-source-of-truth helper (same one the
+                # pre-hash bake pass uses) so the two stay byte-equal -- that
+                # equality is what keeps a relocated build load+rebuild hash-stable
+                read_path = relocatable_read_path_str(
+                    dict(node.read_kwargs)["hash_path"]
+                )
                 new_kwargs = update_read_kwargs(
                     node.read_kwargs,
                     (("hash_path", plan.path), ("read_path", read_path)),

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import json
@@ -7,7 +9,7 @@ import shutil
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Callable, Dict, NamedTuple
 
 import toolz
 import yaml12
@@ -82,6 +84,7 @@ from xorq.ibis_yaml.enums import (
     ExprKind,
     RefEnum,
     RegistryEnum,
+    WritePhase,
 )
 from xorq.ibis_yaml.sql import generate_sql_plans
 from xorq.ibis_yaml.utils import freeze
@@ -518,6 +521,20 @@ def _validate_normalize_method(instance: Any, attribute: Any, value: Any) -> Non
     validate(value)
 
 
+class WritePlan(NamedTuple):
+    """A single deferred write: where, how, when, and whether duplicates are safe.
+
+    dedupable marks content-addressed paths (parquet, SQL files) whose repeated
+    plans always write identical bytes, so dropping duplicates is lossless. Fixed
+    singleton files are not dedupable and colliding on one signals a bug.
+    """
+
+    path: Path
+    writer: Callable[[], Any]
+    phase: WritePhase
+    dedupable: bool = False
+
+
 @frozen
 class ExprDumper:
     """
@@ -566,9 +583,10 @@ class ExprDumper:
     def expr_hash(self):
         return self.expr_path.name
 
-    def _prepare_expr_file(self, expr, profiles):
+    def _prepare_expr_file(self, expr: ir.Expr, profiles: dict) -> WritePlan:
         path = self.artifact_store.get_path(DumpFiles.expr)
-        # we can't translate to yaml until the memtable parquets are written: they will be tokenized
+        # phase EXPR: translation tokenizes memtable parquets, which the DATA
+        # phase must have written first
         writer = toolz.compose(
             functools.partial(self.artifact_store.save_yaml, filename=DumpFiles.expr),
             functools.partial(
@@ -578,16 +596,18 @@ class ExprDumper:
                 self.cache_dir,
             ),
         )
-        return (path, writer)
+        return WritePlan(path, writer, WritePhase.EXPR)
 
-    def _prepare_sql_file(self, sql: str) -> str:
+    def _prepare_sql_file(self, sql: str) -> WritePlan:
         sql_hash = tokenize(sql)[: config.hash_length]
         filename = f"{sql_hash}.sql"
         path = self.artifact_store.get_path(filename)
         writer = functools.partial(self.artifact_store.write_text, sql, filename)
-        return (path, writer)
+        return WritePlan(path, writer, WritePhase.ARTIFACT, dedupable=True)
 
-    def _prepare_memtable(self, mt, which):
+    def _prepare_memtable(
+        self, mt: InMemoryTable | DatabaseTable, which: BundledSourceTypes
+    ) -> WritePlan:
         assert which in BundledSourceTypes
         table = mt.to_expr().to_pyarrow()
         filename = f"{tokenize(table)}.parquet"
@@ -598,11 +618,9 @@ class ExprDumper:
             table,
             *path_parts,
         )
-        return (path, writer)
+        return WritePlan(path, writer, WritePhase.DATA, dedupable=True)
 
-    def _prepare_relocatable_read(
-        self, read_node: Read
-    ) -> tuple[Path, str, functools.partial]:
+    def _prepare_relocatable_read(self, read_node: Read) -> WritePlan:
         kw = dict(read_node.read_kwargs)
         # Internal invariant; see the matching guard in _prepare_relocatable_reads.
         assert "hash_path" in kw, "relocatable Read must have hash_path"
@@ -619,47 +637,55 @@ class ExprDumper:
             source_path,
             *path_parts,
         )
-        return (path, read_path, writer)
+        return WritePlan(path, writer, WritePhase.DATA, dedupable=True)
 
     def _prepare_sql_plans(
         self,
         sql_plans: Dict[str, Any],
-    ) -> Dict[str, Any]:
+    ) -> tuple[WritePlan, ...]:
         queries = {}
-        path_to_writer = {}
+        sql_file_plans = []
         for query_name, query_info in sql_plans["queries"].items():
-            path, writer = self._prepare_sql_file(query_info["sql"])
-            path_to_writer[path] = writer
+            plan = self._prepare_sql_file(query_info["sql"])
+            sql_file_plans.append(plan)
             queries[query_name] = toolz.dissoc(query_info, "sql") | {
-                "sql_file": path.name
+                "sql_file": plan.path.name
             }
         updated_plans = {"queries": queries}
-        path_to_writer[self.artifact_store.get_path(DumpFiles.sql)] = functools.partial(
-            self.artifact_store.save_yaml,
-            updated_plans,
-            filename=DumpFiles.sql,
+        yaml_plan = WritePlan(
+            self.artifact_store.get_path(DumpFiles.sql),
+            functools.partial(
+                self.artifact_store.save_yaml,
+                updated_plans,
+                filename=DumpFiles.sql,
+            ),
+            WritePhase.ARTIFACT,
         )
-        return path_to_writer
+        return (*sql_file_plans, yaml_plan)
 
     def _prepare_deferred_reads(
         self,
         deferred_reads: Dict[str, Any],
-    ) -> Dict[str, Any]:
+    ) -> tuple[WritePlan, ...]:
         reads = {}
-        path_to_writer = {}
+        sql_file_plans = []
         for read_name, read_info in deferred_reads["reads"].items():
-            path, writer = self._prepare_sql_file(read_info["sql"])
-            path_to_writer[path] = writer
-            reads[read_name] = toolz.dissoc(read_info, "sql") | {"sql_file": path.name}
+            plan = self._prepare_sql_file(read_info["sql"])
+            sql_file_plans.append(plan)
+            reads[read_name] = toolz.dissoc(read_info, "sql") | {
+                "sql_file": plan.path.name
+            }
         updated_reads = {"reads": reads}
-        path_to_writer[self.artifact_store.get_path(DumpFiles.deferred_reads)] = (
+        yaml_plan = WritePlan(
+            self.artifact_store.get_path(DumpFiles.deferred_reads),
             functools.partial(
                 self.artifact_store.save_yaml,
                 updated_reads,
                 filename=DumpFiles.deferred_reads,
-            )
+            ),
+            WritePhase.ARTIFACT,
         )
-        return path_to_writer
+        return (*sql_file_plans, yaml_plan)
 
     @staticmethod
     def _make_build_metadata() -> str:
@@ -676,14 +702,14 @@ class ExprDumper:
         metadata_json = json.dumps(metadata, indent=2)
         return metadata_json
 
-    def _prepare_build_metadata_file(self):
+    def _prepare_build_metadata_file(self) -> WritePlan:
         path = self.artifact_store.get_path(DumpFiles.build_metadata)
         writer = functools.partial(
             self.artifact_store.write_text,
             self._make_build_metadata(),
             DumpFiles.build_metadata,
         )
-        return path, writer
+        return WritePlan(path, writer, WritePhase.ARTIFACT)
 
     def _make_expr_metadata(self, expr) -> Dict[str, Any]:
         from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
@@ -703,30 +729,30 @@ class ExprDumper:
         metadata = evolve(metadata, sql_queries=sql_queries, lineage=lineage)
         return metadata.to_dict()
 
-    def _prepare_expr_metadata_file(self, expr):
+    def _prepare_expr_metadata_file(self, expr: ir.Expr) -> WritePlan:
         path = self.artifact_store.get_path(DumpFiles.expr_metadata)
         writer = functools.partial(
             self.artifact_store.write_json,
             self._make_expr_metadata(expr),
             DumpFiles.expr_metadata,
         )
-        return path, writer
+        return WritePlan(path, writer, WritePhase.ARTIFACT)
 
-    def _prepare_profiles_file(self, profiles):
+    def _prepare_profiles_file(self, profiles: dict) -> WritePlan:
         path = self.artifact_store.get_path(DumpFiles.profiles)
         writer = functools.partial(
             self.artifact_store.save_yaml,
             profiles,
             DumpFiles.profiles,
         )
-        return path, writer
+        return WritePlan(path, writer, WritePhase.ARTIFACT)
 
-    def _prepare_debug_info(self):
+    def _prepare_debug_info(self) -> tuple[WritePlan, ...]:
         sql_plans, deferred_reads = generate_sql_plans(self.expr)
-        path_to_writer0 = self._prepare_sql_plans(sql_plans)
-        path_to_writer1 = self._prepare_deferred_reads(deferred_reads)
-        path_to_writer = path_to_writer0 | path_to_writer1
-        return path_to_writer
+        return (
+            *self._prepare_sql_plans(sql_plans),
+            *self._prepare_deferred_reads(deferred_reads),
+        )
 
     def _replace_tables(self, expr):
         """Single-pass replacement of InMemoryTable and qualifying DatabaseTable nodes.
@@ -735,7 +761,7 @@ class ExprDumper:
         calls (_memtables_to_deferred_reads and _replace_inmemory_backend_tables)
         into one graph traversal and one replacement pass.
         """
-        path_to_writer = {}
+        plans = []
         replacements = {}
         for node in walk_nodes((InMemoryTable, DatabaseTable), expr):
             if isinstance(node, InMemoryTable):
@@ -747,15 +773,17 @@ class ExprDumper:
                 type_kwargs = {str(which): True}
                 con_kwargs = {}
             elif _is_relocatable_read(node):
-                path, read_path, writer = self._prepare_relocatable_read(node)
+                plan = self._prepare_relocatable_read(node)
+                which = BundledSourceTypes.read
+                read_path = f"{which}/{plan.path.name}"
                 new_kwargs = update_read_kwargs(
                     node.read_kwargs,
-                    (("hash_path", path), ("read_path", read_path)),
+                    (("hash_path", plan.path), ("read_path", read_path)),
                 )
                 args = dict(zip(node.__argnames__, node.__args__)) | {
                     "read_kwargs": new_kwargs
                 }
-                path_to_writer[path] = writer
+                plans.append(plan)
                 replacements[node] = node.__recreate__(args)
                 continue
             elif (
@@ -768,24 +796,43 @@ class ExprDumper:
                 type_kwargs = {}
                 con_kwargs = {"con": node.source}
 
-            path, writer = self._prepare_memtable(node, which)
+            plan = self._prepare_memtable(node, which)
             dr_op = make_read_op(
-                parquet_path=path,
+                parquet_path=plan.path,
                 read_kwargs={
                     "table_name": node.name,
                     "schema": node.schema,
                     **type_kwargs,
                     "normalize_method": normalize_read_path_md5sum,
-                    "read_path": str(Path(which, path.name)),
+                    "read_path": str(Path(which, plan.path.name)),
                 },
                 **con_kwargs,
             )
-            path_to_writer[path] = writer
+            plans.append(plan)
             replacements[node] = dr_op
         op = expr.op()
         if replacements:
             op = replace_nodes(replace_from_mapping(replacements), op)
-        return op.to_expr(), path_to_writer
+        return op.to_expr(), tuple(plans)
+
+    @staticmethod
+    def _execute_write_plans(plans: tuple[WritePlan, ...]) -> None:
+        """Run every plan's writer, sorted by phase, after deduping paths.
+
+        Content-addressed plans (dedupable) may target the same path more than
+        once with byte-identical output, so extra copies are dropped. Any other
+        path collision is a bug and raises rather than silently losing a writer.
+        """
+        by_path = {}
+        for plan in plans:
+            existing = by_path.get(plan.path)
+            if existing is not None:
+                if not (existing.dedupable and plan.dedupable):
+                    raise ValueError(f"conflicting write plans for {plan.path}")
+                continue
+            by_path[plan.path] = plan
+        for plan in sorted(by_path.values(), key=operator.attrgetter("phase")):
+            plan.writer()
 
     def dump_expr(self) -> str:
         from xorq.ibis_yaml.translate import (  # noqa: PLC0415
@@ -798,26 +845,21 @@ class ExprDumper:
         expr = self.expr
 
         # write in-memory data to build dir (single walk + single replacement pass)
-        expr, path_to_writer0 = self._replace_tables(expr)
+        expr, data_plans = self._replace_tables(expr)
 
         profiles = dehydrate_cons(find_all_sources(expr))
-        path_to_writer2 = dict(
-            (
-                self._prepare_expr_metadata_file(self.expr),
-                self._prepare_build_metadata_file(),
-                self._prepare_profiles_file(profiles),
-            )
+        plans = (
+            *data_plans,
+            self._prepare_expr_metadata_file(self.expr),
+            self._prepare_build_metadata_file(),
+            self._prepare_profiles_file(profiles),
+            # phase ordering guarantees this runs after the DATA parquets exist
+            self._prepare_expr_file(expr, profiles),
         )
-        path_to_writer = path_to_writer0 | path_to_writer2
         if self.debug:
             # write SQL plan and deferred-read artifacts if debug enabled
-            path_to_writer |= self._prepare_debug_info()
-        for writer in path_to_writer.values():
-            writer()
-
-        # expr must be written last
-        _, writer = self._prepare_expr_file(expr, profiles)
-        writer()
+            plans += self._prepare_debug_info()
+        self._execute_write_plans(plans)
         return self.expr_path
 
 

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, NamedTuple
+from typing import Any, Callable, Dict
 
 import toolz
 import yaml12
@@ -520,8 +520,8 @@ def _validate_normalize_method(instance: Any, attribute: Any, value: Any) -> Non
 
     validate(value)
 
-
-class WritePlan(NamedTuple):
+@frozen
+class WritePlan:
     """A single deferred write: where, how, when, and whether duplicates are safe.
 
     dedupable marks content-addressed paths (parquet, SQL files) whose repeated
@@ -529,10 +529,30 @@ class WritePlan(NamedTuple):
     singleton files are not dedupable and colliding on one signals a bug.
     """
 
-    path: Path
-    writer: Callable[[], Any]
-    phase: WritePhase
-    dedupable: bool = False
+    path = field(validator=instance_of(Path), converter=Path)
+    writer = field(validator=is_callable())
+    phase = field(validator=instance_of(WritePhase))
+    dedupable = field(validator=instance_of(bool), default=False)
+
+    @classmethod
+    def build(
+        cls,
+        artifact_store: "ArtifactStore",
+        write_fn: Callable[..., Path],
+        payload: Any,
+        path_parts: str | tuple[str, ...],
+        phase: WritePhase,
+        dedupable: bool = False,
+    ) -> "WritePlan":
+        """Build a WritePlan whose path and deferred writer share one path_parts.
+
+        write_fn is an ArtifactStore method taking (payload, *path_parts); binding
+        both the path and the writer to the same parts keeps them from drifting.
+        """
+        parts = path_parts if isinstance(path_parts, tuple) else (path_parts,)
+        path = artifact_store.get_path(*parts)
+        writer = functools.partial(write_fn, payload, *parts)
+        return cls(path, writer, phase, dedupable=dedupable)
 
 
 @frozen
@@ -583,24 +603,6 @@ class ExprDumper:
     def expr_hash(self):
         return self.expr_path.name
 
-    def _plan(
-        self,
-        write_fn: Callable[..., Path],
-        payload: Any,
-        path_parts: str | tuple[str, ...],
-        phase: WritePhase,
-        dedupable: bool = False,
-    ) -> WritePlan:
-        """Build a WritePlan whose path and deferred writer share one path_parts.
-
-        write_fn is an ArtifactStore method taking (payload, *path_parts); binding
-        both the path and the writer to the same parts keeps them from drifting.
-        """
-        parts = path_parts if isinstance(path_parts, tuple) else (path_parts,)
-        path = self.artifact_store.get_path(*parts)
-        writer = functools.partial(write_fn, payload, *parts)
-        return WritePlan(path, writer, phase, dedupable=dedupable)
-
     def _prepare_expr_file(self, expr: ir.Expr, profiles: dict) -> WritePlan:
         path = self.artifact_store.get_path(DumpFiles.expr)
         # phase EXPR: translation tokenizes memtable parquets, which the DATA
@@ -618,7 +620,8 @@ class ExprDumper:
 
     def _prepare_sql_file(self, sql: str) -> WritePlan:
         filename = f"{tokenize(sql)[: config.hash_length]}.sql"
-        return self._plan(
+        return WritePlan.build(
+            self.artifact_store,
             self.artifact_store.write_text,
             sql,
             filename,
@@ -631,7 +634,8 @@ class ExprDumper:
     ) -> WritePlan:
         assert which in BundledSourceTypes
         table = mt.to_expr().to_pyarrow()
-        return self._plan(
+        return WritePlan.build(
+            self.artifact_store,
             self.artifact_store.write_parquet,
             table,
             (which, f"{tokenize(table)}.parquet"),
@@ -644,7 +648,8 @@ class ExprDumper:
         # Internal invariant; see the matching guard in _prepare_relocatable_reads.
         assert "hash_path" in kw, "relocatable Read must have hash_path"
         source_path = Path(kw["hash_path"])
-        return self._plan(
+        return WritePlan.build(
+            self.artifact_store,
             self.artifact_store.copy_file,
             source_path,
             relocatable_read_path(source_path),
@@ -670,7 +675,8 @@ class ExprDumper:
             plan = self._prepare_sql_file(info["sql"])
             sql_file_plans.append(plan)
             items[name] = toolz.dissoc(info, "sql") | {"sql_file": plan.path.name}
-        yaml_plan = self._plan(
+        yaml_plan = WritePlan.build(
+            self.artifact_store,
             self.artifact_store.write_yaml,
             {collection_key: items},
             dump_file,
@@ -694,7 +700,8 @@ class ExprDumper:
         return metadata_json
 
     def _prepare_build_metadata_file(self) -> WritePlan:
-        return self._plan(
+        return WritePlan.build(
+            self.artifact_store,
             self.artifact_store.write_text,
             self._make_build_metadata(),
             DumpFiles.build_metadata,
@@ -720,7 +727,8 @@ class ExprDumper:
         return metadata.to_dict()
 
     def _prepare_expr_metadata_file(self, expr: ir.Expr) -> WritePlan:
-        return self._plan(
+        return WritePlan.build(
+            self.artifact_store,
             self.artifact_store.write_json,
             self._make_expr_metadata(expr),
             DumpFiles.expr_metadata,
@@ -728,7 +736,8 @@ class ExprDumper:
         )
 
     def _prepare_profiles_file(self, profiles: dict) -> WritePlan:
-        return self._plan(
+        return WritePlan.build(
+            self.artifact_store,
             self.artifact_store.write_yaml,
             profiles,
             DumpFiles.profiles,

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -828,7 +828,8 @@ class ExprDumper:
         """
         by_path = toolz.groupby(operator.attrgetter("path"), plans)
         conflicts = tuple(
-            f"{keeper.path}: {keeper.phase.name} vs {other.phase.name}"
+            f"{keeper.path}: non-dedupable collision "
+            f"(phases {keeper.phase.name}, {other.phase.name})"
             for (keeper, *rest) in by_path.values()
             for other in rest
             if not (keeper.dedupable and other.dedupable)

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -583,6 +583,24 @@ class ExprDumper:
     def expr_hash(self):
         return self.expr_path.name
 
+    def _plan(
+        self,
+        write_fn: Callable[..., Path],
+        payload: Any,
+        path_parts: str | tuple[str, ...],
+        phase: WritePhase,
+        dedupable: bool = False,
+    ) -> WritePlan:
+        """Build a WritePlan whose path and deferred writer share one path_parts.
+
+        write_fn is an ArtifactStore method taking (payload, *path_parts); binding
+        both the path and the writer to the same parts keeps them from drifting.
+        """
+        parts = path_parts if isinstance(path_parts, tuple) else (path_parts,)
+        path = self.artifact_store.get_path(*parts)
+        writer = functools.partial(write_fn, payload, *parts)
+        return WritePlan(path, writer, phase, dedupable=dedupable)
+
     def _prepare_expr_file(self, expr: ir.Expr, profiles: dict) -> WritePlan:
         path = self.artifact_store.get_path(DumpFiles.expr)
         # phase EXPR: translation tokenizes memtable parquets, which the DATA
@@ -599,90 +617,63 @@ class ExprDumper:
         return WritePlan(path, writer, WritePhase.EXPR)
 
     def _prepare_sql_file(self, sql: str) -> WritePlan:
-        sql_hash = tokenize(sql)[: config.hash_length]
-        filename = f"{sql_hash}.sql"
-        path = self.artifact_store.get_path(filename)
-        writer = functools.partial(self.artifact_store.write_text, sql, filename)
-        return WritePlan(path, writer, WritePhase.ARTIFACT, dedupable=True)
+        filename = f"{tokenize(sql)[: config.hash_length]}.sql"
+        return self._plan(
+            self.artifact_store.write_text,
+            sql,
+            filename,
+            WritePhase.ARTIFACT,
+            dedupable=True,
+        )
 
     def _prepare_memtable(
         self, mt: InMemoryTable | DatabaseTable, which: BundledSourceTypes
     ) -> WritePlan:
         assert which in BundledSourceTypes
         table = mt.to_expr().to_pyarrow()
-        filename = f"{tokenize(table)}.parquet"
-        path_parts = (which, filename)
-        path = self.artifact_store.get_path(*path_parts)
-        writer = functools.partial(
+        return self._plan(
             self.artifact_store.write_parquet,
             table,
-            *path_parts,
+            (which, f"{tokenize(table)}.parquet"),
+            WritePhase.DATA,
+            dedupable=True,
         )
-        return WritePlan(path, writer, WritePhase.DATA, dedupable=True)
 
     def _prepare_relocatable_read(self, read_node: Read) -> WritePlan:
         kw = dict(read_node.read_kwargs)
         # Internal invariant; see the matching guard in _prepare_relocatable_reads.
         assert "hash_path" in kw, "relocatable Read must have hash_path"
         source_path = Path(kw["hash_path"])
-        # relocatable_read_path is the single source of the (dir, filename)
-        # layout; relocatable_read_path_str is its joined form -- the *same*
-        # helper the pre-hash pass uses -- so the store path and the serialized
-        # read_path cannot drift.
-        path_parts = relocatable_read_path(source_path)
-        read_path = relocatable_read_path_str(source_path)
-        path = self.artifact_store.get_path(*path_parts)
-        writer = functools.partial(
+        return self._plan(
             self.artifact_store.copy_file,
             source_path,
-            *path_parts,
+            relocatable_read_path(source_path),
+            WritePhase.DATA,
+            dedupable=True,
         )
-        return WritePlan(path, writer, WritePhase.DATA, dedupable=True)
 
-    def _prepare_sql_plans(
+    def _prepare_sql_bundle(
         self,
-        sql_plans: Dict[str, Any],
+        mapping: Dict[str, Any],
+        collection_key: str,
+        dump_file: DumpFiles,
     ) -> tuple[WritePlan, ...]:
-        queries = {}
-        sql_file_plans = []
-        for query_name, query_info in sql_plans["queries"].items():
-            plan = self._prepare_sql_file(query_info["sql"])
-            sql_file_plans.append(plan)
-            queries[query_name] = toolz.dissoc(query_info, "sql") | {
-                "sql_file": plan.path.name
-            }
-        updated_plans = {"queries": queries}
-        yaml_plan = WritePlan(
-            self.artifact_store.get_path(DumpFiles.sql),
-            functools.partial(
-                self.artifact_store.save_yaml,
-                updated_plans,
-                filename=DumpFiles.sql,
-            ),
-            WritePhase.ARTIFACT,
-        )
-        return (*sql_file_plans, yaml_plan)
+        """Plan one SQL file per entry, plus the index YAML naming those files.
 
-    def _prepare_deferred_reads(
-        self,
-        deferred_reads: Dict[str, Any],
-    ) -> tuple[WritePlan, ...]:
-        reads = {}
+        mapping is name -> info dict carrying a "sql" key; each entry's SQL is
+        spilled to its own content-addressed file and the info is rewritten to
+        reference that file by name under collection_key in dump_file.
+        """
+        items = {}
         sql_file_plans = []
-        for read_name, read_info in deferred_reads["reads"].items():
-            plan = self._prepare_sql_file(read_info["sql"])
+        for name, info in mapping.items():
+            plan = self._prepare_sql_file(info["sql"])
             sql_file_plans.append(plan)
-            reads[read_name] = toolz.dissoc(read_info, "sql") | {
-                "sql_file": plan.path.name
-            }
-        updated_reads = {"reads": reads}
-        yaml_plan = WritePlan(
-            self.artifact_store.get_path(DumpFiles.deferred_reads),
-            functools.partial(
-                self.artifact_store.save_yaml,
-                updated_reads,
-                filename=DumpFiles.deferred_reads,
-            ),
+            items[name] = toolz.dissoc(info, "sql") | {"sql_file": plan.path.name}
+        yaml_plan = self._plan(
+            self.artifact_store.write_yaml,
+            {collection_key: items},
+            dump_file,
             WritePhase.ARTIFACT,
         )
         return (*sql_file_plans, yaml_plan)
@@ -703,13 +694,12 @@ class ExprDumper:
         return metadata_json
 
     def _prepare_build_metadata_file(self) -> WritePlan:
-        path = self.artifact_store.get_path(DumpFiles.build_metadata)
-        writer = functools.partial(
+        return self._plan(
             self.artifact_store.write_text,
             self._make_build_metadata(),
             DumpFiles.build_metadata,
+            WritePhase.ARTIFACT,
         )
-        return WritePlan(path, writer, WritePhase.ARTIFACT)
 
     def _make_expr_metadata(self, expr) -> Dict[str, Any]:
         from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
@@ -730,28 +720,28 @@ class ExprDumper:
         return metadata.to_dict()
 
     def _prepare_expr_metadata_file(self, expr: ir.Expr) -> WritePlan:
-        path = self.artifact_store.get_path(DumpFiles.expr_metadata)
-        writer = functools.partial(
+        return self._plan(
             self.artifact_store.write_json,
             self._make_expr_metadata(expr),
             DumpFiles.expr_metadata,
+            WritePhase.ARTIFACT,
         )
-        return WritePlan(path, writer, WritePhase.ARTIFACT)
 
     def _prepare_profiles_file(self, profiles: dict) -> WritePlan:
-        path = self.artifact_store.get_path(DumpFiles.profiles)
-        writer = functools.partial(
-            self.artifact_store.save_yaml,
+        return self._plan(
+            self.artifact_store.write_yaml,
             profiles,
             DumpFiles.profiles,
+            WritePhase.ARTIFACT,
         )
-        return WritePlan(path, writer, WritePhase.ARTIFACT)
 
     def _prepare_debug_info(self) -> tuple[WritePlan, ...]:
         sql_plans, deferred_reads = generate_sql_plans(self.expr)
         return (
-            *self._prepare_sql_plans(sql_plans),
-            *self._prepare_deferred_reads(deferred_reads),
+            *self._prepare_sql_bundle(sql_plans["queries"], "queries", DumpFiles.sql),
+            *self._prepare_sql_bundle(
+                deferred_reads["reads"], "reads", DumpFiles.deferred_reads
+            ),
         )
 
     def _replace_tables(self, expr):

--- a/python/xorq/ibis_yaml/enums.py
+++ b/python/xorq/ibis_yaml/enums.py
@@ -1,4 +1,20 @@
+from __future__ import annotations
+
+import enum
+
 from xorq.common.compat import StrEnum
+
+
+class WritePhase(enum.IntEnum):
+    """Ordering for deferred writes; lower phases run first.
+
+    DATA content files must exist before the expr YAML is written, because
+    the translator tokenizes memtable parquets by content on the way out.
+    """
+
+    DATA = 0  # parquet + copied read files — tokenized by the expr YAML
+    ARTIFACT = 1  # metadata / profiles / debug SQL — order-independent
+    EXPR = 2  # expr YAML — must follow DATA so its inputs exist
 
 
 class DumpFiles(StrEnum):

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -48,8 +48,10 @@ from xorq.expr.udf import ExprScalarUDF
 from xorq.ibis_yaml.compiler import (
     ArtifactStore,
     DumpFiles,
+    ExprDumper,
     ExprKind,
     RefEnum,
+    WritePlan,
     _extract_sql_queries,
     _is_relocatable_candidate,
     _prepare_relocatable_reads,
@@ -1937,3 +1939,32 @@ def test_write_phase_expr_is_last() -> None:
     # That invariant holds only while EXPR is the highest phase value — lock it
     # so adding a new phase can't silently reorder the expr write.
     assert max(WritePhase) is WritePhase.EXPR
+
+
+def test_execute_write_plans_non_dedupable_collision_raises(
+    tmp_path: pathlib.Path,
+) -> None:
+    # Two non-dedupable plans on the same path is a bug: must raise, and the
+    # error must name every colliding path (here, one).
+    path = tmp_path / "collision"
+    plans = (
+        WritePlan(path, lambda: None, WritePhase.ARTIFACT, dedupable=False),
+        WritePlan(path, lambda: None, WritePhase.EXPR, dedupable=False),
+    )
+    with pytest.raises(ValueError, match=str(path)):
+        ExprDumper._execute_write_plans(plans)
+
+
+def test_execute_write_plans_dedupable_writes_once(
+    tmp_path: pathlib.Path,
+) -> None:
+    # Two dedupable plans on the same path collapse to one: only the kept
+    # plan's writer runs, exactly once.
+    path = tmp_path / "dupe"
+    calls = []
+    plans = (
+        WritePlan(path, lambda: calls.append("a"), WritePhase.DATA, dedupable=True),
+        WritePlan(path, lambda: calls.append("b"), WritePhase.DATA, dedupable=True),
+    )
+    ExprDumper._execute_write_plans(plans)
+    assert calls == ["a"]

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -58,6 +58,7 @@ from xorq.ibis_yaml.compiler import (
     load_expr,
 )
 from xorq.ibis_yaml.config import config
+from xorq.ibis_yaml.enums import WritePhase
 from xorq.ibis_yaml.sql import find_relations
 from xorq.ibis_yaml.translate import warn_on_local_path
 from xorq.tests.util import assert_frame_equal
@@ -1928,3 +1929,11 @@ def test_execution_handles_remote_table_in_computed_kwargs_expr(
     # my_sum(1+2+3) = 6.0; each row: x + 6.0
     expected_out = [7.0, 8.0, 9.0]
     assert list(result["out"]) == expected_out
+
+
+def test_write_phase_expr_is_last() -> None:
+    # ExprDumper._execute_write_plans sorts plans by phase, and the expr YAML
+    # must be written last because it tokenizes the DATA parquets by content.
+    # That invariant holds only while EXPR is the highest phase value — lock it
+    # so adding a new phase can't silently reorder the expr write.
+    assert max(WritePhase) is WritePhase.EXPR


### PR DESCRIPTION
## Summary

Refactors `ExprDumper`'s `path_to_writer` dict pattern into a `WritePlan` abstraction, addressing all seven design issues raised in #2074.

`WritePlan` is a frozen `attrs` class (`compiler.py`) with a `build` factory, paired with a `WritePhase` IntEnum (`enums.py`):

```python
@frozen
class WritePlan:
    path = field(validator=instance_of(Path), converter=Path)
    writer = field(validator=is_callable())
    phase = field(validator=instance_of(WritePhase))   # DATA=0, ARTIFACT=1, EXPR=2
    dedupable = field(validator=instance_of(bool), default=False)

    @classmethod
    def build(cls, artifact_store, write_fn, payload, path_parts,
              *, phase=WritePhase.ARTIFACT, dedupable=False):
        ...
```

`build` binds the path and the deferred writer to a single `path_parts`, so they can't drift. `phase` is keyword-only and defaults to `ARTIFACT` (the common case — order-independent metadata); the two DATA callers pass `phase=WritePhase.DATA` explicitly, keeping the exception self-documenting.

## How each issue maps

1. **Unused dict keys** → plans are a flat tuple; no throwaway keys.
2. **Inconsistent return types** → every `_prepare_*` returns `WritePlan` (or `tuple[WritePlan, ...]`).
3. **Confusing `dict(tuple_of_tuples)`** → replaced with plain tuple assembly.
4. **Silent data loss on collision** → `_execute_write_plans` raises `ValueError` on non-`dedupable` path collisions (error names both plans' phases); only byte-identical content-addressed dupes drop.
5. **Hidden ordering constraint** → modeled structurally via `WritePhase`; DATA parquets sort before the EXPR YAML that tokenizes them. Removed the manual "write expr last" tail-call. A unit test (`test_write_phase_expr_is_last`) locks `EXPR` as the highest phase so a future phase can't silently reorder the expr write.
6. **Wrong `_prepare_sql_file` annotation** → `str` → `WritePlan`.
7. **Fragmented `path_to_writer0`/`path_to_writer2`** → single unified `plans` tuple.

## Testing

- `python -m pytest python/xorq/ibis_yaml/tests/test_compiler.py` → 97 passed, 1 skipped
- `python -m pytest python/xorq/ibis_yaml/tests/` → 549 passed, 1 skipped, 3 xfailed, 1 xpassed; 6 pre-existing postgres failures (no postgres service in this env, unrelated to this change)
- ruff check + format clean; style hook clean on changed lines

Closes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)
