### PR TITLE
feat(profiles): backends declare their own secret keys (static)

### DIFF
--- a/python/xorq/backends/postgres/__init__.py
+++ b/python/xorq/backends/postgres/__init__.py
@@ -37,6 +37,15 @@ __all__ = [
 
 class Backend(IbisPostgresBackend):
     _top_level_methods = ("connect_examples", "connect_env")
+    _secret_keys = (
+        "password",
+        "sslcert",
+        "sslkey",
+        "sslrootcert",
+        "sslcrl",
+        "options",
+        "passfile",
+    )
     compiler = compiler
 
     @classmethod

--- a/python/xorq/backends/snowflake/__init__.py
+++ b/python/xorq/backends/snowflake/__init__.py
@@ -60,6 +60,15 @@ class Backend(IbisSnowflakeBackend):
         "connect_env_password",
         "connect_env_keypair",
     )
+    _secret_keys = (
+        "password",
+        "user",
+        "account",
+        "token",
+        "private_key",
+        "private_key_path",
+        "oauth_token",
+    )
 
     @staticmethod
     def connect_env(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -5,8 +5,13 @@ import pytest
 
 import xorq.api as xo
 from xorq.common.utils.env_utils import maybe_substitute_env_vars
+from xorq.loader import _load_entry_points
 from xorq.vendor.ibis.backends import BaseBackend
-from xorq.vendor.ibis.backends.profiles import Profile, Profiles
+from xorq.vendor.ibis.backends.profiles import (
+    Profile,
+    Profiles,
+    con_name_to_secret_keys,
+)
 
 
 local_con_names = ("duckdb", "xorq_datafusion", "datafusion", "pandas", "pyiceberg")
@@ -628,8 +633,28 @@ def test_profile_from_con_preserves_env_vars(monkeypatch, tmp_path):
             raise
 
 
-def test_profile_matches_find_backend(data_dir):
+def test_profile_matches_find_backend(data_dir: pathlib.Path) -> None:
     path = data_dir / "parquet" / "diamonds.parquet"
     con = xo.connect()
     t = xo.deferred_read_parquet(path, con)
     assert con._profile == t._find_backend()._profile
+
+
+@pytest.mark.parametrize("con_name", sorted(con_name_to_secret_keys))
+def test_fallback_secret_keys_match_backend_declaration(con_name: str) -> None:
+    """The con_name_to_secret_keys fallback must not drift from the keys the
+    backend's Backend class declares in _secret_keys. The fallback only fires
+    when the backend module can't be imported, so a silent divergence would go
+    unnoticed until then; this pins the two together."""
+    entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
+    assert entry_point is not None, f"no entry point for {con_name!r}"
+    try:
+        module = entry_point.load()
+    except ImportError as e:
+        pytest.skip(f"{con_name} backend not importable: {e}")
+    declared = getattr(module.Backend, "_secret_keys", None)
+    assert declared is not None, (
+        f"{con_name} is in the fallback dict but its Backend declares no "
+        "_secret_keys; declare them so the fallback stays a mirror"
+    )
+    assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 
@@ -656,5 +658,29 @@ def test_fallback_secret_keys_match_backend_declaration(con_name: str) -> None:
     assert declared is not None, (
         f"{con_name} is in the fallback dict but its Backend declares no "
         "_secret_keys; declare them so the fallback stays a mirror"
+    )
+    assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])
+
+
+@pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
+def test_declared_secret_keys_are_mirrored_in_fallback(con_name: str) -> None:
+    """Inverse of test_fallback_secret_keys_match_backend_declaration: every
+    installed backend that declares _secret_keys must also appear (and match)
+    in the con_name_to_secret_keys fallback. Without this, a backend could
+    declare keys yet be absent from the fallback, and when that backend's
+    module can't be imported its secrets would fall through to just
+    ("password",)."""
+    entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
+    try:
+        module = entry_point.load()
+    except ImportError as e:
+        pytest.skip(f"{con_name} backend not importable: {e}")
+    declared = getattr(getattr(module, "Backend", None), "_secret_keys", None)
+    if declared is None:
+        pytest.skip(f"{con_name} declares no _secret_keys")
+    assert con_name in con_name_to_secret_keys, (
+        f"{con_name} declares _secret_keys but is missing from the "
+        "con_name_to_secret_keys fallback; add it so the fallback stays a "
+        "complete mirror of all declaring backends"
     )
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -643,11 +643,11 @@ def test_profile_matches_find_backend(data_dir: pathlib.Path) -> None:
 
 
 @pytest.mark.parametrize("con_name", sorted(con_name_to_secret_keys))
