### PR TITLE
fix(adbc): clear error when the driver cannot bulk ingest

### DIFF
--- a/python/xorq/common/utils/adbc_utils.py
+++ b/python/xorq/common/utils/adbc_utils.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from adbc_driver_manager import ProgrammingError
+
 
 class ADBCBase(ABC):
     """Mixin base class for ADBC-backed ingestion helpers.
@@ -10,6 +12,10 @@ class ADBCBase(ABC):
     """
 
     __slots__ = ()
+
+    # appended to the capability error below; subclasses override with
+    # backend-specific driver install instructions
+    ingest_install_hint = ""
 
     @abstractmethod
     def get_conn(self, **kwargs): ...
@@ -25,6 +31,21 @@ class ADBCBase(ABC):
     ):
         with self.get_conn(**(conn_kwargs or {})) as conn:
             with conn.cursor() as cur:
+                # capability probe: a driver that cannot bulk ingest rejects
+                # the standard target-table option key, locally and before any
+                # data is bound or sent. Probing it ourselves keys the error
+                # off the failing call rather than the driver's message text
+                # (`cursor.adbc_ingest` re-sets the same option, so a passing
+                # probe is harmless).
+                try:
+                    cur.adbc_statement.set_options(
+                        **{"adbc.ingest.target_table": table_name}
+                    )
+                except ProgrammingError as e:
+                    msg = "this ADBC driver build does not support bulk ingest"
+                    if self.ingest_install_hint:
+                        msg = f"{msg}; {self.ingest_install_hint}"
+                    raise RuntimeError(msg) from e
                 cur.adbc_ingest(
                     table_name,
                     record_batch_reader,

--- a/python/xorq/common/utils/adbc_utils.py
+++ b/python/xorq/common/utils/adbc_utils.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
 
-from adbc_driver_manager import ProgrammingError
-
 
 class ADBCBase(ABC):
     """Mixin base class for ADBC-backed ingestion helpers.
@@ -29,6 +27,9 @@ class ADBCBase(ABC):
         conn_kwargs=None,
         **kwargs,
     ):
+        # deferred so importing this module doesn't require the ADBC extras
+        from adbc_driver_manager import ProgrammingError  # noqa: PLC0415
+
         with self.get_conn(**(conn_kwargs or {})) as conn:
             with conn.cursor() as cur:
                 # capability probe: a driver that cannot bulk ingest rejects

--- a/python/xorq/common/utils/bigquery_utils.py
+++ b/python/xorq/common/utils/bigquery_utils.py
@@ -122,5 +122,7 @@ class BigQueryADBC(ADBCBase):
                 raise
             raise RuntimeError(
                 "could not load the BigQuery ADBC driver; install it with "
-                "`dbc install bigquery` (https://dbc.columnar.tech)"
+                "`dbc install bigquery` (https://dbc.columnar.tech). Note the "
+                "PyPI `adbc-driver-bigquery` package will not work for "
+                "ingestion: its build predates `adbc.ingest.*` support."
             ) from e

--- a/python/xorq/common/utils/bigquery_utils.py
+++ b/python/xorq/common/utils/bigquery_utils.py
@@ -29,6 +29,16 @@ _AUTH_TYPE_USER = "adbc.bigquery.sql.auth_type.user_authentication"
 class BigQueryADBC(ADBCBase):
     con = field(validator=instance_of(BigQueryBackend))
 
+    # the PyPI `adbc-driver-bigquery` wheel is a plausible-looking trap: it
+    # loads and can run queries, but is a stale lineage (<=1.11.x) whose
+    # statement options predate bulk ingest; only the dbc-distributed Foundry
+    # driver (>=1.12.1) supports it
+    ingest_install_hint = (
+        "install the maintained BigQuery driver with `dbc install bigquery` "
+        "(https://dbc.columnar.tech); the PyPI `adbc-driver-bigquery` wheel "
+        "does not support bulk ingest"
+    )
+
     @property
     def credentials(self) -> Any:
         # google.cloud.client.Client stores the auth object on the private

--- a/python/xorq/common/utils/tests/test_adbc_utils.py
+++ b/python/xorq/common/utils/tests/test_adbc_utils.py
@@ -25,11 +25,14 @@ class FakeStatement:
 
 
 class FakeCursor:
-    def __init__(self, supports_ingest):
+    def __init__(self, supports_ingest, ingest_exc=None):
         self.adbc_statement = FakeStatement(supports_ingest)
+        self.ingest_exc = ingest_exc
         self.ingested = None
 
     def adbc_ingest(self, table_name, reader, **kwargs):
+        if self.ingest_exc is not None:
+            raise self.ingest_exc
         self.ingested = (table_name, reader)
 
     def __enter__(self):
@@ -40,8 +43,8 @@ class FakeCursor:
 
 
 class FakeConn:
-    def __init__(self, supports_ingest):
-        self._cursor = FakeCursor(supports_ingest)
+    def __init__(self, supports_ingest, ingest_exc=None):
+        self._cursor = FakeCursor(supports_ingest, ingest_exc)
         self.committed = False
 
     def cursor(self):
@@ -57,12 +60,12 @@ class FakeConn:
         return False
 
 
-def make_adbc(supports_ingest, hint=""):
+def make_adbc(supports_ingest, hint="", ingest_exc=None):
     class FakeADBC(ADBCBase):
         ingest_install_hint = hint
 
         def __init__(self):
-            self.conn = FakeConn(supports_ingest)
+            self.conn = FakeConn(supports_ingest, ingest_exc)
 
         def get_conn(self, **kwargs):
             return self.conn
@@ -99,3 +102,15 @@ def test_adbc_ingest_probe_rejects_without_hint():
     adbc = make_adbc(supports_ingest=False)
     with pytest.raises(RuntimeError, match="does not support bulk ingest$"):
         adbc.adbc_ingest("t", make_reader())
+
+
+def test_adbc_ingest_unrelated_error_propagates():
+    # a driver whose probe passes but whose ingest fails for an unrelated
+    # reason (auth, bad table) must raise the original error untranslated
+    exc = ProgrammingError(
+        "PERMISSION_DENIED: caller lacks bigquery.tables.create", status_code=1
+    )
+    adbc = make_adbc(supports_ingest=True, ingest_exc=exc)
+    with pytest.raises(ProgrammingError, match="PERMISSION_DENIED"):
+        adbc.adbc_ingest("t", make_reader())
+    assert not adbc.conn.committed

--- a/python/xorq/common/utils/tests/test_adbc_utils.py
+++ b/python/xorq/common/utils/tests/test_adbc_utils.py
@@ -1,8 +1,12 @@
 import pyarrow as pa
 import pytest
-from adbc_driver_manager import ProgrammingError
 
-from xorq.common.utils.adbc_utils import ADBCBase
+
+pytest.importorskip("adbc_driver_manager")
+
+from adbc_driver_manager import ProgrammingError  # noqa: E402
+
+from xorq.common.utils.adbc_utils import ADBCBase  # noqa: E402
 
 
 INGEST_UNSUPPORTED = ProgrammingError(

--- a/python/xorq/common/utils/tests/test_adbc_utils.py
+++ b/python/xorq/common/utils/tests/test_adbc_utils.py
@@ -1,0 +1,101 @@
+from contextlib import contextmanager
+
+import pyarrow as pa
+import pytest
+from adbc_driver_manager import ProgrammingError
+
+from xorq.common.utils.adbc_utils import ADBCBase
+
+
+INGEST_UNSUPPORTED = ProgrammingError(
+    "INVALID_ARGUMENT: unknown statement string type option `adbc.ingest.target_table`",
+    status_code=3,
+)
+
+
+class FakeStatement:
+    def __init__(self, supports_ingest):
+        self.supports_ingest = supports_ingest
+        self.options = {}
+
+    def set_options(self, **kwargs):
+        if not self.supports_ingest:
+            raise INGEST_UNSUPPORTED
+        self.options |= kwargs
+
+
+class FakeCursor:
+    def __init__(self, supports_ingest):
+        self.adbc_statement = FakeStatement(supports_ingest)
+        self.ingested = None
+
+    def adbc_ingest(self, table_name, reader, **kwargs):
+        self.ingested = (table_name, reader)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeConn:
+    def __init__(self, supports_ingest):
+        self._cursor = FakeCursor(supports_ingest)
+        self.committed = False
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def make_adbc(supports_ingest, hint=""):
+    class FakeADBC(ADBCBase):
+        ingest_install_hint = hint
+
+        def __init__(self):
+            self.conn = FakeConn(supports_ingest)
+
+        def get_conn(self, **kwargs):
+            return self.conn
+
+    return FakeADBC()
+
+
+def make_reader():
+    schema = pa.schema([("id", pa.int64())])
+    return pa.RecordBatchReader.from_batches(
+        schema, [pa.record_batch([[1]], schema=schema)]
+    )
+
+
+def test_adbc_ingest_probe_passes_through():
+    adbc = make_adbc(supports_ingest=True)
+    adbc.adbc_ingest("t", make_reader())
+    cur = adbc.conn._cursor
+    assert cur.adbc_statement.options == {"adbc.ingest.target_table": "t"}
+    assert cur.ingested[0] == "t"
+    assert adbc.conn.committed
+
+
+def test_adbc_ingest_probe_rejects_with_hint():
+    adbc = make_adbc(supports_ingest=False, hint="install it with `dbc install x`")
+    with pytest.raises(RuntimeError, match="does not support bulk ingest") as exc_info:
+        adbc.adbc_ingest("t", make_reader())
+    assert "dbc install x" in str(exc_info.value)
+    assert exc_info.value.__cause__ is INGEST_UNSUPPORTED
+    assert adbc.conn._cursor.ingested is None
+
+
+def test_adbc_ingest_probe_rejects_without_hint():
+    adbc = make_adbc(supports_ingest=False)
+    with pytest.raises(RuntimeError, match="does not support bulk ingest$"):
+        adbc.adbc_ingest("t", make_reader())

--- a/python/xorq/common/utils/tests/test_adbc_utils.py
+++ b/python/xorq/common/utils/tests/test_adbc_utils.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import pyarrow as pa
 import pytest
 from adbc_driver_manager import ProgrammingError


### PR DESCRIPTION
Follow-up to #2158 (see [this thread](https://github.com/xorq-labs/xorq/pull/2158#issuecomment-5023937839)). Combines with @mesejo's parallel #2170 — this PR now carries both halves (co-authored).

## Problem

When the BigQuery ADBC driver is missing, the natural first instinct is `pip install adbc-driver-bigquery` — but that wheel is the stale apache lineage (≤1.11.x) that predates bulk ingest. It loads and queries fine, then fails at ingest time with the driver's opaque:

```
ProgrammingError: INVALID_ARGUMENT: unknown statement string type option `adbc.ingest.target_table`
```

— no pointer back to `dbc`. Field-tested: this was exactly the debugging path on a fresh machine.

## Changes

1. **Capability probe** (`ADBCBase.adbc_ingest`) — set the standard `adbc.ingest.target_table` option on the statement before ingesting; a driver that rejects it cannot bulk ingest, so fail fast with an actionable error. Keyed to the failing call rather than the driver's message text, so it's robust to wording changes; generic, so snowflake/databricks get the guard too, via a per-backend `ingest_install_hint`. A passing probe is a no-op (`cursor.adbc_ingest` re-sets the same option). Unrelated driver errors propagate untranslated.
2. **`get_conn` message sharpening** (from #2170) — the driver-load-failure message now also warns up front that the PyPI package will not work for ingestion, intercepting the pip instinct at the earlier failure point.

Resulting ingest-time error on the stale wheel:

```
RuntimeError: this ADBC driver build does not support bulk ingest; install the
maintained BigQuery driver with `dbc install bigquery` (https://dbc.columnar.tech);
the PyPI `adbc-driver-bigquery` wheel does not support bulk ingest
```

## Verification

- E2E on macOS against a real project, both driver builds by-name via manifest resolution:
  - PyPI wheel 1.11.0 → new `RuntimeError` above (previously the opaque driver error)
  - dbc/Foundry 1.12.1 → probe passes, ingest + read-back succeed
- 4 unit tests with a stubbed cursor: probe pass-through, reject with/without hint (no ingest attempted, cause chained), unrelated `ProgrammingError` propagates untranslated

🤖 Generated with [Claude Code](https://claude.com/claude-code)