### PR TITLE
refactor(graph_utils): unify opaque descent via OPAQUE_EDGES table

### DIFF
--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict, deque
 from collections.abc import Callable
 from typing import Any, OrderedDict, Tuple
@@ -22,6 +24,45 @@ opaque_ops = (
 )
 
 
+# Single source of truth for opaque descent: the field name(s) on each opaque op
+# holding children that the standard ``__children__`` protocol does not surface
+# (they are ``Expr``-typed or stored in ``__config__``). Consumed by the read
+# side (``gen_children_of`` + policy variants) and the write side
+# (``replace_nodes``). Descent policies are edge-filter overrides of this table
+# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``gen_children_flight_leaf``);
+# the write side additionally skips the edges in ``_WRITE_SKIP_EDGES``.
+OPAQUE_EDGES = {
+    rel.RemoteTable: ("remote_expr",),
+    rel.CachedNode: ("parent",),
+    rel.CacheTag: ("parent", "uncached"),
+    rel.FlightExpr: ("input_expr",),
+    rel.FlightUDXF: ("input_expr",),
+    udf.ExprScalarUDF: ("computed_kwargs_expr",),
+    rel.Read: (),
+}
+
+# Edges the *write* path (``replace_nodes``) must NOT descend even though the
+# read path does: a ``CacheTag``'s ``parent`` is the frozen native read the
+# replacer already produced; re-driving it diverges the read's backend identity
+# from ``cache`` and breaks profile resolution on load (test_pinned_cache_yaml_roundtrip).
+_WRITE_SKIP_EDGES = {
+    rel.CacheTag: ("parent",),
+}
+
+
+def _opaque_edges_for(node: Node, table: dict = OPAQUE_EDGES) -> Tuple[str, ...] | None:
+    """Return the opaque child-edge names for *node*, or ``None`` if not opaque.
+
+    Matches by ``isinstance`` (preserving the original ``match`` semantics); the
+    opaque op types are mutually non-subclassing, so iteration order is
+    immaterial.
+    """
+    for typ, edges in table.items():
+        if isinstance(node, typ):
+            return edges
+    return None
+
+
 def to_node(maybe_expr: Any) -> Node:
     match maybe_expr:
         case Node():
@@ -32,44 +73,54 @@ def to_node(maybe_expr: Any) -> Node:
             raise ValueError(f"Don't know how to handle type {type(maybe_expr)}")
 
 
-def gen_children_of(node: Node) -> Tuple[Node, ...]:
-    match node:
-        case ops.Field():
-            rel_node = node.rel
-            gen = () if rel_node is None else (to_node(rel_node),)
+def gen_children_of(
+    node: Node, *, opaque_edges: dict = OPAQUE_EDGES
+) -> Tuple[Node, ...]:
+    """Yield a node's children, descending opaque ops per *opaque_edges*.
 
-        case rel.RemoteTable():
-            gen = (to_node(node.remote_expr),)
-
-        case rel.CachedNode():
-            gen = (to_node(node.parent),)
-
-        case rel.CacheTag():
-            # descend both opaque children (see CacheTag docstring)
-            gen = (to_node(node.parent), to_node(node.uncached))
-
-        case rel.FlightExpr() | rel.FlightUDXF():
-            gen = (to_node(node.input_expr),)
-
-        case udf.ExprScalarUDF():
-            gen = (to_node(node.computed_kwargs_expr),)
-
-        case rel.Read():
-            gen = ()
-        case _:
-            raw_children = getattr(node, "__children__", ())
-            gen = map(to_node, raw_children)
+    For an opaque op, children are the nodes referenced by its edge fields (see
+    ``OPAQUE_EDGES``); a descent policy passes a modified *opaque_edges* to prune
+    or redirect specific edges (see ``_gen_children_exec`` and friends). All
+    other nodes fall back to the standard ``__children__`` protocol.
+    """
+    edges = _opaque_edges_for(node, opaque_edges)
+    if edges is not None:
+        gen = (getattr(node, name, None) for name in edges)
+        gen = (to_node(child) for child in gen if child is not None)
+    else:
+        match node:
+            case ops.Field():
+                rel_node = node.rel
+                gen = () if rel_node is None else (to_node(rel_node),)
+            case _:
+                raw_children = getattr(node, "__children__", ())
+                gen = map(to_node, raw_children)
     yield from filter(None, gen)
 
 
-def bfs(node):
+def bfs(
+    node: Expr | Node,
+    *,
+    children: Callable[[Node], Any] = gen_children_of,
+    filter: Callable[[Node], bool] | None = None,
+) -> Graph:
+    """Build an opaque-descending :class:`Graph` from *node* by BFS.
+
+    ``children`` overrides child enumeration (default ``gen_children_of``); pass
+    a policy variant to prune opaque edges. ``filter`` stops the walk at any
+    child for which it returns ``False`` (the boundary-stopping form used to
+    collapse non-boundary runs); the filtered-out node is neither recorded nor
+    descended.
+    """
     queue = deque((to_node(node),))
     dct = {}
     while queue:
         if (node := queue.popleft()) not in dct:
-            children = tuple(gen_children_of(node))
-            dct[node] = children
-            queue.extend(children)
+            kids = tuple(children(node))
+            if filter is not None:
+                kids = tuple(child for child in kids if filter(child))
+            dct[node] = kids
+            queue.extend(kids)
     return Graph(dct)
 
 