-def test_fallback_secret_keys_match_backend_declaration(con_name: str) -> None:
-    """The con_name_to_secret_keys fallback must not drift from the keys the
-    backend's Backend class declares in _secret_keys. The fallback only fires
-    when the backend module can't be imported, so a silent divergence would go
-    unnoticed until then; this pins the two together."""
+def test_secret_key_mirror_matches_backend_declaration(con_name: str) -> None:
+    """The con_name_to_secret_keys mirror must not drift from the keys each
+    backend's Backend class declares in _secret_keys. check_for_exposed_secrets
+    reads the mirror rather than the backend (so it needn't import the backend),
+    so a silent divergence would go unnoticed; this pins the two together."""
     entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
     assert entry_point is not None, f"no entry point for {con_name!r}"
     try:
@@ -656,20 +656,19 @@ def test_fallback_secret_keys_match_backend_declaration(con_name: str) -> None:
         pytest.skip(f"{con_name} backend not importable: {e}")
     declared = getattr(module.Backend, "_secret_keys", None)
     assert declared is not None, (
-        f"{con_name} is in the fallback dict but its Backend declares no "
-        "_secret_keys; declare them so the fallback stays a mirror"
+        f"{con_name} is in con_name_to_secret_keys but its Backend declares no "
+        "_secret_keys; declare them so the mirror stays honest"
     )
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])
 
 
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
-def test_declared_secret_keys_are_mirrored_in_fallback(con_name: str) -> None:
-    """Inverse of test_fallback_secret_keys_match_backend_declaration: every
+def test_declared_secret_keys_are_mirrored(con_name: str) -> None:
+    """Inverse of test_secret_key_mirror_matches_backend_declaration: every
     installed backend that declares _secret_keys must also appear (and match)
-    in the con_name_to_secret_keys fallback. Without this, a backend could
-    declare keys yet be absent from the fallback, and when that backend's
-    module can't be imported its secrets would fall through to just
-    ("password",)."""
+    in the con_name_to_secret_keys mirror. Without this a backend could declare
+    keys yet be absent from the mirror, so check_for_exposed_secrets would
+    silently fall back to just ("password",) for it."""
     entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
     try:
         module = entry_point.load()
@@ -680,7 +679,7 @@ def test_declared_secret_keys_are_mirrored_in_fallback(con_name: str) -> None:
         pytest.skip(f"{con_name} declares no _secret_keys")
     assert con_name in con_name_to_secret_keys, (
         f"{con_name} declares _secret_keys but is missing from the "
-        "con_name_to_secret_keys fallback; add it so the fallback stays a "
-        "complete mirror of all declaring backends"
+        "con_name_to_secret_keys mirror; add it so the mirror stays a complete "
+        "reflection of all declaring backends"
     )
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -439,9 +439,11 @@ class Profile:
         return cls(con_name=con.name, kwargs_tuple=tuple(sorted(kwargs.items())))
 
 
