### PR TITLE
fix(ibis_yaml): serialize Read.normalize_method by name, not cloudpickle (#2155)

### DIFF
--- a/python/xorq/common/exceptions.py
+++ b/python/xorq/common/exceptions.py
@@ -62,6 +62,10 @@ class UnboundExpressionError(ValueError, XorqError):
     """UnboundExpressionError."""
 
 
+class NormalizeMethodError(TranslationError):
+    """A Read's normalize_method could not be resolved by name (see #2155)."""
+
+
 class XorqInputError(ValueError, XorqError):
     """IbisInputError."""
 

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import toolz
 
@@ -151,7 +151,7 @@ def deferred_read_csv(
     schema: Schema | None = None,
     normalize_method: Callable = normalize_read_path_stat,
     relocatable: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> ir.Table:
     """
     Create a deferred read operation for CSV files that will execute only when needed.
@@ -224,6 +224,10 @@ def deferred_read_csv(
     if relocatable:
         read_kwargs = read_kwargs + (("relocatable", True),)
         normalize_method = normalize_read_path_md5sum
+    # lock down: only registry-resolvable methods survive serialization (#2155)
+    from xorq.ibis_yaml.normalize_registry import validate  # noqa: PLC0415
+
+    validate(normalize_method)
     return Read(
         method_name=method_name,
         name=table_name,
@@ -241,7 +245,7 @@ def deferred_read_parquet(
     schema: Schema | None = None,
     normalize_method: Callable = normalize_read_path_stat,
     relocatable: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> ir.Table:
     """
      Create a deferred read operation for Parquet files that will execute only when needed.
@@ -294,6 +298,10 @@ def deferred_read_parquet(
     if relocatable:
         read_kwargs = read_kwargs + (("relocatable", True),)
         normalize_method = normalize_read_path_md5sum
+    # lock down: only registry-resolvable methods survive serialization (#2155)
+    from xorq.ibis_yaml.normalize_registry import validate  # noqa: PLC0415
+
+    validate(normalize_method)
     return Read(
         method_name=method_name,
         name=table_name,

--- a/python/xorq/common/utils/defer_utils.py
+++ b/python/xorq/common/utils/defer_utils.py
@@ -221,13 +221,14 @@ def deferred_read_csv(
         read_kwargs = make_read_kwargs(
             method, path, table_name, schema=schema, **kwargs
         )
-    if relocatable:
-        read_kwargs = read_kwargs + (("relocatable", True),)
-        normalize_method = normalize_read_path_md5sum
-    # lock down: only registry-resolvable methods survive serialization (#2155)
+    # lock down: reject unserializable methods up front -- before the relocatable
+    # override would mask a user-supplied custom callable (#2155)
     from xorq.ibis_yaml.normalize_registry import validate  # noqa: PLC0415
 
     validate(normalize_method)
+    if relocatable:
+        read_kwargs = read_kwargs + (("relocatable", True),)
+        normalize_method = normalize_read_path_md5sum
     return Read(
         method_name=method_name,
         name=table_name,
@@ -295,13 +296,14 @@ def deferred_read_parquet(
     if con.name in _ADBC_BACKENDS:
         kwargs.setdefault("mode", "replace")
     read_kwargs = make_read_kwargs(method, path, table_name=table_name, **kwargs)
-    if relocatable:
-        read_kwargs = read_kwargs + (("relocatable", True),)
-        normalize_method = normalize_read_path_md5sum
-    # lock down: only registry-resolvable methods survive serialization (#2155)
+    # lock down: reject unserializable methods up front -- before the relocatable
+    # override would mask a user-supplied custom callable (#2155)
     from xorq.ibis_yaml.normalize_registry import validate  # noqa: PLC0415
 
     validate(normalize_method)
+    if relocatable:
+        read_kwargs = read_kwargs + (("relocatable", True),)
+        normalize_method = normalize_read_path_md5sum
     return Read(
         method_name=method_name,
         name=table_name,

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -510,6 +510,14 @@ def _extract_sql_queries(expr, kind) -> tuple[tuple[str, str, str], ...]:
             )
 
 
+def _validate_normalize_method(instance: Any, attribute: Any, value: Any) -> None:
+    # lock down: the build-time normalize_method must be serializable by name so
+    # the resulting build loads across xorq versions (#2155).
+    from xorq.ibis_yaml.normalize_registry import validate  # noqa: PLC0415
+
+    validate(value)
+
+
 @frozen
 class ExprDumper:
     """
@@ -529,7 +537,8 @@ class ExprDumper:
     # extract dir is kept alive for the fused expr's lifetime); see #2133.
     relocate_reads = field(validator=instance_of(bool), default=True)
     read_normalize_method = field(
-        validator=is_callable(), default=normalize_read_path_stat
+        validator=[is_callable(), _validate_normalize_method],
+        default=normalize_read_path_stat,
     )
 
     def __attrs_post_init__(self) -> None:

--- a/python/xorq/ibis_yaml/normalize_registry.py
+++ b/python/xorq/ibis_yaml/normalize_registry.py
@@ -82,11 +82,12 @@ def deserialize_normalize_method(payload: Any) -> Optional[Callable]:
     if kind == "none":
         return None
     if kind == "named":
+        name = payload.get("name")
         try:
-            return _KEY_TO_FN[payload["name"]]
+            return _KEY_TO_FN[name]
         except KeyError:
             raise NormalizeMethodError(
-                f"unknown normalize_method {payload['name']!r}; this build was "
+                f"unknown normalize_method {name!r}; this build was "
                 "produced by a newer or incompatible xorq version"
             ) from None
     if kind == "pickle":

--- a/python/xorq/ibis_yaml/normalize_registry.py
+++ b/python/xorq/ibis_yaml/normalize_registry.py
@@ -21,6 +21,7 @@ those through the guarded legacy branch.
 
 from __future__ import annotations
 
+import pickle
 from typing import Any, Callable, Optional
 
 from xorq.common.exceptions import NormalizeMethodError
@@ -74,15 +75,38 @@ def serialize_normalize_method(fn: Optional[Callable]) -> dict:
     return {"kind": "named", "name": key_for(fn)}
 
 
+def _require(payload: dict, key: str) -> Any:
+    """Fetch ``key`` from a tagged payload or raise a catchable error.
+
+    Malformed/foreign builds must surface ``NormalizeMethodError`` -- the whole
+    point of this module -- never a raw ``KeyError``. The message does *not*
+    re-index ``payload`` (that would raise a second ``KeyError`` from inside the
+    handler and mask the intended error)."""
+    try:
+        return payload[key]
+    except KeyError:
+        raise NormalizeMethodError(
+            f"malformed normalize_method payload {payload!r}: missing {key!r}"
+        ) from None
+
+
 def deserialize_normalize_method(payload: Any) -> Optional[Callable]:
+    # absent (pre-#1064 builds omitted the key entirely) -> no normalize_method.
+    if payload is None:
+        return None
     # backward compat: pre-fix builds stored a bare base64 cloudpickle string.
     if isinstance(payload, str):
         return _legacy_unpickle(payload)
-    kind = payload["kind"]
+    if not isinstance(payload, dict):
+        raise NormalizeMethodError(
+            f"malformed normalize_method payload {payload!r}: expected a tagged "
+            "dict or a legacy base64 string"
+        )
+    kind = _require(payload, "kind")
     if kind == "none":
         return None
     if kind == "named":
-        name = payload.get("name")
+        name = _require(payload, "name")
         try:
             return _KEY_TO_FN[name]
         except KeyError:
@@ -92,20 +116,40 @@ def deserialize_normalize_method(payload: Any) -> Optional[Callable]:
             ) from None
     if kind == "pickle":
         # reserved tag; only legacy/foreign builds reach here.
-        return _legacy_unpickle(payload["pickle"])
+        return _legacy_unpickle(_require(payload, "pickle"))
     raise NormalizeMethodError(f"unknown normalize_method encoding {kind!r}")
 
 
+# cloudpickle.loads of a foreign/legacy pickle can fail many ways depending on
+# how the target moved between versions: the module is gone (ModuleNotFoundError,
+# a subclass of ImportError), the symbol moved within a surviving module
+# (ImportError/AttributeError), or the payload itself is malformed
+# (UnpicklingError/EOFError, or binascii.Error -- a ValueError subclass -- from
+# b64decode). All must become a catchable NormalizeMethodError; only the SIGSEGV
+# (module moved, 0.3.33) is uncatchable, and new builds never pickle at all.
+_LEGACY_UNPICKLE_ERRORS = (
+    ImportError,  # covers ModuleNotFoundError
+    AttributeError,
+    ValueError,  # covers binascii.Error
+    EOFError,
+    pickle.UnpicklingError,
+)
+
+
 def _legacy_unpickle(encoded: str) -> Callable:
-    # Guards ModuleNotFoundError (the 0.3.28 case). CANNOT catch the 0.3.33
-    # SIGSEGV -- cloudpickle can segfault inside loads before Python raises.
-    # Only legacy/foreign builds reach here; new builds never pickle.
+    # CANNOT catch the 0.3.33 SIGSEGV -- cloudpickle can segfault inside loads
+    # before Python raises. Only legacy/foreign builds reach here.
     from xorq.ibis_yaml.common import deserialize_callable  # noqa: PLC0415
 
     try:
         return deserialize_callable(encoded)
-    except ModuleNotFoundError as e:
+    except _LEGACY_UNPICKLE_ERRORS as e:
+        # .name is only defined on ImportError subclasses; fall back otherwise.
+        missing = getattr(e, "name", None)
+        detail = (
+            f"module {missing!r} is absent" if missing else f"{type(e).__name__}: {e}"
+        )
         raise NormalizeMethodError(
-            "normalize_method was pickled against a module absent in this "
-            f"environment ({e.name!r}); rebuild with a matching xorq version"
+            "normalize_method was pickled against an incompatible environment "
+            f"({detail}); rebuild with a matching xorq version"
         ) from e

--- a/python/xorq/ibis_yaml/normalize_registry.py
+++ b/python/xorq/ibis_yaml/normalize_registry.py
@@ -1,0 +1,110 @@
+"""By-name registry for ``Read.normalize_method``.
+
+``normalize_method`` used to be cloudpickled into ``expr.yaml`` (see #2155). The
+pickle embedded a module path, so loading a build produced by a different xorq
+version failed uncatchably (``ModuleNotFoundError`` or SIGSEGV inside
+``cloudpickle.loads``). We instead serialize it *by name* against this registry,
+mirroring how ``Read.method_name`` has always been stored (a string resolved with
+``getattr``).
+
+The on-disk shape is a tagged envelope with a ``kind`` discriminator::
+
+    {"kind": "none"}                              # normalize_method is None
+    {"kind": "named", "name": "read_path_stat"}   # a registry key
+    {"kind": "pickle", "pickle": "<base64>"}      # RESERVED -- never emitted
+
+Only ``none`` and ``named`` are emitted. The ``pickle`` tag is reserved so that
+re-enabling custom callables later stays purely additive (see the plan). Legacy
+builds stored a bare base64 string; ``deserialize_normalize_method`` still reads
+those through the guarded legacy branch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from xorq.common.exceptions import NormalizeMethodError
+from xorq.common.utils.file_utils import (
+    normalize_read_path_md5sum,
+    normalize_read_path_stat,
+)
+
+
+# Append-only contract: these keys ARE the serialization contract. Never rename
+# or repurpose a key; only append. (Same discipline as dasher._EXTRA_RULES.)
+_NORMALIZE_RULES: tuple[tuple[str, object], ...] = (
+    ("read_path_stat", normalize_read_path_stat),
+    ("read_path_md5sum", normalize_read_path_md5sum),
+)
+_KEY_TO_FN = dict(_NORMALIZE_RULES)
+_FN_TO_KEY = {fn: key for key, fn in _NORMALIZE_RULES}
+
+
+def is_registered(fn: Optional[Callable]) -> bool:
+    """True if ``fn`` (or ``None``) can be serialized by name."""
+    return fn is None or fn in _FN_TO_KEY
+
+
+def key_for(fn: Callable) -> str:
+    """Registry key for a normalize_method, or raise.
+
+    Used by the lockdown validators so an unserializable callable fails early --
+    at Read construction / compiler init -- rather than at build time.
+    """
+    try:
+        return _FN_TO_KEY[fn]
+    except KeyError:
+        raise NormalizeMethodError(
+            f"{getattr(fn, '__qualname__', fn)!r} is not a registered "
+            f"normalize_method; use one of {sorted(_KEY_TO_FN)}"
+        ) from None
+
+
+def validate(fn: Optional[Callable]) -> None:
+    """Raise ``NormalizeMethodError`` unless ``fn`` (or ``None``) is serializable
+    by name. Used to lock down the surfaces that can set ``normalize_method`` so
+    an unserializable callable fails early rather than at build time."""
+    if not is_registered(fn):
+        key_for(fn)  # raises with the list of valid keys
+
+
+def serialize_normalize_method(fn: Optional[Callable]) -> dict:
+    if fn is None:
+        return {"kind": "none"}
+    return {"kind": "named", "name": key_for(fn)}
+
+
+def deserialize_normalize_method(payload: Any) -> Optional[Callable]:
+    # backward compat: pre-fix builds stored a bare base64 cloudpickle string.
+    if isinstance(payload, str):
+        return _legacy_unpickle(payload)
+    kind = payload["kind"]
+    if kind == "none":
+        return None
+    if kind == "named":
+        try:
+            return _KEY_TO_FN[payload["name"]]
+        except KeyError:
+            raise NormalizeMethodError(
+                f"unknown normalize_method {payload['name']!r}; this build was "
+                "produced by a newer or incompatible xorq version"
+            ) from None
+    if kind == "pickle":
+        # reserved tag; only legacy/foreign builds reach here.
+        return _legacy_unpickle(payload["pickle"])
+    raise NormalizeMethodError(f"unknown normalize_method encoding {kind!r}")
+
+
+def _legacy_unpickle(encoded: str) -> Callable:
+    # Guards ModuleNotFoundError (the 0.3.28 case). CANNOT catch the 0.3.33
+    # SIGSEGV -- cloudpickle can segfault inside loads before Python raises.
+    # Only legacy/foreign builds reach here; new builds never pickle.
+    from xorq.ibis_yaml.common import deserialize_callable  # noqa: PLC0415
+
+    try:
+        return deserialize_callable(encoded)
+    except ModuleNotFoundError as e:
+        raise NormalizeMethodError(
+            "normalize_method was pickled against a module absent in this "
+            f"environment ({e.name!r}); rebuild with a matching xorq version"
+        ) from e

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "222f26324a6e",
-  "expr.yaml": "ee02c0156828a89802a7666361b28296",
+  "expr.yaml": "18723faa585294793ceac0440fad042c",
   "expr_metadata.json": "4cbefa4e5f8a0fa46c975be7b795f821",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -4,7 +4,7 @@
   "8907ecd78b8c.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "1569fa2c7c9f512176a545e521dd79f6",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
-  "expr.yaml": "f453e132e71430f33c2db83a5358af2e",
+  "expr.yaml": "1f2feefe679834bdf31db4038900e4b8",
   "expr_metadata.json": "c0e3848c82aa094c71567c940c9ae659",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -4,7 +4,7 @@
   "8907ecd78b8c.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "d2ba95a6587082eb55386c11f201e398",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
-  "expr.yaml": "f88f16be6fa560a81d8292eed1ad596b",
+  "expr.yaml": "5a037e3af6cacd794609a74ec29d9985",
   "expr_metadata.json": "302a269626729dd357931508183954d6",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"

--- a/python/xorq/ibis_yaml/tests/test_normalize_registry.py
+++ b/python/xorq/ibis_yaml/tests/test_normalize_registry.py
@@ -69,9 +69,9 @@ def test_deserialize_unknown_named_key() -> None:
 
 
 def test_deserialize_named_missing_name_key() -> None:
-    # a malformed build artifact must not leak a bare KeyError -- the error
-    # surface stays uniformly NormalizeMethodError
-    with pytest.raises(NormalizeMethodError, match="newer or incompatible"):
+    # a malformed build artifact must not leak a bare KeyError -- and must not
+    # raise a *second* KeyError while formatting the error message either
+    with pytest.raises(NormalizeMethodError, match="missing 'name'"):
         nr.deserialize_normalize_method({"kind": "named"})
 
 
@@ -103,6 +103,53 @@ def test_legacy_missing_module_raises_catchable(
     monkeypatch.setattr("xorq.ibis_yaml.common.deserialize_callable", boom)
     with pytest.raises(NormalizeMethodError, match="ghost"):
         nr.deserialize_normalize_method("anything")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # a legacy pickle whose module is present but the symbol moved
+        pytest.param(ImportError("cannot import name 'x' from 'y'"), id="import"),
+        pytest.param(AttributeError("module 'y' has no attribute 'x'"), id="attr"),
+        # b64decode of a corrupt payload raises binascii.Error (a ValueError)
+        pytest.param(ValueError("Invalid base64-encoded string"), id="value"),
+        pytest.param(EOFError("Ran out of input"), id="eof"),
+    ],
+)
+def test_legacy_unpickle_other_errors_are_catchable(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    # not just ModuleNotFoundError: any version-skew unpickle failure must
+    # surface a catchable NormalizeMethodError, never a raw cloudpickle error.
+    def boom(_encoded: str) -> Callable:
+        raise exc
+
+    monkeypatch.setattr("xorq.ibis_yaml.common.deserialize_callable", boom)
+    with pytest.raises(NormalizeMethodError, match="incompatible environment"):
+        nr.deserialize_normalize_method("anything")
+
+
+# --- malformed / foreign payloads surface catchable errors, not raw KeyError -
+
+
+def test_deserialize_none_payload_is_no_method() -> None:
+    # pre-#1064 builds omitted the key entirely; an absent value means None
+    assert nr.deserialize_normalize_method(None) is None
+
+
+def test_deserialize_missing_kind_is_catchable() -> None:
+    with pytest.raises(NormalizeMethodError, match="missing 'kind'"):
+        nr.deserialize_normalize_method({"name": "read_path_stat"})
+
+
+def test_deserialize_pickle_missing_pickle_is_catchable() -> None:
+    with pytest.raises(NormalizeMethodError, match="missing 'pickle'"):
+        nr.deserialize_normalize_method({"kind": "pickle"})
+
+
+def test_deserialize_non_dict_payload_is_catchable() -> None:
+    with pytest.raises(NormalizeMethodError, match="expected a tagged"):
+        nr.deserialize_normalize_method(["not", "a", "payload"])
 
 
 # --- lockdown at the two injection points -----------------------------------

--- a/python/xorq/ibis_yaml/tests/test_normalize_registry.py
+++ b/python/xorq/ibis_yaml/tests/test_normalize_registry.py
@@ -13,7 +13,7 @@ import pytest
 
 import xorq.api as xo
 from xorq.common.exceptions import NormalizeMethodError
-from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.common.utils.defer_utils import deferred_read_csv, deferred_read_parquet
 from xorq.common.utils.file_utils import (
     normalize_read_path_md5sum,
     normalize_read_path_stat,
@@ -68,6 +68,13 @@ def test_deserialize_unknown_named_key() -> None:
         nr.deserialize_normalize_method({"kind": "named", "name": "bogus"})
 
 
+def test_deserialize_named_missing_name_key() -> None:
+    # a malformed build artifact must not leak a bare KeyError -- the error
+    # surface stays uniformly NormalizeMethodError
+    with pytest.raises(NormalizeMethodError, match="newer or incompatible"):
+        nr.deserialize_normalize_method({"kind": "named"})
+
+
 def test_deserialize_unknown_kind() -> None:
     with pytest.raises(NormalizeMethodError, match="unknown normalize_method encoding"):
         nr.deserialize_normalize_method({"kind": "sideways"})
@@ -101,24 +108,63 @@ def test_legacy_missing_module_raises_catchable(
 # --- lockdown at the two injection points -----------------------------------
 
 
-def test_deferred_read_rejects_custom_normalize_method(tmp_path: Path) -> None:
-    pq = tmp_path / "data.parquet"
-    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(pq)
+def _write_parquet(df: pd.DataFrame, path: Path) -> None:
+    df.to_parquet(path)
+
+
+def _write_csv(df: pd.DataFrame, path: Path) -> None:
+    df.to_csv(path, index=False)
+
+
+# deferred_read_csv and deferred_read_parquet received identical lockdown
+# changes -- exercise both so neither can silently regress.
+_READERS = [
+    pytest.param(deferred_read_parquet, _write_parquet, "data.parquet", id="parquet"),
+    pytest.param(deferred_read_csv, _write_csv, "data.csv", id="csv"),
+]
+
+
+@pytest.mark.parametrize("reader, writer, filename", _READERS)
+def test_deferred_read_rejects_custom_normalize_method(
+    reader: Callable, writer: Callable, filename: str, tmp_path: Path
+) -> None:
+    path = tmp_path / filename
+    writer(pd.DataFrame({"a": [1, 2, 3]}), path)
     con = xo.connect()
     with pytest.raises(NormalizeMethodError, match="not a registered"):
-        deferred_read_parquet(
-            pq, con, table_name="t", normalize_method=_custom_normalize
+        reader(path, con, table_name="t", normalize_method=_custom_normalize)
+
+
+@pytest.mark.parametrize("reader, writer, filename", _READERS)
+def test_deferred_read_rejects_custom_even_when_relocatable(
+    reader: Callable, writer: Callable, filename: str, tmp_path: Path
+) -> None:
+    # relocatable=True overrides normalize_method with md5sum; the user's custom
+    # callable must still be rejected up front rather than silently ignored.
+    path = tmp_path / filename
+    writer(pd.DataFrame({"a": [1, 2, 3]}), path)
+    con = xo.connect()
+    with pytest.raises(NormalizeMethodError, match="not a registered"):
+        reader(
+            path,
+            con,
+            table_name="t",
+            normalize_method=_custom_normalize,
+            relocatable=True,
         )
 
 
-def test_deferred_read_builtins_accepted(tmp_path: Path) -> None:
-    pq = tmp_path / "data.parquet"
-    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(pq)
+@pytest.mark.parametrize("reader, writer, filename", _READERS)
+def test_deferred_read_builtins_accepted(
+    reader: Callable, writer: Callable, filename: str, tmp_path: Path
+) -> None:
+    path = tmp_path / filename
+    writer(pd.DataFrame({"a": [1, 2, 3]}), path)
     con = xo.connect()
-    t = deferred_read_parquet(pq, con, table_name="t")
+    t = reader(path, con, table_name="t")
     assert t.op().normalize_method is normalize_read_path_stat
     # relocatable forces md5sum, still registry-resolvable
-    t2 = deferred_read_parquet(pq, con, table_name="t2", relocatable=True)
+    t2 = reader(path, con, table_name="t2", relocatable=True)
     assert t2.op().normalize_method is normalize_read_path_md5sum
 
 

--- a/python/xorq/ibis_yaml/tests/test_normalize_registry.py
+++ b/python/xorq/ibis_yaml/tests/test_normalize_registry.py
@@ -1,0 +1,151 @@
+"""Tests for the by-name normalize_method registry (fixes #2155).
+
+Every claim here fails if the by-name mechanism regresses to cloudpickle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+import pandas as pd
+import pytest
+
+import xorq.api as xo
+from xorq.common.exceptions import NormalizeMethodError
+from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.common.utils.file_utils import (
+    normalize_read_path_md5sum,
+    normalize_read_path_stat,
+)
+from xorq.ibis_yaml import normalize_registry as nr
+from xorq.ibis_yaml.common import serialize_callable
+from xorq.ibis_yaml.compiler import ExprDumper, build_expr, load_expr
+
+
+def _custom_normalize(path: str | Path) -> tuple:
+    return (("custom", str(path)),)
+
+
+def test_builtins_serialize_by_name() -> None:
+    assert nr.serialize_normalize_method(normalize_read_path_stat) == {
+        "kind": "named",
+        "name": "read_path_stat",
+    }
+    assert nr.serialize_normalize_method(normalize_read_path_md5sum) == {
+        "kind": "named",
+        "name": "read_path_md5sum",
+    }
+    assert nr.serialize_normalize_method(None) == {"kind": "none"}
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        pytest.param(None, id="none"),
+        pytest.param(normalize_read_path_stat, id="stat"),
+        pytest.param(normalize_read_path_md5sum, id="md5sum"),
+    ],
+)
+def test_roundtrip_identity(fn: Optional[Callable]) -> None:
+    payload = nr.serialize_normalize_method(fn)
+    # the same function object comes back -- no pickle, no re-import
+    assert nr.deserialize_normalize_method(payload) is fn
+
+
+def test_serialize_rejects_custom_callable() -> None:
+    with pytest.raises(NormalizeMethodError, match="not a registered"):
+        nr.serialize_normalize_method(_custom_normalize)
+
+
+def test_validate_allows_none_and_builtins() -> None:
+    for fn in (None, normalize_read_path_stat, normalize_read_path_md5sum):
+        nr.validate(fn)  # no raise
+
+
+def test_deserialize_unknown_named_key() -> None:
+    with pytest.raises(NormalizeMethodError, match="newer or incompatible"):
+        nr.deserialize_normalize_method({"kind": "named", "name": "bogus"})
+
+
+def test_deserialize_unknown_kind() -> None:
+    with pytest.raises(NormalizeMethodError, match="unknown normalize_method encoding"):
+        nr.deserialize_normalize_method({"kind": "sideways"})
+
+
+def test_legacy_bare_string_resolvable_still_loads() -> None:
+    # pre-fix builds stored a bare base64 cloudpickle string
+    encoded = serialize_callable(normalize_read_path_stat)
+    assert nr.deserialize_normalize_method(encoded) is normalize_read_path_stat
+
+
+def test_legacy_reserved_pickle_tag_resolvable_loads() -> None:
+    encoded = serialize_callable(normalize_read_path_md5sum)
+    payload = {"kind": "pickle", "pickle": encoded}
+    assert nr.deserialize_normalize_method(payload) is normalize_read_path_md5sum
+
+
+def test_legacy_missing_module_raises_catchable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the 0.3.28 case: a legacy pickle whose module is absent must surface a
+    # clean, catchable NormalizeMethodError -- not a bare ModuleNotFoundError.
+    def boom(_encoded: str) -> Callable:
+        raise ModuleNotFoundError("no module named ghost", name="ghost")
+
+    monkeypatch.setattr("xorq.ibis_yaml.common.deserialize_callable", boom)
+    with pytest.raises(NormalizeMethodError, match="ghost"):
+        nr.deserialize_normalize_method("anything")
+
+
+# --- lockdown at the two injection points -----------------------------------
+
+
+def test_deferred_read_rejects_custom_normalize_method(tmp_path: Path) -> None:
+    pq = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(pq)
+    con = xo.connect()
+    with pytest.raises(NormalizeMethodError, match="not a registered"):
+        deferred_read_parquet(
+            pq, con, table_name="t", normalize_method=_custom_normalize
+        )
+
+
+def test_deferred_read_builtins_accepted(tmp_path: Path) -> None:
+    pq = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(pq)
+    con = xo.connect()
+    t = deferred_read_parquet(pq, con, table_name="t")
+    assert t.op().normalize_method is normalize_read_path_stat
+    # relocatable forces md5sum, still registry-resolvable
+    t2 = deferred_read_parquet(pq, con, table_name="t2", relocatable=True)
+    assert t2.op().normalize_method is normalize_read_path_md5sum
+
+
+def test_expr_dumper_rejects_custom_read_normalize_method(tmp_path: Path) -> None:
+    pq = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(pq)
+    con = xo.connect()
+    expr = deferred_read_parquet(pq, con, table_name="t")
+    with pytest.raises(NormalizeMethodError, match="not a registered"):
+        ExprDumper(expr, read_normalize_method=_custom_normalize)
+
+
+# --- end-to-end build round-trip --------------------------------------------
+
+
+def test_build_yaml_has_named_not_pickle(tmp_path: Path) -> None:
+    pq = tmp_path / "data.parquet"
+    pd.DataFrame({"a": [1, 2, 3]}).to_parquet(pq)
+    con = xo.connect()
+    expr = deferred_read_parquet(pq, con, table_name="t").filter(xo._.a > 1)
+
+    build_path = build_expr(expr, builds_dir=str(tmp_path / "builds"))
+    yaml_text = (build_path / "expr.yaml").read_text()
+
+    assert "kind: named" in yaml_text
+    # the by-name key is present; no base64 pickle blob for normalize_method
+    assert "read_path" in yaml_text
+
+    loaded = load_expr(build_path)
+    assert loaded.execute().shape == (2, 1)

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -39,6 +39,10 @@ from xorq.ibis_yaml.common import (
     translate_to_yaml,
 )
 from xorq.ibis_yaml.enums import RefEnum, RegistryEnum
+from xorq.ibis_yaml.normalize_registry import (
+    deserialize_normalize_method,
+    serialize_normalize_method,
+)
 from xorq.ibis_yaml.udf import _scalar_udf_from_yaml, _scalar_udf_to_yaml  # noqa: F401
 from xorq.ibis_yaml.utils import (
     freeze,
@@ -613,7 +617,7 @@ def _read_to_yaml(op: Read, context: TranslationContext) -> dict:
             "name": table_name,
             "profile": profile_hash_name,
             "read_kwargs": read_kwargs,
-            "normalize_method": serialize_callable(op.normalize_method),
+            "normalize_method": serialize_normalize_method(op.normalize_method),
         }
         | context.registry.register_schema(op.schema)
     )
@@ -633,7 +637,7 @@ def _read_from_yaml(yaml_dict: dict, context: TranslationContext) -> ir.Expr:
         schema=schema,
         source=source,
         read_kwargs=read_kwargs,
-        normalize_method=deserialize_callable(yaml_dict["normalize_method"]),
+        normalize_method=deserialize_normalize_method(yaml_dict["normalize_method"]),
     )
 
     return read_op.to_expr()

--- a/python/xorq/ibis_yaml/translate.py
+++ b/python/xorq/ibis_yaml/translate.py
@@ -637,7 +637,9 @@ def _read_from_yaml(yaml_dict: dict, context: TranslationContext) -> ir.Expr:
         schema=schema,
         source=source,
         read_kwargs=read_kwargs,
-        normalize_method=deserialize_normalize_method(yaml_dict["normalize_method"]),
+        normalize_method=deserialize_normalize_method(
+            yaml_dict.get("normalize_method")
+        ),
     )
 
     return read_op.to_expr()


### PR DESCRIPTION
## Problem

Closes #2155.

`Read.normalize_method` is cloudpickled into `expr.yaml` (`ibis_yaml/translate.py`, added in #1064). The pickle embeds a module path (`xorq.common.utils.file_utils`), so loading a catalog entry produced by a **different xorq version** fails uncatchably:

- `ModuleNotFoundError` on 0.3.28 (module absent)
- **SIGSEGV** on 0.3.33 (module moved) — crashes the interpreter inside `cloudpickle.loads`

`Catalog.from_repo_path()` and `.list_aliases()` work; only `.load(alias)` (the cloudpickle path) crashes. `xorq catalog run` is unaffected (different code path).

By contrast, `Read.method_name` has always been stored **by name** (a string resolved with `getattr`) and is version-robust. This PR applies the same mechanism to `normalize_method`.

## Approach

Serialize `normalize_method` **by name** against a registry, and **lock down** the two surfaces that can set it so only registry-resolvable methods are ever produced:

- `deferred_read_csv` / `deferred_read_parquet(normalize_method=...)`
- `ExprDumper.read_normalize_method` (the build-time serializer, reached via `build_expr(..., read_normalize_method=...)`)

Built-in methods (`normalize_read_path_stat`, `normalize_read_path_md5sum` — the ~100% case) now travel as `{"kind": "named", "name": ...}` and **never touch `cloudpickle`**, so the crash is structurally impossible for new builds rather than merely guarded.

### On-disk format: tagged envelope

```
{"kind": "none"}                              # normalize_method is None
{"kind": "named", "name": "read_path_stat"}   # a registry key
{"kind": "pickle", "pickle": "<base64>"}      # RESERVED — never emitted
```

The `pickle` tag is reserved (never reused) so re-enabling custom callables later — ideally via a user-extensible registry rather than reviving cloudpickle — is a purely additive change with no format migration.

### Backward compatibility

Builds produced by prior versions still load: a bare base64 string (pre-fix format) and the reserved `pickle` tag both route through a guarded branch. Every way a version-skewed `cloudpickle.loads` can fail — `ModuleNotFoundError`/`ImportError` (module or symbol gone), `AttributeError` (symbol relocated within a surviving module), and malformed-payload errors (`ValueError`/`binascii.Error`, `EOFError`, `UnpicklingError`) — is turned into a catchable `NormalizeMethodError`. (The 0.3.33 SIGSEGV can't be caught for legacy builds — cloudpickle segfaults before Python raises — but new builds never pickle, so it's eliminated going forward.)

Deserialization is also hardened against malformed/foreign `expr.yaml`: a missing `kind`/`name`/`pickle` key, a non-dict payload, or an absent key (pre-#1064 builds that never wrote `normalize_method`) all surface a clean `NormalizeMethodError` or resolve to `None` — never a raw `KeyError`/`TypeError`.

### Breaking change

Passing a **custom** callable to `deferred_read_*(normalize_method=...)` or `build_expr(..., read_normalize_method=...)` (`ExprDumper`) now raises `NormalizeMethodError`. This holds even with `relocatable=True`: validation runs *before* the relocatable override, so a custom callable is rejected rather than silently swapped for `md5sum`. Blast radius is nil: no in-repo caller (production, tests, examples, or docs) passes a non-built-in.

Note: loading a legacy build that stored a custom cloudpickled callable still works, but *re-serializing* (rebuilding) it now raises `NormalizeMethodError`, since custom callables no longer round-trip.

## Hashing invariant

The build/cache key is **unaffected**. Rebuilding the build-stability exprs and diffing all build files against their snapshots shows **only `expr.yaml`'s bytes changed** — every content-hashed `.sql` file, `deferred_reads.yaml`, `sql.yaml`, `expr_metadata.json`, and `profiles.yaml` is byte-identical. `tokenize` hashes the runtime callable (unchanged), not the serialized bytes. All three stability snapshots (`test_build_file_stability_https`, `_local`, and `_and_relocatability`) are regenerated accordingly — each a single-line `expr.yaml`-hash diff.

## Tests

New `python/xorq/ibis_yaml/tests/test_normalize_registry.py` (28 tests): by-name serialization, round-trip identity, both lockdown points rejecting custom callables (parametrized over `deferred_read_parquet` **and** `deferred_read_csv`, including the `relocatable=True` case), unknown-key/unknown-kind errors, legacy bare-string + reserved-`pickle`-tag loads, the full family of legacy-unpickle failures (`ModuleNotFoundError`/`ImportError`/`AttributeError`/`ValueError`/`EOFError`) → catchable error, malformed-payload cases (missing `kind`/`name`/`pickle`, non-dict, `None`), and an end-to-end build round-trip asserting the YAML carries `kind: named` (no pickle blob) and reloads/executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