@@ -150,37 +201,28 @@ def replace_nodes(
 
     def process_node(op, _kwargs):
         op = replacer(op, _kwargs)
-        match op:
-            case rel.RemoteTable():
-                remote_expr = _replace_sub(op.remote_expr.op())
-                return do_recreate(op, _kwargs, remote_expr=remote_expr)
-            case rel.CachedNode():
-                parent = _replace_sub(to_node(op.parent))
-                return do_recreate(op, _kwargs, parent=parent)
-            case rel.CacheTag():
-                # Do NOT forward _kwargs (the asymmetry vs the sibling branches
-                # is load-bearing, not accidental -- it is covered by
-                # test_pinned_cache_yaml_roundtrip). ``parent`` is the materialized
-                # cache read paired with ``cache``; re-driving it from the BFS
-                # rewrite diverges the read's backend identity from ``cache`` and
-                # breaks profile resolution on load. The replacer has already
-                # produced ``op`` with the correct native ``parent``; only the opaque
-                # ``uncached`` payload still needs descending here.
-                uncached = _replace_sub(to_node(op.uncached))
-                return do_recreate(op, None, uncached=uncached)
-            case rel.FlightExpr() | rel.FlightUDXF():
-                input_expr = _replace_sub(op.input_expr.op())
-                return do_recreate(op, _kwargs, input_expr=input_expr)
-            case udf.ExprScalarUDF():
-                computed_kwargs_expr = _replace_sub(op.computed_kwargs_expr.op())
-                with_cke = op.with_computed_kwargs_expr(computed_kwargs_expr)
-                return do_recreate(with_cke, _kwargs)
-            case rel.Read():
-                return op
-            case _:
-                if isinstance(op, opaque_ops):
-                    raise ValueError(f"unhandled opaque op {type(op)}")
-                return op
+        edges = _opaque_edges_for(op)
+        if edges is None:
+            if isinstance(op, opaque_ops):
+                raise ValueError(f"unhandled opaque op {type(op)}")
+            return op
+        # ExprScalarUDF rebinds its sub-expr through a dedicated method rather
+        # than a plain __recreate__ kwarg (computed_kwargs_expr lives in __config__).
+        if isinstance(op, udf.ExprScalarUDF):
+            with_cke = op.with_computed_kwargs_expr(
+                _replace_sub(op.computed_kwargs_expr.op())
+            )
+            return do_recreate(with_cke, _kwargs)
+        # CacheTag: descend only the edges not in _WRITE_SKIP_EDGES (i.e. skip
+        # ``parent``) and do NOT forward _kwargs -- both load-bearing, see
+        # _WRITE_SKIP_EDGES and test_pinned_cache_yaml_roundtrip.
+        skip = _WRITE_SKIP_EDGES.get(type(op), ())
+        descend = tuple(name for name in edges if name not in skip)
+        if not descend:
+            return op  # Read (no opaque children)
+        overrides = {name: _replace_sub(to_node(getattr(op, name))) for name in descend}
+        forward_kwargs = None if isinstance(op, rel.CacheTag) else _kwargs
+        return do_recreate(op, forward_kwargs, **overrides)
 
     # hasattr(x, "op") is unreliable: some Nodes have an `op` field (e.g. IntervalAdd)
     initial_op = to_node(expr)
@@ -430,6 +472,12 @@ def get_ordered_unique_sources(nodes: Tuple[Node, ...]) -> Tuple[Any, ...]:
     return sources
 
 
+# Descent policies are OPAQUE_EDGES with specific edges overridden.
+_EXEC_EDGES = {**OPAQUE_EDGES, rel.CacheTag: ("parent",)}
+_SKIP_PINS_EDGES = {**OPAQUE_EDGES, rel.CacheTag: ()}
+_FLIGHT_LEAF_EDGES = {**OPAQUE_EDGES, rel.FlightExpr: (), rel.FlightUDXF: ()}
+
+
 def _gen_children_exec(node: Node) -> Tuple[Node, ...]:
     """Child enumeration along the *execution* path only.
 
@@ -439,9 +487,7 @@ def _gen_children_exec(node: Node) -> Tuple[Node, ...]:
     pruning of pinned-leaf data so source discovery stays consistent with
     hashing.
     """
-    if isinstance(node, rel.CacheTag):
-        return (to_node(node.parent),)
-    return tuple(gen_children_of(node))
+    return tuple(gen_children_of(node, opaque_edges=_EXEC_EDGES))
 
 
 def _gen_children_skip_pins(node: Node) -> Tuple[Node, ...]:
@@ -451,9 +497,17 @@ def _gen_children_skip_pins(node: Node) -> Tuple[Node, ...]:
     leaves reachable *without* passing through any pin -- the "live" leaves used
     by :func:`exclusively_pinned_leaves`.
     """
-    if isinstance(node, rel.CacheTag):
-        return ()
-    return tuple(gen_children_of(node))
+    return tuple(gen_children_of(node, opaque_edges=_SKIP_PINS_EDGES))
+
+
+def gen_children_flight_leaf(node: Node) -> Tuple[Node, ...]:
+    """Child enumeration treating ``FlightExpr``/``FlightUDXF`` as opaque leaves.
+
+    So a Flight node's ``input_expr`` is not flattened into the outer graph; its
+    lineage is extracted separately as a nested sub-DAG (see XOR-363). Not used
+    by any existing caller -- a capability added for lineage extraction.
+    """
+    return tuple(gen_children_of(node, opaque_edges=_FLIGHT_LEAF_EDGES))
 
 
 def exclusively_pinned_leaves(

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Any, OrderedDict, Tuple
 
 import xorq.expr.relations as rel
@@ -13,23 +13,12 @@ from xorq.vendor.ibis.common.graph import Graph
 from xorq.vendor.ibis.expr.operations.core import Node
 
 
-opaque_ops = (
-    rel.Read,
-    rel.CachedNode,
-    rel.CacheTag,
-    rel.RemoteTable,
-    rel.FlightUDXF,
-    rel.FlightExpr,
-    udf.ExprScalarUDF,
-)
-
-
 # Single source of truth for opaque descent: the field name(s) on each opaque op
 # holding children that the standard ``__children__`` protocol does not surface
 # (they are ``Expr``-typed or stored in ``__config__``). Consumed by the read
 # side (``gen_children_of`` + policy variants) and the write side
 # (``replace_nodes``). Descent policies are edge-filter overrides of this table
-# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``gen_children_flight_leaf``);
+# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``_gen_children_flight_leaf``);
 # the write side additionally skips the edges in ``_WRITE_SKIP_EDGES``.
 OPAQUE_EDGES = {
     rel.RemoteTable: ("remote_expr",),
@@ -41,6 +30,10 @@ OPAQUE_EDGES = {
     rel.Read: (),
 }
 
+# The opaque op types themselves -- derived from OPAQUE_EDGES so the two cannot
+# drift (``replace_nodes`` raises on an opaque op with no edge entry).
+opaque_ops = tuple(OPAQUE_EDGES)
+
 # Edges the *write* path (``replace_nodes``) must NOT descend even though the
 # read path does: a ``CacheTag``'s ``parent`` is the frozen native read the
 # replacer already produced; re-driving it diverges the read's backend identity
@@ -51,11 +44,14 @@ _WRITE_SKIP_EDGES = {
 
 
 def _opaque_edges_for(node: Node, table: dict = OPAQUE_EDGES) -> Tuple[str, ...] | None:
-    """Return the opaque child-edge names for *node*, or ``None`` if not opaque.
+    """Return *table*'s edge names for *node*, or ``None`` if it has no entry.
 
     Matches by ``isinstance`` (preserving the original ``match`` semantics); the
     opaque op types are mutually non-subclassing, so iteration order is
-    immaterial.
+    immaterial. Used for every edge-table lookup (``OPAQUE_EDGES``, the descent
+    policies, ``_WRITE_SKIP_EDGES``) so they all match the same way -- an exact
+    ``type()`` lookup on one table and ``isinstance`` on another would diverge
+    the moment an opaque op grows a subclass.
     """
     for typ, edges in table.items():
         if isinstance(node, typ):
@@ -73,20 +69,22 @@ def to_node(maybe_expr: Any) -> Node:
             raise ValueError(f"Don't know how to handle type {type(maybe_expr)}")
 
 
-def gen_children_of(
-    node: Node, *, opaque_edges: dict = OPAQUE_EDGES
-) -> Tuple[Node, ...]:
+def gen_children_of(node: Node, *, opaque_edges: dict = OPAQUE_EDGES) -> Iterator[Node]:
     """Yield a node's children, descending opaque ops per *opaque_edges*.
 
     For an opaque op, children are the nodes referenced by its edge fields (see
     ``OPAQUE_EDGES``); a descent policy passes a modified *opaque_edges* to prune
     or redirect specific edges (see ``_gen_children_exec`` and friends). All
     other nodes fall back to the standard ``__children__`` protocol.
+
+    Edge fields are read unguarded: a stale/misspelled name in an edge table
+    raises ``AttributeError`` and an unexpectedly ``None`` edge raises
+    ``ValueError`` from ``to_node``, rather than silently yielding an incomplete
+    child set. Prune an edge by removing it from the table, not by nulling it.
     """
     edges = _opaque_edges_for(node, opaque_edges)
     if edges is not None:
-        gen = (getattr(node, name, None) for name in edges)
-        gen = (to_node(child) for child in gen if child is not None)
+        gen = (to_node(getattr(node, name)) for name in edges)
     else:
         match node:
             case ops.Field():
@@ -102,23 +100,24 @@ def bfs(
     node: Expr | Node,
     *,
     children: Callable[[Node], Any] = gen_children_of,
-    filter: Callable[[Node], bool] | None = None,
+    node_filter: Callable[[Node], bool] | None = None,
 ) -> Graph:
     """Build an opaque-descending :class:`Graph` from *node* by BFS.
 
     ``children`` overrides child enumeration (default ``gen_children_of``); pass
-    a policy variant to prune opaque edges. ``filter`` stops the walk at any
+    a policy variant to prune opaque edges. ``node_filter`` stops the walk at any
     child for which it returns ``False`` (the boundary-stopping form used to
     collapse non-boundary runs); the filtered-out node is neither recorded nor
-    descended.
+    descended, and never appears in another node's children, so the returned
+    graph has no dangling references. The root is never filtered.
     """
     queue = deque((to_node(node),))
     dct = {}
     while queue:
         if (node := queue.popleft()) not in dct:
             kids = tuple(children(node))
-            if filter is not None:
-                kids = tuple(child for child in kids if filter(child))
+            if node_filter is not None:
+                kids = tuple(child for child in kids if node_filter(child))
             dct[node] = kids
             queue.extend(kids)
     return Graph(dct)
@@ -216,7 +215,7 @@ def replace_nodes(
         # CacheTag: descend only the edges not in _WRITE_SKIP_EDGES (i.e. skip
         # ``parent``) and do NOT forward _kwargs -- both load-bearing, see
         # _WRITE_SKIP_EDGES and test_pinned_cache_yaml_roundtrip.
-        skip = _WRITE_SKIP_EDGES.get(type(op), ())
+        skip = _opaque_edges_for(op, _WRITE_SKIP_EDGES) or ()
         descend = tuple(name for name in edges if name not in skip)
         if not descend:
             return op  # Read (no opaque children)
@@ -500,12 +499,13 @@ def _gen_children_skip_pins(node: Node) -> Tuple[Node, ...]:
     return tuple(gen_children_of(node, opaque_edges=_SKIP_PINS_EDGES))
 
 
-def gen_children_flight_leaf(node: Node) -> Tuple[Node, ...]:
+def _gen_children_flight_leaf(node: Node) -> Tuple[Node, ...]:
     """Child enumeration treating ``FlightExpr``/``FlightUDXF`` as opaque leaves.
 
     So a Flight node's ``input_expr`` is not flattened into the outer graph; its
-    lineage is extracted separately as a nested sub-DAG (see XOR-363). Not used
-    by any existing caller -- a capability added for lineage extraction.
+    lineage is extracted separately as a nested sub-DAG (see XOR-363). Private
+    until XOR-363 lands its caller; covered by
+    ``test_gen_children_flight_leaf_treats_flight_as_leaf``.
     """
     return tuple(gen_children_of(node, opaque_edges=_FLIGHT_LEAF_EDGES))
 

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -4,6 +4,9 @@ from collections import defaultdict, deque
 from collections.abc import Callable, Iterator
 from typing import Any, OrderedDict, Tuple
 
+from attrs import field, frozen
+from attrs.validators import deep_iterable, instance_of, optional
+
 import xorq.expr.relations as rel
 import xorq.expr.udf as udf
 import xorq.vendor.ibis.expr.operations as ops
@@ -13,45 +16,97 @@ from xorq.vendor.ibis.common.graph import Graph
 from xorq.vendor.ibis.expr.operations.core import Node
 
 
-# Single source of truth for opaque descent: the field name(s) on each opaque op
-# holding children that the standard ``__children__`` protocol does not surface
-# (they are ``Expr``-typed or stored in ``__config__``). Consumed by the read
-# side (``gen_children_of`` + policy variants) and the write side
-# (``replace_nodes``). Descent policies are edge-filter overrides of this table
-# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``_gen_children_flight_leaf``);
-# the write side additionally skips the edges in ``_WRITE_SKIP_EDGES``.
-OPAQUE_EDGES = {
-    rel.RemoteTable: ("remote_expr",),
-    rel.CachedNode: ("parent",),
-    rel.CacheTag: ("parent", "uncached"),
-    rel.FlightExpr: ("input_expr",),
-    rel.FlightUDXF: ("input_expr",),
-    udf.ExprScalarUDF: ("computed_kwargs_expr",),
-    rel.Read: (),
+@frozen
+class OpaqueSpec:
+    """Everything graph traversal needs to know about one opaque op type.
+
+    An *opaque* op holds children the standard ``__children__`` protocol does not
+    surface (they are ``Expr``-typed or stored in ``__config__``); the edge fields
+    naming those children, plus the per-op quirks of rewriting them, live here so
+    one entry tells the whole story for one op type.
+    """
+
+    # Edge fields the read side descends (``gen_children_of`` + policy variants).
+    read_edges: Tuple[str, ...] = field(
+        default=(), validator=deep_iterable(instance_of(str))
+    )
+    # Edge fields the write side descends (``replace_nodes``); ``None`` means
+    # "same as read_edges". Set it only where the two genuinely differ.
+    write_edges: Tuple[str, ...] | None = field(
+        default=None, validator=optional(deep_iterable(instance_of(str)))
+    )
+    # Whether ``replace_nodes`` forwards the pre-replacer ``_kwargs`` to
+    # ``__recreate__``.
+    forward_kwargs: bool = field(default=True, validator=instance_of(bool))
+    # For ops whose sub-expression rebinds through a dedicated method rather than
+    # a plain ``__recreate__`` kwarg: ``rebind(op, new_sub_expr) -> op``.
+    rebind: Callable | None = field(
+        default=None, validator=optional(instance_of(Callable))
+    )
+
+    @property
+    def descend_edges(self) -> Tuple[str, ...]:
+        return self.read_edges if self.write_edges is None else self.write_edges
+
+
+# Single source of truth for opaque descent, consumed by both the read side
+# (``gen_children_of`` + policy variants) and the write side (``replace_nodes``).
+# Read-side descent policies are edge overrides of the derived ``OPAQUE_EDGES``
+# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``_gen_children_flight_leaf``).
+OPAQUE_SPECS = {
+    rel.RemoteTable: OpaqueSpec(("remote_expr",)),
+    rel.CachedNode: OpaqueSpec(("parent",)),
+    rel.CacheTag: OpaqueSpec(
+        # The read/write asymmetry is load-bearing, not accidental -- it is covered
+        # by test_pinned_cache_yaml_roundtrip. Reads descend both children (see the
+        # CacheTag docstring). Writes descend only the opaque ``uncached`` payload
+        # and do not forward ``_kwargs``: ``parent`` is the materialized cache read
+        # paired with ``cache``, already produced correctly by the replacer, and
+        # re-driving it from the BFS rewrite diverges the read's backend identity
+        # from ``cache``, breaking profile resolution on load.
+        read_edges=("parent", "uncached"),
+        write_edges=("uncached",),
+        forward_kwargs=False,
+    ),
+    rel.FlightExpr: OpaqueSpec(("input_expr",)),
+    rel.FlightUDXF: OpaqueSpec(("input_expr",)),
+    udf.ExprScalarUDF: OpaqueSpec(
+        # ``computed_kwargs_expr`` lives in ``__config__``, so it is rebound by
+        # method instead of by ``__recreate__`` kwarg.
+        ("computed_kwargs_expr",),
+        rebind=lambda op, sub_expr: op.with_computed_kwargs_expr(sub_expr),
+    ),
+    rel.Read: OpaqueSpec(),  # opaque leaf: no edges on either side
 }
 
-# The opaque op types themselves -- derived from OPAQUE_EDGES so the two cannot
-# drift (``replace_nodes`` raises on an opaque op with no edge entry).
-opaque_ops = tuple(OPAQUE_EDGES)
+# The opaque op types themselves -- derived from OPAQUE_SPECS so the two cannot
+# drift (``replace_nodes`` raises on an opaque op with no spec).
+opaque_ops = tuple(OPAQUE_SPECS)
 
-# Edges the *write* path (``replace_nodes``) must NOT descend even though the
-# read path does: a ``CacheTag``'s ``parent`` is the frozen native read the
-# replacer already produced; re-driving it diverges the read's backend identity
-# from ``cache`` and breaks profile resolution on load (test_pinned_cache_yaml_roundtrip).
-_WRITE_SKIP_EDGES = {
-    rel.CacheTag: ("parent",),
-}
+# Read-side edge names, derived. Descent policies override entries of this.
+OPAQUE_EDGES = {typ: spec.read_edges for typ, spec in OPAQUE_SPECS.items()}
+
+
+def _spec_for(node: Node) -> OpaqueSpec | None:
+    """Return *node*'s :class:`OpaqueSpec`, or ``None`` if it is not opaque.
+
+    Matches by ``isinstance`` (preserving the original ``match`` semantics); the
+    opaque op types are mutually non-subclassing, so iteration order is
+    immaterial.
+    """
+    for typ, spec in OPAQUE_SPECS.items():
+        if isinstance(node, typ):
+            return spec
+    return None
 
 
 def _opaque_edges_for(node: Node, table: dict = OPAQUE_EDGES) -> Tuple[str, ...] | None:
     """Return *table*'s edge names for *node*, or ``None`` if it has no entry.
 
-    Matches by ``isinstance`` (preserving the original ``match`` semantics); the
-    opaque op types are mutually non-subclassing, so iteration order is
-    immaterial. Used for every edge-table lookup (``OPAQUE_EDGES``, the descent
-    policies, ``_WRITE_SKIP_EDGES``) so they all match the same way -- an exact
-    ``type()`` lookup on one table and ``isinstance`` on another would diverge
-    the moment an opaque op grows a subclass.
+    Matches by ``isinstance``, like :func:`_spec_for`, so a read-side policy table
+    and ``OPAQUE_SPECS`` cannot diverge on how they resolve an op -- an exact
+    ``type()`` lookup on one and ``isinstance`` on the other would come apart the
+    moment an opaque op grows a subclass.
     """
     for typ, edges in table.items():
         if isinstance(node, typ):
@@ -200,28 +255,22 @@ def replace_nodes(
 
     def process_node(op, _kwargs):
         op = replacer(op, _kwargs)
-        edges = _opaque_edges_for(op)
-        if edges is None:
+        spec = _spec_for(op)
+        if spec is None:
             if isinstance(op, opaque_ops):
                 raise ValueError(f"unhandled opaque op {type(op)}")
             return op
-        # ExprScalarUDF rebinds its sub-expr through a dedicated method rather
-        # than a plain __recreate__ kwarg (computed_kwargs_expr lives in __config__).
-        if isinstance(op, udf.ExprScalarUDF):
-            with_cke = op.with_computed_kwargs_expr(
-                _replace_sub(op.computed_kwargs_expr.op())
-            )
-            return do_recreate(with_cke, _kwargs)
-        # CacheTag: descend only the edges not in _WRITE_SKIP_EDGES (i.e. skip
-        # ``parent``) and do NOT forward _kwargs -- both load-bearing, see
-        # _WRITE_SKIP_EDGES and test_pinned_cache_yaml_roundtrip.
-        skip = _opaque_edges_for(op, _WRITE_SKIP_EDGES) or ()
-        descend = tuple(name for name in edges if name not in skip)
-        if not descend:
-            return op  # Read (no opaque children)
-        overrides = {name: _replace_sub(to_node(getattr(op, name))) for name in descend}
-        forward_kwargs = None if isinstance(op, rel.CacheTag) else _kwargs
-        return do_recreate(op, forward_kwargs, **overrides)
+        if spec.rebind is not None:
+            (name,) = spec.descend_edges
+            rebound = spec.rebind(op, _replace_sub(to_node(getattr(op, name))))
+            return do_recreate(rebound, _kwargs)
+        if not spec.descend_edges:
+            return op
+        overrides = {
+            name: _replace_sub(to_node(getattr(op, name)))
+            for name in spec.descend_edges
+        }
+        return do_recreate(op, _kwargs if spec.forward_kwargs else None, **overrides)
 
     # hasattr(x, "op") is unreliable: some Nodes have an `op` field (e.g. IntervalAdd)
     initial_op = to_node(expr)

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -155,24 +155,24 @@ def bfs(
     node: Expr | Node,
     *,
     children: Callable[[Node], Any] = gen_children_of,
-    node_filter: Callable[[Node], bool] | None = None,
 ) -> Graph:
     """Build an opaque-descending :class:`Graph` from *node* by BFS.
 
     ``children`` overrides child enumeration (default ``gen_children_of``); pass
-    a policy variant to prune opaque edges. ``node_filter`` stops the walk at any
-    child for which it returns ``False`` (the boundary-stopping form used to
-    collapse non-boundary runs); the filtered-out node is neither recorded nor
-    descended, and never appears in another node's children, so the returned
-    graph has no dangling references. The root is never filtered.
+    a policy variant to prune opaque edges.
+
+    Boundary-*terminating* descent (record a node but do not descend it, as
+    ``LineageDAG.compact()`` needs to emit boundary-to-boundary edges) is not
+    expressible here and is deliberately absent: the vendored ``bfs_while``
+    filter shape drops a non-matching node together with its whole subtree, so
+    the terminating node never lands in the graph. XOR-363 adds that mechanism
+    with its first caller.
     """
     queue = deque((to_node(node),))
     dct = {}
     while queue:
         if (node := queue.popleft()) not in dct:
             kids = tuple(children(node))
-            if node_filter is not None:
-                kids = tuple(child for child in kids if node_filter(child))
             dct[node] = kids
             queue.extend(kids)
     return Graph(dct)

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
+from types import MappingProxyType
 from typing import Any, OrderedDict, Tuple
 
 from attrs import field, frozen
@@ -44,6 +45,16 @@ class OpaqueSpec:
         default=None, validator=optional(instance_of(Callable))
     )
 
+    def __attrs_post_init__(self) -> None:
+        # ``replace_nodes`` rebinds by passing the single rewritten sub-expression
+        # to ``rebind``; a multi-edge rebind has no defined call shape. Reject it
+        # here so a bad table entry fails at import time, not mid-traversal.
+        if self.rebind is not None and len(self.descend_edges) != 1:
+            raise ValueError(
+                f"rebind requires exactly one write-side edge, "
+                f"got {self.descend_edges!r}"
+            )
+
     @property
     def descend_edges(self) -> Tuple[str, ...]:
         return self.read_edges if self.write_edges is None else self.write_edges
@@ -53,64 +64,58 @@ class OpaqueSpec:
 # (``gen_children_of`` + policy variants) and the write side (``replace_nodes``).
 # Read-side descent policies are edge overrides of the derived ``OPAQUE_EDGES``
 # (see ``_gen_children_exec``/``_gen_children_skip_pins``/``_gen_children_flight_leaf``).
-OPAQUE_SPECS = {
-    rel.RemoteTable: OpaqueSpec(("remote_expr",)),
-    rel.CachedNode: OpaqueSpec(("parent",)),
-    rel.CacheTag: OpaqueSpec(
-        # The read/write asymmetry is load-bearing, not accidental -- it is covered
-        # by test_pinned_cache_yaml_roundtrip. Reads descend both children (see the
-        # CacheTag docstring). Writes descend only the opaque ``uncached`` payload
-        # and do not forward ``_kwargs``: ``parent`` is the materialized cache read
-        # paired with ``cache``, already produced correctly by the replacer, and
-        # re-driving it from the BFS rewrite diverges the read's backend identity
-        # from ``cache``, breaking profile resolution on load.
-        read_edges=("parent", "uncached"),
-        write_edges=("uncached",),
-        forward_kwargs=False,
-    ),
-    rel.FlightExpr: OpaqueSpec(("input_expr",)),
-    rel.FlightUDXF: OpaqueSpec(("input_expr",)),
-    udf.ExprScalarUDF: OpaqueSpec(
-        # ``computed_kwargs_expr`` lives in ``__config__``, so it is rebound by
-        # method instead of by ``__recreate__`` kwarg.
-        ("computed_kwargs_expr",),
-        rebind=lambda op, sub_expr: op.with_computed_kwargs_expr(sub_expr),
-    ),
-    rel.Read: OpaqueSpec(),  # opaque leaf: no edges on either side
-}
+OPAQUE_SPECS = MappingProxyType(
+    {
+        rel.RemoteTable: OpaqueSpec(("remote_expr",)),
+        rel.CachedNode: OpaqueSpec(("parent",)),
+        rel.CacheTag: OpaqueSpec(
+            # The read/write asymmetry is load-bearing, not accidental -- it is covered
+            # by test_pinned_cache_yaml_roundtrip. Reads descend both children (see the
+            # CacheTag docstring). Writes descend only the opaque ``uncached`` payload
+            # and do not forward ``_kwargs``: ``parent`` is the materialized cache read
+            # paired with ``cache``, already produced correctly by the replacer, and
+            # re-driving it from the BFS rewrite diverges the read's backend identity
+            # from ``cache``, breaking profile resolution on load.
+            read_edges=("parent", "uncached"),
+            write_edges=("uncached",),
+            forward_kwargs=False,
+        ),
+        rel.FlightExpr: OpaqueSpec(("input_expr",)),
+        rel.FlightUDXF: OpaqueSpec(("input_expr",)),
+        udf.ExprScalarUDF: OpaqueSpec(
+            # ``computed_kwargs_expr`` lives in ``__config__``, so it is rebound by
+            # method instead of by ``__recreate__`` kwarg.
+            ("computed_kwargs_expr",),
+            rebind=lambda op, sub_expr: op.with_computed_kwargs_expr(sub_expr),
+        ),
+        rel.Read: OpaqueSpec(),  # opaque leaf: no edges on either side
+    }
+)
 
 # The opaque op types themselves -- derived from OPAQUE_SPECS so the two cannot
-# drift (``replace_nodes`` raises on an opaque op with no spec).
+# drift: being opaque and having a spec are by construction the same test
+# (``isinstance`` over the table's keys).
 opaque_ops = tuple(OPAQUE_SPECS)
 
 # Read-side edge names, derived. Descent policies override entries of this.
-OPAQUE_EDGES = {typ: spec.read_edges for typ, spec in OPAQUE_SPECS.items()}
+OPAQUE_EDGES = MappingProxyType(
+    {typ: spec.read_edges for typ, spec in OPAQUE_SPECS.items()}
+)
 
 
-def _spec_for(node: Node) -> OpaqueSpec | None:
-    """Return *node*'s :class:`OpaqueSpec`, or ``None`` if it is not opaque.
+def _opaque_lookup(node: Node, table: Mapping) -> Any | None:
+    """Return *table*'s value for *node*'s opaque op type, or ``None``.
 
-    Matches by ``isinstance`` (preserving the original ``match`` semantics); the
-    opaque op types are mutually non-subclassing, so iteration order is
-    immaterial.
+    The single lookup shared by the read side (edge tables) and the write side
+    (``OPAQUE_SPECS``), so the two cannot diverge on how they resolve an op --
+    an exact ``type()`` lookup on one and ``isinstance`` on the other would
+    come apart the moment an opaque op grows a subclass. Matches by
+    ``isinstance`` (preserving the original ``match`` semantics); the opaque op
+    types are mutually non-subclassing, so iteration order is immaterial.
     """
-    for typ, spec in OPAQUE_SPECS.items():
+    for typ, value in table.items():
         if isinstance(node, typ):
-            return spec
-    return None
-
-
-def _opaque_edges_for(node: Node, table: dict = OPAQUE_EDGES) -> Tuple[str, ...] | None:
-    """Return *table*'s edge names for *node*, or ``None`` if it has no entry.
-
-    Matches by ``isinstance``, like :func:`_spec_for`, so a read-side policy table
-    and ``OPAQUE_SPECS`` cannot diverge on how they resolve an op -- an exact
-    ``type()`` lookup on one and ``isinstance`` on the other would come apart the
-    moment an opaque op grows a subclass.
-    """
-    for typ, edges in table.items():
-        if isinstance(node, typ):
-            return edges
+            return value
     return None
 
 
@@ -124,7 +129,9 @@ def to_node(maybe_expr: Any) -> Node:
             raise ValueError(f"Don't know how to handle type {type(maybe_expr)}")
 
 
-def gen_children_of(node: Node, *, opaque_edges: dict = OPAQUE_EDGES) -> Iterator[Node]:
+def gen_children_of(
+    node: Node, *, opaque_edges: Mapping = OPAQUE_EDGES
+) -> Iterator[Node]:
     """Yield a node's children, descending opaque ops per *opaque_edges*.
 
     For an opaque op, children are the nodes referenced by its edge fields (see
@@ -137,7 +144,7 @@ def gen_children_of(node: Node, *, opaque_edges: dict = OPAQUE_EDGES) -> Iterato
     ``ValueError`` from ``to_node``, rather than silently yielding an incomplete
     child set. Prune an edge by removing it from the table, not by nulling it.
     """
-    edges = _opaque_edges_for(node, opaque_edges)
+    edges = _opaque_lookup(node, opaque_edges)
     if edges is not None:
         gen = (to_node(getattr(node, name)) for name in edges)
     else:
@@ -255,15 +262,17 @@ def replace_nodes(
 
     def process_node(op, _kwargs):
         op = replacer(op, _kwargs)
-        spec = _spec_for(op)
+        # No "unhandled opaque op" guard: opaque_ops is derived from
+        # OPAQUE_SPECS and this lookup matches by isinstance over the same
+        # keys, so "no spec" and "not opaque" are the same condition.
+        spec = _opaque_lookup(op, OPAQUE_SPECS)
         if spec is None:
-            if isinstance(op, opaque_ops):
-                raise ValueError(f"unhandled opaque op {type(op)}")
             return op
         if spec.rebind is not None:
+            # Exactly one edge, enforced at spec construction time.
             (name,) = spec.descend_edges
             rebound = spec.rebind(op, _replace_sub(to_node(getattr(op, name))))
-            return do_recreate(rebound, _kwargs)
+            return do_recreate(rebound, _kwargs if spec.forward_kwargs else None)
         if not spec.descend_edges:
             return op
         overrides = {
@@ -521,9 +530,11 @@ def get_ordered_unique_sources(nodes: Tuple[Node, ...]) -> Tuple[Any, ...]:
 
 
 # Descent policies are OPAQUE_EDGES with specific edges overridden.
-_EXEC_EDGES = {**OPAQUE_EDGES, rel.CacheTag: ("parent",)}
-_SKIP_PINS_EDGES = {**OPAQUE_EDGES, rel.CacheTag: ()}
-_FLIGHT_LEAF_EDGES = {**OPAQUE_EDGES, rel.FlightExpr: (), rel.FlightUDXF: ()}
+_EXEC_EDGES = MappingProxyType({**OPAQUE_EDGES, rel.CacheTag: ("parent",)})
+_SKIP_PINS_EDGES = MappingProxyType({**OPAQUE_EDGES, rel.CacheTag: ()})
+_FLIGHT_LEAF_EDGES = MappingProxyType(
+    {**OPAQUE_EDGES, rel.FlightExpr: (), rel.FlightUDXF: ()}
+)
 
 
 def _gen_children_exec(node: Node) -> Tuple[Node, ...]:

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -45,7 +45,6 @@ import xorq.common.utils.dasher as dasher
 import xorq.expr.datatypes as dt
 import xorq.expr.relations as rel
 from xorq.caching import ParquetCache
-from xorq.common.utils import graph_utils
 from xorq.common.utils.dasher import (
     _EXTRA_RULES,
     HASHER,
@@ -80,7 +79,6 @@ from xorq.expr import api
 from xorq.expr.ml.metrics import MetricComputation, deferred_sklearn_metric
 from xorq.expr.udf import agg, make_pandas_expr_udf
 from xorq.ibis_yaml.compiler import build_expr
-from xorq.vendor.ibis.expr.operations.generic import Cast
 from xorq.vendor.ibis.expr.operations.relations import DatabaseTable, Schema
 from xorq.vendor.ibis.expr.operations.udf import ScalarUDF
 from xorq.vendor.ibis.expr.types import Expr
@@ -642,18 +640,12 @@ def test_normalize_computed_kwargs_expr_is_data_free():
     )
 
 
-def test_replace_nodes_raises_on_unhandled_opaque(monkeypatch):
-    """A future addition to ``opaque_ops`` without a corresponding ``case``
-    arm in ``replace_nodes.process_node`` must raise loudly rather than
-    silently producing a wrong hash."""
-    monkeypatch.setattr(graph_utils, "opaque_ops", graph_utils.opaque_ops + (Cast,))
-
-    con = xo.connect()
-    con.create_table("t", pd.DataFrame({"a": [1, 2, 3]}))
-    expr = con.table("t").mutate(a_float=xo._.a.cast("float64"))
-
-    with pytest.raises(ValueError, match="unhandled opaque op"):
-        graph_utils.replace_nodes(lambda op, _kw: op, expr.op())
+# NOTE: test_replace_nodes_raises_on_unhandled_opaque was removed: it guarded
+# against ``opaque_ops`` drifting from ``replace_nodes``'s match arms, drift
+# that is now impossible by construction (both derive from OPAQUE_SPECS and
+# resolve via the same isinstance lookup). Its structural replacements live in
+# test_graph_utils.py: test_opaque_ops_matches_opaque_edges and
+# test_opaque_ops_mutually_non_subclassing.
 
 
 # --- _gap_rules normalizers ------------------------------------------------

--- a/python/xorq/common/utils/tests/test_graph_utils.py
+++ b/python/xorq/common/utils/tests/test_graph_utils.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import itertools
 import operator
 
 import pytest
@@ -139,6 +142,15 @@ def test_opaque_edges_name_real_fields() -> None:
 
 def test_opaque_ops_matches_opaque_edges() -> None:
     assert set(opaque_ops) == set(OPAQUE_EDGES)
+
+
+def test_opaque_ops_mutually_non_subclassing() -> None:
+    """``_opaque_lookup`` resolves to the first ``isinstance`` match, so its
+    order-independence rests on no opaque op subclassing another. A new opaque
+    op related by inheritance to an existing one needs an explicit ordering
+    decision in ``OPAQUE_SPECS``, not an accidental one."""
+    for a, b in itertools.permutations(opaque_ops, 2):
+        assert not issubclass(a, b), f"{a.__name__} subclasses {b.__name__}"
 
 
 def test_opaque_edges_is_read_only() -> None:

--- a/python/xorq/common/utils/tests/test_graph_utils.py
+++ b/python/xorq/common/utils/tests/test_graph_utils.py
@@ -10,11 +10,16 @@ import xorq.expr.selectors as s
 import xorq.vendor.ibis.expr.operations as ops
 from xorq.caching import SourceCache
 from xorq.common.utils.graph_utils import (
+    OPAQUE_EDGES,
+    _gen_children_flight_leaf,
     find_all_sources,
+    gen_children_of,
+    opaque_ops,
     walk_nodes,
 )
 from xorq.expr.relations import Tag
 from xorq.ml import deferred_fit_predict_sklearn
+from xorq.vendor.ibis import Expr
 
 
 LinearRegression = pytest.importorskip("sklearn.linear_model").LinearRegression
@@ -116,3 +121,46 @@ def test_replace_computed_kwargs_expr(parquet_dir):
     removed = xo.expr.api._remove_tag_nodes(predicted)
     assert not walk_nodes(Tag, removed)
     assert not walk_nodes(Tag, predicted.ls.untagged)
+
+
+def test_opaque_edges_name_real_fields() -> None:
+    """Every ``OPAQUE_EDGES`` name must resolve on its op type.
+
+    ``gen_children_of`` reads edge fields unguarded, so a stale name after a
+    rename is an ``AttributeError`` at traversal time; catch it here instead.
+    """
+    for typ, edges in OPAQUE_EDGES.items():
+        for name in edges:
+            assert name in typ.__argnames__ or hasattr(typ, name), (
+                f"{typ.__name__} has no field {name!r}"
+            )
+
+
+def test_opaque_ops_matches_opaque_edges() -> None:
+    assert set(opaque_ops) == set(OPAQUE_EDGES)
+
+
+def make_flight_expr() -> Expr:
+    con = xo.connect()
+    t = con.register(xo.memtable({"a": [1, 2, 3]}).to_pyarrow(), "t")
+    return rel.FlightExpr(
+        name="test_flight",
+        schema=t.schema(),
+        source=con,
+        input_expr=t,
+        unbound_expr=xo.table(t.schema(), name="u"),
+        make_server=toolz.identity,
+        make_connection=toolz.identity,
+    ).to_expr()
+
+
+def test_gen_children_flight_leaf_treats_flight_as_leaf() -> None:
+    expr = make_flight_expr()
+    node = expr.op()
+    assert tuple(gen_children_of(node)) == (node.input_expr.op(),)
+    assert _gen_children_flight_leaf(node) == ()
+    # the outer graph no longer reaches the input_expr's leaves
+    assert walk_nodes(ops.DatabaseTable, node)
+    assert walk_nodes(
+        (ops.DatabaseTable,), node, gen_children=_gen_children_flight_leaf
+    ) == (node,)

--- a/python/xorq/common/utils/tests/test_graph_utils.py
+++ b/python/xorq/common/utils/tests/test_graph_utils.py
@@ -11,6 +11,7 @@ import xorq.vendor.ibis.expr.operations as ops
 from xorq.caching import SourceCache
 from xorq.common.utils.graph_utils import (
     OPAQUE_EDGES,
+    OpaqueSpec,
     _gen_children_flight_leaf,
     find_all_sources,
     gen_children_of,
@@ -138,6 +139,30 @@ def test_opaque_edges_name_real_fields() -> None:
 
 def test_opaque_ops_matches_opaque_edges() -> None:
     assert set(opaque_ops) == set(OPAQUE_EDGES)
+
+
+def test_opaque_edges_is_read_only() -> None:
+    """The edge tables are shared semantic constants; mutation must fail loudly."""
+    with pytest.raises(TypeError):
+        OPAQUE_EDGES[rel.Read] = ("nope",)
+
+
+def test_gen_children_of_raises_on_stale_edge_name() -> None:
+    """Edge fields are read unguarded: a stale name in an edge table must raise
+    ``AttributeError`` at traversal time, not silently drop a child."""
+    node = make_flight_expr().op()
+    stale = {**OPAQUE_EDGES, rel.FlightExpr: ("input_exprs",)}
+    with pytest.raises(AttributeError):
+        tuple(gen_children_of(node, opaque_edges=stale))
+
+
+def test_opaque_spec_rejects_multi_edge_rebind() -> None:
+    """``rebind`` passes a single rewritten sub-expression, so a spec pairing it
+    with more than one write-side edge must fail at construction time."""
+    with pytest.raises(ValueError, match="rebind requires exactly one"):
+        OpaqueSpec(("a", "b"), rebind=lambda op, sub_expr: op)
+    with pytest.raises(ValueError, match="rebind requires exactly one"):
+        OpaqueSpec(("a",), write_edges=(), rebind=lambda op, sub_expr: op)
 
 
 def make_flight_expr() -> Expr:


### PR DESCRIPTION
## What

Unify the graph-of-nodes iteration in `common/utils/graph_utils.py` behind one declarative table.

## Why

Prep #2 for XOR-363 (compact/expandable lineage). The opaque-op child enumeration was hand-written ~5× (`gen_children_of`, exec/skip-pins policies, `replace_nodes`'s write-side match). XOR-363 needs another descent policy; adding it to the old design meant a 6th copy. This collapses them to one source of truth and adds exactly the policy XOR-363 consumes.

## How

- **`OPAQUE_SPECS` table** — one frozen `OpaqueSpec` per opaque op type, carrying everything traversal needs to know about it: `read_edges`, `write_edges` (`None` = same as read), `forward_kwargs`, `rebind`. Covers `RemoteTable.remote_expr`, `CachedNode.parent`, `CacheTag.{parent,uncached}`, `Flight*.input_expr`, `ExprScalarUDF.computed_kwargs_expr`, `Read`=leaf.
- Read path (`gen_children_of` + policies) and write path (`replace_nodes`) both derive descent from it. `opaque_ops` and the read-side `OPAQUE_EDGES` are **derived** from `OPAQUE_SPECS`, so the type tuple, the read table and the write table cannot drift.
- Descent policies become **edge overrides** of `OPAQUE_EDGES`, not separate function bodies (`_EXEC_EDGES`, `_SKIP_PINS_EDGES`, `_FLIGHT_LEAF_EDGES`).
- **`bfs(node, *, children=)`** — one function covers opaque descent and the pruned policies.
- Write-side quirks live on the spec, not scattered: `CacheTag` states `write_edges=("uncached",)` and `forward_kwargs=False` directly, with the reason attached to its entry, instead of as a set-subtraction against a separate skip table plus a conditional in the traversal. `ExprScalarUDF`'s method-based rebinding is the `rebind` field rather than an `isinstance` branch mid-traversal.
- Edge fields are read **unguarded**: a stale name raises `AttributeError` and a `None` edge raises `ValueError` from `to_node`, instead of silently dropping a child from the set (pre-refactor behavior). Prune an edge by removing it from the table, not by nulling it.
- Every edge-table lookup matches by `isinstance`. An exact-`type()` lookup on one table and `isinstance` on another would diverge the moment an opaque op grows a subclass, silently re-driving a `CacheTag`'s `parent` on the write path.

## New capability — added but NOT activated (behavior-preserving)

- `_gen_children_flight_leaf` — treats `FlightExpr`/`FlightUDXF` as leaves (XOR-363 outer lineage walk; nested lineage extracted separately as a sub-DAG). Private here; XOR-363 flips it public alongside its first caller, `extract_lineage_dag`.

Nothing in this PR turns it on. Defaults reproduce today's behavior.

### Removed: `bfs(filter=)`

An earlier revision of this branch also added a `filter=` boundary-stop parameter to `bfs` for XOR-363's `LineageDAG.compact()`. It is gone (see the last commit) for two reasons:

1. **Wrong semantics for the stated need.** The shape was copied from the vendored `bfs_while` (`vendor/ibis/common/graph.py`), which drops a non-matching child *together with its whole subtree*. Filtering on "not a boundary" therefore deletes the boundary nodes instead of leaving them as the graph's leaves — the opposite of what a boundary→boundary edge needs. Terminating descent requires record-but-do-not-descend, which that filter shape cannot express.
2. **No consumer.** `compact()` as implemented never walks the op-graph: it is a generic adjacency BFS over the *stored id-graph* (labels + edges), accumulating the shortest non-boundary `via` run per boundary pair. At render time there are no ops.

Rather than test-freeze semantics XOR-363 would have to change, the parameter is removed and the `bfs` docstring records why boundary-terminating descent is absent.

## Post-review hardening (`e658e8a9`, `ed2ac655`)

Two rounds of review (one independent/cold) produced two follow-up commits:

- **`e658e8a9`** — harden the table against drift: the `rebind` branch of `replace_nodes` now respects `forward_kwargs`; `OpaqueSpec` rejects `rebind` with ≠ 1 write-side edge at construction (import) time; `_spec_for`/`_opaque_edges_for` merged into one `_opaque_lookup` shared by read and write sides; `OPAQUE_SPECS`/`OPAQUE_EDGES` and the policy tables wrapped in `MappingProxyType` (params typed `Mapping`). The now-unreachable "unhandled opaque op" guard is removed — `opaque_ops` derives from `OPAQUE_SPECS` and resolves via the same `isinstance` lookup, so "no spec" and "not opaque" are the same condition. New tests pin the fail-loud stale-edge contract, table read-only-ness, and the rebind single-edge validator.
- **`ed2ac655`** — the independent review caught that removing the guard broke `test_dasher.py::test_replace_nodes_raises_on_unhandled_opaque`, which monkeypatched `opaque_ops` to force that path. The drift it guarded against is now impossible by construction (and patching the derived tuple no longer influences `replace_nodes` at all), so the test is retired in favor of structural invariants co-located in `test_graph_utils.py`: `test_opaque_ops_matches_opaque_edges` and the new `test_opaque_ops_mutually_non_subclassing` (which locks in `_opaque_lookup`'s order-independence).

## Verification

Diffed the full test outcome against `main` in the same env (at the pre-review head):

- `graph_utils`, `node_utils` (incl. `test_snapshot_hash_alignment_with_ibis_yaml`), `lineage_utils`, `dasher`, `common/tests/test_cache`, `cache_pin`, `transform_driver`/`transform_scope` — all pass.
- The load-bearing `test_pinned_cache_yaml_roundtrip` (covers the `CacheTag` write-side asymmetry) passes.
- ibis_yaml suite: 616 passed; failure **set identical to main** (pre-existing env gaps — `psycopg`/`datafusion` not installed), confirmed by re-running the same selection on the parent commit.

Re-verified at the current head (`ed2ac655`): `test_graph_utils` 10 passed; `test_dasher` + `test_cache_pin` 121 passed / 1 xfailed; `test_node_utils` + `test_lineage_utils` 44 passed; `test_pinned_cache_yaml_roundtrip` 2 passed.

**CI note:** the four `ci-test-lowest-direct` jobs fail on two ibis_yaml snapshot tests (`test_build_file_stability_and_relocatability`, `test_generated_name_sanitization_memtable`). The same two tests fail identically on `main`'s latest run of that workflow (`d1afd759`) — pre-existing dependency-floor snapshot drift, unrelated to this PR (the merge-base `93791fbb` run was green). All other checks pass, including lint, codecov patch/project, and the full linux matrix.

## Scope

Behavior-preserving refactor. Part of the XOR-363 prep chain (Prep #1 content_hash → **Prep #2 graph refactor** → XOR-363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