-# fallback secret keys by connection name, used when the backend module is not
-# loadable (e.g. its extra is not installed) or predates declared secret keys;
-# backends override by declaring a `_secret_keys` tuple on their Backend class
+# static secret keys by connection name. This is the runtime source of truth:
+# a backend's `_secret_keys` tuple is mirrored here (enforced bidirectionally by
+# tests in test_profile.py), so secret validation reads this dict instead of
+# importing the backend just to read a tuple. The backend's own `_secret_keys`
+# declaration is only consulted by those tests, to keep this mirror honest.
 con_name_to_secret_keys = MappingProxyType(
     {
         "postgres": (
@@ -466,30 +468,11 @@ con_name_to_secret_keys = MappingProxyType(
 )
 
 
-def get_declared_secret_keys(con_name: str) -> tuple[str, ...] | None:
-    """Return the secret keys the backend's Backend class declares, if any.
-
-    Reads the static ``_secret_keys`` tuple from the backend's ``Backend``
-    class. Returns None when the backend has no entry point, its module fails
-    to import (e.g. optional dependencies are absent), or it declares nothing.
-    """
-    entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
-    if entry_point is None:
-        return None
-    try:
-        module = entry_point.load()
-    except ImportError:
-        return None
-    backend_cls = getattr(module, "Backend", None)
-    secret_keys = getattr(backend_cls, "_secret_keys", None)
-    return tuple(secret_keys) if secret_keys is not None else None
-
-
 def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     """Check if profile contains exposed secret keys.
 
-    Secret keys come from the backend's declared `Backend._secret_keys`,
-    falling back to `con_name_to_secret_keys`, then to `("password",)`.
+    Secret keys come from the static `con_name_to_secret_keys` mirror,
+    defaulting to `("password",)` for backends not listed.
 
     Raises
     ------
@@ -497,12 +480,10 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
         If profile contains exposed secret keys not using environment variables
     """
 
-    relevant_keys = get_declared_secret_keys(con_name)
-    if relevant_keys is None:
-        relevant_keys = con_name_to_secret_keys.get(
-            con_name,
-            ("password",),  # default to just password
-        )
+    relevant_keys = con_name_to_secret_keys.get(
+        con_name,
+        ("password",),  # default to just password
+    )
 
     exposed_secrets = tuple(
         key

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 from pathlib import Path
+from types import MappingProxyType
 
 import toolz
 import yaml12
@@ -441,26 +442,28 @@ class Profile:
 # fallback secret keys by connection name, used when the backend module is not
 # loadable (e.g. its extra is not installed) or predates declared secret keys;
 # backends override by declaring a `_secret_keys` tuple on their Backend class
-con_name_to_secret_keys = {
-    "postgres": [
-        "password",
-        "sslcert",
-        "sslkey",
-        "sslrootcert",
-        "sslcrl",
-        "options",
-        "passfile",
-    ],
-    "snowflake": [
-        "password",
-        "user",
-        "account",
-        "token",
-        "private_key",
-        "private_key_path",
-        "oauth_token",
-    ],
-}
+con_name_to_secret_keys = MappingProxyType(
+    {
+        "postgres": (
+            "password",
+            "sslcert",
+            "sslkey",
+            "sslrootcert",
+            "sslcrl",
+            "options",
+            "passfile",
+        ),
+        "snowflake": (
+            "password",
+            "user",
+            "account",
+            "token",
+            "private_key",
+            "private_key_path",
+            "oauth_token",
+        ),
+    }
+)
 
 
 def get_declared_secret_keys(con_name: str) -> tuple[str, ...] | None:
@@ -498,7 +501,7 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     if relevant_keys is None:
         relevant_keys = con_name_to_secret_keys.get(
             con_name,
-            ["password"],  # default to just password
+            ("password",),  # default to just password
         )
 
     exposed_secrets = tuple(

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -438,8 +438,55 @@ class Profile:
         return cls(con_name=con.name, kwargs_tuple=tuple(sorted(kwargs.items())))
 
 
+# fallback secret keys by connection name, used when the backend module is not
+# loadable (e.g. its extra is not installed) or predates declared secret keys;
+# backends override by declaring a `_secret_keys` tuple on their Backend class
+con_name_to_secret_keys = {
+    "postgres": [
+        "password",
+        "sslcert",
+        "sslkey",
+        "sslrootcert",
+        "sslcrl",
+        "options",
+        "passfile",
+    ],
+    "snowflake": [
+        "password",
+        "user",
+        "account",
+        "token",
+        "private_key",
+        "private_key_path",
+        "oauth_token",
+    ],
+}
+
+
+def get_declared_secret_keys(con_name: str) -> tuple[str, ...] | None:
+    """Return the secret keys the backend's Backend class declares, if any.
+
+    Reads the static ``_secret_keys`` tuple from the backend's ``Backend``
+    class. Returns None when the backend has no entry point, its module fails
+    to import (e.g. optional dependencies are absent), or it declares nothing.
+    """
+    entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
+    if entry_point is None:
+        return None
+    try:
+        module = entry_point.load()
+    except ImportError:
+        return None
+    backend_cls = getattr(module, "Backend", None)
+    secret_keys = getattr(backend_cls, "_secret_keys", None)
+    return tuple(secret_keys) if secret_keys is not None else None
+
+
 def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     """Check if profile contains exposed secret keys.
+
+    Secret keys come from the backend's declared `Backend._secret_keys`,
+    falling back to `con_name_to_secret_keys`, then to `("password",)`.
 
     Raises
     ------
@@ -447,35 +494,12 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
         If profile contains exposed secret keys not using environment variables
     """
 
-    # Define secret keys by connection name
-    # TODO: Add more database types as needed
-    # maybe user sets this in options
-    con_name_to_secret_keys = {
-        "postgres": [
-            "password",
-            "sslcert",
-            "sslkey",
-            "sslrootcert",
-            "sslcrl",
-            "options",
-            "passfile",
-        ],
-        "snowflake": [
-            "password",
-            "user",
-            "account",
-            "token",
-            "private_key",
-            "private_key_path",
-            "oauth_token",
-        ],
-        # Add more database types as needed
-    }
-
-    relevant_keys = con_name_to_secret_keys.get(
-        con_name,
-        ["password"],  # default to just password
-    )
+    relevant_keys = get_declared_secret_keys(con_name)
+    if relevant_keys is None:
+        relevant_keys = con_name_to_secret_keys.get(
+            con_name,
+            ["password"],  # default to just password
+        )
 
     exposed_secrets = tuple(
         key

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -439,11 +439,12 @@ class Profile:
         return cls(con_name=con.name, kwargs_tuple=tuple(sorted(kwargs.items())))
 
 
-# static secret keys by connection name. This is the runtime source of truth:
-# a backend's `_secret_keys` tuple is mirrored here (enforced bidirectionally by
-# tests in test_profile.py), so secret validation reads this dict instead of
-# importing the backend just to read a tuple. The backend's own `_secret_keys`
-# declaration is only consulted by those tests, to keep this mirror honest.
+# Static secret keys by connection name, mirrored from each backend's
+# `Backend._secret_keys` declaration. `check_for_exposed_secrets` reads this
+# mirror at runtime so that validating a profile never imports the backend just
+# to read its tuple. The colocated `_secret_keys` declaration is the authored
+# source; the tests in test_profile.py enforce, in both directions, that this
+# mirror stays identical to it.
 con_name_to_secret_keys = MappingProxyType(
     {
         "postgres": (


### PR DESCRIPTION
## Summary

Secret-key detection for connection profiles is driven by a per-backend declaration instead of a dict hardcoded inside `check_for_exposed_secrets`.

- Backends declare a `_secret_keys` tuple on their `Backend` class (Postgres and Snowflake here) — the authored source.
- `con_name_to_secret_keys` (a `MappingProxyType`) mirrors those declarations and is the runtime source consulted unconditionally by `check_for_exposed_secrets` — so validating a profile no longer imports the backend just to read a tuple.
- The only genuine fallback is the `("password",)` default for backends not listed in the mirror.

## Testing

Two tests pin the mirror to the declarations in **both** directions so they can't drift:
- `test_secret_key_mirror_matches_backend_declaration` — every mirror entry matches its backend's `_secret_keys`.
- `test_declared_secret_keys_are_mirrored` — every installed backend that declares `_secret_keys` appears in (and matches) the mirror.

## Note

Dynamic, kwargs-dependent secret keys (`Backend._get_secret_keys(kwargs)`) are split into a follow-on PR, #2184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
