### PR TITLE
refactor(transform): P4 pure-pass fusion, remote-pass guard, and produces_resources ownership gate

### DIFF
--- a/python/xorq/backends/duckdb/tests/test_into_backend.py
+++ b/python/xorq/backends/duckdb/tests/test_into_backend.py
@@ -1,7 +1,7 @@
 """into_backend fan-out edge cases for the duckdb backend.
 
-The duckdb backend scans the StreamCache built by
-``register_and_transform_remote_tables`` directly, once per physical table
+The duckdb backend scans the StreamCache built by the remote pass
+(``REMOTE_PASS``) directly, once per physical table
 reference in the compiled SQL. ``max_readers`` must equal that scan count
 exactly: an under-count crashes with "Maximum number of readers reached", an
 over-count silently disables eviction. These tests pin the count for each

--- a/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_into_backend.py
@@ -1,7 +1,7 @@
 """into_backend fan-out edge cases for the xorq_datafusion backend.
 
-Unlike duckdb, the datafusion backend reads the StreamCache built by
-``register_and_transform_remote_tables`` exactly once (``from_stream``) and
+Unlike duckdb, the datafusion backend reads the StreamCache built by the remote
+pass (``REMOTE_PASS``) exactly once (``from_stream``) and
 re-wraps it into an inner cache that DataFusion scans per reference. So the
 outer cache's ``max_readers`` (the value computed here) only ever sees one
 reader — an over-count merely disables eviction, never crashes. These tests

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -464,12 +464,12 @@ _PASSES = (
     TransformPass(
         name="bind_params",
         traversal=Traversal.DESCEND,
+        # No ``when`` gate: ``build`` (via ``_resolve_bind_op_params``) already
+        # walks for NamedScalarParameters and the replacer no-ops on empty
+        # bindings, so a gate would only duplicate that walk -- and this pass
+        # always fuses with ``remove_tags`` into one walk, so gating saves none.
         build=lambda expr, ctx: _make_bind_params_replacer(
             _resolve_bind_op_params(expr, ctx.name_values)
-        ),
-        # Skip entirely when there is nothing to bind (no values, no params).
-        when=lambda expr, ctx: (
-            bool(ctx.name_values) or bool(walk_nodes(NamedScalarParameter, expr))
         ),
     ),
     TransformPass(

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -12,7 +12,7 @@ from xorq.common.compat import raise_collected_errors
 from xorq.common.utils.logging_utils import get_logger
 from xorq.expr.enums import Traversal
 from xorq.expr.relations import RemoteTable, gen_name
-from xorq.expr.transform import Replacer, TransformPass
+from xorq.expr.transform import Replacer, TransformCtx, TransformPass
 from xorq.vendor.ibis import Expr
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.expr import operations as ops
@@ -330,6 +330,13 @@ def _make_remote_replacer(
     (e.g. Snowflake's ``database=(catalog, db)``). The replacer never closes
     ``scope`` -- teardown stays with the caller that created it.
     """
+    # A required pre-pass, not a foldable extra walk: ``max_readers`` must be
+    # known when each ``StreamCache`` is constructed below (it is immutable after
+    # -- backed by a Rust ``_PyStreamCache``), and the count needs a *compiled*
+    # SQL AST because one graph reference can become several physical scans (a
+    # self-join over one RemoteTable). So it cannot be merged into the
+    # materializing walk. REMOTE_PASS's ``when`` keeps it (and this walk) from
+    # running at all when no RemoteTable is reachable at this boundary.
     reader_counts = count_remote_table_readers(expr)
 
     def replacer(node, kwargs):
@@ -368,6 +375,20 @@ def _make_remote_replacer(
     return replacer
 
 
+def _has_boundary_remote_table(expr: Expr, ctx: TransformCtx) -> bool:
+    """Whether a ``RemoteTable`` is reachable at *this* execution boundary.
+
+    Uses ``op.find`` (not the opaque-descending ``walk_nodes``) so it matches the
+    pass's own ``op.replace`` reach exactly: a RemoteTable buried inside an opaque
+    sub-expr (e.g. ``CachedNode.parent``) is transformed when that node executes,
+    not here, so the pass -- and its ``count_remote_table_readers`` pre-walk plus
+    SQL compile -- would only no-op on it. Skipping keeps both walks off every
+    expr that has no boundary RemoteTable (the common case, and any remote nested
+    only inside a cache).
+    """
+    return bool(expr.op().find(RemoteTable))
+
+
 # BOUNDARY: mark_remote_table has side effects, so it must not descend into opaque
 # sub-exprs (e.g. ExprScalarUDF.computed_kwargs_expr) -- see Traversal. Runs after
 # tee so a tee placeholder registered earlier is torn down by the same shared scope
@@ -379,6 +400,7 @@ REMOTE_PASS = TransformPass(
         expr, ctx.scope, ctx.read_record_batches_kwargs
     ),
     produces_resources=True,
+    when=_has_boundary_remote_table,
     after=("tee",),
 )
 

--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -10,6 +10,7 @@ from batchcorder import StreamCache
 
 from xorq.common.compat import raise_collected_errors
 from xorq.common.utils.logging_utils import get_logger
+from xorq.common.utils.otel_utils import get_current_span
 from xorq.expr.enums import Traversal
 from xorq.expr.relations import RemoteTable, gen_name
 from xorq.expr.transform import Replacer, TransformCtx, TransformPass
@@ -338,6 +339,15 @@ def _make_remote_replacer(
     # materializing walk. REMOTE_PASS's ``when`` keeps it (and this walk) from
     # running at all when no RemoteTable is reachable at this boundary.
     reader_counts = count_remote_table_readers(expr)
+
+    # ``reader_counts`` has one entry per boundary RemoteTable, so its length is
+    # the eventual ``scope.table_count``. Emit the historical
+    # ``remote_table.replace`` event on the active ``transform.remote`` span so
+    # trace/dashboards keyed on the RemoteTable fan-out keep firing.
+    if reader_counts:
+        get_current_span().add_event(
+            "remote_table.replace", {"remote_table.count": len(reader_counts)}
+        )
 
     def replacer(node, kwargs):
         if isinstance(node, RemoteTable):

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -202,6 +202,40 @@ def test_produces_resources_pass_requires_scope() -> None:
         apply_pass(resource_pass, t, TransformCtx())  # scope defaults to None
 
 
+def test_non_producer_pass_is_handed_a_scopeless_ctx() -> None:
+    """``produces_resources`` is an enforced resource-ownership gate: a declared
+    producer's ``build`` sees the shared scope, a non-producer's sees ``None`` --
+    so a pass that adopts into the scope without declaring it fails loudly instead
+    of silently leaking."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    seen: dict[str, object] = {}
+
+    def record_scope(name):
+        def build(expr, ctx):
+            seen[name] = ctx.scope
+            return _identity_replacer()
+
+        return build
+
+    ctx = _ctx()  # carries a real RemoteTableScope
+    producer = TransformPass(
+        name="prod",
+        traversal=Traversal.BOUNDARY,
+        build=record_scope("prod"),
+        produces_resources=True,
+    )
+    non_producer = TransformPass(
+        name="pure",
+        traversal=Traversal.DESCEND,
+        build=record_scope("pure"),
+    )
+    apply_pass(producer, t, ctx)
+    apply_pass(non_producer, t, ctx)
+
+    assert seen["prod"] is ctx.scope, "a producer's build sees the shared scope"
+    assert seen["pure"] is None, "a non-producer's build is handed a scopeless ctx"
+
+
 # --- P4: fusion of adjacent pure DESCEND passes -----------------------------
 
 

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -185,6 +185,23 @@ def test_apply_pass_traversal_selected_from_record() -> None:
     assert len(descend_seen) > len(boundary_seen)
 
 
+def test_produces_resources_pass_requires_scope() -> None:
+    """A ``produces_resources`` pass run with ``ctx.scope is None`` fails loudly
+    (its replacer would otherwise ``AttributeError`` deep inside on
+    ``ctx.scope.adopt_*``)."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    resource_pass = TransformPass(
+        name="needs_scope",
+        traversal=Traversal.BOUNDARY,
+        build=lambda expr, ctx: _identity_replacer(),
+        produces_resources=True,
+    )
+    with pytest.raises(
+        InternalError, match=r"produces resources but ctx.scope is None"
+    ):
+        apply_pass(resource_pass, t, TransformCtx())  # scope defaults to None
+
+
 # --- P4: fusion of adjacent pure DESCEND passes -----------------------------
 
 

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -7,6 +7,9 @@ of any concrete pass:
   positioned earlier, instead of silently mis-transforming.
 - P2: ``apply_pass`` selects the graph walk (descend into opaque sub-exprs vs
   stop at them) solely from the pass's ``Traversal``.
+- P4: adjacent fusable passes (``DESCEND`` and ``not produces_resources``) share
+  one ``replace_nodes`` walk, ``produces_resources`` gates membership, and the
+  fused result is identical to applying the passes one at a time.
 
 The pipeline-level tests in ``test_transform_scope.py`` cover the real passes;
 this covers the mechanism they ride on.
@@ -19,14 +22,25 @@ from typing import Callable
 import pytest
 
 import xorq.api as xo
+import xorq.common.utils.graph_utils as graph_utils
 from xorq.common.exceptions import InternalError
 from xorq.common.utils.graph_utils import walk_nodes
+from xorq.common.utils.provenance_utils import get_expr_hash
+from xorq.expr.api import (
+    _make_bind_params_replacer,
+    _make_remove_tag_nodes_replacer,
+    _resolve_bind_op_params,
+)
 from xorq.expr.enums import Traversal
-from xorq.expr.relations import RemoteTable
+from xorq.expr.operations import NamedScalarParameter
+from xorq.expr.relations import RemoteTable, Tag
 from xorq.expr.remote_table_exec import RemoteTableScope
 from xorq.expr.transform import (
     TransformCtx,
     TransformPass,
+    _fuse_replacers,
+    _fusion_groups,
+    _is_fusable,
     apply_pass,
     run_transform_passes,
 )
@@ -169,3 +183,185 @@ def test_apply_pass_traversal_selected_from_record() -> None:
     # DESCEND recurses through RemoteTable.remote_expr, so it visits strictly more
     # nodes than BOUNDARY, which stops at the RemoteTable.
     assert len(descend_seen) > len(boundary_seen)
+
+
+# --- P4: fusion of adjacent pure DESCEND passes -----------------------------
+
+
+def _descend(name: str, *, produces: bool = False) -> TransformPass:
+    return TransformPass(
+        name=name,
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: _identity_replacer(),
+        produces_resources=produces,
+    )
+
+
+def _boundary(name: str) -> TransformPass:
+    return TransformPass(
+        name=name,
+        traversal=Traversal.BOUNDARY,
+        build=lambda expr, ctx: _identity_replacer(),
+    )
+
+
+def test_is_fusable_reads_produces_resources() -> None:
+    """A pass is fusable iff it is DESCEND and produces no resources -- this is
+    the one consumer of ``produces_resources``."""
+    assert _is_fusable(_descend("pure"))
+    assert not _is_fusable(_descend("effectful", produces=True))
+    assert not _is_fusable(_boundary("bnd"))
+
+
+def test_fusion_groups_coalesce_adjacent_pure_descend() -> None:
+    """Maximal runs of fusable passes coalesce; a BOUNDARY or a DESCEND producer
+    breaks the run and stays a singleton."""
+    passes = (
+        _descend("a"),
+        _descend("b"),
+        _boundary("c"),
+        _descend("d", produces=True),  # DESCEND but effectful -> not fused
+        _descend("e"),
+        _descend("f"),
+    )
+    grouped = [tuple(p.name for p in g) for g in _fusion_groups(passes)]
+    assert grouped == [("a", "b"), ("c",), ("d",), ("e", "f")]
+
+
+def test_fused_run_uses_one_graph_walk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two adjacent fusable passes share a single ``replace_nodes`` traversal;
+    the same two applied one at a time would walk twice."""
+    calls = {"n": 0}
+    real = graph_utils.replace_nodes
+
+    def counting(replacer, expr):
+        calls["n"] += 1
+        return real(replacer, expr)
+
+    monkeypatch.setattr(graph_utils, "replace_nodes", counting)
+
+    t = xo.memtable({"a": [1, 2, 3]})
+    passes = (_descend("a"), _descend("b"))
+    run_transform_passes(t, passes, _ctx())
+    assert calls["n"] == 1, "adjacent fusable passes must share one walk"
+
+    calls["n"] = 0
+    apply_pass(passes[0], t, _ctx())
+    apply_pass(passes[1], t, _ctx())
+    assert calls["n"] == 2, "applied singly, each pass walks on its own"
+
+
+def test_effectful_descend_pass_is_not_folded_into_the_fused_walk() -> None:
+    """A DESCEND pass flagged ``produces_resources`` runs on its own walk, never
+    under the shared fused replacer -- so its side effect fires exactly once,
+    under a traversal it owns."""
+    fired: list[str] = []
+
+    def effectful_build(expr, ctx):
+        def replacer(node, kwargs):
+            fired.append("walk")
+            return node.__recreate__(kwargs) if kwargs else node
+
+        return replacer
+
+    t = xo.memtable({"a": [1, 2, 3]})
+    passes = (
+        _descend("pure_a"),
+        TransformPass(
+            name="effectful",
+            traversal=Traversal.DESCEND,
+            build=effectful_build,
+            produces_resources=True,
+        ),
+        _descend("pure_b"),
+    )
+    # three groups: (pure_a,), (effectful,), (pure_b,) -- none fuse with effectful
+    grouped = [tuple(p.name for p in g) for g in _fusion_groups(passes)]
+    assert grouped == [("pure_a",), ("effectful",), ("pure_b",)]
+    run_transform_passes(t, passes, _ctx())
+    # the effectful replacer ran its own single walk (once per node, one walk)
+    assert fired, "effectful pass must still run"
+
+
+def test_when_false_collapses_group_to_single_pass_path() -> None:
+    """When ``when`` leaves a single active pass in a fusion group, the driver
+    falls back to the plain single-pass path (no composed replacer needed)."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    ran: list[str] = []
+
+    def rec(name):
+        def build(expr, ctx):
+            ran.append(name)
+            return _identity_replacer()
+
+        return build
+
+    passes = (
+        TransformPass(
+            name="skipped",
+            traversal=Traversal.DESCEND,
+            build=rec("skipped"),
+            when=lambda expr, ctx: False,
+        ),
+        TransformPass(name="kept", traversal=Traversal.DESCEND, build=rec("kept")),
+    )
+    run_transform_passes(t, passes, _ctx())
+    assert ran == ["kept"], "skipped pass contributes no replacer"
+
+
+def test_fused_bind_and_remove_tags_equals_sequential() -> None:
+    """The real fusable pair: fusing ``bind_params`` + ``remove_tags`` into one
+    walk yields an expression identical (by build hash) to applying them singly,
+    including the interaction where a bound parameter lives inside a tagged
+    subtree (a Tag wraps a relation; the param sits below it)."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    p = xo.param("thresh", "int64")
+    inner = t.filter(t.a > p)
+    tagged = Tag(schema=inner.op().schema, parent=inner.op()).to_expr()
+    assert walk_nodes(Tag, tagged) and walk_nodes(NamedScalarParameter, tagged)
+
+    bind = TransformPass(
+        name="bind_params",
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: _make_bind_params_replacer(
+            _resolve_bind_op_params(expr, ctx.name_values)
+        ),
+    )
+    tags = TransformPass(
+        name="remove_tags",
+        traversal=Traversal.DESCEND,
+        build=lambda expr, ctx: _make_remove_tag_nodes_replacer(),
+    )
+    ctx = TransformCtx(name_values={"thresh": 2})
+
+    fused = run_transform_passes(tagged, (bind, tags), ctx)
+    # sequential: two separate walks, one pass each
+    step1 = apply_pass(bind, tagged, ctx)
+    sequential = apply_pass(tags, step1, ctx)
+
+    assert not walk_nodes(Tag, fused) and not walk_nodes(NamedScalarParameter, fused)
+    assert get_expr_hash(fused) == get_expr_hash(sequential)
+
+
+def test_fuse_replacers_applies_in_order_once_each() -> None:
+    """``_fuse_replacers`` applies replacers left-to-right, and only the first
+    consumes the recreate ``kwargs`` (so a node is recreated exactly once)."""
+    order: list[str] = []
+    recreated: list[str] = []
+
+    def make(name):
+        def replacer(node, kwargs):
+            order.append(name)
+            if kwargs:
+                recreated.append(name)
+                node = node.__recreate__(kwargs)
+            return node
+
+        return replacer
+
+    fused = _fuse_replacers([make("first"), make("second")])
+    t = xo.memtable({"a": [1, 2, 3]})
+    graph_utils.replace_nodes(fused, t)
+
+    assert order[:2] == ["first", "second"], "replacers apply in list order"
+    assert "second" not in recreated, "only the first replacer sees kwargs"

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -33,7 +33,7 @@ from xorq.expr.api import (
 )
 from xorq.expr.enums import Traversal
 from xorq.expr.operations import NamedScalarParameter
-from xorq.expr.relations import RemoteTable, Tag
+from xorq.expr.relations import TEE_PASS, RemoteTable, Tag, TeeNode
 from xorq.expr.remote_table_exec import RemoteTableScope
 from xorq.expr.transform import (
     TransformCtx,
@@ -234,6 +234,32 @@ def test_non_producer_pass_is_handed_a_scopeless_ctx() -> None:
 
     assert seen["prod"] is ctx.scope, "a producer's build sees the shared scope"
     assert seen["pure"] is None, "a non-producer's build is handed a scopeless ctx"
+
+
+def test_producer_that_never_adopts_is_not_flagged() -> None:
+    """The reverse of the gate -- a pass that declares ``produces_resources`` but
+    never adopts -- is deliberately *not* enforced (see ``_pass_ctx``). ``TEE_PASS``
+    is the false-positive trap: it has no ``when``, so it runs on every expr, and on
+    one with no ``TeeNode`` it legitimately adopts nothing. That zero-adopt run is
+    indistinguishable from a genuinely miswired producer, so a naive "a producer
+    must adopt at least one resource" check would misfire here. This pins that the
+    driver does *not* raise and touches nothing on this legitimate no-op."""
+    t = xo.memtable({"a": [1, 2, 3]})
+    assert not walk_nodes(TeeNode, t)  # precondition: nothing for tee to adopt
+    scope = RemoteTableScope()
+
+    out = apply_pass(TEE_PASS, t, TransformCtx(scope=scope))
+
+    # ran cleanly, adopted nothing, left the scope open and the expr unchanged.
+    assert (
+        scope.reader_count
+        == scope.cache_count
+        == scope.table_count
+        == scope.drain_count
+        == 0
+    )
+    assert not scope.closed
+    assert get_expr_hash(out) == get_expr_hash(t)
 
 
 # --- P4: fusion of adjacent pure DESCEND passes -----------------------------

--- a/python/xorq/expr/tests/test_transform_driver.py
+++ b/python/xorq/expr/tests/test_transform_driver.py
@@ -343,17 +343,18 @@ def test_fused_bind_and_remove_tags_equals_sequential() -> None:
     assert get_expr_hash(fused) == get_expr_hash(sequential)
 
 
-def test_fuse_replacers_applies_in_order_once_each() -> None:
-    """``_fuse_replacers`` applies replacers left-to-right, and only the first
-    consumes the recreate ``kwargs`` (so a node is recreated exactly once)."""
+def test_fuse_replacers_applies_in_order_recreates_centrally() -> None:
+    """``_fuse_replacers`` applies replacers left-to-right and performs the single
+    ``__recreate__`` itself, so no individual replacer ever sees the recreate
+    ``kwargs`` -- recreation happens exactly once, independent of pass order."""
     order: list[str] = []
-    recreated: list[str] = []
+    saw_kwargs: list[str] = []
 
     def make(name):
         def replacer(node, kwargs):
             order.append(name)
             if kwargs:
-                recreated.append(name)
+                saw_kwargs.append(name)
                 node = node.__recreate__(kwargs)
             return node
 
@@ -364,4 +365,6 @@ def test_fuse_replacers_applies_in_order_once_each() -> None:
     graph_utils.replace_nodes(fused, t)
 
     assert order[:2] == ["first", "second"], "replacers apply in list order"
-    assert "second" not in recreated, "only the first replacer sees kwargs"
+    assert saw_kwargs == [], (
+        "_fuse_replacers recreates centrally; no replacer is handed the kwargs"
+    )

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -432,6 +432,49 @@ def test_replacer_adopts_reader_cache_and_table() -> None:
     assert target.list_tables() == []
 
 
+def test_remote_pass_skips_count_walk_when_no_boundary_remote_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The remote pass -- and its ``count_remote_table_readers`` pre-walk + SQL
+    compile -- must not fire for an expr with no ``RemoteTable`` at this
+    boundary. Guards the ``when=_has_boundary_remote_table`` short-circuit that
+    keeps both the count walk and the transform walk off the common case."""
+    calls: list = []
+    real = remote_table_exec.count_remote_table_readers
+    monkeypatch.setattr(
+        remote_table_exec,
+        "count_remote_table_readers",
+        lambda expr: calls.append(expr) or real(expr),
+    )
+
+    plain = xo.memtable({"a": [1, 2, 3]}).filter(lambda t: t.a > 1)
+    _, scope = _transform_expr(plain)
+    scope.close()
+    assert calls == [], "count must be skipped when no boundary RemoteTable exists"
+
+
+def test_remote_pass_runs_count_when_boundary_remote_table_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a ``RemoteTable`` is reachable at this boundary the pass runs and the
+    count pre-walk fires exactly once -- it is an intrinsic prerequisite
+    (``StreamCache.max_readers`` is set at construction and needs the compiled
+    scan counts), not a foldable extra walk."""
+    calls: list = []
+    real = remote_table_exec.count_remote_table_readers
+    monkeypatch.setattr(
+        remote_table_exec,
+        "count_remote_table_readers",
+        lambda expr: calls.append(expr) or real(expr),
+    )
+
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    _, scope = _transform_expr(expr)
+    scope.close()
+    assert len(calls) == 1, "count must run once when a boundary RemoteTable is present"
+
+
 def test_tee_resources_released_when_remote_pass_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -140,40 +140,67 @@ def _fusion_groups(
 def _fuse_replacers(replacers: list[Replacer]) -> Replacer:
     """Chain per-node replacers into one, applied in list order at each node.
 
-    The first replacer consumes the bottom-up recreate ``kwargs`` (rebuild with
-    already-transformed children); the rest see the resulting node with
-    ``kwargs=None`` so recreation happens exactly once. Applying r1-then-r2 at
-    each node of a single bottom-up walk equals r1-everywhere then r2-everywhere
-    because a fusable pass is a *node-local* rewrite -- its output at a node
-    depends only on that node and its already-transformed children, never on the
-    global post-r1 tree -- which the pure DESCEND passes satisfy.
+    The fused replacer does the single bottom-up ``__recreate__`` (rebuild the
+    node with its already-transformed children) itself, then applies every pass
+    replacer to that recreated node with ``kwargs=None`` -- so recreation happens
+    exactly once *regardless of pass order*: no replacer has to be a
+    "kwargs-consuming head", so reordering the group (or adding a pass that skips
+    the recreate on some branch, as ``remove_tags`` does for a ``Tag``) cannot
+    silently drop the transformed children.
+
+    Applying r1-then-r2 at each node of one bottom-up walk equals r1-everywhere
+    then r2-everywhere because a fusable pass is a *node-local* rewrite -- its
+    output at a node depends only on that node and its already-transformed
+    children, never on the global post-r1 tree -- which pure DESCEND passes satisfy.
     """
 
     def fused(node, kwargs):
-        node = replacers[0](node, kwargs)
-        for replacer in replacers[1:]:
+        if kwargs:
+            node = node.__recreate__(kwargs)
+        for replacer in replacers:
             node = replacer(node, None)
         return node
 
     return fused
 
 
-def apply_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
-    """Run a single pass, selecting the traversal from ``pass_.traversal``.
+def _apply_active_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
+    """Build and run one pass whose ``when`` is already evaluated (or absent),
+    selecting the walk from ``pass_.traversal``.
 
-    The caller owns ``ctx.scope`` teardown; a failure here just propagates.
+    A ``produces_resources`` pass may adopt readers/caches/tables into
+    ``ctx.scope`` before failing; on any exception the whole shared scope (this
+    pass's resources and earlier passes') is torn down before the error
+    propagates, so a direct caller that has not yet entered its own ``with scope:``
+    does not leak. ``close`` is idempotent, so an outer guard closing again is a
+    no-op.
     """
     # lazy: graph_utils imports xorq.expr.relations, which imports this module at
     # module level -- importing it here keeps that edge out of the import cycle.
     from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
+    with tracer.start_as_current_span(f"transform.{pass_.name}"):
+        try:
+            replacer = pass_.build(expr, ctx)
+            if pass_.traversal is Traversal.DESCEND:
+                return replace_nodes(replacer, expr).to_expr()
+            return expr.op().replace(replacer).to_expr()
+        except BaseException:
+            if pass_.produces_resources and ctx.scope is not None:
+                ctx.scope.close()
+            raise
+
+
+def apply_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
+    """Run a single pass: skip it when its ``when`` predicate is False, else build
+    and walk it (selecting the traversal from ``pass_.traversal``).
+
+    A resource-producing pass tears its (and earlier passes') scope resources
+    down on failure; see :func:`_apply_active_pass`.
+    """
     if pass_.when is not None and not pass_.when(expr, ctx):
         return expr
-    with tracer.start_as_current_span(f"transform.{pass_.name}"):
-        replacer = pass_.build(expr, ctx)
-        if pass_.traversal is Traversal.DESCEND:
-            return replace_nodes(replacer, expr).to_expr()
-        return expr.op().replace(replacer).to_expr()
+    return _apply_active_pass(pass_, expr, ctx)
 
 
 def _assert_after_ordering(passes: tuple[TransformPass, ...]) -> None:
@@ -195,20 +222,23 @@ def _assert_after_ordering(passes: tuple[TransformPass, ...]) -> None:
 def _apply_group(
     expr: Expr, group: tuple[TransformPass, ...], ctx: TransformCtx
 ) -> Expr:
-    """Apply one fusion group. A singleton (or a group whose ``when`` predicates
-    leave a single active pass) goes through :func:`apply_pass` unchanged; two or
-    more active passes share one ``replace_nodes`` walk under a composed replacer.
+    """Apply one fusion group. A singleton goes through :func:`apply_pass`; a
+    group whose ``when`` predicates leave a single active pass runs that one pass
+    directly (its ``when`` already evaluated); two or more active passes share one
+    ``replace_nodes`` walk under a composed replacer.
     """
     if len(group) == 1:
         return apply_pass(group[0], expr, ctx)
-    # lazy import: see apply_pass.
+    # lazy import: see _apply_active_pass.
     from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
     active = tuple(p for p in group if p.when is None or p.when(expr, ctx))
     if not active:
         return expr
     if len(active) == 1:
-        return apply_pass(active[0], expr, ctx)
+        # ``when`` already evaluated above; skip ``apply_pass`` so its predicate
+        # (a graph walk) is not re-run.
+        return _apply_active_pass(active[0], expr, ctx)
     label = "+".join(p.name for p in active)
     with tracer.start_as_current_span(f"transform.fuse[{label}]"):
         replacers = [p.build(expr, ctx) for p in active]

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -175,7 +175,21 @@ def _pass_ctx(pass_: TransformPass, ctx: TransformCtx) -> TransformCtx:
     a non-producer gets a scopeless copy, so ``produces_resources`` is an enforced
     resource-ownership gate, not only a fusion gate: a pass that adopts into the
     scope without declaring it fails loudly (``scope is None``) instead of silently
-    leaking into a scope nobody expects it to own."""
+    leaking into a scope nobody expects it to own.
+
+    The gate is deliberately one-directional. It catches *undeclared* adoption
+    but not the reverse -- a pass that declares ``produces_resources`` yet never
+    calls ``scope.adopt_*`` -- and that reverse case cannot be caught here without
+    false positives: ``TEE_PASS`` is a producer with no ``when``, so it runs on
+    every expr and, on one with no ``TeeNode``, legitimately adopts nothing. That
+    zero-adopt run is runtime-indistinguishable from a producer miswired to never
+    touch the scope -- instrumenting the scope to count adopts flags both, and a
+    build-time "did it read ``ctx.scope``" probe is neither necessary (a replacer
+    may close over ``ctx`` and read ``scope`` only at walk time) nor sufficient
+    (reading the scope is not adopting). The only signal that separates them --
+    "an adoptable node was present yet ignored" -- is each pass's own domain
+    predicate (``isinstance(node, TeeNode)``, ``_has_boundary_remote_table``), not
+    anything the generic driver has. So this half is left unenforced by design."""
     if pass_.produces_resources:
         return ctx
     return ctx if ctx.scope is None else evolve(ctx, scope=None)

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -19,6 +19,13 @@ selects the traversal from the record (so no call site can pick the wrong walk),
 and :func:`run_transform_passes` folds the ordered table while asserting every
 ``after`` constraint holds -- a reorder now raises loudly instead of silently
 breaking correctness.
+
+Adjacent *fusable* passes -- pure structural rewrites (``DESCEND`` and
+``not produces_resources``) -- are coalesced into a single ``replace_nodes``
+walk whose composed replacer applies each pass's rewrite in table order at every
+node. This is the one place ``produces_resources`` is read: it keeps an
+effectful DESCEND pass out of the shared walk. Fusion only collapses *how many*
+graph traversals a run of pure rewrites costs, never their order or result.
 """
 
 from __future__ import annotations
@@ -96,6 +103,61 @@ class TransformPass:
     )
 
 
+def _is_fusable(pass_: TransformPass) -> bool:
+    """Whether ``pass_`` can share a single descend-walk with its neighbours.
+
+    True for a pure structural rewrite: it descends (``DESCEND``) and
+    materializes nothing (``not produces_resources``). This is the sole consumer
+    of ``produces_resources`` -- the flag exists to keep an effectful DESCEND
+    pass out of the fused walk, where its side effect would fire under a shared
+    traversal it does not own. A BOUNDARY pass is never fusable: it must fire
+    once, at the execution boundary (see :class:`~xorq.expr.enums.Traversal`).
+    """
+    return pass_.traversal is Traversal.DESCEND and not pass_.produces_resources
+
+
+def _fusion_groups(
+    passes: tuple[TransformPass, ...],
+) -> list[tuple[TransformPass, ...]]:
+    """Partition ``passes`` into ordered groups: each maximal run of adjacent
+    fusable passes becomes one group, every other pass a singleton. Order is
+    preserved, so passes still apply in table order."""
+    groups: list[tuple[TransformPass, ...]] = []
+    run: list[TransformPass] = []
+    for pass_ in passes:
+        if _is_fusable(pass_):
+            run.append(pass_)
+            continue
+        if run:
+            groups.append(tuple(run))
+            run = []
+        groups.append((pass_,))
+    if run:
+        groups.append(tuple(run))
+    return groups
+
+
+def _fuse_replacers(replacers: list[Replacer]) -> Replacer:
+    """Chain per-node replacers into one, applied in list order at each node.
+
+    The first replacer consumes the bottom-up recreate ``kwargs`` (rebuild with
+    already-transformed children); the rest see the resulting node with
+    ``kwargs=None`` so recreation happens exactly once. Applying r1-then-r2 at
+    each node of a single bottom-up walk equals r1-everywhere then r2-everywhere
+    because a fusable pass is a *node-local* rewrite -- its output at a node
+    depends only on that node and its already-transformed children, never on the
+    global post-r1 tree -- which the pure DESCEND passes satisfy.
+    """
+
+    def fused(node, kwargs):
+        node = replacers[0](node, kwargs)
+        for replacer in replacers[1:]:
+            node = replacer(node, None)
+        return node
+
+    return fused
+
+
 def apply_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
     """Run a single pass, selecting the traversal from ``pass_.traversal``.
 
@@ -114,23 +176,56 @@ def apply_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
         return expr.op().replace(replacer).to_expr()
 
 
+def _assert_after_ordering(passes: tuple[TransformPass, ...]) -> None:
+    """Raise unless every pass's ``after`` deps are positioned earlier in the
+    tuple. Positioning is by table order, not execution: a pass skipped via
+    ``when`` still counts as positioned, so a reorder raises immediately instead
+    of silently mis-transforming."""
+    positioned: set[str] = set()
+    for pass_ in passes:
+        missing = tuple(dep for dep in pass_.after if dep not in positioned)
+        if missing:
+            raise InternalError(
+                f"transform pass {pass_.name!r} must run after {missing}, "
+                f"but they are not positioned earlier (seen: {sorted(positioned)})"
+            )
+        positioned.add(pass_.name)
+
+
+def _apply_group(
+    expr: Expr, group: tuple[TransformPass, ...], ctx: TransformCtx
+) -> Expr:
+    """Apply one fusion group. A singleton (or a group whose ``when`` predicates
+    leave a single active pass) goes through :func:`apply_pass` unchanged; two or
+    more active passes share one ``replace_nodes`` walk under a composed replacer.
+    """
+    if len(group) == 1:
+        return apply_pass(group[0], expr, ctx)
+    # lazy import: see apply_pass.
+    from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
+
+    active = tuple(p for p in group if p.when is None or p.when(expr, ctx))
+    if not active:
+        return expr
+    if len(active) == 1:
+        return apply_pass(active[0], expr, ctx)
+    label = "+".join(p.name for p in active)
+    with tracer.start_as_current_span(f"transform.fuse[{label}]"):
+        replacers = [p.build(expr, ctx) for p in active]
+        return replace_nodes(_fuse_replacers(replacers), expr).to_expr()
+
+
 def run_transform_passes(
     expr: Expr, passes: tuple[TransformPass, ...], ctx: TransformCtx
 ) -> Expr:
     """Fold the ordered ``passes`` over ``expr``, asserting ``after`` deps.
 
-    The ordering constraints are checked against passes *already positioned*
-    earlier in the tuple (whether or not they no-op'd via ``when``), so a
-    reordered table raises immediately instead of silently mis-transforming.
+    Ordering is validated up front (:func:`_assert_after_ordering`), then passes
+    execute in fusion groups (:func:`_fusion_groups`): adjacent pure DESCEND
+    rewrites share one graph walk, everything else applies on its own. The result
+    is identical to applying every pass singly -- fusion only saves traversals.
     """
-    done: set[str] = set()
-    for pass_ in passes:
-        missing = tuple(dep for dep in pass_.after if dep not in done)
-        if missing:
-            raise InternalError(
-                f"transform pass {pass_.name!r} must run after {missing}, "
-                f"but they are not positioned earlier (seen: {sorted(done)})"
-            )
-        expr = apply_pass(pass_, expr, ctx)
-        done.add(pass_.name)
+    _assert_after_ordering(passes)
+    for group in _fusion_groups(passes):
+        expr = _apply_group(expr, group, ctx)
     return expr

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -180,8 +180,7 @@ def _apply_active_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> E
     from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
     if pass_.produces_resources and ctx.scope is None:
-        # A resource pass adopts into ctx.scope unconditionally; fail loudly here
-        # rather than with an opaque AttributeError deep inside the replacer.
+        # loud error instead of an opaque AttributeError inside the replacer.
         raise InternalError(
             f"transform pass {pass_.name!r} produces resources but ctx.scope is None"
         )

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -23,9 +23,13 @@ breaking correctness.
 Adjacent *fusable* passes -- pure structural rewrites (``DESCEND`` and
 ``not produces_resources``) -- are coalesced into a single ``replace_nodes``
 walk whose composed replacer applies each pass's rewrite in table order at every
-node. This is the one place ``produces_resources`` is read: it keeps an
-effectful DESCEND pass out of the shared walk. Fusion only collapses *how many*
-graph traversals a run of pure rewrites costs, never their order or result.
+node. Fusion only collapses *how many* graph traversals a run of pure rewrites
+costs, never their order or result.
+
+``produces_resources`` is read in two places: :func:`_is_fusable` (an effectful
+pass stays off the shared fused walk) and :func:`_pass_ctx` (only a declared
+producer is handed the scope, so a pass that adopts resources without declaring
+it fails loudly instead of silently leaking).
 """
 
 from __future__ import annotations
@@ -33,7 +37,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable
 
 from attr.validators import deep_iterable, instance_of, is_callable, optional
-from attrs import field, frozen
+from attrs import evolve, field, frozen
 
 from xorq.common.exceptions import InternalError
 from xorq.common.utils.otel_utils import tracer
@@ -73,9 +77,10 @@ class TransformCtx:
     """Per-transform context threaded to every pass builder.
 
     ``scope`` owns every resource the effectful passes materialize (created once,
-    up front, in ``_transform_expr``); it is ``None`` only when driving a subset
-    of passes that produce nothing (e.g. a lone pure pass in a test).
-    ``name_values`` are the resolved parameter bindings;
+    up front, in ``_transform_expr``). It is ``None`` when no scope is available
+    (driving pure passes in a test) and is *deliberately* swapped to ``None`` for
+    non-producer passes by :func:`_pass_ctx`, so only a declared producer can
+    adopt into it. ``name_values`` are the resolved parameter bindings;
     ``read_record_batches_kwargs`` are the backend read kwargs that must reach
     ``read_record_batches`` (e.g. Snowflake's ``database=``).
     """
@@ -107,11 +112,12 @@ def _is_fusable(pass_: TransformPass) -> bool:
     """Whether ``pass_`` can share a single descend-walk with its neighbours.
 
     True for a pure structural rewrite: it descends (``DESCEND``) and
-    materializes nothing (``not produces_resources``). This is the sole consumer
-    of ``produces_resources`` -- the flag exists to keep an effectful DESCEND
-    pass out of the fused walk, where its side effect would fire under a shared
-    traversal it does not own. A BOUNDARY pass is never fusable: it must fire
-    once, at the execution boundary (see :class:`~xorq.expr.enums.Traversal`).
+    materializes nothing (``not produces_resources``). ``produces_resources`` here
+    keeps an effectful DESCEND pass out of the fused walk, where its side effect
+    would fire under a shared traversal it does not own (the flag is also read by
+    :func:`_pass_ctx` to gate scope access). A BOUNDARY pass is never fusable: it
+    must fire once, at the execution boundary (see
+    :class:`~xorq.expr.enums.Traversal`).
     """
     return pass_.traversal is Traversal.DESCEND and not pass_.produces_resources
 
@@ -164,6 +170,17 @@ def _fuse_replacers(replacers: list[Replacer]) -> Replacer:
     return fused
 
 
+def _pass_ctx(pass_: TransformPass, ctx: TransformCtx) -> TransformCtx:
+    """The ctx a pass's ``build`` sees. A declared producer gets the shared scope;
+    a non-producer gets a scopeless copy, so ``produces_resources`` is an enforced
+    resource-ownership gate, not only a fusion gate: a pass that adopts into the
+    scope without declaring it fails loudly (``scope is None``) instead of silently
+    leaking into a scope nobody expects it to own."""
+    if pass_.produces_resources:
+        return ctx
+    return ctx if ctx.scope is None else evolve(ctx, scope=None)
+
+
 def _apply_active_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> Expr:
     """Build and run one pass whose ``when`` is already evaluated (or absent),
     selecting the walk from ``pass_.traversal``.
@@ -186,7 +203,7 @@ def _apply_active_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> E
         )
     with tracer.start_as_current_span(f"transform.{pass_.name}"):
         try:
-            replacer = pass_.build(expr, ctx)
+            replacer = pass_.build(expr, _pass_ctx(pass_, ctx))
             if pass_.traversal is Traversal.DESCEND:
                 return replace_nodes(replacer, expr).to_expr()
             return expr.op().replace(replacer).to_expr()
@@ -246,7 +263,8 @@ def _apply_group(
         return _apply_active_pass(active[0], expr, ctx)
     label = "+".join(p.name for p in active)
     with tracer.start_as_current_span(f"transform.fuse[{label}]"):
-        replacers = [p.build(expr, ctx) for p in active]
+        # fusable passes are non-producers, so each builds with a scopeless ctx.
+        replacers = [p.build(expr, _pass_ctx(p, ctx)) for p in active]
         return replace_nodes(_fuse_replacers(replacers), expr).to_expr()
 
 

--- a/python/xorq/expr/transform.py
+++ b/python/xorq/expr/transform.py
@@ -179,6 +179,12 @@ def _apply_active_pass(pass_: TransformPass, expr: Expr, ctx: TransformCtx) -> E
     # module level -- importing it here keeps that edge out of the import cycle.
     from xorq.common.utils.graph_utils import replace_nodes  # noqa: PLC0415
 
+    if pass_.produces_resources and ctx.scope is None:
+        # A resource pass adopts into ctx.scope unconditionally; fail loudly here
+        # rather than with an opaque AttributeError deep inside the replacer.
+        raise InternalError(
+            f"transform pass {pass_.name!r} produces resources but ctx.scope is None"
+        )
     with tracer.start_as_current_span(f"transform.{pass_.name}"):
         try:
             replacer = pass_.build(expr, ctx)


### PR DESCRIPTION
## Summary

**P4** of the `to_pyarrow_batches` transform-robustness plan: fuse the adjacent **pure DESCEND passes** into a single graph walk, and give `produces_resources` its first real consumer.

`run_transform_passes` now validates `after` ordering up front, then executes the pass table in **fusion groups**: each maximal run of adjacent *fusable* passes — `traversal == DESCEND and not produces_resources` — shares one `replace_nodes` walk under a composed replacer, and every other pass applies on its own. On the real `_PASSES` the one fused group is `(bind_params, remove_tags)`, so **two full graph traversals collapse into one**.

## Why this closes the "dead field" question

Before this PR, `produces_resources` was **declarative-only** — set on the tee/remote passes, documented, but never read by the driver. Now `_is_fusable` reads it:

```python
def _is_fusable(pass_):
    return pass_.traversal is Traversal.DESCEND and not pass_.produces_resources
```

It keeps an effectful DESCEND pass off the shared traversal it doesn't own. (Today no real DESCEND pass sets it `True`, but the flag is a live input to every fusion decision and is covered for the `True` branch by a synthetic test.) As of the review follow-ups below, it is **also** an enforced resource-ownership gate — see "Review follow-ups".

## Design: composition, not an algorithm change

The fused replacer (`_fuse_replacers`) **chains the existing per-pass replacers**: it performs the single bottom-up `__recreate__` itself, then applies every pass replacer to the recreated node with `kwargs=None`, so recreation happens once *regardless of pass order* (no replacer has to be a "kwargs-consuming head"). `bind_params` and `remove_tags` are **untouched**.

This was the key call. `_make_remove_tag_nodes_replacer`'s internal `replace_nodes` self-recursion is **load-bearing**: a node returned from a replacer is not re-traversed by `.replace()`, so the re-descent is what strips deeper- and opaque-nested tags. A parallel `_remove_non_hashing_tag_nodes` (backing `.ls.untagged`) would also have to stay in sync. So simplifying it was rejected. Because `bind_params` runs first and recreates each tag with already-bound children, the tags re-walk operates on bound subtrees — fusion adds **no** new re-walk cost, it only removes `bind_params`' separate walk.

## Observability

- A fused group emits one `transform.fuse[bind_params+remove_tags]` span instead of two `transform.<name>` spans.
- A group left with a single active pass (e.g. `bind_params` skipped via `when` when there's nothing to bind) falls back to the plain `apply_pass` path and keeps its `transform.<name>` span.

## Tests (`test_transform_driver.py`)

- `_is_fusable` reads `produces_resources`; `_fusion_groups` coalescing/splitting (BOUNDARY and DESCEND-producer break a run).
- **One-walk assertion**: two adjacent fusable passes call `replace_nodes` once; applied singly, twice.
- An effectful DESCEND pass is **not** folded into the fused walk.
- `when`-collapse to the single-pass path.
- **Equivalence anchor**: `get_expr_hash(fused) == get_expr_hash(sequential)` for the param-inside-a-tagged-subtree interaction. (`==` is unreliable here — `InMemoryTable` proxies compare by identity, and the pre-existing `remove_tags` is itself `==`-nondeterministic on cached exprs — so the build hash / SQL are the contract.)

No regressions across the tag-consumer surface: cache-pin, pinned-cache YAML roundtrip, write-through, stream-cache, relations, builders, ml pipeline, lineage, catalog bind, datafusion `into_backend`. End-to-end: a param+tag expr through `_transform_expr` resolves to 0 tags / 0 params and executes to the correct rows.

## Stacking

Builds on **#2139** (R2 driver), which builds on **#2138** (R1 scope). Opened against `main`, so this diff currently **includes #2138 + #2139's commits** until they merge. Behaviour-preserving except the span change noted above.

## Reducing the seventh walk (`count_remote_table_readers`)

The remote pass ran `count_remote_table_readers` — a full `op.replace` walk **plus** a SQL compile — and then its own transform walk on *every* expr, including those with no `RemoteTable`, where both are pure no-ops.

A `when=_has_boundary_remote_table` guard on `REMOTE_PASS` now skips the whole pass (count walk + compile + transform walk) unless a `RemoteTable` is reachable **at this boundary**. It uses `expr.op().find(RemoteTable)` — matching the pass's own `op.replace` reach — rather than the opaque-descending `walk_nodes`, so it also skips a `RemoteTable` nested only inside an opaque node (e.g. `CachedNode.parent`), where the boundary pass would no-op anyway. No false negatives: a boundary `RemoteTable` is always found.

The count itself is **not foldable** when a `RemoteTable` is present: `StreamCache.max_readers` is set at construction and immutable after (Rust `_PyStreamCache`), and accurate scan counts need a *compiled* SQL AST (a self-join over one `RemoteTable` is several physical scans), so counting must complete before the materializing walk. A comment at the call site records this so nobody merges it and breaks the hard-cap (undercount → `ValueError`) correctness. Tests assert the count is skipped when no boundary `RemoteTable` and runs exactly once when present.

## Review follow-ups

Landed after review, on top of the P4 fusion above:

- **Restored the `remote_table.replace` OTel event.** The refactor had dropped the aggregate event; it is re-emitted on the `transform.remote` span with `remote_table.count = len(reader_counts)` (equal to the eventual `scope.table_count`), so RemoteTable-fan-out traces/dashboards keep firing.
- **Dropped a duplicate graph walk in `bind_params`.** Its `when` gate re-walked for `NamedScalarParameter`s that `build` then walked again; the gate is removed (the replacer no-ops on empty bindings and the pass always fuses with `remove_tags` into one walk), so the walk happens once. Defaults / missing-required validation are unchanged.
- **Hardened `_fuse_replacers`** to recreate centrally (above), removing the "first replacer must consume `kwargs`" footgun so reordering a fusable group can't silently drop transformed children.
- **Scope teardown on any pass failure.** `apply_pass` split into a `when`-checking wrapper + `_apply_active_pass`, which tears down the shared scope when a `produces_resources` pass fails — direct callers no longer leak before entering `with scope:` (idempotent close, so the outer guard is a no-op).
- **`produces_resources` is now an enforced resource-ownership gate.** Non-producer passes build with a scopeless ctx (`_pass_ctx`) and producers require a scope, so a pass that adopts without declaring the flag fails loudly instead of silently leaking. This closes the last open R2/P4 item. (The "declares the flag but never adopts" case is left unenforced by design — fragile to detect, since remote/tee legitimately no-op.)

## Scope

This PR is **P4 + the R2 review follow-ups**: pure-pass fusion, the seventh-walk guard, and promoting `produces_resources` to an enforced resource-ownership gate (plus the review fixes above). It does **not** include R1/R2 (its dependencies) or R3.

**R3 (Flight)** is split into its own stacked draft PR, #2146, which builds on this PR's commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




