### PR TITLE
fix(bigquery): guard against stale PyPI ADBC driver on ingest

### DIFF
--- a/python/xorq/backends/bigquery/tests/test_backend.py
+++ b/python/xorq/backends/bigquery/tests/test_backend.py
@@ -5,6 +5,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 import pytest
+from adbc_driver_manager import AdbcStatusCode, ProgrammingError
 
 import xorq.api as xo
 import xorq.vendor.ibis as ibis
@@ -151,6 +152,69 @@ def test_adbc_quiet_for_adc_credentials() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         BigQueryADBC(con).db_kwargs
+
+
+def _fake_conn_raising(exc: Exception) -> object:
+    # a stand-in ADBC connection whose cursor.adbc_ingest raises `exc`, so the
+    # base-class ingest path runs end-to-end without a real driver/network
+    class FakeCursor:
+        def adbc_ingest(self, *args, **kwargs):
+            raise exc
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+
+        def commit(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+    return FakeConn()
+
+
+def test_adbc_ingest_translates_stale_wheel_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the stale PyPI wheel rejects `adbc.ingest.*` in its own option parser; the
+    # cryptic message must be translated into the `dbc install bigquery` fix
+    exc = ProgrammingError(
+        "INVALID_ARGUMENT: unknown statement string type option "
+        "`adbc.ingest.target_table`",
+        status_code=AdbcStatusCode.INVALID_ARGUMENT,
+    )
+    con = _mock_con({}, None)
+    monkeypatch.setattr(
+        BigQueryADBC, "get_conn", lambda self, **k: _fake_conn_raising(exc)
+    )
+    with pytest.raises(RuntimeError, match="does not support bulk ingest"):
+        BigQueryADBC(con).adbc_ingest("t", object())
+
+
+def test_adbc_ingest_passes_through_unrelated_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # an unrelated driver ProgrammingError (auth, bad table) must propagate as-is
+    exc = ProgrammingError(
+        "PERMISSION_DENIED: caller lacks bigquery.tables.create",
+        status_code=AdbcStatusCode.UNAUTHORIZED,
+    )
+    con = _mock_con({}, None)
+    monkeypatch.setattr(
+        BigQueryADBC, "get_conn", lambda self, **k: _fake_conn_raising(exc)
+    )
+    with pytest.raises(ProgrammingError, match="PERMISSION_DENIED"):
+        BigQueryADBC(con).adbc_ingest("t", object())
 
 
 @pytest.mark.parametrize(

--- a/python/xorq/common/utils/bigquery_utils.py
+++ b/python/xorq/common/utils/bigquery_utils.py
@@ -112,5 +112,26 @@ class BigQueryADBC(ADBCBase):
                 raise
             raise RuntimeError(
                 "could not load the BigQuery ADBC driver; install it with "
-                "`dbc install bigquery` (https://dbc.columnar.tech)"
+                "`dbc install bigquery` (https://dbc.columnar.tech). Note the "
+                "PyPI `adbc-driver-bigquery` package will not work for "
+                "ingestion: its build predates `adbc.ingest.*` support."
             ) from e
+
+    def adbc_ingest(self, *args: Any, **kwargs: Any) -> None:
+        # the stale PyPI `adbc-driver-bigquery` wheel (old apache/arrow-adbc
+        # lineage) loads and queries fine but was built without bulk-ingest, so
+        # it rejects `adbc.ingest.*` in its own option parser on the first
+        # ingest call — before any rows stream. Translate its cryptic
+        # "unknown statement string type option" into the real fix.
+        try:
+            super().adbc_ingest(*args, **kwargs)
+        except ProgrammingError as e:
+            msg = str(e)
+            if "unknown statement string type option" in msg and "adbc.ingest" in msg:
+                raise RuntimeError(
+                    "the loaded BigQuery ADBC driver does not support bulk "
+                    "ingest; this is the stale PyPI `adbc-driver-bigquery` "
+                    "wheel. Install the supported driver with `dbc install "
+                    "bigquery` (https://dbc.columnar.tech)."
+                ) from e
+            raise


### PR DESCRIPTION
## Summary

Follow-up to the merged BigQuery backend (#2158). Closes a UX trap flagged in review by @ghoersti.

The PyPI `adbc-driver-bigquery` wheel (old apache/arrow-adbc lineage) loads and queries fine but was built **without bulk-ingest support**. It rejects `adbc.ingest.*` in its own option parser on the first `adbc_ingest` call with a cryptic error and no pointer to the fix:

```
unknown statement string type option `adbc.ingest.target_table`
```

Only the `dbc install bigquery` (Foundry 1.12.1) driver has ingest compiled in. Binary confirmation from review:

```
strings … adbc_driver_bigquery/libadbc_driver_bigquery.so | grep -c adbc.ingest   # 0  (PyPI 1.11.0)
strings … ADBC/Drivers/bigquery_*/libadbc_driver_bigquery.dylib | grep -c adbc.ingest   # 5  (dbc Foundry 1.12.1)
```

## Changes

1. **Catch + translate** (`BigQueryADBC.adbc_ingest`) — intercept the stale-wheel `ProgrammingError` (`unknown statement string type option` + `adbc.ingest`) and re-raise pointing at `dbc install bigquery`. Unrelated driver errors propagate unchanged.
2. **Sharpen `get_conn` message** — the driver-load-failure message now also warns the PyPI `adbc-driver-bigquery` package will not work for ingestion.
3. **No trap shipped** — verified `adbc-driver-bigquery` is not a dependency of `xorq[bigquery]` and docs never suggest it (no change needed).

The failure fires on the *first* ingest call before any rows stream, so translation is sufficient — no partial-write risk, no separate capability probe needed.

## Tests

Two offline tests (no driver/network): translation fires on the stale-wheel error; unrelated `ProgrammingError`s pass through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)