### PR TITLE
fix(transform): emit remote_table.replace even when the reader-count is empty

### DIFF
--- a/python/xorq/expr/remote_table_exec.py
+++ b/python/xorq/expr/remote_table_exec.py
@@ -340,13 +340,18 @@ def _make_remote_replacer(
     # running at all when no RemoteTable is reachable at this boundary.
     reader_counts = count_remote_table_readers(expr)
 
-    # ``reader_counts`` has one entry per boundary RemoteTable, so its length is
-    # the eventual ``scope.table_count``. Emit the historical
-    # ``remote_table.replace`` event on the active ``transform.remote`` span so
-    # trace/dashboards keyed on the RemoteTable fan-out keep firing.
-    if reader_counts:
+    # Emit the historical ``remote_table.replace`` event on the active
+    # ``transform.remote`` span so trace/dashboards keyed on the RemoteTable
+    # fan-out keep firing. Count the boundary RemoteTables directly (== the
+    # eventual ``scope.table_count``, matching this pass's own ``find``-based
+    # ``when`` guard) rather than ``len(reader_counts)``: the count returns ``{}``
+    # for a compiler-less backend or a failed SQL compile even when RemoteTables
+    # are present, so gating on it would silently drop the event in exactly that
+    # case (see gh-2160).
+    remote_table_count = len(expr.op().find(RemoteTable))
+    if remote_table_count:
         get_current_span().add_event(
-            "remote_table.replace", {"remote_table.count": len(reader_counts)}
+            "remote_table.replace", {"remote_table.count": remote_table_count}
         )
 
     def replacer(node, kwargs):

--- a/python/xorq/expr/tests/test_transform_scope.py
+++ b/python/xorq/expr/tests/test_transform_scope.py
@@ -475,6 +475,49 @@ def test_remote_pass_runs_count_when_boundary_remote_table_present(
     assert len(calls) == 1, "count must run once when a boundary RemoteTable is present"
 
 
+def test_remote_table_replace_event_fires_when_count_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``remote_table.replace`` span event must fire whenever the remote pass
+    replaces a boundary ``RemoteTable``, even when ``count_remote_table_readers``
+    returns ``{}`` -- which it legitimately does for a compiler-less backend or a
+    failed SQL compile (see its docstring), while RemoteTables are still present
+    and adopted. Regression guard for gh-2160: gating the event on
+    ``len(reader_counts)`` silently dropped it in exactly that case, whereas the
+    count of boundary RemoteTables (== the eventual ``scope.table_count``) does
+    not. Fails if the event is gated on the reader-count again."""
+    # force the documented empty-count return (compiler-less / compile-fail path)
+    monkeypatch.setattr(
+        remote_table_exec, "count_remote_table_readers", lambda expr: {}
+    )
+
+    events: list[tuple[str, dict]] = []
+
+    class _RecordingSpan:
+        def add_event(self, name: str, attributes: dict | None = None) -> None:
+            events.append((name, dict(attributes or {})))
+
+    monkeypatch.setattr(remote_table_exec, "get_current_span", lambda: _RecordingSpan())
+
+    target = xo.duckdb.connect()
+    expr = make_remote_expr(target)
+    assert walk_nodes(RemoteTable, expr), "test needs a boundary RemoteTable present"
+
+    scope = RemoteTableScope()
+    apply_pass(REMOTE_PASS, expr, TransformCtx(scope=scope))
+    try:
+        assert scope.table_count == 1, "the RemoteTable is still replaced and adopted"
+        replace_events = [
+            attrs for name, attrs in events if name == "remote_table.replace"
+        ]
+        assert replace_events == [{"remote_table.count": 1}], (
+            "remote_table.replace must fire with the boundary RemoteTable count "
+            f"even when the reader-count is empty; got {events}"
+        )
+    finally:
+        scope.close()
+
+
 def test_tee_resources_released_when_remote_pass_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #2160. The restored `remote_table.replace` OpenTelemetry span event was silently dropped whenever `count_remote_table_readers()` returned `{}` while boundary `RemoteTable`s were actually present — i.e. for a backend with no SQL compiler, or when the SQL compile raised. The RemoteTables were still replaced and their placeholder tables still adopted; only the telemetry went missing (observability-only, no data-correctness impact).

## Root cause

`_make_remote_replacer` gated the event on `if reader_counts:` and sized it with `len(reader_counts)`:

```python
if reader_counts:
    get_current_span().add_event(
        "remote_table.replace", {"remote_table.count": len(reader_counts)}
    )
```

But `count_remote_table_readers` documents two branches that return `{}` **even when RemoteTables are present**: `compiler is None` (non-SQL backend) and `except Exception` (SQL compile raises). Since `REMOTE_PASS.when=_has_boundary_remote_table` already guarantees a boundary RemoteTable exists whenever this replacer is built, `reader_counts == {}` does not mean "no RemoteTables". Pre-#2144 the event fired after the walk, gated on the true `scope.table_count`, so it was correct in these cases.

## Fix

Count boundary RemoteTables directly (== the eventual `scope.table_count`, matching the pass's own `find`-based `when` guard) instead of relying on `len(reader_counts)`:

```python
remote_table_count = len(expr.op().find(RemoteTable))
if remote_table_count:
    get_current_span().add_event(
        "remote_table.replace", {"remote_table.count": remote_table_count}
    )
```

This equals `len(reader_counts)` whenever the count succeeds (no change for the common SQL case) and restores pre-#2144 behavior for the uncountable case. The stale comment is fixed too.

Residual (unchanged, out of scope): the event still fires at build time, before the materializing walk, so it fires even if that walk later raises — moving it post-walk doesn't fit the builder-based structure and is low value.

## Test

`test_remote_table_replace_event_fires_when_count_is_empty` forces the documented empty-count return, runs `apply_pass(REMOTE_PASS, ...)` with a recording span, and asserts `remote_table.replace` still fires with `remote_table.count == 1`. Verified fail-if-false: it **fails** against the old `len(reader_counts)` gating and passes with the fix. Full `test_transform_scope.py` (33 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
