### PR TITLE
feat(writes): publish_expr — fully-remote W-A-P via CTAS staging (ADR-0017)

### DIFF
--- a/docs/adr/0017-incremental-wap-publish.md
+++ b/docs/adr/0017-incremental-wap-publish.md
@@ -434,6 +434,40 @@ publish(con, staging, final, *, key, mode)                # backend target
 publish_parquet(staging_path, final_path, *, key, mode)
 ```
 
+### CTAS staging — the fully-remote W-A-P (`publish_expr`)
+
+The tee is the client-mediated write primitive: `WriteThrough` is a Python generator over arrow
+batches, so a `TeeNode` forces the changeset through the client — the right shape when the pipeline
+is heterogeneous (cross-backend sources, Python UDFs mid-stream), where the data must transit anyway
+and the tee makes the staging write free, plus the in-stream audit judges exactly the staged rows.
+When **every source already lives on the target connection**, that round-trip is pure overhead:
+staging can be one server-side `CREATE TABLE AS`, the audit a scalar query, and the publish the same
+reconciliation — no changeset row ever leaves the warehouse. `publish_expr` is that procedure:
+
+```python
+publish_expr(con, changeset, staging, final, *, key, mode, audit_fn=None)
+#  W  con.create_table(staging, changeset)   server-side CTAS (create-mode: raises on leftovers)
+#  A  audit_fn(staging_table) -> bool        remote scalar (default: no-duplicate-keys gate)
+#  P  publish(con, staging, final, ...)      the same resolve_strategy dispatch
+```
+
+Same contract as the WAP builders, different transport: the default audit is the no-duplicate-keys
+gate expressed as one aggregate on `con` instead of pandas over the stream; audit failure retains
+staging for forensics and leaves `final` untouched; the leftover blocks an identical rerun at its
+CREATE. `changeset` must be fully resident on `con` (checked against its source backends) — a
+cross-backend changeset is exactly the case the tee path exists for, and gets a pointed error.
+Proven shape: the xaffle-jop warehouse-resident run (`dbt run` semantics — catalogued model entries,
+CTAS + remote audits + `publish()` per model in DAG order, zero client data movement).
+
+**Reserved: `StagingStrategy.CTAS` (expr-shaped).** Folding this into `make_backend_wap_expr` as a
+third staging strategy — a deferred, catalogable expr like TABLE/BRANCH — requires the W+A steps to
+collapse into a UDF over a control row (no batch stream to tee or audit), which today would carry the
+changeset expr and the con as opaque closure pickles: the build hash loses the pipeline structure,
+and the con diverges from the writer's on rehydration (#2165). It stays reserved until TeeNode
+serialization (#2152) and profile-based con rehydration in publish closures land; `publish_expr` is
+the mechanism in the meantime, with `#2162`'s cache-as-staging (`MERGE INTO final USING
+letsql_cache-<key>`) as the natural extension once publish can reconcile without consuming staging.
+
 ### Validation (structural — sees `mode`/`key`/`columns`, never rows)
 
 ```python

--- a/python/xorq/tests/test_incremental_publish.py
+++ b/python/xorq/tests/test_incremental_publish.py
@@ -21,6 +21,7 @@ from xorq.writes.publish import (
     _publish_rewrite,
     _publish_statement_dml,
     publish,
+    publish_expr,
     publish_parquet,
 )
 from xorq.writes.wap import make_backend_wap_expr, make_parquet_wap_expr
@@ -541,3 +542,96 @@ def test_backend_wap_default_audit_allows_unique_keys(ddb) -> None:
     out = _run_backend_wap(ddb, UPSERT_DELTA, ["id"], PublishMode.UPSERT)
     assert out["published"].iloc[0]
     assert "final" in ddb.list_tables()
