### PR TITLE
feat(transform): route the Flight execution boundary through the transform passes (R3/P5)

### DIFF
--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -546,16 +546,39 @@ def remote_table_scope(expr: ir.Expr, **kwargs: Any) -> Generator[ir.Expr]:
         scope.close(raise_drain_errors=True)
 
 
-def _pandas_execute(con, expr: ir.Expr, **kwargs):
+def _flight_to_rbr(
+    expr: ir.Expr, params: dict | None = None, **read_kwargs: Any
+) -> pa.RecordBatchReader:
+    """The Flight execution boundary, routed through the transform discipline.
+
+    A bare ``FlightExpr``/``FlightUDXF`` root is a childless physical-table view,
+    so the effectful BOUNDARY passes no-op on it and the scope comes back empty --
+    but the DESCEND passes must still run: ``to_rbr`` re-enters
+    ``input_expr.to_pyarrow_batches()`` with no ``params``, so binding here is what
+    resolves a parameter living inside ``input_expr`` (and strips its tags). We
+    still dispatch via ``to_rbr`` (a FlightExpr has no normal backend), tie the
+    (empty) scope to the reader, and instrument it -- exactly as the non-Flight
+    path does.
+    """
+    expr, scope = _transform_expr(expr, params=params, **read_kwargs)
+    try:
+        reader = expr.op().to_rbr()
+    except BaseException:
+        scope.close()
+        raise
+    return otel_instrument_reader(bind_scope_to_reader(scope, reader))
+
+
+def _pandas_execute(con: BaseBackend, expr: ir.Expr, **kwargs: Any) -> "pd.DataFrame":
     span = get_current_span()
 
     node = expr.op()
-    if isinstance(node, (FlightExpr, FlightUDXF)):
-        # TODO: verify correct caching behavior
-        span.set_attribute("engine", "flight")
-        df = node.to_rbr().read_pandas(timestamp_as_object=True)
-        return expr.__pandas_result__(df)
     params = kwargs.pop("params", None)
+    if isinstance(node, (FlightExpr, FlightUDXF)):
+        span.set_attribute("engine", "flight")
+        reader = _flight_to_rbr(expr, params=params)
+        df = reader.read_pandas(timestamp_as_object=True)
+        return expr.__pandas_result__(df)
 
     span.set_attribute("engine", "pandas")
     # full close is safe here: con.execute returns a materialized DataFrame
