### PR TITLE
feat(tui): add catalog entry mutation actions

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -784,6 +784,15 @@ class Catalog:
             catalog_alias.add()
             return catalog_alias
 
+    def remove_alias(self, alias: str, sync: bool = True) -> "CatalogAlias":
+        """Remove *alias*, leaving its target entry untouched.
+
+        Symmetric with ``add_alias``/``remove``: git sync is managed via
+        *sync*.  Raises ``ValueError`` if *alias* is not registered.
+        """
+        with self.maybe_synchronizing(sync):
+            return CatalogAlias.from_name(alias, self).remove()
+
     def list_aliases(self):
         """Return the list of alias names in the catalog."""
         return self.catalog_yaml.contents[CatalogInfix.ALIAS]

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -660,12 +660,15 @@ def remove_alias(ctx, aliases, sync):
     """
     with click_context_catalog(ctx):
         catalog = ctx.obj.make_catalog(init=False)
-        alias_map = {ca.alias: ca for ca in catalog.catalog_aliases}
+        # Validate every alias up front so an unknown one cancels the whole
+        # operation before any change is committed (see docstring).
+        known = set(catalog.list_aliases())
+        unknown = next((alias for alias in aliases if alias not in known), None)
+        if unknown is not None:
+            raise click.UsageError(f"Unknown alias: {unknown!r}")
         with catalog.maybe_synchronizing(sync):
             for alias in aliases:
-                if alias not in alias_map:
-                    raise click.UsageError(f"Unknown alias: {alias!r}")
-                alias_map[alias].remove()
+                catalog.remove_alias(alias, sync=False)
                 click.echo(f"Removed alias {alias!r}")
 
 

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -1547,6 +1547,24 @@ def test_add_alias_overwrite(catalog_populated):
     catalog_populated.assert_consistency()
 
 
+def test_remove_alias(catalog_populated: Catalog) -> None:
+    name = catalog_populated.list()[0]
+    catalog_populated.add_alias(name, "doomed")
+    assert "doomed" in catalog_populated.list_aliases()
+
+    catalog_populated.remove_alias("doomed")
+
+    assert "doomed" not in catalog_populated.list_aliases()
+    # The target entry is left untouched.
+    assert name in catalog_populated.list()
+    catalog_populated.assert_consistency()
+
+
+def test_remove_alias_unknown_raises(catalog_populated: Catalog) -> None:
+    with pytest.raises(ValueError, match="no such alias"):
+        catalog_populated.remove_alias("nonexistent")
+
+
 def _commit_count(catalog: Catalog) -> int:
     return len(list(catalog.repo.iter_commits()))
 

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -27,6 +27,7 @@ import xorq.config
 from xorq.caching import ParquetSnapshotCache
 from xorq.catalog.bind import _eval_code
 from xorq.catalog.catalog import Catalog, CatalogAlias, CatalogEntry
+from xorq.catalog.exceptions import CatalogPushError
 from xorq.catalog.tests.testing import (
     Assert,
     Press,
@@ -53,6 +54,7 @@ from xorq.catalog.tui import (
     RevisionRowData,
     _build_git_log_rows,
     _entry_info,
+    _find_project_path,
     _format_cached,
     _get_catalog_aliases,
     _list_revisions_cached,
@@ -474,7 +476,148 @@ def test_remove_alias_keeps_entry_and_other_aliases(catalog, entry_a):
     _run(_test())
 
 
-def test_j_k_moves_cursor(catalog, entry_a, entry_b):
+@pytest.mark.parametrize(
+    "key",
+    [pytest.param("d", id="delete"), pytest.param("r", id="remove-alias")],
+)
+def test_destructive_binding_only_visible_on_focused_entry(
+    catalog: Catalog, entry_a: CatalogEntry, key: str
+) -> None:
+    """delete (d) and remove-alias (r) must be gated on the entries tree being
+    focused with a leaf selected -- otherwise the key bubbles up from another
+    panel and acts on a stale tree cursor (mirrors the add-alias guard)."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            # Cursor starts on the kind branch (no leaf selected) -> hidden.
+            assert key not in app.active_bindings
+
+            await pilot.press("j")
+            await settle(pilot)
+            assert screen._selected_row_data() is not None
+            assert key in app.active_bindings
+
+            # Moving focus off the entries panel hides the action again.
+            await pilot.press("tab")
+            await settle(pilot)
+            assert key not in app.active_bindings
+
+    _run(_test())
+
+
+def test_find_project_path_walks_up_from_build_dir(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    build_dir = project / "builds" / "abc123"
+    build_dir.mkdir(parents=True)
+    (project / "pyproject.toml").touch()
+    assert _find_project_path(build_dir) == project
+
+
+def test_find_project_path_returns_none_when_absent(tmp_path: Path) -> None:
+    build_dir = tmp_path / "orphan"
+    build_dir.mkdir()
+    assert _find_project_path(build_dir) is None
+
+
+def test_add_entry_forwards_project_path_anchored_on_build_dir(
+    catalog: Catalog,
+    entry_a: CatalogEntry,
+    entry_b: CatalogEntry,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The TUI add path must anchor project_path on the build directory, not
+    the process cwd, so an unpackaged build adds even when the TUI was launched
+    from outside the project tree."""
+
+    async def _test():
+        zip_path = catalog.get_zip(entry_b.name, dir_path=tmp_path)
+        project = tmp_path / "proj"
+        (project / "pyproject.toml").parent.mkdir(parents=True, exist_ok=True)
+        (project / "pyproject.toml").touch()
+        extract_dir = project / "builds"
+        extract_dir.mkdir()
+        build_dir = extract_build_zip_to(zip_path, extract_dir)
+        catalog.remove(entry_b.name)
+
+        captured = {}
+        real_add = Catalog.add
+
+        def spy_add(self, obj, *args, **kwargs):
+            captured["project_path"] = kwargs.get("project_path")
+            return real_add(self, obj, *args, **kwargs)
+
+        monkeypatch.setattr(Catalog, "add", spy_add)
+
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _populate_tree(pilot, catalog, entry_a)
+            await pilot.press("a")
+            await settle(pilot)
+
+            assert isinstance(app.screen, AddEntryScreen)
+            app.screen.query_one("#add-entry-path", Input).value = str(build_dir)
+            await pilot.press("ctrl+r")
+            await wait_until(pilot, lambda: entry_b.name in catalog.list())
+
+            assert captured["project_path"] == project
+
+    _run(_test())
+
+
+def test_delete_push_failure_warns_and_keeps_local_change(
+    catalog: Catalog, entry_a: CatalogEntry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-commit remote push failure leaves the local change applied; the
+    TUI must re-render as applied and surface a warning about the divergence,
+    not an error that reads as 'nothing happened'."""
+
+    async def _test():
+        real_remove = Catalog.remove
+
+        def remove_local_then_push_fails(self, name, sync=True):
+            real_remove(self, name, sync=False)  # local commit lands, no push
+            raise CatalogPushError("push failed: simulated remote rejection")
+
+        monkeypatch.setattr(Catalog, "remove", remove_local_then_push_fails)
+
+        app = _make_tui(catalog)
+        notifications = []
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            monkeypatch.setattr(
+                app,
+                "notify",
+                lambda message, **kwargs: notifications.append((message, kwargs)),
+            )
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            await pilot.press("j", "d")
+            await settle(pilot)
+            assert isinstance(app.screen, DeleteEntryScreen)
+
+            await pilot.press("ctrl+r")
+            await wait_until(pilot, lambda: entry_a.name not in catalog.list())
+            await settle(pilot)
+
+            # Applied locally and re-rendered as such.
+            assert entry_a.name not in catalog.list()
+            assert entry_a.name not in app.screen._tree_entry_hashes()
+
+            # Warned (not errored) about the divergence.
+            message, kwargs = notifications[-1]
+            assert kwargs["severity"] == "warning"
+            assert "applied locally but remote push failed" in message
+
+    _run(_test())
+
+
+def test_j_k_moves_cursor(
+    catalog: Catalog, entry_a: CatalogEntry, entry_b: CatalogEntry
+) -> None:
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -615,6 +615,122 @@ def test_delete_push_failure_warns_and_keeps_local_change(
     _run(_test())
 
 
+@pytest.mark.parametrize(
+    ("exc", "severity", "fragment"),
+    [
+        pytest.param(
+            CatalogPushError("push failed: simulated"),
+            "warning",
+            "applied locally but remote push failed",
+            id="push-error",
+        ),
+        pytest.param(ValueError("boom"), "error", "failed:", id="generic-error"),
+    ],
+)
+def test_run_locked_mutation_classifies_push_vs_generic_errors(
+    catalog: Catalog,
+    entry_a: CatalogEntry,
+    monkeypatch: pytest.MonkeyPatch,
+    exc: Exception,
+    severity: str,
+    fragment: str,
+) -> None:
+    """The shared mutation helper -- used by all four modal actions (add
+    entry/alias, delete, remove alias) -- warns on a post-commit push failure
+    but errors on any other exception.  Exercised here once directly rather
+    than through each of the four flows, which share this code path."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        notifications = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            monkeypatch.setattr(
+                app,
+                "notify",
+                lambda message, **kwargs: notifications.append((message, kwargs)),
+            )
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            def mutate(_catalog):
+                raise exc
+
+            # call_from_thread must run off the main thread, as the worker does.
+            await asyncio.to_thread(
+                screen._run_locked_mutation,
+                mutate,
+                log_event="test_event",
+                log_kwargs={},
+                title="Test",
+                verb="Do",
+                success=lambda result: "ok",
+            )
+            await settle(pilot)
+
+            message, kwargs = notifications[-1]
+            assert kwargs["severity"] == severity
+            assert fragment in message
+
+    _run(_test())
+
+
+def test_add_entry_can_be_cancelled(catalog: Catalog) -> None:
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("a")
+            await settle(pilot)
+            assert isinstance(app.screen, AddEntryScreen)
+
+            await pilot.press("escape")
+            await settle(pilot)
+            assert isinstance(app.screen, CatalogScreen)
+            assert catalog.list() == []
+
+    _run(_test())
+
+
+def test_add_alias_can_be_cancelled(catalog: Catalog, entry_a: CatalogEntry) -> None:
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _populate_tree(pilot, catalog, entry_a)
+            await pilot.press("j", "A")
+            await settle(pilot)
+            assert isinstance(app.screen, AddAliasScreen)
+
+            await pilot.press("escape")
+            await settle(pilot)
+            assert isinstance(app.screen, CatalogScreen)
+            assert catalog.list_aliases() == []
+
+    _run(_test())
+
+
+def test_remove_alias_can_be_cancelled(catalog: Catalog, entry_a: CatalogEntry) -> None:
+    async def _test():
+        catalog.add_alias(entry_a.name, "keep-me")
+        app = _make_tui(catalog)
+        row = CatalogRowData(entry=entry_a, aliases=("keep-me",))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = app.screen
+            screen._row_cache = {row.row_key: row}
+            screen._render_refresh(catalog.repo.working_dir, (row,))
+            await settle(pilot)
+
+            await pilot.press("j", "r")
+            await settle(pilot)
+            assert isinstance(app.screen, RemoveAliasScreen)
+
+            await pilot.press("escape")
+            await settle(pilot)
+            assert isinstance(app.screen, CatalogScreen)
+            assert "keep-me" in catalog.list_aliases()
+
+    _run(_test())
+
+
 def test_j_k_moves_cursor(
     catalog: Catalog, entry_a: CatalogEntry, entry_b: CatalogEntry
 ) -> None:

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from textual.widgets import DataTable, Input, Static, Tree
+from textual.widgets import DataTable, Input, Select, Static, Tree
 
 import xorq.api as xo
 import xorq.config
@@ -39,13 +39,17 @@ from xorq.catalog.tui import (
     GIT_LOG_COLUMNS,
     KIND_ORDER,
     KIND_STYLES,
+    AddAliasScreen,
+    AddEntryScreen,
     CatalogRowData,
     CatalogScreen,
     CatalogTUI,
     DataViewScreen,
+    DeleteEntryScreen,
     ExprStack,
     ExprStep,
     GitLogRowData,
+    RemoveAliasScreen,
     RevisionRowData,
     _build_git_log_rows,
     _entry_info,
@@ -59,6 +63,7 @@ from xorq.catalog.tui import (
     _styled_branch_label,
     get_cache_key_path,
 )
+from xorq.catalog.zip_utils import extract_build_zip_to
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.env_utils import (
     EnvConfigable,
@@ -300,6 +305,171 @@ def test_quit_exits_app(catalog):
         async with app.run_test(size=(120, 40)) as pilot:
             await settle(pilot)
             await pilot.press("q")
+
+    _run(_test())
+
+
+def test_add_entry_from_build_directory_with_alias(catalog, entry_a, entry_b, tmp_path):
+    async def _test():
+        zip_path = catalog.get_zip(entry_b.name, dir_path=tmp_path)
+        extract_dir = tmp_path / "extracted"
+        extract_dir.mkdir()
+        build_dir = extract_build_zip_to(zip_path, extract_dir)
+        catalog.remove(entry_b.name)
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _populate_tree(pilot, catalog, entry_a)
+            await pilot.press("a")
+            await settle(pilot)
+
+            assert isinstance(app.screen, AddEntryScreen)
+            app.screen.query_one("#add-entry-path", Input).value = str(build_dir)
+            app.screen.query_one("#add-entry-alias", Input).value = "restored"
+            await pilot.press("ctrl+r")
+            await wait_until(pilot, lambda: entry_b.name in catalog.list())
+
+            assert isinstance(app.screen, CatalogScreen)
+            assert "restored" in catalog.list_aliases()
+            assert entry_b.name in app.screen._tree_entry_hashes()
+            assert app.screen._row_cache[entry_b.name].aliases == ("restored",)
+
+    _run(_test())
+
+
+def test_add_entry_rejects_zip_path(catalog, tmp_path):
+    async def _test():
+        zip_path = tmp_path / "build.zip"
+        zip_path.touch()
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            await pilot.press("a")
+            await settle(pilot)
+
+            assert isinstance(app.screen, AddEntryScreen)
+            app.screen.query_one("#add-entry-path", Input).value = str(zip_path)
+            await pilot.press("ctrl+r")
+            await settle(pilot)
+
+            assert isinstance(app.screen, AddEntryScreen)
+            assert catalog.list() == []
+
+    _run(_test())
+
+
+def test_add_alias_to_selected_entry(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _populate_tree(pilot, catalog, entry_a)
+            await pilot.press("j", "A")
+            await settle(pilot)
+
+            assert isinstance(app.screen, AddAliasScreen)
+            app.screen.query_one("#add-alias-name", Input).value = "new-alias"
+            await pilot.press("ctrl+r")
+            await wait_until(pilot, lambda: "new-alias" in catalog.list_aliases())
+
+            assert isinstance(app.screen, CatalogScreen)
+            assert entry_a.name in catalog.list()
+            assert app.screen._row_cache[entry_a.name].aliases == ("new-alias",)
+            assert "new-alias" in _leaf_label_for(app.screen, entry_a.name)
+
+    _run(_test())
+
+
+def test_add_alias_binding_only_visible_on_focused_entry(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            screen, _ = await _populate_tree(pilot, catalog, entry_a)
+
+            # The cursor starts on the kind branch, so Add Alias is hidden.
+            assert "A" not in app.active_bindings
+
+            await pilot.press("j")
+            await settle(pilot)
+            assert screen._selected_row_data() is not None
+            assert "A" in app.active_bindings
+
+            # Moving focus away from the entries panel hides the action again.
+            await pilot.press("tab")
+            await settle(pilot)
+            assert "A" not in app.active_bindings
+
+    _run(_test())
+
+
+def test_delete_entry_can_be_cancelled(catalog, entry_a):
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _populate_tree(pilot, catalog, entry_a)
+            await pilot.press("j", "d")
+            await settle(pilot)
+
+            assert isinstance(app.screen, DeleteEntryScreen)
+            await pilot.press("escape")
+            await settle(pilot)
+
+            assert isinstance(app.screen, CatalogScreen)
+            assert entry_a.name in catalog.list()
+
+    _run(_test())
+
+
+def test_delete_entry_removes_entry_and_aliases(catalog, entry_a):
+    async def _test():
+        catalog.add_alias(entry_a.name, "to-delete")
+        app = _make_tui(catalog)
+        row = CatalogRowData(entry=entry_a, aliases=("to-delete",))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = app.screen
+            screen._row_cache = {row.row_key: row}
+            screen._render_refresh(catalog.repo.working_dir, (row,))
+            await settle(pilot)
+
+            await pilot.press("j", "d")
+            await settle(pilot)
+            assert isinstance(app.screen, DeleteEntryScreen)
+
+            await pilot.press("ctrl+r")
+            await wait_until(pilot, lambda: entry_a.name not in catalog.list())
+
+            assert isinstance(app.screen, CatalogScreen)
+            assert "to-delete" not in catalog.list_aliases()
+            assert entry_a.name not in app.screen._tree_entry_hashes()
+
+    _run(_test())
+
+
+def test_remove_alias_keeps_entry_and_other_aliases(catalog, entry_a):
+    async def _test():
+        catalog.add_alias(entry_a.name, "keep-me")
+        catalog.add_alias(entry_a.name, "remove-me")
+        app = _make_tui(catalog)
+        row = CatalogRowData(entry=entry_a, aliases=("keep-me", "remove-me"))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = app.screen
+            screen._row_cache = {row.row_key: row}
+            screen._render_refresh(catalog.repo.working_dir, (row,))
+            await settle(pilot)
+
+            await pilot.press("j", "r")
+            await settle(pilot)
+            assert isinstance(app.screen, RemoveAliasScreen)
+
+            select = app.screen.query_one("#remove-alias-select", Select)
+            select.value = "remove-me"
+            await pilot.press("ctrl+r")
+            await wait_until(pilot, lambda: "remove-me" not in catalog.list_aliases())
+
+            assert isinstance(app.screen, CatalogScreen)
+            assert entry_a.name in catalog.list()
+            assert "keep-me" in catalog.list_aliases()
+            assert app.screen._row_cache[entry_a.name].aliases == ("keep-me",)
 
     _run(_test())
 

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import threading
 from collections import Counter
+from collections.abc import Callable
 from datetime import datetime
 from functools import cache, cached_property, lru_cache
 from itertools import groupby
@@ -878,9 +879,6 @@ class CatalogScreen(Screen):
 
     @on(Tree.NodeHighlighted, "#catalog-tree")
     def _on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
-        # Add Alias is a dynamic binding: it is visible only while an entry
-        # leaf is selected in the focused catalog tree.
-        self.refresh_bindings()
         # Debounce: rapid j/k traversal fires NodeHighlighted per intermediate
         # node.  Defer the synchronous panel render until the cursor settles so
         # holding a key moves at terminal-repeat-rate.  _render_highlighted_node
@@ -910,6 +908,10 @@ class CatalogScreen(Screen):
         # timer; querying removed widgets would raise NoMatches.
         if not self.is_attached:
             return
+        # Add Alias is a dynamic binding, visible only on an entry leaf. Refresh
+        # once per settled selection rather than per intermediate j/k node, so a
+        # held key does not trigger a Footer recompose at terminal-repeat-rate.
+        self.refresh_bindings()
         # Clear panels first so an emptied tree (cursor_node None) doesn't leave
         # the prior selection's content stranded on screen.
         schema_in_table = self.query_one("#schema-in-table", DataTable)
@@ -1526,24 +1528,33 @@ class CatalogScreen(Screen):
             lambda alias: self._remove_alias(alias) if alias is not None else None,
         )
 
-    @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
-    def _add_entry(self, build_dir_path: str, alias: str | None) -> None:
-        catalog = self.app._catalog
+    def _run_locked_mutation(
+        self,
+        mutate: Callable[[Catalog], object],
+        *,
+        log_event: str,
+        log_kwargs: dict[str, str],
+        title: str,
+        verb: str,
+        success: Callable[[object], str],
+    ) -> None:
+        # Shared body for the catalog-mutation workers: guard the async-loaded
+        # catalog, run `mutate` under the refresh lock, and always re-render the
+        # view (success or failure) before notifying.  `success` maps the
+        # mutation's return value to the confirmation message.
+        catalog = self.app._catalog  # xorq-style: disable=protected-access
         if catalog is None:
             return
-        path = Path(build_dir_path).expanduser()
         with self._refresh_lock:
             try:
-                if not path.is_dir():
-                    raise ValueError(f"build path is not a directory: {path}")
-                entry = catalog.add(path, aliases=(alias,) if alias else ())
+                result = mutate(catalog)
             except Exception as exc:
-                logger.exception("catalog_entry_add_failed", build_dir_path=str(path))
+                logger.exception(log_event, **log_kwargs)
                 self._do_refresh_locked()
                 self.app.call_from_thread(
                     self.app.notify,
-                    f"Add failed: {exc}",
-                    title="Add Entry",
+                    f"{verb} failed: {exc}",
+                    title=title,
                     severity="error",
                     timeout=6,
                 )
@@ -1551,93 +1562,64 @@ class CatalogScreen(Screen):
             self._do_refresh_locked()
         self.app.call_from_thread(
             self.app.notify,
-            f"Added {entry.name[:12]}",
-            title="Add Entry",
+            success(result),
+            title=title,
             severity="information",
+        )
+
+    @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
+    def _add_entry(self, build_dir_path: str, alias: str | None) -> None:
+        path = Path(build_dir_path).expanduser()
+
+        def mutate(catalog):
+            if not path.is_dir():
+                raise ValueError(f"build path is not a directory: {path}")
+            return catalog.add(path, aliases=(alias,) if alias else ())
+
+        self._run_locked_mutation(
+            mutate,
+            log_event="catalog_entry_add_failed",
+            log_kwargs={"build_dir_path": str(path)},
+            title="Add Entry",
+            verb="Add",
+            success=lambda entry: f"Added {entry.name[:12]}",
         )
 
     @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
     def _add_alias(self, entry_hash: str, alias: str) -> None:
-        catalog = self.app._catalog
-        if catalog is None:
-            return
-        with self._refresh_lock:
-            try:
-                catalog.add_alias(entry_hash, alias)
-            except Exception as exc:
-                logger.exception(
-                    "catalog_alias_add_failed", entry_hash=entry_hash, alias=alias
-                )
-                self._do_refresh_locked()
-                self.app.call_from_thread(
-                    self.app.notify,
-                    f"Add failed: {exc}",
-                    title="Add Alias",
-                    severity="error",
-                    timeout=6,
-                )
-                return
-            self._do_refresh_locked()
-        self.app.call_from_thread(
-            self.app.notify,
-            f"Added alias {alias!r}",
+        self._run_locked_mutation(
+            lambda catalog: catalog.add_alias(entry_hash, alias),
+            log_event="catalog_alias_add_failed",
+            log_kwargs={"entry_hash": entry_hash, "alias": alias},
             title="Add Alias",
-            severity="information",
+            verb="Add",
+            success=lambda _: f"Added alias {alias!r}",
         )
 
     @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
     def _delete_entry(self, entry_hash: str) -> None:
-        catalog = self.app._catalog
-        if catalog is None:
-            return
-        with self._refresh_lock:
-            try:
-                catalog.remove(entry_hash)
-            except Exception as exc:
-                logger.exception("catalog_entry_delete_failed", entry_hash=entry_hash)
-                self._do_refresh_locked()
-                self.app.call_from_thread(
-                    self.app.notify,
-                    f"Delete failed: {exc}",
-                    title="Delete Entry",
-                    severity="error",
-                    timeout=6,
-                )
-                return
-            self._do_refresh_locked()
-        self.app.call_from_thread(
-            self.app.notify,
-            f"Deleted {entry_hash[:12]}",
+        self._run_locked_mutation(
+            lambda catalog: catalog.remove(entry_hash),
+            log_event="catalog_entry_delete_failed",
+            log_kwargs={"entry_hash": entry_hash},
             title="Delete Entry",
-            severity="information",
+            verb="Delete",
+            success=lambda _: f"Deleted {entry_hash[:12]}",
         )
 
     @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
     def _remove_alias(self, alias: str) -> None:
-        catalog = self.app._catalog
-        if catalog is None:
-            return
-        with self._refresh_lock:
-            try:
-                with catalog.maybe_synchronizing(True):
-                    CatalogAlias.from_name(alias, catalog).remove()
-            except Exception as exc:
-                logger.exception("catalog_alias_remove_failed", alias=alias)
-                self._do_refresh_locked()
-                self.app.call_from_thread(
-                    self.app.notify,
-                    f"Remove failed: {exc}",
-                    title="Remove Alias",
-                    severity="error",
-                    timeout=6,
-                )
-                return
-            self._do_refresh_locked()
-        self.app.call_from_thread(
-            self.app.notify,
-            f"Removed alias {alias!r}",
+        def mutate(catalog):
+            with catalog.maybe_synchronizing(True):
+                CatalogAlias.from_name(alias, catalog).remove()
+
+        self._run_locked_mutation(
+            mutate,
+            log_event="catalog_alias_remove_failed",
+            log_kwargs={"alias": alias},
             title="Remove Alias",
-            severity="information",
+            verb="Remove",
+            success=lambda _: f"Removed alias {alias!r}",
         )
 
     def action_quit_app(self) -> None:

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -46,7 +46,7 @@ from textual.widgets import (
 )
 
 from xorq.caching.storage import resolve_parquet_cache_path
-from xorq.catalog.catalog import Catalog, CatalogAlias, CatalogEntry
+from xorq.catalog.catalog import Catalog, CatalogEntry
 from xorq.catalog.enums import CatalogInfix
 from xorq.catalog.exceptions import CatalogPushError
 from xorq.common.utils.caching_utils import CacheKey
@@ -1493,14 +1493,20 @@ class CatalogScreen(Screen):
             return None
         return self._row_cache.get(node.data)
 
-    def _tree_action_available(self) -> bool:
-        # Row-targeting actions (add/remove alias, delete) may only fire while
-        # the entries tree is focused and a leaf row is selected; otherwise the
-        # key bubbles up from another panel and acts on a stale tree cursor.
+    def _tree_action_row(self) -> CatalogRowData | None:
+        # Single source of truth for the row-targeting actions (add/remove
+        # alias, delete): return the selected row only while the entries tree
+        # is focused and a leaf is selected, else None.  Otherwise the key
+        # bubbles up from another panel and acts on a stale tree cursor.
         if not self.is_mounted:
-            return False
+            return None
         tree = self.query_one("#catalog-tree", Tree)
-        return self.app.focused is tree and self._selected_row_data() is not None
+        if self.app.focused is not tree:
+            return None
+        return self._selected_row_data()
+
+    def _tree_action_available(self) -> bool:
+        return self._tree_action_row() is not None
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         if action in ("add_alias", "remove_alias", "delete_entry"):
@@ -1511,7 +1517,7 @@ class CatalogScreen(Screen):
         self.refresh_bindings()
 
     def action_delete_entry(self) -> None:
-        row_data = self._selected_row_data()
+        row_data = self._tree_action_row()
         if row_data is None:
             return
         self.app.push_screen(
@@ -1526,9 +1532,7 @@ class CatalogScreen(Screen):
         )
 
     def action_add_alias(self) -> None:
-        if not self._tree_action_available():
-            return
-        row_data = self._selected_row_data()
+        row_data = self._tree_action_row()
         if row_data is None:
             return
         self.app.push_screen(
@@ -1539,7 +1543,7 @@ class CatalogScreen(Screen):
         )
 
     def action_remove_alias(self) -> None:
-        row_data = self._selected_row_data()
+        row_data = self._tree_action_row()
         if row_data is None:
             return
         if not row_data.aliases:
@@ -1655,12 +1659,8 @@ class CatalogScreen(Screen):
 
     @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
     def _remove_alias(self, alias: str) -> None:
-        def mutate(catalog):
-            with catalog.maybe_synchronizing(True):
-                CatalogAlias.from_name(alias, catalog).remove()
-
         self._run_locked_mutation(
-            mutate,
+            lambda catalog: catalog.remove_alias(alias),
             log_event="catalog_alias_remove_failed",
             log_kwargs={"alias": alias},
             title="Remove Alias",

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -48,6 +48,7 @@ from textual.widgets import (
 from xorq.caching.storage import resolve_parquet_cache_path
 from xorq.catalog.catalog import Catalog, CatalogAlias, CatalogEntry
 from xorq.catalog.enums import CatalogInfix
+from xorq.catalog.exceptions import CatalogPushError
 from xorq.common.utils.caching_utils import CacheKey
 from xorq.common.utils.logging_utils import get_logger
 from xorq.config import options
@@ -55,6 +56,28 @@ from xorq.ibis_yaml.enums import ExprKind
 
 
 logger = get_logger(__name__)
+
+
+def _find_project_path(build_dir: Path) -> Path | None:
+    """Locate the pyproject.toml project root by walking up from a build dir.
+
+    ``Catalog.add`` needs a *project_path* to (re)build wheel/requirements
+    sidecars for an unpackaged build directory, and otherwise walks up from
+    the process cwd -- which is wrong for the TUI, whose cwd need not be inside
+    the project.  Anchor the search on the build directory instead.  Returns
+    ``None`` when no pyproject.toml is found, letting ``Catalog.add`` fall back
+    to its own lookup (and raise its own error message).
+    """
+    from xorq.ibis_yaml.packager import (  # noqa: PLC0415
+        PYPROJECT_NAME,
+        find_file_upwards,
+    )
+
+    try:
+        return find_file_upwards(build_dir, PYPROJECT_NAME).parent
+    except ValueError:
+        return None
+
 
 DEFAULT_REFRESH_INTERVAL = 10
 
@@ -1470,15 +1493,18 @@ class CatalogScreen(Screen):
             return None
         return self._row_cache.get(node.data)
 
-    def _add_alias_available(self) -> bool:
+    def _tree_action_available(self) -> bool:
+        # Row-targeting actions (add/remove alias, delete) may only fire while
+        # the entries tree is focused and a leaf row is selected; otherwise the
+        # key bubbles up from another panel and acts on a stale tree cursor.
         if not self.is_mounted:
             return False
         tree = self.query_one("#catalog-tree", Tree)
         return self.app.focused is tree and self._selected_row_data() is not None
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        if action == "add_alias":
-            return self._add_alias_available()
+        if action in ("add_alias", "remove_alias", "delete_entry"):
+            return self._tree_action_available()
         return super().check_action(action, parameters)
 
     def on_descendant_focus(self) -> None:
@@ -1500,7 +1526,7 @@ class CatalogScreen(Screen):
         )
 
     def action_add_alias(self) -> None:
-        if not self._add_alias_available():
+        if not self._tree_action_available():
             return
         row_data = self._selected_row_data()
         if row_data is None:
@@ -1548,6 +1574,22 @@ class CatalogScreen(Screen):
         with self._refresh_lock:
             try:
                 result = mutate(catalog)
+            except CatalogPushError as exc:
+                # The local commit already happened (synchronizing() commits
+                # before pushing); only the remote push failed.  Re-render --
+                # the change IS applied locally -- and warn about the
+                # local/remote divergence rather than framing it as a total
+                # failure the user would expect to have left no trace.
+                logger.exception(log_event, **log_kwargs)
+                self._do_refresh_locked()
+                self.app.call_from_thread(
+                    self.app.notify,
+                    f"{verb} applied locally but remote push failed: {exc}",
+                    title=title,
+                    severity="warning",
+                    timeout=8,
+                )
+                return
             except Exception as exc:
                 logger.exception(log_event, **log_kwargs)
                 self._do_refresh_locked()
@@ -1574,7 +1616,11 @@ class CatalogScreen(Screen):
         def mutate(catalog):
             if not path.is_dir():
                 raise ValueError(f"build path is not a directory: {path}")
-            return catalog.add(path, aliases=(alias,) if alias else ())
+            return catalog.add(
+                path,
+                aliases=(alias,) if alias else (),
+                project_path=_find_project_path(path),
+            )
 
         self._run_locked_mutation(
             mutate,

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -30,20 +30,22 @@ from textual import on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
 from textual.suggester import SuggestFromList
 from textual.theme import Theme
 from textual.widgets import (
+    Button,
     DataTable,
     Footer,
     Header,
     Input,
+    Select,
     Static,
     Tree,
 )
 
 from xorq.caching.storage import resolve_parquet_cache_path
-from xorq.catalog.catalog import Catalog, CatalogEntry
+from xorq.catalog.catalog import Catalog, CatalogAlias, CatalogEntry
 from xorq.catalog.enums import CatalogInfix
 from xorq.common.utils.caching_utils import CacheKey
 from xorq.common.utils.logging_utils import get_logger
@@ -534,6 +536,209 @@ def _revision_pair(i, rev_entry, commit):
 # ---------------------------------------------------------------------------
 
 
+class AddEntryScreen(ModalScreen[tuple[str, str | None] | None]):
+    """Collect a build directory path and optional alias for a new entry."""
+
+    BINDINGS = (
+        Binding("ctrl+r", "confirm", "Add"),
+        Binding("escape", "cancel", "Cancel"),
+    )
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="add-entry-dialog", classes="entry-action-dialog"):
+            yield Static("Add catalog entry", classes="entry-action-title")
+            yield Static(
+                "Enter a build directory path. Paths may be absolute or relative "
+                "to the current directory.",
+                classes="entry-action-message",
+            )
+            yield Input(
+                placeholder="build directory path",
+                id="add-entry-path",
+            )
+            yield Input(
+                placeholder="alias (optional)",
+                id="add-entry-alias",
+            )
+            with Horizontal(classes="entry-action-buttons"):
+                yield Button("Cancel", id="cancel-add-entry")
+                yield Button("Add Entry", id="confirm-add-entry", variant="success")
+
+    def action_confirm(self) -> None:
+        path = self.query_one("#add-entry-path", Input).value.strip()
+        if not path:
+            self.app.notify(
+                "Enter a build directory path.",
+                title="Add Entry",
+                severity="warning",
+            )
+            return
+        build_dir = Path(path).expanduser()
+        if not build_dir.exists():
+            self.app.notify(
+                f"Path does not exist: {path}",
+                title="Add Entry",
+                severity="warning",
+            )
+            return
+        if not build_dir.is_dir():
+            self.app.notify(
+                f"Build path is not a directory: {path}",
+                title="Add Entry",
+                severity="warning",
+            )
+            return
+        alias = self.query_one("#add-entry-alias", Input).value.strip() or None
+        self.dismiss((path, alias))
+
+    @on(Button.Pressed)
+    def _on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "confirm-add-entry":
+            self.action_confirm()
+        else:
+            self.action_cancel()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class AddAliasScreen(ModalScreen[str | None]):
+    """Collect an alias to attach to the selected entry."""
+
+    BINDINGS = (
+        Binding("ctrl+r", "confirm", "Add"),
+        Binding("escape", "cancel", "Cancel"),
+    )
+
+    def __init__(self, row_data: CatalogRowData):
+        super().__init__()
+        self._row_data = row_data
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="add-alias-dialog", classes="entry-action-dialog"):
+            yield Static("Add alias", classes="entry-action-title")
+            yield Static(
+                f"Attach a new alias to {self._row_data.hash}.",
+                classes="entry-action-message",
+            )
+            yield Input(placeholder="alias", id="add-alias-name")
+            with Horizontal(classes="entry-action-buttons"):
+                yield Button("Cancel", id="cancel-add-alias")
+                yield Button("Add Alias", id="confirm-add-alias", variant="success")
+
+    def action_confirm(self) -> None:
+        alias = self.query_one("#add-alias-name", Input).value.strip()
+        if not alias:
+            self.app.notify(
+                "Enter an alias.",
+                title="Add Alias",
+                severity="warning",
+            )
+            return
+        self.dismiss(alias)
+
+    @on(Button.Pressed)
+    def _on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "confirm-add-alias":
+            self.action_confirm()
+        else:
+            self.action_cancel()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class DeleteEntryScreen(ModalScreen[bool]):
+    """Confirm removal of an entry and all aliases that point to it."""
+
+    BINDINGS = (
+        Binding("ctrl+r", "confirm", "Delete"),
+        Binding("escape", "cancel", "Cancel"),
+    )
+
+    def __init__(self, row_data: CatalogRowData):
+        super().__init__()
+        self._row_data = row_data
+
+    def compose(self) -> ComposeResult:
+        row_data = self._row_data
+        aliases = (
+            f"\nAliases also removed: {row_data.aliases_display}"
+            if row_data.aliases
+            else ""
+        )
+        with Vertical(id="delete-entry-dialog", classes="entry-action-dialog"):
+            yield Static("Delete catalog entry?", classes="entry-action-title")
+            yield Static(
+                f"{row_data.hash}\n\nThis removes the entry from the catalog.{aliases}",
+                classes="entry-action-message",
+            )
+            with Horizontal(classes="entry-action-buttons"):
+                yield Button("Cancel", id="cancel-delete-entry")
+                yield Button("Delete Entry", id="confirm-delete-entry", variant="error")
+
+    @on(Button.Pressed)
+    def _on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm-delete-entry")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+
+class RemoveAliasScreen(ModalScreen[str | None]):
+    """Choose and confirm an alias to detach from a catalog entry."""
+
+    BINDINGS = (
+        Binding("ctrl+r", "confirm", "Remove"),
+        Binding("escape", "cancel", "Cancel"),
+    )
+
+    def __init__(self, row_data: CatalogRowData):
+        super().__init__()
+        self._row_data = row_data
+
+    def compose(self) -> ComposeResult:
+        aliases = self._row_data.aliases
+        with Vertical(id="remove-alias-dialog", classes="entry-action-dialog"):
+            yield Static("Remove alias?", classes="entry-action-title")
+            yield Static(
+                "The catalog entry and its other aliases will be kept.",
+                classes="entry-action-message",
+            )
+            yield Select(
+                ((alias, alias) for alias in aliases),
+                value=aliases[0],
+                allow_blank=False,
+                id="remove-alias-select",
+            )
+            with Horizontal(classes="entry-action-buttons"):
+                yield Button("Cancel", id="cancel-remove-alias")
+                yield Button(
+                    "Remove Alias", id="confirm-remove-alias", variant="warning"
+                )
+
+    def _selected_alias(self) -> str | None:
+        value = self.query_one("#remove-alias-select", Select).value
+        return value if isinstance(value, str) else None
+
+    @on(Button.Pressed)
+    def _on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(
+            self._selected_alias()
+            if event.button.id == "confirm-remove-alias"
+            else None
+        )
+
+    def action_confirm(self) -> None:
+        self.dismiss(self._selected_alias())
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
 class CatalogScreen(Screen):
     BINDINGS = (
         Binding("q", "quit_app", "Quit"),
@@ -545,6 +750,12 @@ class CatalogScreen(Screen):
         Binding("tab", "focus_next_panel", "Next", show=False),
         Binding("shift+tab", "focus_prev_panel", "Prev", show=False),
         Binding("e", "open_data_view", "Explore"),
+        Binding("a", "add_entry", "Add Entry"),
+        # Terminals report Shift+A as the uppercase character "A", not the
+        # synthetic key name "shift+a" used by Textual's test pilot.
+        Binding("A", "add_alias", "Add Alias"),
+        Binding("r", "remove_alias", "Remove Alias"),
+        Binding("d", "delete_entry", "Delete"),
         Binding("v", "toggle_revisions", "Revisions"),
         Binding("g", "toggle_git_log", "Git Log"),
         Binding("1", "view_sql", "SQL", priority=True),
@@ -667,6 +878,9 @@ class CatalogScreen(Screen):
 
     @on(Tree.NodeHighlighted, "#catalog-tree")
     def _on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
+        # Add Alias is a dynamic binding: it is visible only while an entry
+        # leaf is selected in the focused catalog tree.
+        self.refresh_bindings()
         # Debounce: rapid j/k traversal fires NodeHighlighted per intermediate
         # node.  Defer the synchronous panel render until the cursor settles so
         # holding a key moves at terminal-repeat-rate.  _render_highlighted_node
@@ -922,6 +1136,7 @@ class CatalogScreen(Screen):
             total = sum(1 + len(b.children) for b in tree.root.children)
             if total > 0:
                 tree.cursor_line = min(saved_line, total - 1)
+            self.refresh_bindings()
 
     def _render_catalog_row(self, row_data) -> None:
         with self.app.batch_update():
@@ -1241,14 +1456,189 @@ class CatalogScreen(Screen):
         self.query_one(visible[next_idx]).focus()
 
     def action_open_data_view(self) -> None:
-        tree = self.query_one("#catalog-tree", Tree)
-        node = tree.cursor_node
-        if node is None or node.children:
-            return
-        row_data = self._row_cache.get(node.data)
+        row_data = self._selected_row_data()
         if row_data is None or row_data.kind == "unbound_expr":
             return
         self.app.push_screen(DataViewScreen(entry=row_data.entry, row_data=row_data))
+
+    def _selected_row_data(self) -> CatalogRowData | None:
+        tree = self.query_one("#catalog-tree", Tree)
+        node = tree.cursor_node
+        if node is None or node.children:
+            return None
+        return self._row_cache.get(node.data)
+
+    def _add_alias_available(self) -> bool:
+        if not self.is_mounted:
+            return False
+        tree = self.query_one("#catalog-tree", Tree)
+        return self.app.focused is tree and self._selected_row_data() is not None
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "add_alias":
+            return self._add_alias_available()
+        return super().check_action(action, parameters)
+
+    def on_descendant_focus(self) -> None:
+        self.refresh_bindings()
+
+    def action_delete_entry(self) -> None:
+        row_data = self._selected_row_data()
+        if row_data is None:
+            return
+        self.app.push_screen(
+            DeleteEntryScreen(row_data),
+            lambda confirmed: self._delete_entry(row_data.hash) if confirmed else None,
+        )
+
+    def action_add_entry(self) -> None:
+        self.app.push_screen(
+            AddEntryScreen(),
+            lambda request: self._add_entry(*request) if request is not None else None,
+        )
+
+    def action_add_alias(self) -> None:
+        if not self._add_alias_available():
+            return
+        row_data = self._selected_row_data()
+        if row_data is None:
+            return
+        self.app.push_screen(
+            AddAliasScreen(row_data),
+            lambda alias: (
+                self._add_alias(row_data.hash, alias) if alias is not None else None
+            ),
+        )
+
+    def action_remove_alias(self) -> None:
+        row_data = self._selected_row_data()
+        if row_data is None:
+            return
+        if not row_data.aliases:
+            self.app.notify(
+                "The selected entry has no aliases.",
+                title="Remove Alias",
+                severity="warning",
+            )
+            return
+        self.app.push_screen(
+            RemoveAliasScreen(row_data),
+            lambda alias: self._remove_alias(alias) if alias is not None else None,
+        )
+
+    @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
+    def _add_entry(self, build_dir_path: str, alias: str | None) -> None:
+        catalog = self.app._catalog
+        if catalog is None:
+            return
+        path = Path(build_dir_path).expanduser()
+        with self._refresh_lock:
+            try:
+                if not path.is_dir():
+                    raise ValueError(f"build path is not a directory: {path}")
+                entry = catalog.add(path, aliases=(alias,) if alias else ())
+            except Exception as exc:
+                logger.exception("catalog_entry_add_failed", build_dir_path=str(path))
+                self._do_refresh_locked()
+                self.app.call_from_thread(
+                    self.app.notify,
+                    f"Add failed: {exc}",
+                    title="Add Entry",
+                    severity="error",
+                    timeout=6,
+                )
+                return
+            self._do_refresh_locked()
+        self.app.call_from_thread(
+            self.app.notify,
+            f"Added {entry.name[:12]}",
+            title="Add Entry",
+            severity="information",
+        )
+
+    @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
+    def _add_alias(self, entry_hash: str, alias: str) -> None:
+        catalog = self.app._catalog
+        if catalog is None:
+            return
+        with self._refresh_lock:
+            try:
+                catalog.add_alias(entry_hash, alias)
+            except Exception as exc:
+                logger.exception(
+                    "catalog_alias_add_failed", entry_hash=entry_hash, alias=alias
+                )
+                self._do_refresh_locked()
+                self.app.call_from_thread(
+                    self.app.notify,
+                    f"Add failed: {exc}",
+                    title="Add Alias",
+                    severity="error",
+                    timeout=6,
+                )
+                return
+            self._do_refresh_locked()
+        self.app.call_from_thread(
+            self.app.notify,
+            f"Added alias {alias!r}",
+            title="Add Alias",
+            severity="information",
+        )
+
+    @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
+    def _delete_entry(self, entry_hash: str) -> None:
+        catalog = self.app._catalog
+        if catalog is None:
+            return
+        with self._refresh_lock:
+            try:
+                catalog.remove(entry_hash)
+            except Exception as exc:
+                logger.exception("catalog_entry_delete_failed", entry_hash=entry_hash)
+                self._do_refresh_locked()
+                self.app.call_from_thread(
+                    self.app.notify,
+                    f"Delete failed: {exc}",
+                    title="Delete Entry",
+                    severity="error",
+                    timeout=6,
+                )
+                return
+            self._do_refresh_locked()
+        self.app.call_from_thread(
+            self.app.notify,
+            f"Deleted {entry_hash[:12]}",
+            title="Delete Entry",
+            severity="information",
+        )
+
+    @work(thread=True, exit_on_error=False, exclusive=True, group="catalog_mutation")
+    def _remove_alias(self, alias: str) -> None:
+        catalog = self.app._catalog
+        if catalog is None:
+            return
+        with self._refresh_lock:
+            try:
+                with catalog.maybe_synchronizing(True):
+                    CatalogAlias.from_name(alias, catalog).remove()
+            except Exception as exc:
+                logger.exception("catalog_alias_remove_failed", alias=alias)
+                self._do_refresh_locked()
+                self.app.call_from_thread(
+                    self.app.notify,
+                    f"Remove failed: {exc}",
+                    title="Remove Alias",
+                    severity="error",
+                    timeout=6,
+                )
+                return
+            self._do_refresh_locked()
+        self.app.call_from_thread(
+            self.app.notify,
+            f"Removed alias {alias!r}",
+            title="Remove Alias",
+            severity="information",
+        )
 
     def action_quit_app(self) -> None:
         self.app.exit()
@@ -1790,6 +2180,41 @@ class CatalogTUI(App):
         border-title-color: #2BBE75;
         padding: 0 1;
     }
+
+    AddEntryScreen,
+    AddAliasScreen,
+    DeleteEntryScreen,
+    RemoveAliasScreen {
+        align: center middle;
+        background: $background 65%;
+    }
+    .entry-action-dialog {
+        width: 72;
+        height: auto;
+        padding: 1 2;
+        border: double $accent;
+        background: $surface;
+    }
+    .entry-action-title {
+        height: 1;
+        text-style: bold;
+        color: $accent;
+    }
+    .entry-action-message {
+        height: auto;
+        margin-top: 1;
+        color: $foreground;
+    }
+    #add-entry-path,
+    #add-entry-alias,
+    #add-alias-name,
+    #remove-alias-select { margin-top: 1; }
+    .entry-action-buttons {
+        height: 3;
+        margin-top: 1;
+        align-horizontal: right;
+    }
+    .entry-action-buttons Button { margin-left: 1; }
     """
 
     def __init__(self, make_catalog, refresh_interval=DEFAULT_REFRESH_INTERVAL):


### PR DESCRIPTION
## Summary

Adds entry-mutation actions to the catalog TUI so a catalog can be curated interactively, without dropping back to the CLI. All four mutations run off the existing catalog API and refresh the view under the shared refresh lock.

New key bindings on the catalog screen:

- `a` — **Add Entry**: prompt for a build directory path (absolute or relative) and an optional alias, then `catalog.add(...)`.
- `A` — **Add Alias**: attach a new alias to the selected entry. This is a dynamic binding, shown only while an entry leaf is focused in the catalog tree.
- `r` — **Remove Alias**: pick one of the selected entry's aliases from a dropdown and detach it, keeping the entry and its other aliases.
- `d` — **Delete Entry**: confirm removal of the entry and every alias that points to it.

Each action is a `ModalScreen` dialog (`AddEntryScreen`, `AddAliasScreen`, `RemoveAliasScreen`, `DeleteEntryScreen`) with `ctrl+r` to confirm and `escape` to cancel. Add Entry validates that the path exists and is a directory before dismissing. Mutations execute in a threaded worker (`group="catalog_mutation"`, `exclusive=True`) that holds `_refresh_lock`, re-renders on both success and failure, and surfaces errors via notifications rather than crashing the app.

## Notes

- `A` is bound to the uppercase character rather than `shift+a`: terminals report Shift+A as `"A"`, not the synthetic `shift+a` key name.
- Add Alias visibility is driven through `check_action` / `refresh_bindings`, refreshed on tree navigation and descendant focus changes.

## Test plan

Adds TUI tests in `test_tui.py` (Textual `Pilot`) covering:

- Add entry from an extracted build directory with an alias
- Add Entry rejecting a non-directory (zip) path
- Add Alias to the selected entry
- Add Alias binding visible only when an entry leaf is focused
- Delete entry (confirm and cancel), removing the entry and its aliases
- Remove Alias keeping the entry and remaining aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