+
+
+# --- publish_expr: fully-remote W-A-P (CTAS staging, ADR-0017) ----------------
+
+
+def test_publish_expr_upsert(ddb) -> None:
+    # The changeset is an expr over a warehouse-resident table; W is a CTAS,
+    # A a remote scalar, P the same MERGE the tee path resolves to.
+    ddb.create_table("final", FINAL_SEED)
+    ddb.create_table("src", UPSERT_DELTA)
+    changeset = ddb.table("src").filter(ddb.table("src").id > 0)
+    result = publish_expr(
+        ddb, changeset, "staging", "final", key=["id"], mode=PublishMode.UPSERT
+    )
+    assert result == {
+        "passed": True,
+        "published": True,
+        "staging": "staging",
+        "final": "final",
+    }
+    out = _read(ddb, "final")
+    assert out["id"].tolist() == [1, 2, 3]
+    assert out["v"].tolist() == ["a", "B", "c"]
+    assert "staging" not in ddb.list_tables()  # consumed
+
+
+def test_publish_expr_creates_final_first_run(ddb) -> None:
+    ddb.create_table("src", UPSERT_DELTA)
+    result = publish_expr(
+        ddb, ddb.table("src"), "staging", "final", key=["id"], mode=PublishMode.UPSERT
+    )
+    assert result["published"]
+    assert _read(ddb, "final")["id"].tolist() == [2, 3]
+
+
+def test_publish_expr_append(ddb) -> None:
+    ddb.create_table("final", FINAL_SEED)
+    ddb.create_table("src", pd.DataFrame({"id": [4], "v": ["d"]}))
+    result = publish_expr(
+        ddb, ddb.table("src"), "staging", "final", mode=PublishMode.APPEND
+    )
+    assert result["published"]
+    assert _read(ddb, "final")["id"].tolist() == [1, 2, 3, 4]
+
+
+def test_publish_expr_default_audit_retains_staging_on_failure(ddb) -> None:
+    # Duplicate keys fail the remote no-duplicate-keys gate: final untouched,
+    # staging retained for forensics (and blocking an identical rerun).
+    ddb.create_table("src", pd.DataFrame({"id": [1, 1, 2], "v": ["a", "a2", "b"]}))
+    result = publish_expr(
+        ddb, ddb.table("src"), "staging", "final", key=["id"], mode=PublishMode.UPSERT
+    )
+    assert result == {
+        "passed": False,
+        "published": False,
+        "staging": "staging",
+        "final": "final",
+    }
+    assert "final" not in ddb.list_tables()
+    assert "staging" in ddb.list_tables()
+
+
+def test_publish_expr_custom_audit(ddb) -> None:
+    # audit_fn takes the staged Table and judges it remotely.
+    ddb.create_table("src", UPSERT_DELTA)
+    result = publish_expr(
+        ddb,
+        ddb.table("src"),
+        "staging",
+        "final",
+        key=["id"],
+        mode=PublishMode.UPSERT,
+        audit_fn=lambda staged: (
+            not int(staged.filter(staged.id.isnull()).count().execute())
+        ),
+    )
+    assert result["published"]
+
+
+def test_publish_expr_rejects_cross_backend_changeset(ddb, dff) -> None:
+    # CTAS staging never moves rows through the client, so a changeset with a
+    # source on another connection must fail before anything is created.
+    dff.create_table("src", UPSERT_DELTA)
+    with pytest.raises(ValueError, match="not fully resident"):
+        publish_expr(
+            ddb,
+            dff.table("src"),
+            "staging",
+            "final",
+            key=["id"],
+            mode=PublishMode.UPSERT,
+        )
+    assert "staging" not in ddb.list_tables()