@@ -595,11 +618,11 @@ def to_pyarrow_batches(
 
     span = get_current_span()
 
-    if isinstance(expr.op(), (FlightExpr, FlightUDXF)):
-        # TODO: verify correct caching behavior
-        span.set_attribute("engine", "flight")
-        return expr.op().to_rbr()
     params = kwargs.pop("params", None)
+    if isinstance(expr.op(), (FlightExpr, FlightUDXF)):
+        span.set_attribute("engine", "flight")
+        # chunk_size does not apply to to_rbr; kwargs carry no read kwargs here.
+        return _flight_to_rbr(expr, params=params)
     expr, scope = _transform_expr(expr, params=params)
     try:
         con, _ = find_backend(expr.op(), use_default=True)

--- a/python/xorq/expr/api.py
+++ b/python/xorq/expr/api.py
@@ -563,7 +563,7 @@ def _flight_to_rbr(
     expr, scope = _transform_expr(expr, params=params, **read_kwargs)
     try:
         reader = expr.op().to_rbr()
-    except BaseException:
+    except Exception:
         scope.close()
         raise
     return otel_instrument_reader(bind_scope_to_reader(scope, reader))

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -8,7 +8,10 @@ import pytest
 import toolz
 
 import xorq.api as xo
-from xorq.expr.relations import FlightExpr
+from xorq.expr.relations import (
+    FlightExpr,
+    FlightUDXF,
+)
 from xorq.flight.exchanger import (
     UnboundExprExchanger,
     make_udxf,
@@ -210,4 +213,34 @@ def test_bare_flight_expr_binds_params_through_to_rbr() -> None:
     assert sorted(df["a"].tolist()) == [2, 3]
 
     reader = xo.to_pyarrow_batches(fe, params={"cutoff": 1})
+    assert reader.read_all().num_rows == 2
+
+
+def test_bare_flight_udxf_binds_params_through_to_rbr() -> None:
+    """The ``FlightUDXF`` sibling of the FlightExpr early-return path.
+
+    Both ``_pandas_execute`` and ``to_pyarrow_batches`` branch on
+    ``isinstance(node, (FlightExpr, FlightUDXF))``, so ``FlightUDXF`` has the
+    identical param-binding path and must be covered too. A bare ``FlightUDXF``
+    root re-enters ``input_expr.to_pyarrow_batches()`` in ``to_rbr`` with no
+    ``params``; binding must happen before that.
+    """
+    con = xo.connect()
+    t = con.register(xo.memtable({"a": [1, 2, 3], "b": [10, 20, 30]}), table_name="t0")
+    p = xo.param("cutoff", "int64")
+    input_expr = t.filter(t.a > p)
+    # identity remote program: schema in == schema out, passthrough process_df
+    udxf = make_udxf(
+        lambda df: df,
+        input_expr.schema(),
+        input_expr.schema(),
+        name="identity",
+    )
+    fu = FlightUDXF.from_expr(input_expr=input_expr, udxf=udxf).to_expr()
+    assert isinstance(fu.op(), FlightUDXF), "bare FlightUDXF root hits early return"
+
+    df = fu.execute(params={"cutoff": 1})
+    assert sorted(df["a"].tolist()) == [2, 3]
+
+    reader = xo.to_pyarrow_batches(fu, params={"cutoff": 1})
     assert reader.read_all().num_rows == 2

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -8,6 +8,7 @@ import pytest
 import toolz
 
 import xorq.api as xo
+from xorq.expr.relations import FlightExpr
 from xorq.flight.exchanger import (
     UnboundExprExchanger,
     make_udxf,
@@ -184,3 +185,29 @@ def test_flight_serve_unbound_finds_con_complex(i, j, parquet_dir, tmpdir):
     assert actual.sort_values(list(actual.columns), ignore_index=True).equals(
         expected.sort_values(list(expected.columns), ignore_index=True)
     )
+
+
+def test_bare_flight_expr_binds_params_through_to_rbr() -> None:
+    """A bare ``FlightExpr`` root (the case the execute/to_pyarrow_batches early
+    return fires on) is routed through the transform passes before ``to_rbr`` (R3),
+    so a ``xorq.param`` inside ``input_expr`` is bound.
+
+    Before R3 the Flight branch short-circuited ``_transform_expr`` and ``to_rbr``
+    re-entered ``input_expr.to_pyarrow_batches()`` with no ``params`` -- so this
+    raised ``ValueError: Missing required parameters: cutoff``. Pins both the
+    ``execute`` and ``to_pyarrow_batches`` paths (the two early-return sites).
+    """
+    con = xo.connect()
+    t = con.register(xo.memtable({"a": [1, 2, 3], "b": [10, 20, 30]}), table_name="t0")
+    p = xo.param("cutoff", "int64")
+    input_expr = t.filter(t.a > p)
+    # identity remote program: passes the (already-filtered) input through
+    unbound = xo.table(input_expr.schema(), name="unbound")
+    fe = FlightExpr.from_exprs(input_expr, unbound).to_expr()
+    assert isinstance(fe.op(), FlightExpr), "bare Flight root hits the early return"
+
+    df = fe.execute(params={"cutoff": 1})
+    assert sorted(df["a"].tolist()) == [2, 3]
+
+    reader = xo.to_pyarrow_batches(fe, params={"cutoff": 1})
+    assert reader.read_all().num_rows == 2


### PR DESCRIPTION
## Summary

**R3 / P5** of the `to_pyarrow_batches` transform-robustness plan: route the Flight execution boundary through the transform passes instead of short-circuiting them.

Both Flight early-returns — `execute` (`_pandas_execute`) and `to_pyarrow_batches` — called `to_rbr()` *before* `_transform_expr`. They now go through one shared `_flight_to_rbr` helper: run the transform passes first, then dispatch `to_rbr()` on the transformed expr, tie the (empty) scope to the reader, and `otel_instrument_reader` it — the same discipline as the non-Flight path.

## Why: the TODO was a red herring, the real bug was param binding

The `# TODO: verify correct caching behavior` on both sites was unfounded. A bare `FlightExpr`/`FlightUDXF` root is a *childless* physical-table view (its `input_expr`/`unbound_expr` are excluded from ibis `__children__`), and `to_rbr` already re-enters the pipeline on `input_expr` via `input_expr.to_pyarrow_batches()` — so any cache/remote/tee/deferred-read inside a Flight subtree is materialized exactly once, in that re-entry, never skipped or double-fired.

The **real** defect the short-circuit introduced was `bind_params`: `to_rbr` re-entered `input_expr` with no `params`, so a `xorq.param` inside a bare-Flight-rooted input raised `ValueError: Missing required parameters`. Routing through `_transform_expr` binds it at the outer level — the DESCEND `bind_params`/`remove_tags` recurse into `input_expr`, while the effectful BOUNDARY passes no-op on the childless Flight node (so the returned scope is empty and teardown is a no-op). Both TODOs removed.

## Test

`test_bare_flight_expr_binds_params_through_to_rbr` builds a bare `FlightExpr` root with a `xo.param` in `input_expr` and asserts both `execute(params=...)` and `to_pyarrow_batches(params=...)` bind it — **fails pre-R3, passes after**. Existing Flight suites (`test_flight_exchange`, `test_cache`, `test_basic`) stay green; `test_transform_scope` / `test_write_through` unaffected.

## Stacking

Builds on **#2144** (P4 fusion + `produces_resources` ownership gate), which builds on **#2139** (R2 driver) and **#2138** (R1 scope). Targets `main`, so this diff **includes #2144's commits until it merges**; the R3-specific change is the single commit routing Flight through `_flight_to_rbr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
