### PR TITLE
fix(adbc): translate all ADBC error classes on ingest-capability probe

### DIFF
--- a/python/xorq/common/utils/adbc_utils.py
+++ b/python/xorq/common/utils/adbc_utils.py
@@ -28,7 +28,11 @@ class ADBCBase(ABC):
         **kwargs,
     ):
         # deferred so importing this module doesn't require the ADBC extras
-        from adbc_driver_manager import ProgrammingError  # noqa: PLC0415
+        from adbc_driver_manager import (  # noqa: PLC0415
+            NotSupportedError,
+            OperationalError,
+            ProgrammingError,
+        )
 
         with self.get_conn(**(conn_kwargs or {})) as conn:
             with conn.cursor() as cur:
@@ -37,12 +41,26 @@ class ADBCBase(ABC):
                 # data is bound or sent. Probing it ourselves keys the error
                 # off the failing call rather than the driver's message text
                 # (`cursor.adbc_ingest` re-sets the same option, so a passing
-                # probe is harmless).
+                # probe is harmless). Drivers signal the unknown option in
+                # different ways: NOT_IMPLEMENTED maps to NotSupportedError,
+                # while the stale bigquery build reports INVALID_ARGUMENT
+                # (ProgrammingError); catch the DatabaseError siblings so none
+                # escape untranslated.
                 try:
                     cur.adbc_statement.set_options(
                         **{"adbc.ingest.target_table": table_name}
                     )
-                except ProgrammingError as e:
+                except (ProgrammingError, NotSupportedError, OperationalError) as e:
+                    # only a genuine capability gap translates: the driver
+                    # either maps the unknown option to NOT_IMPLEMENTED
+                    # (NotSupportedError) or names the rejected `adbc.ingest`
+                    # key. Anything else (e.g. a supporting driver rejecting a
+                    # malformed target-table value) is a different failure and
+                    # must propagate untranslated.
+                    if not (
+                        isinstance(e, NotSupportedError) or "adbc.ingest" in str(e)
+                    ):
+                        raise
                     msg = "this ADBC driver build does not support bulk ingest"
                     if self.ingest_install_hint:
                         msg = f"{msg}; {self.ingest_install_hint}"

--- a/python/xorq/common/utils/tests/test_adbc_utils.py
+++ b/python/xorq/common/utils/tests/test_adbc_utils.py
@@ -4,7 +4,10 @@ import pytest
 
 pytest.importorskip("adbc_driver_manager")
 
-from adbc_driver_manager import ProgrammingError  # noqa: E402
+from adbc_driver_manager import (  # noqa: E402
+    NotSupportedError,
+    ProgrammingError,
+)
 
 from xorq.common.utils.adbc_utils import ADBCBase  # noqa: E402
 
@@ -13,63 +16,85 @@ INGEST_UNSUPPORTED = ProgrammingError(
     "INVALID_ARGUMENT: unknown statement string type option `adbc.ingest.target_table`",
     status_code=3,
 )
+# a driver that reports the unknown option via NOT_IMPLEMENTED instead
+INGEST_NOT_IMPLEMENTED = NotSupportedError("NOT_IMPLEMENTED: option not supported")
 
 
 class FakeStatement:
-    def __init__(self, supports_ingest):
+    def __init__(
+        self, supports_ingest: bool, probe_exc: Exception | None = None
+    ) -> None:
         self.supports_ingest = supports_ingest
+        self.probe_exc = probe_exc if probe_exc is not None else INGEST_UNSUPPORTED
         self.options = {}
 
-    def set_options(self, **kwargs):
+    def set_options(self, **kwargs: object) -> None:
         if not self.supports_ingest:
-            raise INGEST_UNSUPPORTED
+            raise self.probe_exc
         self.options |= kwargs
 
 
 class FakeCursor:
-    def __init__(self, supports_ingest, ingest_exc=None):
-        self.adbc_statement = FakeStatement(supports_ingest)
+    def __init__(
+        self,
+        supports_ingest: bool,
+        ingest_exc: Exception | None = None,
+        probe_exc: Exception | None = None,
+    ) -> None:
+        self.adbc_statement = FakeStatement(supports_ingest, probe_exc)
         self.ingest_exc = ingest_exc
         self.ingested = None
 
-    def adbc_ingest(self, table_name, reader, **kwargs):
+    def adbc_ingest(
+        self, table_name: str, reader: pa.RecordBatchReader, **kwargs: object
+    ) -> None:
         if self.ingest_exc is not None:
             raise self.ingest_exc
         self.ingested = (table_name, reader)
 
-    def __enter__(self):
+    def __enter__(self) -> "FakeCursor":
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc: object) -> bool:
         return False
 
 
 class FakeConn:
-    def __init__(self, supports_ingest, ingest_exc=None):
-        self._cursor = FakeCursor(supports_ingest, ingest_exc)
+    def __init__(
+        self,
+        supports_ingest: bool,
+        ingest_exc: Exception | None = None,
+        probe_exc: Exception | None = None,
+    ) -> None:
+        self._cursor = FakeCursor(supports_ingest, ingest_exc, probe_exc)
         self.committed = False
 
-    def cursor(self):
+    def cursor(self) -> FakeCursor:
         return self._cursor
 
-    def commit(self):
+    def commit(self) -> None:
         self.committed = True
 
-    def __enter__(self):
+    def __enter__(self) -> "FakeConn":
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc: object) -> bool:
         return False
 
 
-def make_adbc(supports_ingest, hint="", ingest_exc=None):
+def make_adbc(
+    supports_ingest: bool,
+    hint: str = "",
+    ingest_exc: Exception | None = None,
+    probe_exc: Exception | None = None,
+) -> ADBCBase:
     class FakeADBC(ADBCBase):
         ingest_install_hint = hint
 
-        def __init__(self):
-            self.conn = FakeConn(supports_ingest, ingest_exc)
+        def __init__(self) -> None:
+            self.conn = FakeConn(supports_ingest, ingest_exc, probe_exc)
 
-        def get_conn(self, **kwargs):
+        def get_conn(self, **kwargs: object) -> FakeConn:
             return self.conn
 
     return FakeADBC()
@@ -114,5 +139,28 @@ def test_adbc_ingest_unrelated_error_propagates():
     )
     adbc = make_adbc(supports_ingest=True, ingest_exc=exc)
     with pytest.raises(ProgrammingError, match="PERMISSION_DENIED"):
+        adbc.adbc_ingest("t", make_reader())
+    assert not adbc.conn.committed
+
+
+def test_adbc_ingest_probe_rejects_not_implemented() -> None:
+    # a driver that reports the unknown option via NOT_IMPLEMENTED
+    # (NotSupportedError) must be translated just like the INVALID_ARGUMENT
+    # (ProgrammingError) case
+    adbc = make_adbc(supports_ingest=False, probe_exc=INGEST_NOT_IMPLEMENTED)
+    with pytest.raises(RuntimeError, match="does not support bulk ingest"):
+        adbc.adbc_ingest("t", make_reader())
+    assert adbc.conn._cursor.ingested is None
+
+
+def test_adbc_ingest_unrelated_probe_error_propagates() -> None:
+    # a supporting driver that rejects set_options for a reason unrelated to
+    # the ingest option (e.g. a malformed target-table value) must not be
+    # mislabeled as lacking bulk-ingest capability
+    exc = ProgrammingError(
+        "INVALID_ARGUMENT: invalid table name `bad name`", status_code=3
+    )
+    adbc = make_adbc(supports_ingest=False, probe_exc=exc)
+    with pytest.raises(ProgrammingError, match="invalid table name"):
         adbc.adbc_ingest("t", make_reader())
     assert not adbc.conn.committed


### PR DESCRIPTION
## Summary

Follow-up to #2171 (merged). A high-effort code review of the BigQuery ADBC ingest-guard surfaced two defects in the `set_options` capability probe in `adbc_utils.py`.

**Fix 1 (confirmed):** the probe only caught `ProgrammingError`. `adbc_driver_manager` maps a `NOT_IMPLEMENTED` status to `NotSupportedError` and other statuses to `OperationalError` — both `DatabaseError` siblings, not subclasses. A driver build reporting the missing bulk-ingest option via `NOT_IMPLEMENTED` escaped untranslated, surfacing the opaque low-level driver message the probe was meant to replace. The existing BigQuery test only exercised the `INVALID_ARGUMENT`/`ProgrammingError` path, so the gap was untested.

**Fix 2:** the probe treated *any* `ProgrammingError` from `set_options` as "driver cannot bulk ingest". The shared base path is used by `PgADBC`/`SQLiteADBC` (drivers that do support ingest); an unrelated option-validation failure there would be misdiagnosed with a wrong "does not support bulk ingest" message that hides the real cause.

## Changes

- Broaden the caught classes to `(ProgrammingError, NotSupportedError, OperationalError)`.
- Translate only a genuine capability gap: the error must be `NotSupportedError` or name the rejected `adbc.ingest` key. Anything else propagates untranslated.
- Add tests for the `NotSupportedError` path and for an unrelated `set_options` failure propagating.

## Test plan

- [x] `pytest python/xorq/common/utils/tests/test_adbc_utils.py` — 6 passed
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)