--- a/python/xorq/writes/__init__.py
+++ b/python/xorq/writes/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from xorq.writes.enums import PublishMode, StagingStrategy, WriteMode
-from xorq.writes.publish import publish, publish_parquet
+from xorq.writes.publish import publish, publish_expr, publish_parquet
 from xorq.writes.wap import (
     make_backend_wap_expr,
     make_iceberg_wap_expr,
@@ -31,5 +31,6 @@ __all__ = [
     "make_iceberg_wap_expr",
     "make_parquet_wap_expr",
     "publish",
+    "publish_expr",
     "publish_parquet",
 ]

--- a/python/xorq/writes/enums.py
+++ b/python/xorq/writes/enums.py
@@ -30,6 +30,13 @@ class StagingStrategy(StrEnum):
     fast-forwarding main — metadata-only, all-or-nothing snapshot promotion, so
     it is ``APPEND``-only (no keyed merge is meaningful) and requires a backend
     whose type declares ``publish_branch`` (pyiceberg). See ADR-0017.
+
+    Both members are tee-based: the changeset streams through the client and
+    the sink writes it back (they differ only in where it lands). The
+    fully-remote W-A-P — for a changeset fully resident on the target
+    connection — is not a member here but the procedural
+    :func:`xorq.writes.publish.publish_expr` (CTAS staging + remote audit);
+    an expr-shaped ``CTAS`` member is reserved — see ADR-0017 "CTAS staging".
     """
 
     TABLE = "table"

--- a/python/xorq/writes/publish.py
+++ b/python/xorq/writes/publish.py
@@ -5,9 +5,11 @@ routes on the backend type (matching the con's own MRO, importing nothing) to on
 of five publish mechanisms — native ``MERGE INTO``, iceberg upsert+delete,
 statement DML, full rewrite, parquet file merge — and ``_validate`` checks the
 changeset contract. ``publish(con, staging, final, *, key, mode)`` and
-``publish_parquet(...)`` are the standalone entry points; ``xorq.writes.wap``
-wraps this same reconciliation behind the tee + audit gate (the ``make_*_wap_expr``
-builders). Dependency flows one way: wap imports publish, never the reverse.
+``publish_parquet(...)`` are the standalone entry points, and ``publish_expr``
+is the fully-remote W-A-P over them (CTAS staging + remote audit);
+``xorq.writes.wap`` wraps this same reconciliation behind the tee + audit gate
+(the ``make_*_wap_expr`` builders). Dependency flows one way: wap imports
+publish, never the reverse.
 """
 
 from __future__ import annotations
@@ -413,6 +415,78 @@ def publish(con, staging, final, *, key=(), mode) -> None:
         raise _staging_missing(staging) from None
     _validate(mode, key, columns)
     _PUBLISH[resolve_strategy(con, mode)](con, staging, final, key, columns, mode)
+
+
+# --- CTAS staging: fully-remote W-A-P ----------------------------------------
+
+
+def _default_remote_audit(key, mode):
+    """Remote analogue of ``wap._default_audit``: the no-duplicate-keys gate as
+    one scalar aggregate over the staging table (``APPEND``: pass-through).
+
+    Same contract, different transport — the tee-WAP default judges the streamed
+    changeset in pandas; this judges the staged table with a query on ``con``,
+    moving only a scalar.
+    """
+    if mode is PublishMode.APPEND:
+        return lambda staged: True
+
+    def no_duplicate_keys(staged):
+        counted = staged.group_by(list(key)).agg(n=staged.count())
+        return not int(counted.filter(counted.n > 1).count().execute())
+
+    return no_duplicate_keys
+
+
+def publish_expr(con, changeset, staging, final, *, key=(), mode, audit_fn=None):
+    """Fully-remote W-A-P: CTAS ``changeset`` into ``staging`` on ``con``, audit
+    it remotely, reconcile it into ``final``. No changeset rows transit the
+    client — the remote-staging analogue of ``make_backend_wap_expr`` (ADR-0017
+    "CTAS staging").
+
+    The tee-WAP streams the changeset through the client, which is the right
+    shape when the pipeline is heterogeneous (cross-backend sources, Python
+    UDFs mid-stream) — the data must transit anyway, so the tee makes the
+    staging write free. When every source already lives on ``con``, that
+    round-trip is pure overhead; here staging is one server-side
+    ``CREATE TABLE AS``::
+
+        W  con.create_table(staging, changeset)   server-side CTAS
+        A  audit_fn(staging_table) -> bool        remote scalar query
+        P  publish(con, staging, final, ...)      the same reconciliation layer
+
+    ``changeset`` must therefore be fully resident on ``con`` (checked via its
+    source backends); ``audit_fn`` takes the staged :class:`Table` and returns
+    a bool — default is the no-duplicate-keys gate for ``UPSERT``/``MERGE``,
+    always-True for ``APPEND``. On audit failure staging is retained for
+    inspection and ``final`` is untouched (WAP-builder semantics); the leftover
+    blocks an identical rerun at its CREATE — drop it or stage under a fresh
+    name. Returns ``{"passed", "published", "staging", "final"}``.
+    """
+    key = list(key)
+    _validate(mode, key, changeset.columns)
+    foreign = tuple(b for b in changeset.ls.backends if b is not con)
+    if foreign:
+        raise ValueError(
+            f"changeset is not fully resident on con: found "
+            f"{tuple(type(b).__name__ for b in foreign)}. CTAS staging never "
+            "moves rows through the client, so every source must live on the "
+            "target connection; use make_backend_wap_expr (tee staging) for "
+            "cross-backend pipelines."
+        )
+    con.create_table(staging, changeset)  # W — create-mode: raises on leftovers
+    audit = audit_fn if audit_fn is not None else _default_remote_audit(key, mode)
+    passed = bool(audit(con.table(staging)))  # A — only a scalar moves
+    published = False
+    if passed:
+        publish(con, staging, final, key=key, mode=mode)  # P — consumes staging
+        published = True
+    return {
+        "passed": passed,
+        "published": published,
+        "staging": staging,
+        "final": final,
+    }
 
 
 # --- parquet target ---------------------------------------------------------


### PR DESCRIPTION
> **Stacked on #2129** — base is `george/xor-444-...`; retarget to `main` once #2129 merges. The diff shown is only this feature.

## Summary

The tee is the client-mediated write primitive: `WriteThrough` is a Python generator over arrow batches, so every teed changeset row transits the client. That's the right shape for heterogeneous pipelines (cross-backend sources, Python UDFs mid-stream) — the data must transit anyway, so the tee makes the staging write free. When **every source already lives on the target connection**, the round-trip is pure overhead.

`publish_expr` is the fully-remote counterpart, promoted from the [xaffle-jop](https://github.com/xorq-labs/xaffle-jop) warehouse-resident run (`expr/warehouse_run.py` — dbt-run semantics: CTAS + remote audits + publish per model in DAG order, zero client data movement):

```python
publish_expr(con, changeset, staging, final, *, key, mode, audit_fn=None)
#  W  con.create_table(staging, changeset)   server-side CTAS (create-mode: raises on leftovers)
#  A  audit_fn(staging_table) -> bool        remote scalar query
#  P  publish(con, staging, final, ...)      the same reconciliation layer (#2129)
```

Same contract as the WAP builders, different transport:
- default audit = the no-duplicate-keys gate as **one remote aggregate** (mirrors `_default_audit`); custom `audit_fn` takes the staged `Table`
- audit failure retains staging for forensics, `final` untouched
- `changeset` must be fully resident on `con` (checked via `ls.backends`); cross-backend changesets get a pointed error directing to the tee path

## Why not `StagingStrategy.CTAS` (yet)

An expr-shaped CTAS member on `make_backend_wap_expr` is **reserved, not implemented** (ADR-0017 "CTAS staging"): with no batch stream to tee or audit, W+A collapse into a control-row UDF carrying the changeset expr and con as opaque closure pickles — the build hash loses the pipeline structure, and the con diverges from the writer's on rehydration (#2165). Preconditions before it can land soundly:
- #2152 — TeeNode/WriteThrough serialization (profile-based con rehydration machinery)
- #2165 — publish closures rehydrate their con via profile, not cloudpickle

#2162's cache-as-staging (`MERGE INTO final USING letsql_cache-<key>`) is the natural extension once publish can reconcile without consuming staging.

## Changes

- `xorq.writes.publish.publish_expr` + `_default_remote_audit`; exported from `xorq.writes`
- `StagingStrategy` docstring: both members are tee-based; points at `publish_expr` for the remote path
- ADR-0017: new **"CTAS staging — the fully-remote W-A-P"** section (mechanism, tee-vs-CTAS decision, reserved expr-shaped member + preconditions)
- 6 integration tests (upsert, bootstrap, append, audit-failure forensics, custom audit, cross-backend rejection)

## Testing

`test_incremental_publish.py` 45/45, `test_incremental.py` + `test_wap.py` green, ruff clean.

Refs: #2129, #2152, #2162, #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)