### PR TITLE
feat(profiles): declarative secret keys via Backend._secret_key_sources

### DIFF
--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import functools
 import types
 
 
@@ -7,9 +10,14 @@ except ModuleNotFoundError:
     import importlib_metadata
 
 
-def _load_entry_points():
+@functools.cache
+def _load_entry_points() -> tuple:
+    # cached: the installed xorq.backends entry points are fixed for the life of
+    # the process (nothing installs a backend distribution at runtime), and this
+    # is called on hot paths like secret validation. Returns a tuple so the
+    # shared cached value can't be mutated in place by a caller.
     eps = importlib_metadata.entry_points(group="xorq.backends")
-    return sorted(eps)
+    return tuple(sorted(eps))
 
 
 def load_backend(name):

--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -13,40 +13,25 @@ except ModuleNotFoundError:
 
 @functools.cache
 def _load_entry_points() -> tuple[importlib_metadata.EntryPoint, ...]:
-    # cached: scanning the installed distributions costs ~15ms, and this is
-    # called on paths that run per-object rather than once -- Profile
-    # construction (validate_con_name) and secret validation. Returns a tuple so
-    # the shared cached value can't be mutated in place by a caller.
-    #
-    # The cache can go stale: installing a backend distribution into a live
-    # process (pip install in a Jupyter kernel) adds entry points that an
-    # already-populated cache will not show. Resolution therefore refreshes on a
-    # miss -- see _find_entry_point -- so the staleness is not observable as an
-    # unresolvable backend.
+    # cached: the scan costs ~15ms and validate_con_name runs per Profile. A
+    # tuple, so the shared value can't be mutated in place by a caller.
     eps = importlib_metadata.entry_points(group="xorq.backends")
     return tuple(sorted(eps))
 
 
 def _find_entry_point(name: str) -> importlib_metadata.EntryPoint | None:
-    """Look up a `xorq.backends` entry point by name, refreshing once on a miss.
+    """Look up a `xorq.backends` entry point, refreshing the cache once on a miss.
 
-    A miss can mean either "no such backend" or "the cache predates a
-    mid-process install", and the two are indistinguishable without rescanning.
-    Rescanning only on a miss keeps the hit path free: a name that resolves
-    never pays for it, and a name that genuinely doesn't exist pays a ~15ms
-    rescan rather than staying unresolvable for the life of the process.
-
-    Resolve names through here rather than by scanning `_load_entry_points()`
-    directly -- a direct scan sees the cache as it was, so it would reject a
-    just-installed backend (see `profiles.Profile.validate_con_name`).
+    Resolve through here rather than scanning `_load_entry_points()`: a direct
+    scan sees the cache as it was, so it rejects a backend installed into a live
+    process (pip install in a Jupyter kernel) until that process restarts. Only a
+    miss pays the rescan.
     """
     if entry_point := next(
         (ep for ep in _load_entry_points() if ep.name == name), None
     ):
         return entry_point
-    # a distribution installed after the cache was populated may also postdate
-    # the import system's own path caches
-    importlib.invalidate_caches()
+    importlib.invalidate_caches()  # a new dist postdates the import caches too
     _load_entry_points.cache_clear()
     return next((ep for ep in _load_entry_points() if ep.name == name), None)
 

--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:
 
 
 @functools.cache
-def _load_entry_points() -> tuple:
+def _load_entry_points() -> tuple[importlib_metadata.EntryPoint, ...]:
     # cached: scanning the installed distributions costs ~15ms, and this is
     # called on paths that run per-object rather than once -- Profile
     # construction (validate_con_name) and secret validation. Returns a tuple so
@@ -35,6 +35,10 @@ def _find_entry_point(name: str) -> importlib_metadata.EntryPoint | None:
     Rescanning only on a miss keeps the hit path free: a name that resolves
     never pays for it, and a name that genuinely doesn't exist pays a ~15ms
     rescan rather than staying unresolvable for the life of the process.
+
+    Resolve names through here rather than by scanning `_load_entry_points()`
+    directly -- a direct scan sees the cache as it was, so it would reject a
+    just-installed backend (see `profiles.Profile.validate_con_name`).
     """
     if entry_point := next(
         (ep for ep in _load_entry_points() if ep.name == name), None

--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -25,7 +25,10 @@ def _find_entry_point(name: str) -> importlib_metadata.EntryPoint | None:
     Resolve through here rather than scanning `_load_entry_points()` directly: a
     direct scan sees the cache as it was, so it rejects a backend installed into a
     live process (pip install in a Jupyter kernel) until restart. Only a miss pays
-    the rescan.
+    the rescan -- but *every* miss pays it (no negative caching), and
+    `invalidate_caches` is a process-global side effect that taxes unrelated later
+    imports. Accepted for now; a sys.path + directory-mtime fingerprint could skip
+    both when the environment demonstrably hasn't changed.
     """
     if entry_point := next(
         (ep for ep in _load_entry_points() if ep.name == name), None

--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -22,10 +22,10 @@ def _load_entry_points() -> tuple[importlib_metadata.EntryPoint, ...]:
 def _find_entry_point(name: str) -> importlib_metadata.EntryPoint | None:
     """Look up a `xorq.backends` entry point, refreshing the cache once on a miss.
 
-    Resolve through here rather than scanning `_load_entry_points()`: a direct
-    scan sees the cache as it was, so it rejects a backend installed into a live
-    process (pip install in a Jupyter kernel) until that process restarts. Only a
-    miss pays the rescan.
+    Resolve through here rather than scanning `_load_entry_points()` directly: a
+    direct scan sees the cache as it was, so it rejects a backend installed into a
+    live process (pip install in a Jupyter kernel) until restart. Only a miss pays
+    the rescan.
     """
     if entry_point := next(
         (ep for ep in _load_entry_points() if ep.name == name), None

--- a/python/xorq/loader.py
+++ b/python/xorq/loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import importlib
 import types
 
 
@@ -12,18 +13,42 @@ except ModuleNotFoundError:
 
 @functools.cache
 def _load_entry_points() -> tuple:
-    # cached: the installed xorq.backends entry points are fixed for the life of
-    # the process (nothing installs a backend distribution at runtime), and this
-    # is called on hot paths like secret validation. Returns a tuple so the
-    # shared cached value can't be mutated in place by a caller.
+    # cached: scanning the installed distributions costs ~15ms, and this is
+    # called on paths that run per-object rather than once -- Profile
+    # construction (validate_con_name) and secret validation. Returns a tuple so
+    # the shared cached value can't be mutated in place by a caller.
+    #
+    # The cache can go stale: installing a backend distribution into a live
+    # process (pip install in a Jupyter kernel) adds entry points that an
+    # already-populated cache will not show. Resolution therefore refreshes on a
+    # miss -- see _find_entry_point -- so the staleness is not observable as an
+    # unresolvable backend.
     eps = importlib_metadata.entry_points(group="xorq.backends")
     return tuple(sorted(eps))
 
 
-def load_backend(name):
+def _find_entry_point(name: str) -> importlib_metadata.EntryPoint | None:
+    """Look up a `xorq.backends` entry point by name, refreshing once on a miss.
+
+    A miss can mean either "no such backend" or "the cache predates a
+    mid-process install", and the two are indistinguishable without rescanning.
+    Rescanning only on a miss keeps the hit path free: a name that resolves
+    never pays for it, and a name that genuinely doesn't exist pays a ~15ms
+    rescan rather than staying unresolvable for the life of the process.
+    """
     if entry_point := next(
         (ep for ep in _load_entry_points() if ep.name == name), None
     ):
+        return entry_point
+    # a distribution installed after the cache was populated may also postdate
+    # the import system's own path caches
+    importlib.invalidate_caches()
+    _load_entry_points.cache_clear()
+    return next((ep for ep in _load_entry_points() if ep.name == name), None)
+
+
+def load_backend(name: str) -> types.ModuleType | None:
+    if entry_point := _find_entry_point(name):
         module = entry_point.load()
         backend = module.Backend()
         backend.register_options()

--- a/python/xorq/tests/test_loader.py
+++ b/python/xorq/tests/test_loader.py
@@ -26,13 +26,9 @@ def test_find_entry_point_resolves_an_installed_backend() -> None:
 
 
 def test_find_entry_point_refreshes_a_stale_cache(tmp_path: pathlib.Path) -> None:
-    """A backend installed after the cache was populated is still resolvable.
-
-    The cache is what makes repeated Profile construction cheap, but it means a
-    distribution installed into a live process (pip install in a Jupyter kernel)
-    is invisible to an already-populated cache. Resolution refreshes on a miss so
-    that staleness never surfaces as an unresolvable backend.
-    """
+    """A backend installed after the cache was populated is still resolvable:
+    resolution refreshes on a miss, so staleness never surfaces as an
+    unresolvable backend."""
     with installed_mid_process(tmp_path, "xorqfakebackend") as con_name:
         # resolution refreshes past the stale cache
         entry_point = _find_entry_point(con_name)
@@ -51,13 +47,9 @@ def test_load_backend_returns_none_for_unknown_backend() -> None:
 
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
 def test_load_backend_entry_points_are_loadable(con_name: str) -> None:
-    """Every declared entry point names a module exposing a `Backend`, which is
-    what both `load_backend` and the dynamic secret-key lookup assume.
-
-    A backend whose optional dependencies aren't installed is skipped: entry
-    points are declared for every backend regardless of which extras the
-    environment has.
-    """
+    """Every declared entry point names a module exposing a `Backend`, which both
+    `load_backend` and the dynamic secret-key lookup assume. Skipped for a backend
+    whose extras aren't installed -- entry points are declared regardless."""
     entry_point = _find_entry_point(con_name)
     assert entry_point is not None
     try:

--- a/python/xorq/tests/test_loader.py
+++ b/python/xorq/tests/test_loader.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+from xorq.loader import (
+    _find_entry_point,
+    _load_entry_points,
+    load_backend,
+)
+
+
+def _write_fake_dist(root: pathlib.Path, con_name: str) -> None:
+    """Write a minimal installed distribution declaring a xorq.backends entry
+    point, so adding `root` to sys.path is indistinguishable from installing a
+    backend plugin."""
+    dist_info = root / f"xorq_{con_name}-0.1.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: xorq-{con_name}\nVersion: 0.1\n"
+    )
+    (dist_info / "entry_points.txt").write_text(
+        f"[xorq.backends]\n{con_name} = xorq_{con_name}\n"
+    )
+
+
+def test_load_entry_points_returns_cached_tuple() -> None:
+    """The value is a tuple (callers share it, so it must not be mutable in
+    place) and repeated calls reuse it rather than rescanning."""
+    first = _load_entry_points()
+    assert isinstance(first, tuple)
+    assert _load_entry_points() is first
+
+
+def test_find_entry_point_resolves_an_installed_backend() -> None:
+    name = _load_entry_points()[0].name
+    assert _find_entry_point(name) is not None
+
+
+def test_find_entry_point_refreshes_a_stale_cache(tmp_path: pathlib.Path) -> None:
+    """A backend installed after the cache was populated is still resolvable.
+
+    The cache is what makes repeated Profile construction cheap, but it means a
+    distribution installed into a live process (pip install in a Jupyter kernel)
+    is invisible to an already-populated cache. Resolution refreshes on a miss so
+    that staleness never surfaces as an unresolvable backend.
+    """
+    con_name = "xorqfakebackend"
+    _write_fake_dist(tmp_path, con_name)
+    # populate the cache *before* the install, which is the stale-cache setup
+    assert not any(ep.name == con_name for ep in _load_entry_points())
+    sys.path.insert(0, str(tmp_path))
+    try:
+        # the cached value still predates the install ...
+        assert not any(ep.name == con_name for ep in _load_entry_points())
+        # ... but resolution refreshes past it
+        entry_point = _find_entry_point(con_name)
+        assert entry_point is not None
+        assert entry_point.name == con_name
+    finally:
+        sys.path.remove(str(tmp_path))
+        importlib.invalidate_caches()
+        _load_entry_points.cache_clear()
+    assert not any(ep.name == con_name for ep in _load_entry_points())
+
+
+def test_find_entry_point_returns_none_for_unknown_backend() -> None:
+    assert _find_entry_point("xorq-no-such-backend") is None
+
+
+def test_load_backend_returns_none_for_unknown_backend() -> None:
+    assert load_backend("xorq-no-such-backend") is None
+
+
+@pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
+def test_load_backend_entry_points_are_loadable(con_name: str) -> None:
+    """Every declared entry point names a module exposing a `Backend`, which is
+    what both `load_backend` and the dynamic secret-key lookup assume."""
+    entry_point = _find_entry_point(con_name)
+    assert entry_point is not None
+    module = entry_point.load()
+    assert hasattr(module, "Backend")

--- a/python/xorq/tests/test_loader.py
+++ b/python/xorq/tests/test_loader.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import contextlib
-import importlib
 import pathlib
-import sys
-from collections.abc import Iterator
 
 import pytest
 
@@ -13,42 +9,7 @@ from xorq.loader import (
     _load_entry_points,
     load_backend,
 )
-
-
-def _write_fake_dist(root: pathlib.Path, con_name: str) -> None:
-    """Write a minimal installed distribution declaring a xorq.backends entry
-    point, so adding `root` to sys.path is indistinguishable from installing a
-    backend plugin."""
-    dist_info = root / f"xorq_{con_name}-0.1.dist-info"
-    dist_info.mkdir(parents=True)
-    (dist_info / "METADATA").write_text(
-        f"Metadata-Version: 2.1\nName: xorq-{con_name}\nVersion: 0.1\n"
-    )
-    (dist_info / "entry_points.txt").write_text(
-        f"[xorq.backends]\n{con_name} = xorq_{con_name}\n"
-    )
-
-
-@contextlib.contextmanager
-def installed_mid_process(root: pathlib.Path, con_name: str) -> Iterator[str]:
-    """Install a backend distribution into this live process, with an
-    entry-point cache that predates it -- i.e. `pip install` in a Jupyter kernel.
-
-    Shared with test_profile.py, which asserts the same staleness is invisible to
-    `Profile` construction.
-    """
-    _write_fake_dist(root, con_name)
-    # populate the cache *before* the install, which is the stale-cache setup
-    assert not any(ep.name == con_name for ep in _load_entry_points())
-    sys.path.insert(0, str(root))
-    try:
-        # the cached value still predates the install
-        assert not any(ep.name == con_name for ep in _load_entry_points())
-        yield con_name
-    finally:
-        sys.path.remove(str(root))
-        importlib.invalidate_caches()
-        _load_entry_points.cache_clear()
+from xorq.tests.util import installed_mid_process
 
 
 def test_load_entry_points_returns_cached_tuple() -> None:

--- a/python/xorq/tests/test_loader.py
+++ b/python/xorq/tests/test_loader.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import pathlib
 import sys
+from collections.abc import Iterator
 
 import pytest
 
@@ -27,6 +29,28 @@ def _write_fake_dist(root: pathlib.Path, con_name: str) -> None:
     )
 
 
+@contextlib.contextmanager
+def installed_mid_process(root: pathlib.Path, con_name: str) -> Iterator[str]:
+    """Install a backend distribution into this live process, with an
+    entry-point cache that predates it -- i.e. `pip install` in a Jupyter kernel.
+
+    Shared with test_profile.py, which asserts the same staleness is invisible to
+    `Profile` construction.
+    """
+    _write_fake_dist(root, con_name)
+    # populate the cache *before* the install, which is the stale-cache setup
+    assert not any(ep.name == con_name for ep in _load_entry_points())
+    sys.path.insert(0, str(root))
+    try:
+        # the cached value still predates the install
+        assert not any(ep.name == con_name for ep in _load_entry_points())
+        yield con_name
+    finally:
+        sys.path.remove(str(root))
+        importlib.invalidate_caches()
+        _load_entry_points.cache_clear()
+
+
 def test_load_entry_points_returns_cached_tuple() -> None:
     """The value is a tuple (callers share it, so it must not be mutable in
     place) and repeated calls reuse it rather than rescanning."""
@@ -48,22 +72,11 @@ def test_find_entry_point_refreshes_a_stale_cache(tmp_path: pathlib.Path) -> Non
     is invisible to an already-populated cache. Resolution refreshes on a miss so
     that staleness never surfaces as an unresolvable backend.
     """
-    con_name = "xorqfakebackend"
-    _write_fake_dist(tmp_path, con_name)
-    # populate the cache *before* the install, which is the stale-cache setup
-    assert not any(ep.name == con_name for ep in _load_entry_points())
-    sys.path.insert(0, str(tmp_path))
-    try:
-        # the cached value still predates the install ...
-        assert not any(ep.name == con_name for ep in _load_entry_points())
-        # ... but resolution refreshes past it
+    with installed_mid_process(tmp_path, "xorqfakebackend") as con_name:
+        # resolution refreshes past the stale cache
         entry_point = _find_entry_point(con_name)
         assert entry_point is not None
         assert entry_point.name == con_name
-    finally:
-        sys.path.remove(str(tmp_path))
-        importlib.invalidate_caches()
-        _load_entry_points.cache_clear()
     assert not any(ep.name == con_name for ep in _load_entry_points())
 
 

--- a/python/xorq/tests/test_loader.py
+++ b/python/xorq/tests/test_loader.py
@@ -78,8 +78,16 @@ def test_load_backend_returns_none_for_unknown_backend() -> None:
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
 def test_load_backend_entry_points_are_loadable(con_name: str) -> None:
     """Every declared entry point names a module exposing a `Backend`, which is
-    what both `load_backend` and the dynamic secret-key lookup assume."""
+    what both `load_backend` and the dynamic secret-key lookup assume.
+
+    A backend whose optional dependencies aren't installed is skipped: entry
+    points are declared for every backend regardless of which extras the
+    environment has.
+    """
     entry_point = _find_entry_point(con_name)
     assert entry_point is not None
-    module = entry_point.load()
+    try:
+        module = entry_point.load()
+    except ImportError as e:
+        pytest.skip(f"{con_name} backend not importable: {e}")
     assert hasattr(module, "Backend")

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -10,6 +10,7 @@ import pytest
 import xorq.api as xo
 from xorq.common.utils.env_utils import maybe_substitute_env_vars
 from xorq.loader import _load_entry_points
+from xorq.tests.test_loader import installed_mid_process
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.backends import profiles as profiles_mod
 from xorq.vendor.ibis.backends.profiles import (
@@ -701,13 +702,22 @@ def _install_fake_backend(
     backend_cls. Patches the entry-point lookup, and (when imported=True) marks
     the module as already-imported in sys.modules -- the resolver only inspects
     already-imported backends. Pass imported=False to simulate a backend whose
-    module has not been imported."""
+    module has not been imported.
+
+    The fakes let a hook's *contract* be tested without a real plugin;
+    test_get_dynamic_secret_keys_resolves_a_real_backend covers the resolution
+    these patches stand in for."""
     module = types.ModuleType(module_name)
     module.Backend = backend_cls
     entry_point = types.SimpleNamespace(
         name=con_name, module=module_name, load=lambda: module
     )
     monkeypatch.setattr(profiles_mod, "_load_entry_points", lambda: (entry_point,))
+    monkeypatch.setattr(
+        profiles_mod,
+        "_find_entry_point",
+        lambda name: entry_point if name == con_name else None,
+    )
     if imported:
         monkeypatch.setitem(sys.modules, module_name, module)
     return con_name
@@ -809,6 +819,116 @@ def test_get_dynamic_secret_keys_rejects_bare_string(
         assert get_dynamic_secret_keys(con_name, {}) is None
     with pytest.warns(RuntimeWarning):
         assert "a" not in profiles_mod.get_secret_keys(con_name, {})
+
+
+def test_get_dynamic_secret_keys_drops_a_non_sequence_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook returning something that isn't a sequence of names degrades like a
+    raising hook. The tier is materialized inside the try for this reason: a
+    stray `return 42` must not turn every Profile.save() for the backend into a
+    TypeError."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return 42
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match="TypeError.+not iterable"):
+        assert get_dynamic_secret_keys(con_name, {}) is None
+    with pytest.warns(RuntimeWarning):
+        assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(ValueError, match="password"):
+            check_for_exposed_secrets(con_name, {"password": "plaintext"})
+
+
+def test_get_dynamic_secret_keys_drops_an_iterable_that_raises_midway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook whose return raises only once consumed degrades the same way -- the
+    guard has to cover materializing the keys, not just calling the hook."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            def gen():
+                yield "api_key"
+                raise RuntimeError("late boom")
+
+            return gen()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match="RuntimeError: late boom"):
+        assert get_dynamic_secret_keys(con_name, {}) is None
+
+
+def test_get_dynamic_secret_keys_ignores_non_str_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Names that aren't str are dropped with a warning, and the well-formed ones
+    are kept: a non-str name can never match a kwarg, but the str names alongside
+    it are unambiguous and checking them is strictly safer than dropping the
+    tier."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key", None, 3)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match=r"non-str names \(None, 3\)"):
+        assert get_dynamic_secret_keys(con_name, {}) == ("api_key",)
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(ValueError, match="api_key"):
+            check_for_exposed_secrets(con_name, {"api_key": "plaintext"})
+
+
+def test_get_dynamic_secret_keys_normalizes_missing_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook is always handed a dict, so hook authors needn't defend against
+    None."""
+    received = []
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            received.append(kwargs)
+            return ()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    # asserted outside the hook: an AssertionError raised inside one is caught
+    # and warned about, not propagated
+    assert get_dynamic_secret_keys(con_name) == ()
+    assert received == [{}]
+
+
+def test_get_dynamic_secret_keys_resolves_a_real_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolution works against a real installed backend, not just the fakes: the
+    entry point comes from the loader and the module from sys.modules, so the
+    hook is found on the imported xorq.backends.postgres Backend."""
+    postgres = pytest.importorskip("xorq.backends.postgres")
+
+    @classmethod
+    def _get_secret_keys(cls, kwargs):
+        return tuple(kwargs.get("secret_kwarg_names", ()))
+
+    monkeypatch.setattr(
+        postgres.Backend, "_get_secret_keys", _get_secret_keys, raising=False
+    )
+    assert get_dynamic_secret_keys(
+        "postgres", {"secret_kwarg_names": ("api_key",)}
+    ) == ("api_key",)
+    # and it widens the mirror rather than replacing it
+    keys = profiles_mod.get_secret_keys(
+        "postgres", {"secret_kwarg_names": ("api_key",)}
+    )
+    assert set(con_name_to_secret_keys["postgres"]) < set(keys)
+    assert keys[-1] == "api_key"
 
 
 def test_check_for_exposed_secrets_uses_dynamic_keys(
@@ -934,3 +1054,21 @@ def test_unimported_backend_still_checks_password(
     assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
     with pytest.raises(ValueError, match="password"):
         check_for_exposed_secrets(con_name, {"password": "plaintext"})
+
+
+def test_validate_con_name_sees_a_backend_installed_mid_process(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A backend installed into a live process is usable without a restart.
+
+    validate_con_name resolves through `_find_entry_point` for this reason:
+    scanning the cached entry points directly would reject the just-installed
+    backend as "Unknown backend" -- and list a stale set as the installed ones --
+    for the life of the process.
+    """
+    with installed_mid_process(tmp_path, "xorqfakeprofilebackend") as con_name:
+        profile = Profile(con_name=con_name, kwargs_tuple=())
+        assert profile.con_name == con_name
+        # a name that really doesn't exist still raises, against the fresh list
+        with pytest.raises(ValueError, match="Unknown backend 'xorqnosuchbackend'"):
+            Profile(con_name="xorqnosuchbackend", kwargs_tuple=())

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -1140,43 +1140,41 @@ def test_malformed_sources_contribute_nothing(
     "base",
     (pytest.param(list, id="list_subclass"), pytest.param(tuple, id="tuple_subclass")),
 )
-def test_a_leaf_that_subclasses_list_is_not_iterated(
+def test_a_leaf_subclass_has_its_true_names_read(
     monkeypatch: pytest.MonkeyPatch, base: type
 ) -> None:
-    """The leaf read runs no code belonging to the leaf either: a list/tuple
-    subclass forging __iter__ is unresolved rather than believed, with no call
-    made. Iterating it would let hostile data both invent names and -- by
-    resolving -- cut off the fallback to the next source."""
+    """The leaf is read the way the steps are, through an unbound builtin, so a
+    list/tuple subclass forging __iter__ has the override bypassed and its true
+    data read. Neither believing the forgery (which invents names) nor rejecting
+    the subclass (which drops a benign one's real names, and with them the check
+    on the credential they name) is safe."""
 
     class Forging(base):
-        def __init__(self, *args) -> None:
-            super().__init__()
-            self.iterated = False
-
         def __iter__(self) -> collections.abc.Iterator:
-            self.iterated = True
             return iter(["forged"])
 
     leaf = Forging(["true_key"])
+    assert tuple(leaf) == ("forged",), "the forgery is live"
     con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
     kwargs = {"config": {"auth": {"fields": leaf}}}
-    assert get_declared_secret_keys(con_name, kwargs) == ()
-    assert not leaf.iterated
-    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+    assert get_declared_secret_keys(con_name, kwargs) == ("true_key",)
+    with pytest.raises(ValueError, match="true_key"):
+        check_for_exposed_secrets(con_name, {**kwargs, "true_key": "plaintext"})
 
 
-def test_a_leaf_subclass_falls_through_to_the_next_source(
+def test_a_forged_empty_leaf_cannot_suppress_the_true_names(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unresolved means unresolved: a subclass leaf on the first source hands the
-    fallback to the second rather than resolving to a forged answer."""
+    """Nor can a forgery narrow the check by resolving to less: a subclass whose
+    __iter__ reports nothing still resolves to the names it really holds, rather
+    than to an empty set that would win the fallback."""
 
     class Forging(list):
         def __iter__(self) -> collections.abc.Iterator:
             return iter([])
 
     con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
-    auth = {"secret_fields": Forging(["ignored"]), "fields": ["api_key"]}
+    auth = {"secret_fields": Forging(["api_key"]), "fields": ["other"]}
     kwargs = {"config": {"auth": auth}}
     assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
 

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import collections.abc
 import importlib.util
 import os
 import pathlib
@@ -10,7 +11,6 @@ import types
 import pytest
 
 import xorq.api as xo
-from xorq.common.exceptions import XorqError
 from xorq.common.utils.env_utils import maybe_substitute_env_vars
 from xorq.loader import _load_entry_points
 from xorq.tests.util import installed_mid_process
@@ -20,8 +20,9 @@ from xorq.vendor.ibis.backends.profiles import (
     Profile,
     Profiles,
     check_for_exposed_secrets,
+    con_name_to_secret_key_sources,
     con_name_to_secret_keys,
-    get_dynamic_secret_keys,
+    get_declared_secret_keys,
 )
 
 
@@ -694,6 +695,60 @@ def test_declared_secret_keys_are_mirrored(con_name: str) -> None:
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])
 
 
+def test_mirrored_secret_key_sources_are_tuples_of_str() -> None:
+    """Declaration validity for the mirror itself: every entry is a tuple of
+    sources, each source a non-empty tuple of str steps. A malformed
+    declaration is an authoring-time bug this test catches; resolution never
+    guards for it at runtime."""
+    for con_name, sources in con_name_to_secret_key_sources.items():
+        assert isinstance(sources, tuple), con_name
+        for source in sources:
+            assert isinstance(source, tuple) and source, (con_name, source)
+            assert all(isinstance(step, str) for step in source), (con_name, source)
+
+
+@pytest.mark.parametrize("con_name", sorted(con_name_to_secret_key_sources))
+def test_secret_key_sources_mirror_matches_backend_declaration(con_name: str) -> None:
+    """con_name_to_secret_key_sources must not drift from the sources each
+    backend's Backend class declares in _secret_key_sources, exactly as the
+    static-keys mirror is pinned to _secret_keys."""
+    entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
+    assert entry_point is not None, f"no entry point for {con_name!r}"
+    try:
+        module = entry_point.load()
+    except ImportError as e:
+        pytest.skip(f"{con_name} backend not importable: {e}")
+    declared = getattr(module.Backend, "_secret_key_sources", None)
+    assert declared is not None, (
+        f"{con_name} is in con_name_to_secret_key_sources but its Backend "
+        "declares no _secret_key_sources; declare them so the mirror stays honest"
+    )
+    assert tuple(declared) == tuple(con_name_to_secret_key_sources[con_name])
+
+
+@pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
+def test_declared_secret_key_sources_are_mirrored(con_name: str) -> None:
+    """Inverse of test_secret_key_sources_mirror_matches_backend_declaration:
+    every installed backend declaring _secret_key_sources must also appear (and
+    match) in the mirror. The mirror is what lets the sources resolve with the
+    backend unimported; an unmirrored declaration would silently degrade to the
+    import-dependent class read."""
+    entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
+    try:
+        module = entry_point.load()
+    except ImportError as e:
+        pytest.skip(f"{con_name} backend not importable: {e}")
+    declared = getattr(getattr(module, "Backend", None), "_secret_key_sources", None)
+    if declared is None:
+        pytest.skip(f"{con_name} declares no _secret_key_sources")
+    assert con_name in con_name_to_secret_key_sources, (
+        f"{con_name} declares _secret_key_sources but is missing from the "
+        "con_name_to_secret_key_sources mirror; add it so its sources resolve "
+        "without the backend imported"
+    )
+    assert tuple(declared) == tuple(con_name_to_secret_key_sources[con_name])
+
+
 def _source_declares(module_name: str, name: str) -> bool | None:
     """Whether a module's source defines or assigns `name`, without importing it:
     find_spec locates the file but doesn't execute it. None when there is no
@@ -718,40 +773,40 @@ def test_source_declares_finds_names_without_importing() -> None:
     than as "can't tell"."""
     module_name = "xorq.vendor.ibis.backends.profiles"
     assert _source_declares(module_name, "get_secret_keys") is True
-    assert _source_declares(module_name, "con_name_to_secret_keys") is True
+    assert _source_declares(module_name, "con_name_to_secret_key_sources") is True
     assert _source_declares(module_name, "_get_secret_keys") is False
     assert _source_declares("xorq_no_such_module", "_secret_keys") is None
 
 
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
-def test_dynamic_hook_backends_also_mirror_static_keys(con_name: str) -> None:
-    """A backend declaring the dynamic hook must also declare static
-    _secret_keys: the dynamic tier is skipped for a backend that isn't imported,
-    so a backend relying on it alone gets only ("password",) checked when a
-    profile is hand-authored in a fresh process.
+def test_declaring_backends_also_mirror_static_keys(con_name: str) -> None:
+    """A backend declaring _secret_key_sources must also declare static
+    _secret_keys: a source only resolves when the kwargs actually carry what it
+    points at, so the always-present names belong in the static mirror, which
+    is checked with no kwargs at all.
 
     A backend whose extras aren't installed is checked against its module source
     rather than skipped -- skipping there would leave the guardrail unenforced
     for exactly the backends CI can't import."""
     hint = (
-        f"{con_name} declares a dynamic _get_secret_keys hook but no static "
-        "_secret_keys; mirror the keys the hook always names, since the hook is "
-        "skipped whenever the backend isn't already imported"
+        f"{con_name} declares _secret_key_sources but no static _secret_keys; "
+        "mirror the always-present names, since a source contributes only when "
+        "the kwargs carry what it points at"
     )
     entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
     try:
         module = entry_point.load()
     except ImportError:
-        declares_hook = _source_declares(entry_point.module, "_get_secret_keys")
-        if declares_hook is None:
+        declares_sources = _source_declares(entry_point.module, "_secret_key_sources")
+        if declares_sources is None:
             pytest.skip(f"{con_name} is neither importable nor locatable")
-        if not declares_hook:
-            pytest.skip(f"{con_name} declares no _get_secret_keys hook (by source)")
+        if not declares_sources:
+            pytest.skip(f"{con_name} declares no _secret_key_sources (by source)")
         assert _source_declares(entry_point.module, "_secret_keys"), hint
         return
     backend = getattr(module, "Backend", None)
-    if getattr(backend, "_get_secret_keys", None) is None:
-        pytest.skip(f"{con_name} declares no _get_secret_keys hook")
+    if getattr(backend, "_secret_key_sources", None) is None:
+        pytest.skip(f"{con_name} declares no _secret_key_sources")
     assert getattr(backend, "_secret_keys", None), hint
 
 
@@ -762,9 +817,10 @@ def _install_fake_backend(
     module_name: str = "xorq_fake_backend_mod",
     imported: bool = True,
 ) -> str:
-    """Register a throwaway backend so get_dynamic_secret_keys resolves to
-    backend_cls: patch the entry-point lookup, and mark the module as imported,
-    which the resolver requires. Pass imported=False for the not-imported case."""
+    """Register a throwaway backend so the declared-sources tier finds
+    backend_cls through the import-dependent class read: patch the entry-point
+    lookup, and mark the module as imported, which that read requires. Pass
+    imported=False for the not-imported case."""
     module = types.ModuleType(module_name)
     module.Backend = backend_cls
     entry_point = types.SimpleNamespace(
@@ -781,590 +837,379 @@ def _install_fake_backend(
     return con_name
 
 
-def test_get_dynamic_secret_keys_uses_hook(
+_REST_STYLE_SOURCES = (
+    ("config", "auth", "secret_fields"),
+    ("config", "auth", "fields"),
+)
+
+
+class _DeclaringBackend:
+    _secret_key_sources = _REST_STYLE_SOURCES
+
+
+def test_get_declared_secret_keys_first_resolving_source_wins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The dynamic _get_secret_keys(kwargs) hook is used and receives kwargs."""
+    """Sources are ordered fallback: when the first resolves, the second is
+    never consulted -- an explicit secret_fields narrows what fields would
+    have said."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = {
+        "config": {
+            "auth": {"fields": ["user", "api_key"], "secret_fields": ["api_key"]}
+        }
+    }
+    assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
 
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("password", *(kwargs or {}).get("extra_secret_keys", ()))
 
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    assert get_dynamic_secret_keys(con_name, {"extra_secret_keys": ("api_key",)}) == (
-        "password",
+@pytest.mark.parametrize(
+    "auth",
+    (
+        pytest.param({"fields": ["api_key"]}, id="secret_fields_absent"),
+        pytest.param(
+            {"fields": ["api_key"], "secret_fields": None}, id="secret_fields_null"
+        ),
+    ),
+)
+def test_get_declared_secret_keys_falls_back_in_order(
+    monkeypatch: pytest.MonkeyPatch, auth: dict
+) -> None:
+    """The second source is used exactly when the first doesn't resolve: an
+    absent secret_fields falls through, and so does an explicit null -- None
+    is unresolved, not "no names"."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    assert get_declared_secret_keys(con_name, {"config": {"auth": auth}}) == (
         "api_key",
     )
 
 
-def test_get_dynamic_secret_keys_none_when_hook_returns_none(
+def test_empty_secret_fields_resolves_and_wins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A hook returning None yields None so the caller falls back to the static
-    mapping."""
+    """secret_fields: [] resolves to () and wins -- "none of the fields are
+    secret" is genuinely different from the key being absent
+    (presence-and-not-None, never truthiness) -- and the unconditional default
+    still applies: () is not an opt-out."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = {"config": {"auth": {"fields": ["api_key"], "secret_fields": []}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets(con_name, {**kwargs, "password": "plaintext"})
 
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return None
 
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    assert get_dynamic_secret_keys(con_name, {}) is None
+class _AttrsLike:
+    """A config carried as an object rather than a plain dict -- e.g. a
+    RestBackendConfig instance handed to connect() -- is never reached into;
+    profiles carry configs as plain dicts."""
+
+    auth = {"fields": ["never_reached"]}
 
 
-def test_get_dynamic_secret_keys_none_without_hook(
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        pytest.param({}, id="no_config_at_all"),
+        pytest.param({"config": None}, id="config_is_none"),
+        pytest.param({"config": {"other": 1}}, id="missing_step"),
+        pytest.param({"config": {"auth": "basic"}}, id="non_dict_intermediate"),
+        pytest.param({"config": {"auth": ["fields"]}}, id="list_intermediate"),
+        pytest.param({"config": _AttrsLike()}, id="attrs_instance_intermediate"),
+        pytest.param({"config": {"auth": {"fields": "token"}}}, id="bare_str_leaf"),
+        pytest.param({"config": {"auth": {"fields": {"token": 1}}}}, id="dict_leaf"),
+        pytest.param({"config": {"auth": {"fields": 42}}}, id="non_sequence_leaf"),
+    ),
+)
+def test_unresolved_sources_contribute_nothing(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict
+) -> None:
+    """Every shape a source cannot read -- a missing step, a non-dict
+    intermediate, a leaf that isn't a list/tuple -- is unresolved: the tier
+    contributes nothing, silently, and tiers 1+2 still enforce. The bare-str
+    leaf in particular stops being a hazard rather than being guarded: a str
+    is not a list/tuple, so `fields: "token"` can never be iterated into
+    ('t', 'o', 'k', ...)."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets(con_name, {**kwargs, "password": "plaintext"})
+
+
+def test_mixed_leaf_keeps_the_str_names(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A Backend with no dynamic hook resolves to None (caller uses the dict)."""
-
-    class Backend:
-        pass
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    assert get_dynamic_secret_keys(con_name, {}) is None
-
-
-def test_get_dynamic_secret_keys_none_when_not_imported(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A backend that isn't imported is not force-imported: the hook is skipped
-    and None is returned even though the class declares one."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key",)
-
-    con_name = _install_fake_backend(monkeypatch, Backend, imported=False)
-    assert get_dynamic_secret_keys(con_name, {}) is None
-
-
-def test_get_dynamic_secret_keys_drops_keys_and_warns_on_hook_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A raising hook degrades to None -- neither propagating (aborting the save)
-    nor bypassing the check -- and warns, since dropping the tier is fail-open."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            raise RuntimeError("boom")
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="RuntimeError: boom"):
-        assert get_dynamic_secret_keys(con_name, {}) is None
-
-
-def test_get_dynamic_secret_keys_rejects_bare_string(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hook returning a bare name instead of a sequence is reported, not
-    iterated: tuple("api_key") would drop the key the hook meant to name and add
-    junk single-character keys."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return "api_key"
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="not a bare str"):
-        assert get_dynamic_secret_keys(con_name, {}) is None
-    with pytest.warns(RuntimeWarning):
-        assert "a" not in profiles_mod.get_secret_keys(con_name, {})
-
-
-def test_get_dynamic_secret_keys_drops_a_non_sequence_return(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hook returning something that isn't a sequence of names degrades like a
-    raising hook. The tier is materialized inside the try for this reason: a
-    stray `return 42` must not turn every Profile.save() for the backend into a
-    TypeError."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return 42
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    # matched on the exception type only: the message text is CPython's wording
-    with pytest.warns(RuntimeWarning, match="hook raised TypeError"):
-        assert get_dynamic_secret_keys(con_name, {}) is None
-    with pytest.warns(RuntimeWarning):
-        assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
-    with pytest.warns(RuntimeWarning):
-        with pytest.raises(ValueError, match="password"):
-            check_for_exposed_secrets(con_name, {"password": "plaintext"})
-
-
-def test_get_dynamic_secret_keys_drops_an_iterable_that_raises_midway(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hook whose return raises only once consumed degrades the same way -- the
-    guard has to cover materializing the keys, not just calling the hook."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            def gen():
-                yield "api_key"
-                raise RuntimeError("late boom")
-
-            return gen()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="RuntimeError: late boom"):
-        assert get_dynamic_secret_keys(con_name, {}) is None
-
-
-def test_get_dynamic_secret_keys_ignores_non_str_names(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Names that aren't str are dropped with a warning, and the well-formed ones
-    are kept: a non-str name can never match a kwarg, but the str names alongside
-    it are unambiguous and checking them is strictly safer than dropping the
-    tier."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key", None, 3)
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match=r"non-str names \(None, 3\)"):
-        assert get_dynamic_secret_keys(con_name, {}) == ("api_key",)
-    with pytest.warns(RuntimeWarning):
-        with pytest.raises(ValueError, match="api_key"):
-            check_for_exposed_secrets(con_name, {"api_key": "plaintext"})
-
-
-def test_get_dynamic_secret_keys_normalizes_missing_kwargs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hook is always handed a dict, so hook authors needn't defend against
-    None."""
-    received = []
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            received.append(kwargs)
-            return ()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    # asserted outside the hook: an AssertionError raised inside one is caught
-    # and warned about, not propagated
-    assert get_dynamic_secret_keys(con_name) == ()
-    assert received == [{}]
-
-
-def test_get_dynamic_secret_keys_resolves_a_real_backend(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Resolution works against a real installed backend, not just the fakes: the
-    entry point comes from the loader and the module from sys.modules, so the
-    hook is found on the imported xorq.backends.postgres Backend."""
-    postgres = pytest.importorskip("xorq.backends.postgres")
-
-    @classmethod
-    def _get_secret_keys(cls, kwargs):
-        return tuple(kwargs.get("secret_kwarg_names", ()))
-
-    monkeypatch.setattr(
-        postgres.Backend, "_get_secret_keys", _get_secret_keys, raising=False
-    )
-    assert get_dynamic_secret_keys(
-        "postgres", {"secret_kwarg_names": ("api_key",)}
-    ) == ("api_key",)
-    # and it widens the mirror rather than replacing it
-    keys = profiles_mod.get_secret_keys(
-        "postgres", {"secret_kwarg_names": ("api_key",)}
-    )
-    assert set(con_name_to_secret_keys["postgres"]) < set(keys)
-    assert keys[-1] == "api_key"
-
-
-def test_check_for_exposed_secrets_uses_dynamic_keys(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """End-to-end: a key surfaced only by the dynamic hook is enforced by
-    check_for_exposed_secrets, on top of the default/static keys."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key",)
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
+    """A list mixing str and non-str names keeps the str ones: the leaf is
+    user config data, not the declaration, so a declaration test can't catch
+    it, and checking "api_key" is strictly safer than dropping the source. A
+    non-str name can never match a kwarg, so dropping it needs no warning."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = {"config": {"auth": {"fields": ["api_key", 3, None]}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
     with pytest.raises(ValueError, match="api_key"):
-        check_for_exposed_secrets(con_name, {"api_key": "plaintext"})
-    # an env-var reference is accepted
-    check_for_exposed_secrets(con_name, {"api_key": "${API_KEY}"})
+        check_for_exposed_secrets(con_name, {**kwargs, "api_key": "plaintext"})
+    check_for_exposed_secrets(con_name, {**kwargs, "api_key": "${API_KEY}"})
 
 
-def test_save_is_blocked_by_a_dynamic_key(
+def test_dict_subclass_overrides_are_bypassed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No backend-authored code runs during resolution: a dict subclass
+    forging results from get/__getitem__/__missing__ has those overrides
+    bypassed -- the unbound dict.get reads the true underlying data. Applies
+    to kwargs itself and to every nested step."""
+
+    class Forging(dict):
+        def get(self, key: str, default: object = None) -> object:
+            return {"auth": {"fields": ["forged"]}}
+
+        def __getitem__(self, key: str) -> object:
+            return {"auth": {"fields": ["forged"]}}
+
+        def __missing__(self, key: str) -> object:
+            return {"auth": {"fields": ["forged"]}}
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = Forging(config=Forging(auth=Forging(fields=["true_key"])))
+    assert get_declared_secret_keys(con_name, kwargs) == ("true_key",)
+
+
+def test_a_mapping_that_is_not_a_dict_is_not_reached_into(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An intermediate value that isn't a plain dict is unresolved with no
+    call made: resolution never invokes a Mapping's own lookup methods."""
+
+    class RecordingMapping(collections.abc.Mapping):
+        def __init__(self, data: dict) -> None:
+            self.data = data
+            self.lookups: list[str] = []
+
+        def __getitem__(self, key: str) -> object:
+            self.lookups.append(key)
+            return self.data[key]
+
+        def __iter__(self) -> collections.abc.Iterator:
+            return iter(self.data)
+
+        def __len__(self) -> int:
+            return len(self.data)
+
+    config = RecordingMapping({"auth": {"fields": ["api_key"]}})
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = {"config": config}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert config.lookups == []
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+
+
+def test_a_lying_class_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,
 ) -> None:
-    """The dynamic tier is enforced through Profile.save(), not just the
-    module-level helper: the save aborts and writes nothing."""
+    """An object whose __class__ lies passes the isinstance check and makes
+    the unbound dict.get raise TypeError; the guard converts that into a
+    ValueError naming the con_name and source -- fail closed, with no kwarg
+    value in the message, since only our own declared source is interpolated.
+    (This needs an adversarial object already inside the caller's kwargs, the
+    same trust domain as the credentials themselves.)"""
 
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key",)
+    class Liar:
+        @property
+        def __class__(self) -> type:
+            return dict
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = {"config": Liar(), "token": "hunter2-secret"}
+    with pytest.raises(
+        ValueError, match="could not resolve secret-key source"
+    ) as excinfo:
+        check_for_exposed_secrets(con_name, kwargs)
+    message = str(excinfo.value)
+    assert con_name in message
+    assert "TypeError" in message
+    assert "hunter2" not in message
+    # and through Profile.save(): the save aborts and writes nothing
+    profile = Profile(con_name=con_name, kwargs_tuple=(("config", Liar()),))
+    with pytest.raises(ValueError, match="could not resolve secret-key source"):
+        profile.save(profile_dir=tmp_path)
+    assert not tuple(tmp_path.iterdir())
+
+
+def test_a_property_declaration_contributes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_secret_key_sources declared as a property never executes:
+    inspect.getattr_static reads the class dict without firing descriptors and
+    returns the descriptor object, which fails the tuple check. The property
+    lives on the metaclass, where a plain getattr on the class *would* run it
+    -- and would get back a well-formed tuple, so only the no-execution rule
+    keeps it out."""
+    executed = []
+
+    class Meta(type):
+        @property
+        def _secret_key_sources(cls) -> tuple:
+            executed.append(True)
+            return _REST_STYLE_SOURCES
+
+    class Backend(metaclass=Meta):
+        pass
 
     con_name = _install_fake_backend(monkeypatch, Backend)
-    profile = Profile(con_name=con_name, kwargs_tuple=(("api_key", "plaintext"),))
+    kwargs = {"config": {"auth": {"fields": ["api_key"]}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert not executed
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+
+
+def test_a_non_tuple_class_declaration_contributes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed class declaration -- a list here -- fails the tuple check
+    and contributes nothing: declaration shape is an authoring-time concern
+    (test_mirrored_secret_key_sources_are_tuples_of_str), never a runtime
+    guard."""
+
+    class Backend:
+        _secret_key_sources = [("config", "auth", "fields")]
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    kwargs = {"config": {"auth": {"fields": ["api_key"]}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+
+
+def test_mirrored_sources_resolve_without_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mirror is what makes this tier no longer best-effort: a mirrored
+    backend's sources resolve with the backend never imported, where the old
+    callable tier silently contributed nothing."""
+
+    class Backend:
+        _secret_key_sources = _REST_STYLE_SOURCES
+
+    con_name = _install_fake_backend(monkeypatch, Backend, imported=False)
+    monkeypatch.setattr(
+        profiles_mod,
+        "con_name_to_secret_key_sources",
+        {con_name: _REST_STYLE_SOURCES},
+    )
+    kwargs = {"config": {"auth": {"fields": ["api_key"]}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, {**kwargs, "api_key": "plaintext"})
+
+
+def test_unimported_backend_contributes_no_class_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The class read stays best-effort exactly as the callable tier was: an
+    out-of-tree backend that isn't imported (and, being out-of-tree, has no
+    mirror entry) contributes nothing, and the unconditional default still
+    applies."""
+
+    class Backend:
+        _secret_key_sources = _REST_STYLE_SOURCES
+
+    con_name = _install_fake_backend(monkeypatch, Backend, imported=False)
+    kwargs = {"config": {"auth": {"fields": ["api_key"]}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets(con_name, {"password": "plaintext"})
+
+
+def test_class_and_mirror_sources_are_unioned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Out-of-tree backends cannot add mirror entries, so an imported
+    backend's class declaration tops up the mirror's: mirror sources first,
+    class sources after."""
+
+    class Backend:
+        _secret_key_sources = (("extra_names",),)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    monkeypatch.setattr(
+        profiles_mod,
+        "con_name_to_secret_key_sources",
+        {con_name: (("config", "auth", "fields"),)},
+    )
+    # the mirror's source is consulted first when both could resolve
+    kwargs = {
+        "config": {"auth": {"fields": ["from_mirror"]}},
+        "extra_names": ["from_class"],
+    }
+    assert get_declared_secret_keys(con_name, kwargs) == ("from_mirror",)
+    # the class-declared source is a top-up: used when the mirror's doesn't resolve
+    assert get_declared_secret_keys(con_name, {"extra_names": ["from_class"]}) == (
+        "from_class",
+    )
+
+
+def test_get_declared_secret_keys_handles_missing_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No kwargs at all is just the unresolved case: no error, nothing
+    contributed."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    assert get_declared_secret_keys(con_name) == ()
+    assert profiles_mod.get_secret_keys(con_name) == ("password",)
+
+
+def test_check_for_exposed_secrets_uses_declared_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a key surfaced only by a declared source is enforced by
+    check_for_exposed_secrets, on top of the default/static keys, and an
+    env-var reference is accepted."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    config = {"auth": {"fields": ["api_key"]}}
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, {"config": config, "api_key": "plaintext"})
+    check_for_exposed_secrets(con_name, {"config": config, "api_key": "${API_KEY}"})
+
+
+def test_save_is_blocked_by_a_declared_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The declared tier is enforced through Profile.save(), not just the
+    module-level helper: the save aborts and writes nothing."""
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    config = {"auth": {"fields": ["api_key"]}}
+    profile = Profile(
+        con_name=con_name,
+        kwargs_tuple=(("config", config), ("api_key", "plaintext")),
+    )
     with pytest.raises(ValueError, match="api_key"):
         profile.save(profile_dir=tmp_path)
     assert not tuple(tmp_path.iterdir())
     # the same profile with an env-var reference saves
-    Profile(con_name=con_name, kwargs_tuple=(("api_key", "${API_KEY}"),)).save(
-        profile_dir=tmp_path
-    )
+    Profile(
+        con_name=con_name,
+        kwargs_tuple=(("config", config), ("api_key", "${API_KEY}")),
+    ).save(profile_dir=tmp_path)
     assert tuple(tmp_path.iterdir())
 
 
-def test_hook_mutating_kwargs_does_not_weaken_checking(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
-) -> None:
-    """A hook that mutates what it is handed cannot delete entries from the scan.
-
-    The caller scans the same kwargs after the hook returns, so without the copy
-    a hook doing `kwargs.pop(...)` dropped the key from the scan and
-    `Profile.save()` wrote the plaintext secret to disk."""
-    plaintext = "plaintext-hunter2"
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            kwargs.clear()
-            return ()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    kwargs = {"password": plaintext}
-    with pytest.raises(ValueError, match="password"):
-        check_for_exposed_secrets(con_name, kwargs)
-    assert kwargs == {"password": plaintext}, "the caller's kwargs were mutated"
-    profile = Profile(con_name=con_name, kwargs_tuple=(("password", plaintext),))
-    with pytest.raises(ValueError, match="password"):
-        profile.save(profile_dir=tmp_path)
-    assert not tuple(tmp_path.iterdir())
-
-
-def test_hook_error_warning_redacts_kwarg_values(
+def test_get_secret_keys_unions_default_mirror_and_declared(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A secret echoed by a hook's exception -- `int("hunter2...")` quotes its
-    input back -- is masked in the warning, which reaches stderr and CI logs."""
-    plaintext = "hunter2-super-secret"
+    """The three tiers are unioned, not chained: a backend that is both
+    mirrored and declares sources is checked for the default, the mirrored,
+    and the declared keys together. Ordering is deterministic (default,
+    mirror, declared) and duplicates collapse."""
 
     class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return (int(kwargs["password"]),)
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning) as records:
-        assert get_dynamic_secret_keys(con_name, {"password": plaintext}) is None
-    message = str(records[0].message)
-    assert plaintext not in message
-    assert "***" in message
-    # the useful part survives: which backend, and what went wrong
-    assert con_name in message
-    assert "ValueError" in message
-
-
-def test_hook_error_warning_redacts_nested_kwarg_values(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hook keys off a nested config -- that is the whole reason the hook
-    exists -- so the value it quotes back when parsing fails was never a
-    top-level kwarg value. Redaction walks into the kwargs for that reason."""
-    plaintext = "nested-hunter2-super-secret"
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            raise ValueError(f"bad token: {kwargs['config']['token']}")
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning) as records:
-        assert (
-            get_dynamic_secret_keys(con_name, {"config": {"token": plaintext}}) is None
-        )
-    message = str(records[0].message)
-    assert plaintext not in message
-    assert "hunter2" not in message
-    assert "***" in message
-    assert "ValueError" in message
-
-
-def test_hook_error_warning_redacts_a_truncated_echo(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """int() quotes only the leading ~200 characters of its input, so replacing
-    the whole value leaves that prefix in the message."""
-    plaintext = "hunter2-" + "x" * 400
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return (int(kwargs["password"]),)
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning) as records:
-        assert get_dynamic_secret_keys(con_name, {"password": plaintext}) is None
-    message = str(records[0].message)
-    assert "hunter2" not in message
-    assert "xxxx" not in message
-
-
-def test_hook_error_warning_redacts_an_escaped_echo(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A value holding a newline or a quote is echoed in its repr-escaped form,
-    which the raw value never matches."""
-    plaintext = "hunter2\nsuper-secret"
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            raise ValueError(f"bad token: {kwargs['password']!r}")
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning) as records:
-        assert get_dynamic_secret_keys(con_name, {"password": plaintext}) is None
-    message = str(records[0].message)
-    assert "hunter2" not in message
-    assert "super-secret" not in message
-
-
-def test_bare_string_warning_carries_no_value(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The bare-str report names the type, not the value: a hook returning a
-    credential instead of its name would otherwise put it in the warning. The
-    hook here returns a value it *derived* from a kwarg rather than the kwarg
-    itself, which redaction cannot match -- so the only way the message stays
-    clean is by not carrying the value."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return kwargs["password"].upper()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="not a bare str") as records:
-        assert get_dynamic_secret_keys(con_name, {"password": "hunter2-secret"}) is None
-    message = str(records[0].message)
-    assert "HUNTER2" not in message
-
-
-def test_non_str_names_warning_redacts_non_str_kwarg_values(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A bytes credential returned as a name lands in the non-str warning
-    verbatim, so redaction covers non-str kwarg values too."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key", kwargs["private_key"])
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning) as records:
-        assert get_dynamic_secret_keys(
-            con_name, {"private_key": b"bytes-hunter2-secret"}
-        ) == ("api_key",)
-    message = str(records[0].message)
-    assert "hunter2" not in message
-
-
-def _cyclic(mapping: dict) -> dict:
-    """A mapping that contains itself, so walking it has to terminate."""
-    mapping["self"] = mapping
-    return mapping
-
-
-@pytest.mark.parametrize(
-    ("text", "kwargs"),
-    (
-        pytest.param(
-            "bad token: sk_live_BBBBcccc",
-            {"token": "sk_live_AAAAzzzzzz", "backup": "sk_live_BBBBcccc"},
-            id="shares_a_prefix_with_another_value",
-        ),
-        pytest.param(
-            "bad tail: yyyyyyyyyyyyyyyyyyyy",
-            {"token": "hunter2-" + "y" * 20},
-            id="echoed_from_the_tail",
-        ),
-        pytest.param(
-            "bad: deep-hunter2-secret",
-            {"config": {"a": {"b": {"c": {"d": {"token": "deep-hunter2-secret"}}}}}},
-            id="nested_deeper_than_a_few_levels",
-        ),
-        pytest.param(
-            "bad: cycle-hunter2-secret",
-            {"config": _cyclic({"token": "cycle-hunter2-secret"})},
-            id="reachable_through_a_cycle",
-        ),
-    ),
-)
-def test_redaction_masks_partial_and_deep_echoes(text: str, kwargs: dict) -> None:
-    """Masking whole values only is not enough, because an exception rarely
-    echoes a value intact.
-
-    Each case leaked against a whole-value replace: one value consuming the
-    shared prefix of another stranded that one's remainder, a value quoted from
-    its tail was never matched, and a value nested past a fixed depth was never
-    collected. A cyclic kwarg has to terminate rather than covered."""
-    redacted = profiles_mod._redact_kwarg_values(text, kwargs)
-    assert "hunter2" not in redacted
-    assert "BBBBcccc" not in redacted
-    assert "yyyy" not in redacted
-    assert "***" in redacted
-
-
-def test_redaction_leaves_unrelated_text_alone() -> None:
-    """Redaction must not swallow the diagnostic: nothing that isn't part of a
-    value is masked, and a value too short to hide is left alone."""
-    text = "invalid literal for int() with base 10"
-    assert profiles_mod._redact_kwarg_values(
-        text, {"port": 5432, "sslmode": "req"}
-    ) == (text)
-
-
-class _Unprintable:
-    """A value, name, or exception whose own str()/repr() raises -- all three run
-    while a warning about a misbehaving hook is being built."""
-
-    def __str__(self) -> str:
-        raise RuntimeError("str bomb")
-
-    __repr__ = __str__
-
-
-class _UnprintableError(XorqError):
-    __str__ = _Unprintable.__str__
-
-
-def test_hook_whose_exception_is_unprintable_does_not_break_a_save(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
-) -> None:
-    """`str(e)` runs inside the except handler, so it is not covered by the guard
-    around the hook: an exception whose str() raises escaped from the reporting
-    and aborted a save with nothing wrong with it."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            raise _UnprintableError()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="_UnprintableError: <unprintable>"):
-        assert get_dynamic_secret_keys(con_name, {}) is None
-    # the tier degrades, so the other two still enforce, and a clean profile saves
-    with pytest.warns(RuntimeWarning):
-        assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
-    with pytest.warns(RuntimeWarning):
-        with pytest.raises(ValueError, match="password"):
-            check_for_exposed_secrets(con_name, {"password": "plaintext"})
-    with pytest.warns(RuntimeWarning):
-        Profile(con_name=con_name, kwargs_tuple=(("host", "localhost"),)).save(
-            profile_dir=tmp_path
-        )
-    assert tuple(tmp_path.iterdir())
-
-
-def test_hook_returning_an_unprintable_name_does_not_raise(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Same for `repr()` of the returned names, which is built after the guard
-    has been left. The well-formed name alongside it still gets checked."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key", _Unprintable())
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="non-str names <unprintable>"):
-        assert get_dynamic_secret_keys(con_name, {}) == ("api_key",)
-
-
-def test_unprintable_kwarg_value_keeps_the_rest_of_the_message(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Redaction calls str() on the kwarg values, so a value whose str() raises
-    is a third way into the same crash. It costs only its own masking: the
-    exception the hook raised is still reported, and the other value is still
-    masked."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            raise RuntimeError(f"cannot parse {kwargs['token']}")
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning) as records:
-        assert (
-            get_dynamic_secret_keys(
-                con_name, {"weird": _Unprintable(), "token": "hunter2-secret"}
-            )
-            is None
-        )
-    message = str(records[0].message)
-    assert "hunter2" not in message
-    assert "cannot parse ***" in message
-
-
-def test_hook_mutating_a_nested_kwarg_does_not_reach_disk(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
-) -> None:
-    """The copy handed to the hook is deep, not shallow: `Profile.kwargs_dict`
-    shares nested objects with the `kwargs_tuple` that gets saved, so a hook
-    writing into a nested config would otherwise put tampered content on disk
-    under a check that passed."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            kwargs["config"]["injected"] = "tampered"
-            return ()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    config = {"token": "${TOKEN}"}
-    check_for_exposed_secrets(con_name, {"config": config})
-    assert config == {"token": "${TOKEN}"}, "a nested kwarg value was mutated"
-    Profile(con_name=con_name, kwargs_tuple=(("config", config),)).save(
-        profile_dir=tmp_path
-    )
-    (saved,) = tmp_path.iterdir()
-    assert "tampered" not in saved.read_text()
-
-
-def test_get_secret_keys_unions_default_mirror_and_hook(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The three tiers are unioned, not chained: a backend that is both mirrored
-    and declares a hook is checked for the default, the mirrored, and the
-    dynamic keys together. Ordering is deterministic (default, mirror, hook)."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("token", "sslcert")
+        _secret_key_sources = (("secret_kwarg_names",),)
 
     _install_fake_backend(monkeypatch, Backend, con_name="postgres")
-    keys = profiles_mod.get_secret_keys("postgres", {})
+    keys = profiles_mod.get_secret_keys(
+        "postgres", {"secret_kwarg_names": ["token", "sslcert"]}
+    )
     assert keys == (
         "password",
         "sslcert",
@@ -1375,87 +1220,26 @@ def test_get_secret_keys_unions_default_mirror_and_hook(
         "passfile",
         "token",
     )
-    # no duplicates even though the hook repeated a mirrored key
+    # no duplicates even though the source repeated a mirrored key
     assert len(keys) == len(set(keys))
 
 
-def test_hook_returning_empty_does_not_disable_checking(
+def test_declared_sources_cannot_shrink_mirrored_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A hook returning () must not be read as "nothing is secret": the
-    unconditional password default still applies. () is the natural return for a
-    hook whose kwargs-dependent rule finds nothing to name (e.g. the kwarg it
-    keys off of is absent), so it must not read as an opt-out."""
+    """Monotonicity: a source resolving to a subset of a mirrored backend's
+    keys -- or to () -- can only widen the checked set, never narrow it."""
 
     class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ()
-
-    con_name = _install_fake_backend(monkeypatch, Backend)
-    assert get_dynamic_secret_keys(con_name, {}) == ()
-    assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
-    with pytest.raises(ValueError, match="password"):
-        check_for_exposed_secrets(con_name, {"password": "plaintext"})
-
-
-def test_hook_returning_subset_does_not_shrink_mirrored_keys(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A hook returning a subset of a mirrored backend's keys must not stop the
-    mirrored keys from being checked."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("token",)
+        _secret_key_sources = (("secret_kwarg_names",),)
 
     _install_fake_backend(monkeypatch, Backend, con_name="postgres")
-    keys = profiles_mod.get_secret_keys("postgres", {})
+    keys = profiles_mod.get_secret_keys("postgres", {"secret_kwarg_names": []})
     assert set(con_name_to_secret_keys["postgres"]) <= set(keys)
     with pytest.raises(ValueError, match="password"):
         check_for_exposed_secrets("postgres", {"password": "plaintext"})
     with pytest.raises(ValueError, match="sslcert"):
         check_for_exposed_secrets("postgres", {"sslcert": "/path/to/cert"})
-
-
-def test_raising_hook_does_not_weaken_checking(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A raising hook degrades to the default-plus-mirror union, which still
-    catches every statically known key."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            raise RuntimeError("boom")
-
-    _install_fake_backend(monkeypatch, Backend, con_name="snowflake")
-    with pytest.warns(RuntimeWarning, match="_get_secret_keys hook raised"):
-        assert profiles_mod.get_secret_keys("snowflake", {}) == (
-            "password",
-            *con_name_to_secret_keys["snowflake"][1:],
-        )
-    with pytest.warns(RuntimeWarning, match="_get_secret_keys hook raised"):
-        with pytest.raises(ValueError, match="private_key"):
-            check_for_exposed_secrets("snowflake", {"private_key": "plaintext"})
-
-
-def test_unimported_backend_still_checks_password(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A backend whose module has not been imported contributes no dynamic keys,
-    but the unconditional default still applies."""
-
-    class Backend:
-        @classmethod
-        def _get_secret_keys(cls, kwargs):
-            return ("api_key",)
-
-    con_name = _install_fake_backend(monkeypatch, Backend, imported=False)
-    assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
-    with pytest.raises(ValueError, match="password"):
-        check_for_exposed_secrets(con_name, {"password": "plaintext"})
 
 
 def test_validate_con_name_sees_a_backend_installed_mid_process(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -791,7 +791,7 @@ def test_check_for_exposed_secrets_uses_dynamic_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """End-to-end: a key surfaced only by the dynamic hook is enforced by
-    check_for_exposed_secrets, and takes precedence over the static mapping."""
+    check_for_exposed_secrets, on top of the default/static keys."""
 
     class Backend:
         @classmethod
@@ -803,3 +803,107 @@ def test_check_for_exposed_secrets_uses_dynamic_keys(
         check_for_exposed_secrets(con_name, {"api_key": "plaintext"})
     # an env-var reference is accepted
     check_for_exposed_secrets(con_name, {"api_key": "${API_KEY}"})
+
+
+def test_get_secret_keys_unions_default_mirror_and_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three tiers are unioned, not chained: a backend that is both mirrored
+    and declares a hook is checked for the default, the mirrored, and the
+    dynamic keys together. Ordering is deterministic (default, mirror, hook)."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("token", "sslcert")
+
+    _install_fake_backend(monkeypatch, Backend, con_name="postgres")
+    keys = profiles_mod.get_secret_keys("postgres", {})
+    assert keys == (
+        "password",
+        "sslcert",
+        "sslkey",
+        "sslrootcert",
+        "sslcrl",
+        "options",
+        "passfile",
+        "token",
+    )
+    # no duplicates even though the hook repeated a mirrored key
+    assert len(keys) == len(set(keys))
+
+
+def test_hook_returning_empty_does_not_disable_checking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook returning () must not be read as "nothing is secret": the
+    unconditional password default still applies. (RestBackend._get_secret_keys
+    returns () when its config does not resolve.)"""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert get_dynamic_secret_keys(con_name, {}) == ()
+    assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets(con_name, {"password": "plaintext"})
+
+
+def test_hook_returning_subset_does_not_shrink_mirrored_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook returning a subset of a mirrored backend's keys must not stop the
+    mirrored keys from being checked."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("token",)
+
+    _install_fake_backend(monkeypatch, Backend, con_name="postgres")
+    keys = profiles_mod.get_secret_keys("postgres", {})
+    assert set(con_name_to_secret_keys["postgres"]) <= set(keys)
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets("postgres", {"password": "plaintext"})
+    with pytest.raises(ValueError, match="sslcert"):
+        check_for_exposed_secrets("postgres", {"sslcert": "/path/to/cert"})
+
+
+def test_raising_hook_does_not_weaken_checking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising hook degrades to the default-plus-mirror union, which still
+    catches every statically known key."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            raise RuntimeError("boom")
+
+    _install_fake_backend(monkeypatch, Backend, con_name="snowflake")
+    assert profiles_mod.get_secret_keys("snowflake", {}) == (
+        "password",
+        *con_name_to_secret_keys["snowflake"][1:],
+    )
+    with pytest.raises(ValueError, match="private_key"):
+        check_for_exposed_secrets("snowflake", {"private_key": "plaintext"})
+
+
+def test_unimported_backend_still_checks_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend whose module has not been imported contributes no dynamic keys,
+    but the unconditional default still applies."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key",)
+
+    con_name = _install_fake_backend(monkeypatch, Backend, imported=False)
+    assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets(con_name, {"password": "plaintext"})

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -10,7 +10,7 @@ import pytest
 import xorq.api as xo
 from xorq.common.utils.env_utils import maybe_substitute_env_vars
 from xorq.loader import _load_entry_points
-from xorq.tests.test_loader import installed_mid_process
+from xorq.tests.util import installed_mid_process
 from xorq.vendor.ibis.backends import BaseBackend
 from xorq.vendor.ibis.backends import profiles as profiles_mod
 from xorq.vendor.ibis.backends.profiles import (
@@ -691,6 +691,33 @@ def test_declared_secret_keys_are_mirrored(con_name: str) -> None:
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])
 
 
+@pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
+def test_dynamic_hook_backends_also_mirror_static_keys(con_name: str) -> None:
+    """A backend declaring the dynamic _get_secret_keys hook must also declare
+    static _secret_keys.
+
+    The dynamic tier is best-effort by construction -- it is skipped for a
+    backend that isn't imported -- so a backend relying on it alone gets only
+    ("password",) checked when a profile is hand-authored in a fresh process.
+    get_dynamic_secret_keys' docstring says as much, but a docstring is not a
+    guarantee; this makes the belt-and-braces convention enforceable so a future
+    backend can't quietly opt out of it.
+    """
+    entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
+    try:
+        module = entry_point.load()
+    except ImportError as e:
+        pytest.skip(f"{con_name} backend not importable: {e}")
+    backend = getattr(module, "Backend", None)
+    if getattr(backend, "_get_secret_keys", None) is None:
+        pytest.skip(f"{con_name} declares no _get_secret_keys hook")
+    assert getattr(backend, "_secret_keys", None), (
+        f"{con_name} declares a dynamic _get_secret_keys hook but no static "
+        "_secret_keys; mirror the keys the hook always names, since the hook is "
+        "skipped whenever the backend isn't already imported"
+    )
+
+
 def _install_fake_backend(
     monkeypatch: pytest.MonkeyPatch,
     backend_cls: type,
@@ -835,7 +862,8 @@ def test_get_dynamic_secret_keys_drops_a_non_sequence_return(
             return 42
 
     con_name = _install_fake_backend(monkeypatch, Backend)
-    with pytest.warns(RuntimeWarning, match="TypeError.+not iterable"):
+    # matched on the exception type only: the message text is CPython's wording
+    with pytest.warns(RuntimeWarning, match="hook raised TypeError"):
         assert get_dynamic_secret_keys(con_name, {}) is None
     with pytest.warns(RuntimeWarning):
         assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
@@ -947,6 +975,89 @@ def test_check_for_exposed_secrets_uses_dynamic_keys(
         check_for_exposed_secrets(con_name, {"api_key": "plaintext"})
     # an env-var reference is accepted
     check_for_exposed_secrets(con_name, {"api_key": "${API_KEY}"})
+
+
+def test_save_is_blocked_by_a_dynamic_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The dynamic tier is enforced through Profile.save(), not just the
+    module-level helper: the save aborts and writes nothing."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key",)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    profile = Profile(con_name=con_name, kwargs_tuple=(("api_key", "plaintext"),))
+    with pytest.raises(ValueError, match="api_key"):
+        profile.save(profile_dir=tmp_path)
+    assert not tuple(tmp_path.iterdir())
+    # the same profile with an env-var reference saves
+    Profile(con_name=con_name, kwargs_tuple=(("api_key", "${API_KEY}"),)).save(
+        profile_dir=tmp_path
+    )
+    assert tuple(tmp_path.iterdir())
+
+
+def test_hook_mutating_kwargs_does_not_weaken_checking(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """A hook that mutates what it is handed cannot delete entries from the scan.
+
+    The hook is called with the kwargs the caller then scans, so before the copy
+    a hook doing `kwargs.pop(...)` -- plausible in a hook that consumes a config
+    while walking it -- removed the key from the scan entirely, and
+    `Profile.save()` wrote the plaintext secret to disk. The union of key tiers
+    cannot protect against this: it is the other side of the check.
+    """
+    plaintext = "plaintext-hunter2"
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            kwargs.clear()
+            return ()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    kwargs = {"password": plaintext}
+    with pytest.raises(ValueError, match="password"):
+        check_for_exposed_secrets(con_name, kwargs)
+    assert kwargs == {"password": plaintext}, "the caller's kwargs were mutated"
+    profile = Profile(con_name=con_name, kwargs_tuple=(("password", plaintext),))
+    with pytest.raises(ValueError, match="password"):
+        profile.save(profile_dir=tmp_path)
+    assert not tuple(tmp_path.iterdir())
+
+
+def test_hook_error_warning_redacts_kwarg_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A secret echoed by a hook's exception is masked in the warning.
+
+    A hook that fails while parsing a credential tends to quote it back
+    (`int("hunter2-super-secret")`), and warnings go to stderr and CI logs --
+    which would leak, out of the one module whose job is keeping secrets out of
+    plaintext sinks. Short values are left alone, so the message stays readable.
+    """
+    plaintext = "hunter2-super-secret"
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return (int(kwargs["password"]),)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning) as records:
+        assert get_dynamic_secret_keys(con_name, {"password": plaintext}) is None
+    message = str(records[0].message)
+    assert plaintext not in message
+    assert "***" in message
+    # the useful part survives: which backend, and what went wrong
+    assert con_name in message
+    assert "ValueError" in message
 
 
 def test_get_secret_keys_unions_default_mirror_and_hook(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ast
+import importlib.util
 import os
 import pathlib
 import sys
@@ -691,25 +693,65 @@ def test_declared_secret_keys_are_mirrored(con_name: str) -> None:
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])
 
 
+def _source_declares(module_name: str, name: str) -> bool | None:
+    """Whether a module's source defines or assigns `name`, without importing it:
+    find_spec locates the file but doesn't execute it. None when there is no
+    source to read."""
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ValueError):
+        return None
+    if spec is None or spec.origin is None or not spec.origin.endswith(".py"):
+        return None
+    tree = ast.parse(pathlib.Path(spec.origin).read_text())
+    return any(
+        getattr(node, "name", None) == name
+        or (isinstance(node, ast.Name) and node.id == name)
+        for node in ast.walk(tree)
+    )
+
+
+def test_source_declares_finds_names_without_importing() -> None:
+    """The fallback the guardrail test leans on for an unimportable backend: names
+    are found in the source, and a name that isn't there reads as absent rather
+    than as "can't tell"."""
+    module_name = "xorq.vendor.ibis.backends.profiles"
+    assert _source_declares(module_name, "get_secret_keys") is True
+    assert _source_declares(module_name, "con_name_to_secret_keys") is True
+    assert _source_declares(module_name, "_get_secret_keys") is False
+    assert _source_declares("xorq_no_such_module", "_secret_keys") is None
+
+
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
 def test_dynamic_hook_backends_also_mirror_static_keys(con_name: str) -> None:
     """A backend declaring the dynamic hook must also declare static
     _secret_keys: the dynamic tier is skipped for a backend that isn't imported,
     so a backend relying on it alone gets only ("password",) checked when a
-    profile is hand-authored in a fresh process."""
-    entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
-    try:
-        module = entry_point.load()
-    except ImportError as e:
-        pytest.skip(f"{con_name} backend not importable: {e}")
-    backend = getattr(module, "Backend", None)
-    if getattr(backend, "_get_secret_keys", None) is None:
-        pytest.skip(f"{con_name} declares no _get_secret_keys hook")
-    assert getattr(backend, "_secret_keys", None), (
+    profile is hand-authored in a fresh process.
+
+    A backend whose extras aren't installed is checked against its module source
+    rather than skipped -- skipping there would leave the guardrail unenforced
+    for exactly the backends CI can't import."""
+    hint = (
         f"{con_name} declares a dynamic _get_secret_keys hook but no static "
         "_secret_keys; mirror the keys the hook always names, since the hook is "
         "skipped whenever the backend isn't already imported"
     )
+    entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
+    try:
+        module = entry_point.load()
+    except ImportError:
+        declares_hook = _source_declares(entry_point.module, "_get_secret_keys")
+        if declares_hook is None:
+            pytest.skip(f"{con_name} is neither importable nor locatable")
+        if not declares_hook:
+            pytest.skip(f"{con_name} declares no _get_secret_keys hook (by source)")
+        assert _source_declares(entry_point.module, "_secret_keys"), hint
+        return
+    backend = getattr(module, "Backend", None)
+    if getattr(backend, "_get_secret_keys", None) is None:
+        pytest.skip(f"{con_name} declares no _get_secret_keys hook")
+    assert getattr(backend, "_secret_keys", None), hint
 
 
 def _install_fake_backend(
@@ -1034,6 +1076,138 @@ def test_hook_error_warning_redacts_kwarg_values(
     # the useful part survives: which backend, and what went wrong
     assert con_name in message
     assert "ValueError" in message
+
+
+def test_hook_error_warning_redacts_nested_kwarg_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook keys off a nested config -- that is the whole reason the hook
+    exists -- so the value it quotes back when parsing fails was never a
+    top-level kwarg value. Redaction walks into the kwargs for that reason."""
+    plaintext = "nested-hunter2-super-secret"
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            raise ValueError(f"bad token: {kwargs['config']['token']}")
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning) as records:
+        assert (
+            get_dynamic_secret_keys(con_name, {"config": {"token": plaintext}}) is None
+        )
+    message = str(records[0].message)
+    assert plaintext not in message
+    assert "hunter2" not in message
+    assert "***" in message
+    assert "ValueError" in message
+
+
+def test_hook_error_warning_redacts_a_truncated_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """int() quotes only the leading ~200 characters of its input, so replacing
+    the whole value leaves that prefix in the message."""
+    plaintext = "hunter2-" + "x" * 400
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return (int(kwargs["password"]),)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning) as records:
+        assert get_dynamic_secret_keys(con_name, {"password": plaintext}) is None
+    message = str(records[0].message)
+    assert "hunter2" not in message
+    assert "xxxx" not in message
+
+
+def test_hook_error_warning_redacts_an_escaped_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A value holding a newline or a quote is echoed in its repr-escaped form,
+    which the raw value never matches."""
+    plaintext = "hunter2\nsuper-secret"
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            raise ValueError(f"bad token: {kwargs['password']!r}")
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning) as records:
+        assert get_dynamic_secret_keys(con_name, {"password": plaintext}) is None
+    message = str(records[0].message)
+    assert "hunter2" not in message
+    assert "super-secret" not in message
+
+
+def test_bare_string_warning_carries_no_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bare-str report names the type, not the value: a hook returning a
+    credential instead of its name would otherwise put it in the warning. The
+    hook here returns a value it *derived* from a kwarg rather than the kwarg
+    itself, which redaction cannot match -- so the only way the message stays
+    clean is by not carrying the value."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return kwargs["password"].upper()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match="not a bare str") as records:
+        assert get_dynamic_secret_keys(con_name, {"password": "hunter2-secret"}) is None
+    message = str(records[0].message)
+    assert "HUNTER2" not in message
+
+
+def test_non_str_names_warning_redacts_non_str_kwarg_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bytes credential returned as a name lands in the non-str warning
+    verbatim, so redaction covers non-str kwarg values too."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key", kwargs["private_key"])
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning) as records:
+        assert get_dynamic_secret_keys(
+            con_name, {"private_key": b"bytes-hunter2-secret"}
+        ) == ("api_key",)
+    message = str(records[0].message)
+    assert "hunter2" not in message
+
+
+def test_hook_mutating_a_nested_kwarg_does_not_reach_disk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The copy handed to the hook is deep, not shallow: `Profile.kwargs_dict`
+    shares nested objects with the `kwargs_tuple` that gets saved, so a hook
+    writing into a nested config would otherwise put tampered content on disk
+    under a check that passed."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            kwargs["config"]["injected"] = "tampered"
+            return ()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    config = {"token": "${TOKEN}"}
+    check_for_exposed_secrets(con_name, {"config": config})
+    assert config == {"token": "${TOKEN}"}, "a nested kwarg value was mutated"
+    Profile(con_name=con_name, kwargs_tuple=(("config", config),)).save(
+        profile_dir=tmp_path
+    )
+    (saved,) = tmp_path.iterdir()
+    assert "tampered" not in saved.read_text()
 
 
 def test_get_secret_keys_unions_default_mirror_and_hook(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -10,6 +10,7 @@ import types
 import pytest
 
 import xorq.api as xo
+from xorq.common.exceptions import XorqError
 from xorq.common.utils.env_utils import maybe_substitute_env_vars
 from xorq.loader import _load_entry_points
 from xorq.tests.util import installed_mid_process
@@ -1182,6 +1183,146 @@ def test_non_str_names_warning_redacts_non_str_kwarg_values(
         ) == ("api_key",)
     message = str(records[0].message)
     assert "hunter2" not in message
+
+
+def _cyclic(mapping: dict) -> dict:
+    """A mapping that contains itself, so walking it has to terminate."""
+    mapping["self"] = mapping
+    return mapping
+
+
+@pytest.mark.parametrize(
+    ("text", "kwargs"),
+    (
+        pytest.param(
+            "bad token: sk_live_BBBBcccc",
+            {"token": "sk_live_AAAAzzzzzz", "backup": "sk_live_BBBBcccc"},
+            id="shares_a_prefix_with_another_value",
+        ),
+        pytest.param(
+            "bad tail: yyyyyyyyyyyyyyyyyyyy",
+            {"token": "hunter2-" + "y" * 20},
+            id="echoed_from_the_tail",
+        ),
+        pytest.param(
+            "bad: deep-hunter2-secret",
+            {"config": {"a": {"b": {"c": {"d": {"token": "deep-hunter2-secret"}}}}}},
+            id="nested_deeper_than_a_few_levels",
+        ),
+        pytest.param(
+            "bad: cycle-hunter2-secret",
+            {"config": _cyclic({"token": "cycle-hunter2-secret"})},
+            id="reachable_through_a_cycle",
+        ),
+    ),
+)
+def test_redaction_masks_partial_and_deep_echoes(text: str, kwargs: dict) -> None:
+    """Masking whole values only is not enough, because an exception rarely
+    echoes a value intact.
+
+    Each case leaked against a whole-value replace: one value consuming the
+    shared prefix of another stranded that one's remainder, a value quoted from
+    its tail was never matched, and a value nested past a fixed depth was never
+    collected. A cyclic kwarg has to terminate rather than covered."""
+    redacted = profiles_mod._redact_kwarg_values(text, kwargs)
+    assert "hunter2" not in redacted
+    assert "BBBBcccc" not in redacted
+    assert "yyyy" not in redacted
+    assert "***" in redacted
+
+
+def test_redaction_leaves_unrelated_text_alone() -> None:
+    """Redaction must not swallow the diagnostic: nothing that isn't part of a
+    value is masked, and a value too short to hide is left alone."""
+    text = "invalid literal for int() with base 10"
+    assert profiles_mod._redact_kwarg_values(
+        text, {"port": 5432, "sslmode": "req"}
+    ) == (text)
+
+
+class _Unprintable:
+    """A value, name, or exception whose own str()/repr() raises -- all three run
+    while a warning about a misbehaving hook is being built."""
+
+    def __str__(self) -> str:
+        raise RuntimeError("str bomb")
+
+    __repr__ = __str__
+
+
+class _UnprintableError(XorqError):
+    __str__ = _Unprintable.__str__
+
+
+def test_hook_whose_exception_is_unprintable_does_not_break_a_save(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """`str(e)` runs inside the except handler, so it is not covered by the guard
+    around the hook: an exception whose str() raises escaped from the reporting
+    and aborted a save with nothing wrong with it."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            raise _UnprintableError()
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match="_UnprintableError: <unprintable>"):
+        assert get_dynamic_secret_keys(con_name, {}) is None
+    # the tier degrades, so the other two still enforce, and a clean profile saves
+    with pytest.warns(RuntimeWarning):
+        assert profiles_mod.get_secret_keys(con_name, {}) == ("password",)
+    with pytest.warns(RuntimeWarning):
+        with pytest.raises(ValueError, match="password"):
+            check_for_exposed_secrets(con_name, {"password": "plaintext"})
+    with pytest.warns(RuntimeWarning):
+        Profile(con_name=con_name, kwargs_tuple=(("host", "localhost"),)).save(
+            profile_dir=tmp_path
+        )
+    assert tuple(tmp_path.iterdir())
+
+
+def test_hook_returning_an_unprintable_name_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same for `repr()` of the returned names, which is built after the guard
+    has been left. The well-formed name alongside it still gets checked."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key", _Unprintable())
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match="non-str names <unprintable>"):
+        assert get_dynamic_secret_keys(con_name, {}) == ("api_key",)
+
+
+def test_unprintable_kwarg_value_keeps_the_rest_of_the_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redaction calls str() on the kwarg values, so a value whose str() raises
+    is a third way into the same crash. It costs only its own masking: the
+    exception the hook raised is still reported, and the other value is still
+    masked."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            raise RuntimeError(f"cannot parse {kwargs['token']}")
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning) as records:
+        assert (
+            get_dynamic_secret_keys(
+                con_name, {"weird": _Unprintable(), "token": "hunter2-secret"}
+            )
+            is None
+        )
+    message = str(records[0].message)
+    assert "hunter2" not in message
+    assert "cannot parse ***" in message
 
 
 def test_hook_mutating_a_nested_kwarg_does_not_reach_disk(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -772,11 +772,15 @@ def test_get_dynamic_secret_keys_none_when_not_imported(
     assert get_dynamic_secret_keys(con_name, {}) is None
 
 
-def test_get_dynamic_secret_keys_fail_closed_on_hook_error(
+def test_get_dynamic_secret_keys_drops_keys_and_warns_on_hook_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A hook that raises degrades to None (fail closed) rather than
-    propagating and aborting/bypassing the secret check."""
+    """A raising hook degrades to None -- it neither propagates (aborting the
+    save) nor bypasses the check. Dropping this tier is fail-*open* for the
+    dynamic keys (tiers 1+2 still apply, see
+    test_raising_hook_does_not_weaken_checking), so it must warn rather than
+    swallow: an always-raising hook otherwise contributes nothing forever and
+    silently."""
 
     class Backend:
         @classmethod
@@ -784,7 +788,8 @@ def test_get_dynamic_secret_keys_fail_closed_on_hook_error(
             raise RuntimeError("boom")
 
     con_name = _install_fake_backend(monkeypatch, Backend)
-    assert get_dynamic_secret_keys(con_name, {}) is None
+    with pytest.warns(RuntimeWarning, match="RuntimeError: boom"):
+        assert get_dynamic_secret_keys(con_name, {}) is None
 
 
 def test_check_for_exposed_secrets_uses_dynamic_keys(
@@ -837,8 +842,9 @@ def test_hook_returning_empty_does_not_disable_checking(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A hook returning () must not be read as "nothing is secret": the
-    unconditional password default still applies. (RestBackend._get_secret_keys
-    returns () when its config does not resolve.)"""
+    unconditional password default still applies. () is the natural return for a
+    hook whose kwargs-dependent rule finds nothing to name (e.g. the kwarg it
+    keys off of is absent), so it must not read as an opt-out."""
 
     class Backend:
         @classmethod
@@ -884,12 +890,14 @@ def test_raising_hook_does_not_weaken_checking(
             raise RuntimeError("boom")
 
     _install_fake_backend(monkeypatch, Backend, con_name="snowflake")
-    assert profiles_mod.get_secret_keys("snowflake", {}) == (
-        "password",
-        *con_name_to_secret_keys["snowflake"][1:],
-    )
-    with pytest.raises(ValueError, match="private_key"):
-        check_for_exposed_secrets("snowflake", {"private_key": "plaintext"})
+    with pytest.warns(RuntimeWarning, match="_get_secret_keys hook raised"):
+        assert profiles_mod.get_secret_keys("snowflake", {}) == (
+            "password",
+            *con_name_to_secret_keys["snowflake"][1:],
+        )
+    with pytest.warns(RuntimeWarning, match="_get_secret_keys hook raised"):
+        with pytest.raises(ValueError, match="private_key"):
+            check_for_exposed_secrets("snowflake", {"private_key": "plaintext"})
 
 
 def test_unimported_backend_still_checks_password(

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -751,19 +751,25 @@ def test_declared_secret_key_sources_are_mirrored(con_name: str) -> None:
 
 def _source_declares(module_name: str, name: str) -> bool | None:
     """Whether a module's source defines or assigns `name`, without importing it:
-    find_spec locates the file but doesn't execute it. None when there is no
-    source to read."""
+    find_spec locates the file but doesn't execute it. A package is searched
+    whole, since a Backend is commonly re-exported from a submodule. None when
+    there is no source to read."""
     try:
         spec = importlib.util.find_spec(module_name)
     except (ImportError, ValueError):
         return None
-    if spec is None or spec.origin is None or not spec.origin.endswith(".py"):
+    if spec is None:
         return None
-    tree = ast.parse(pathlib.Path(spec.origin).read_text())
+    paths = [pathlib.Path(spec.origin)] if str(spec.origin).endswith(".py") else []
+    for location in spec.submodule_search_locations or ():
+        paths.extend(sorted(pathlib.Path(location).rglob("*.py")))
+    if not paths:
+        return None
     return any(
         getattr(node, "name", None) == name
         or (isinstance(node, ast.Name) and node.id == name)
-        for node in ast.walk(tree)
+        for path in paths
+        for node in ast.walk(ast.parse(path.read_text()))
     )
 
 
@@ -776,6 +782,28 @@ def test_source_declares_finds_names_without_importing() -> None:
     assert _source_declares(module_name, "con_name_to_secret_key_sources") is True
     assert _source_declares(module_name, "_get_secret_keys") is False
     assert _source_declares("xorq_no_such_module", "_secret_keys") is None
+
+
+def test_source_declares_searches_a_package_for_a_re_exported_name(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A backend package whose Backend is re-exported from a submodule is still
+    searched: reading only the entry-point module's own source would report the
+    declaration as absent and skip the guardrail for exactly the backends CI
+    cannot import."""
+    package = tmp_path / "xorq_reexporting_backend"
+    package.mkdir()
+    (package / "__init__.py").write_text("from .backend import Backend\n")
+    (package / "backend.py").write_text(
+        "class Backend:\n"
+        "    _secret_keys = ('token',)\n"
+        "    _secret_key_sources = (('config', 'auth', 'fields'),)\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    assert _source_declares(package.name, "_secret_key_sources") is True
+    assert _source_declares(package.name, "_secret_keys") is True
+    assert _source_declares(package.name, "_no_such_declaration") is False
 
 
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
@@ -1066,10 +1094,9 @@ def test_a_property_declaration_contributes_nothing(
 def test_a_non_tuple_class_declaration_contributes_nothing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A malformed class declaration -- a list here -- fails the tuple check
-    and contributes nothing: declaration shape is an authoring-time concern
-    (test_mirrored_secret_key_sources_are_tuples_of_str), never a runtime
-    guard."""
+    """A malformed class declaration -- a list here -- fails the tuple check and
+    contributes nothing: declaration shape is an authoring-time concern, pinned by
+    the mirror tests, never a runtime guard."""
 
     class Backend:
         _secret_key_sources = [("config", "auth", "fields")]
@@ -1078,6 +1105,99 @@ def test_a_non_tuple_class_declaration_contributes_nothing(
     kwargs = {"config": {"auth": {"fields": ["api_key"]}}}
     assert get_declared_secret_keys(con_name, kwargs) == ()
     assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+
+
+@pytest.mark.parametrize(
+    "declared",
+    (
+        pytest.param((42,), id="source_is_not_a_tuple"),
+        pytest.param((["config", "auth"],), id="source_is_a_list"),
+        pytest.param(((),), id="source_is_empty"),
+        pytest.param((("config", 3),), id="step_is_not_str"),
+        pytest.param(("config", "auth", "fields"), id="steps_not_nested_in_a_source"),
+    ),
+)
+def test_malformed_sources_contribute_nothing(
+    monkeypatch: pytest.MonkeyPatch, declared: tuple
+) -> None:
+    """A declaration whose *elements* are malformed contributes nothing, like a
+    malformed declaration as a whole -- it does not raise, and it does not block
+    every save for that backend. The last case is the likely authoring slip: a
+    flat tuple of steps, which without the shape check walks single-character
+    keys."""
+
+    class Backend:
+        _secret_key_sources = declared
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    kwargs = {"config": {"auth": {"fields": ["api_key"]}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+    check_for_exposed_secrets(con_name, {**kwargs, "api_key": "plaintext"})
+
+
+@pytest.mark.parametrize(
+    "base",
+    (pytest.param(list, id="list_subclass"), pytest.param(tuple, id="tuple_subclass")),
+)
+def test_a_leaf_that_subclasses_list_is_not_iterated(
+    monkeypatch: pytest.MonkeyPatch, base: type
+) -> None:
+    """The leaf read runs no code belonging to the leaf either: a list/tuple
+    subclass forging __iter__ is unresolved rather than believed, with no call
+    made. Iterating it would let hostile data both invent names and -- by
+    resolving -- cut off the fallback to the next source."""
+
+    class Forging(base):
+        def __init__(self, *args) -> None:
+            super().__init__()
+            self.iterated = False
+
+        def __iter__(self) -> collections.abc.Iterator:
+            self.iterated = True
+            return iter(["forged"])
+
+    leaf = Forging(["true_key"])
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = {"config": {"auth": {"fields": leaf}}}
+    assert get_declared_secret_keys(con_name, kwargs) == ()
+    assert not leaf.iterated
+    assert profiles_mod.get_secret_keys(con_name, kwargs) == ("password",)
+
+
+def test_a_leaf_subclass_falls_through_to_the_next_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unresolved means unresolved: a subclass leaf on the first source hands the
+    fallback to the second rather than resolving to a forged answer."""
+
+    class Forging(list):
+        def __iter__(self) -> collections.abc.Iterator:
+            return iter([])
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    auth = {"secret_fields": Forging(["ignored"]), "fields": ["api_key"]}
+    kwargs = {"config": {"auth": auth}}
+    assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
+
+
+def test_a_kwargs_subclass_lying_about_len_still_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normalizing absent kwargs tests for None, not truthiness: a dict subclass
+    whose __len__ reports empty would otherwise disable the whole tier, silently
+    and without the fail-closed error, despite every lookup on it reading the true
+    data."""
+
+    class LenLying(dict):
+        def __len__(self) -> int:
+            return 0
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = LenLying(config={"auth": {"fields": ["api_key"]}})
+    assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, LenLying(**kwargs, api_key="plaintext"))
 
 
 def test_mirrored_sources_resolve_without_import(
@@ -1210,17 +1330,12 @@ def test_get_secret_keys_unions_default_mirror_and_declared(
     keys = profiles_mod.get_secret_keys(
         "postgres", {"secret_kwarg_names": ["token", "sslcert"]}
     )
-    assert keys == (
-        "password",
-        "sslcert",
-        "sslkey",
-        "sslrootcert",
-        "sslcrl",
-        "options",
-        "passfile",
-        "token",
-    )
-    # no duplicates even though the source repeated a mirrored key
+    mirror = con_name_to_secret_keys["postgres"]
+    assert set(keys) == {*profiles_mod.default_secret_keys, *mirror, "token"}
+    assert keys[0] == "password"  # tier 1, unconditionally
+    assert tuple(key for key in keys if key in mirror) == mirror  # tier 2, in order
+    assert keys[-1] == "token"  # tier 3, after the tiers it can only widen
+    # first occurrence wins, so the source repeating "sslcert" adds no duplicate
     assert len(keys) == len(set(keys))
 
 

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import pathlib
+import sys
+import types
 
 import pytest
 
@@ -9,10 +11,13 @@ import xorq.api as xo
 from xorq.common.utils.env_utils import maybe_substitute_env_vars
 from xorq.loader import _load_entry_points
 from xorq.vendor.ibis.backends import BaseBackend
+from xorq.vendor.ibis.backends import profiles as profiles_mod
 from xorq.vendor.ibis.backends.profiles import (
     Profile,
     Profiles,
+    check_for_exposed_secrets,
     con_name_to_secret_keys,
+    get_dynamic_secret_keys,
 )
 
 
@@ -683,3 +688,118 @@ def test_declared_secret_keys_are_mirrored(con_name: str) -> None:
         "reflection of all declaring backends"
     )
     assert tuple(declared) == tuple(con_name_to_secret_keys[con_name])
+
+
+def _install_fake_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    backend_cls: type,
+    con_name: str = "fakedb",
+    module_name: str = "xorq_fake_backend_mod",
+    imported: bool = True,
+) -> str:
+    """Register a throwaway backend so get_dynamic_secret_keys resolves to
+    backend_cls. Patches the entry-point lookup, and (when imported=True) marks
+    the module as already-imported in sys.modules -- the resolver only inspects
+    already-imported backends. Pass imported=False to simulate a backend whose
+    module has not been imported."""
+    module = types.ModuleType(module_name)
+    module.Backend = backend_cls
+    entry_point = types.SimpleNamespace(
+        name=con_name, module=module_name, load=lambda: module
+    )
+    monkeypatch.setattr(profiles_mod, "_load_entry_points", lambda: (entry_point,))
+    if imported:
+        monkeypatch.setitem(sys.modules, module_name, module)
+    return con_name
+
+
+def test_get_dynamic_secret_keys_uses_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dynamic _get_secret_keys(kwargs) hook is used and receives kwargs."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("password", *(kwargs or {}).get("extra_secret_keys", ()))
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert get_dynamic_secret_keys(con_name, {"extra_secret_keys": ("api_key",)}) == (
+        "password",
+        "api_key",
+    )
+
+
+def test_get_dynamic_secret_keys_none_when_hook_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook returning None yields None so the caller falls back to the static
+    mapping."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return None
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert get_dynamic_secret_keys(con_name, {}) is None
+
+
+def test_get_dynamic_secret_keys_none_without_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Backend with no dynamic hook resolves to None (caller uses the dict)."""
+
+    class Backend:
+        pass
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert get_dynamic_secret_keys(con_name, {}) is None
+
+
+def test_get_dynamic_secret_keys_none_when_not_imported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend that isn't imported is not force-imported: the hook is skipped
+    and None is returned even though the class declares one."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key",)
+
+    con_name = _install_fake_backend(monkeypatch, Backend, imported=False)
+    assert get_dynamic_secret_keys(con_name, {}) is None
+
+
+def test_get_dynamic_secret_keys_fail_closed_on_hook_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook that raises degrades to None (fail closed) rather than
+    propagating and aborting/bypassing the secret check."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            raise RuntimeError("boom")
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert get_dynamic_secret_keys(con_name, {}) is None
+
+
+def test_check_for_exposed_secrets_uses_dynamic_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a key surfaced only by the dynamic hook is enforced by
+    check_for_exposed_secrets, and takes precedence over the static mapping."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return ("api_key",)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, {"api_key": "plaintext"})
+    # an env-var reference is accepted
+    check_for_exposed_secrets(con_name, {"api_key": "${API_KEY}"})

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -1179,6 +1179,78 @@ def test_a_forged_empty_leaf_cannot_suppress_the_true_names(
     assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
 
 
+def test_a_forged_str_name_cannot_escape_the_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """A name is a value out of the kwargs too, so it comes back as an exact str
+    copy. A str subclass returned as-is would carry its own __eq__ into the
+    membership test that matches it against a kwarg -- the source resolves, the
+    key is named, and the literal saves anyway."""
+
+    class Ghost(str):
+        def __eq__(self, other: object) -> bool:
+            return False
+
+        def __hash__(self) -> int:
+            return str.__hash__(self)
+
+        def __str__(self) -> str:
+            return "not_a_kwarg"
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    config = {"auth": {"fields": [Ghost("api_key")]}}
+    names = get_declared_secret_keys(con_name, {"config": config})
+    assert names == ("api_key",)
+    assert all(type(name) is str for name in names)
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, {"config": config, "api_key": "plaintext"})
+    profile = Profile(
+        con_name=con_name,
+        kwargs_tuple=(("config", config), ("api_key", "plaintext")),
+    )
+    with pytest.raises(ValueError, match="api_key"):
+        profile.save(profile_dir=tmp_path)
+    assert not tuple(tmp_path.iterdir())
+
+
+def test_a_name_whose_hash_raises_cannot_escape_the_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nor can a name reach the dedupe in get_secret_keys, which hashes it outside
+    the fail-closed guard: an exact str copy has nothing left to raise."""
+
+    class HashBomb(str):
+        def __hash__(self) -> int:
+            raise RuntimeError("boom")
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    config = {"auth": {"fields": [HashBomb("api_key")]}}
+    assert profiles_mod.get_secret_keys(con_name, {"config": config}) == (
+        "password",
+        "api_key",
+    )
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, {"config": config, "api_key": "plaintext"})
+
+
+def test_forged_items_cannot_hide_a_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The enforcement loop reads the kwargs the way the resolver does: a subclass
+    hiding an entry from items() cannot hide it from the check that the resolver
+    just named it in."""
+
+    class Hiding(dict):
+        def items(self) -> list:
+            return [(k, v) for k, v in dict.items(self) if k != "api_key"]
+
+    con_name = _install_fake_backend(monkeypatch, _DeclaringBackend)
+    kwargs = Hiding(config={"auth": {"fields": ["api_key"]}}, api_key="plaintext")
+    assert get_declared_secret_keys(con_name, kwargs) == ("api_key",)
+    with pytest.raises(ValueError, match="api_key"):
+        check_for_exposed_secrets(con_name, kwargs)
+
+
 def test_a_kwargs_subclass_lying_about_len_still_resolves(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -792,6 +792,25 @@ def test_get_dynamic_secret_keys_drops_keys_and_warns_on_hook_error(
         assert get_dynamic_secret_keys(con_name, {}) is None
 
 
+def test_get_dynamic_secret_keys_rejects_bare_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hook returning a bare name instead of a sequence is reported, not
+    iterated: tuple("api_key") would drop the key the hook meant to name and add
+    junk single-character keys."""
+
+    class Backend:
+        @classmethod
+        def _get_secret_keys(cls, kwargs):
+            return "api_key"
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    with pytest.warns(RuntimeWarning, match="not a bare str"):
+        assert get_dynamic_secret_keys(con_name, {}) is None
+    with pytest.warns(RuntimeWarning):
+        assert "a" not in profiles_mod.get_secret_keys(con_name, {})
+
+
 def test_check_for_exposed_secrets_uses_dynamic_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -693,16 +693,10 @@ def test_declared_secret_keys_are_mirrored(con_name: str) -> None:
 
 @pytest.mark.parametrize("con_name", sorted(ep.name for ep in _load_entry_points()))
 def test_dynamic_hook_backends_also_mirror_static_keys(con_name: str) -> None:
-    """A backend declaring the dynamic _get_secret_keys hook must also declare
-    static _secret_keys.
-
-    The dynamic tier is best-effort by construction -- it is skipped for a
-    backend that isn't imported -- so a backend relying on it alone gets only
-    ("password",) checked when a profile is hand-authored in a fresh process.
-    get_dynamic_secret_keys' docstring says as much, but a docstring is not a
-    guarantee; this makes the belt-and-braces convention enforceable so a future
-    backend can't quietly opt out of it.
-    """
+    """A backend declaring the dynamic hook must also declare static
+    _secret_keys: the dynamic tier is skipped for a backend that isn't imported,
+    so a backend relying on it alone gets only ("password",) checked when a
+    profile is hand-authored in a fresh process."""
     entry_point = next(ep for ep in _load_entry_points() if ep.name == con_name)
     try:
         module = entry_point.load()
@@ -726,14 +720,8 @@ def _install_fake_backend(
     imported: bool = True,
 ) -> str:
     """Register a throwaway backend so get_dynamic_secret_keys resolves to
-    backend_cls. Patches the entry-point lookup, and (when imported=True) marks
-    the module as already-imported in sys.modules -- the resolver only inspects
-    already-imported backends. Pass imported=False to simulate a backend whose
-    module has not been imported.
-
-    The fakes let a hook's *contract* be tested without a real plugin;
-    test_get_dynamic_secret_keys_resolves_a_real_backend covers the resolution
-    these patches stand in for."""
+    backend_cls: patch the entry-point lookup, and mark the module as imported,
+    which the resolver requires. Pass imported=False for the not-imported case."""
     module = types.ModuleType(module_name)
     module.Backend = backend_cls
     entry_point = types.SimpleNamespace(
@@ -812,12 +800,8 @@ def test_get_dynamic_secret_keys_none_when_not_imported(
 def test_get_dynamic_secret_keys_drops_keys_and_warns_on_hook_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A raising hook degrades to None -- it neither propagates (aborting the
-    save) nor bypasses the check. Dropping this tier is fail-*open* for the
-    dynamic keys (tiers 1+2 still apply, see
-    test_raising_hook_does_not_weaken_checking), so it must warn rather than
-    swallow: an always-raising hook otherwise contributes nothing forever and
-    silently."""
+    """A raising hook degrades to None -- neither propagating (aborting the save)
+    nor bypassing the check -- and warns, since dropping the tier is fail-open."""
 
     class Backend:
         @classmethod
@@ -1007,12 +991,9 @@ def test_hook_mutating_kwargs_does_not_weaken_checking(
 ) -> None:
     """A hook that mutates what it is handed cannot delete entries from the scan.
 
-    The hook is called with the kwargs the caller then scans, so before the copy
-    a hook doing `kwargs.pop(...)` -- plausible in a hook that consumes a config
-    while walking it -- removed the key from the scan entirely, and
-    `Profile.save()` wrote the plaintext secret to disk. The union of key tiers
-    cannot protect against this: it is the other side of the check.
-    """
+    The caller scans the same kwargs after the hook returns, so without the copy
+    a hook doing `kwargs.pop(...)` dropped the key from the scan and
+    `Profile.save()` wrote the plaintext secret to disk."""
     plaintext = "plaintext-hunter2"
 
     class Backend:
@@ -1035,13 +1016,8 @@ def test_hook_mutating_kwargs_does_not_weaken_checking(
 def test_hook_error_warning_redacts_kwarg_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A secret echoed by a hook's exception is masked in the warning.
-
-    A hook that fails while parsing a credential tends to quote it back
-    (`int("hunter2-super-secret")`), and warnings go to stderr and CI logs --
-    which would leak, out of the one module whose job is keeping secrets out of
-    plaintext sinks. Short values are left alone, so the message stays readable.
-    """
+    """A secret echoed by a hook's exception -- `int("hunter2...")` quotes its
+    input back -- is masked in the warning, which reaches stderr and CI logs."""
     plaintext = "hunter2-super-secret"
 
     class Backend:
@@ -1170,13 +1146,9 @@ def test_unimported_backend_still_checks_password(
 def test_validate_con_name_sees_a_backend_installed_mid_process(
     tmp_path: pathlib.Path,
 ) -> None:
-    """A backend installed into a live process is usable without a restart.
-
-    validate_con_name resolves through `_find_entry_point` for this reason:
-    scanning the cached entry points directly would reject the just-installed
-    backend as "Unknown backend" -- and list a stale set as the installed ones --
-    for the life of the process.
-    """
+    """A backend installed into a live process is usable without a restart: a
+    direct scan of the cached entry points would reject it as "Unknown backend",
+    listing a stale set as the installed ones, until the process restarted."""
     with installed_mid_process(tmp_path, "xorqfakeprofilebackend") as con_name:
         profile = Profile(con_name=con_name, kwargs_tuple=())
         assert profile.con_name == con_name

--- a/python/xorq/tests/util.py
+++ b/python/xorq/tests/util.py
@@ -32,15 +32,10 @@ def write_fake_dist(root: pathlib.Path, con_name: str) -> None:
 
 @contextlib.contextmanager
 def installed_mid_process(root: pathlib.Path, con_name: str) -> Iterator[str]:
-    """Install a backend distribution into this live process, with an
-    entry-point cache that predates it -- i.e. `pip install` in a Jupyter kernel.
-
-    Used by test_loader.py (resolution refreshes past the stale cache) and
-    test_profile.py (the staleness is invisible to `Profile` construction).
-    """
+    """Install a backend distribution into this live process, with an entry-point
+    cache that predates it -- i.e. `pip install` in a Jupyter kernel."""
     write_fake_dist(root, con_name)
-    # populate the cache *before* the install, which is the stale-cache setup
-    assert not any(ep.name == con_name for ep in _load_entry_points())
+    assert not any(ep.name == con_name for ep in _load_entry_points())  # warm it
     sys.path.insert(0, str(root))
     try:
         # the cached value still predates the install

--- a/python/xorq/tests/util.py
+++ b/python/xorq/tests/util.py
@@ -1,10 +1,55 @@
+from __future__ import annotations
+
+import contextlib
+import importlib
+import pathlib
+import sys
+from collections.abc import Iterator
 from typing import Any
 
 import pandas as pd
 import pandas.testing as tm
 
+from xorq.loader import _load_entry_points
+
 
 reduction_tolerance = 1e-7
+
+
+def write_fake_dist(root: pathlib.Path, con_name: str) -> None:
+    """Write a minimal installed distribution declaring a xorq.backends entry
+    point, so adding `root` to sys.path is indistinguishable from installing a
+    backend plugin."""
+    dist_info = root / f"xorq_{con_name}-0.1.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: xorq-{con_name}\nVersion: 0.1\n"
+    )
+    (dist_info / "entry_points.txt").write_text(
+        f"[xorq.backends]\n{con_name} = xorq_{con_name}\n"
+    )
+
+
+@contextlib.contextmanager
+def installed_mid_process(root: pathlib.Path, con_name: str) -> Iterator[str]:
+    """Install a backend distribution into this live process, with an
+    entry-point cache that predates it -- i.e. `pip install` in a Jupyter kernel.
+
+    Used by test_loader.py (resolution refreshes past the stale cache) and
+    test_profile.py (the staleness is invisible to `Profile` construction).
+    """
+    write_fake_dist(root, con_name)
+    # populate the cache *before* the install, which is the stale-cache setup
+    assert not any(ep.name == con_name for ep in _load_entry_points())
+    sys.path.insert(0, str(root))
+    try:
+        # the cached value still predates the install
+        assert not any(ep.name == con_name for ep in _load_entry_points())
+        yield con_name
+    finally:
+        sys.path.remove(str(root))
+        importlib.invalidate_caches()
+        _load_entry_points.cache_clear()
 
 
 def _pandas_semi_join(left, right, on, **_):

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -16,7 +16,7 @@ from attr.validators import (
 from xorq.backends._lazy import LazyBackend
 from xorq.common.utils.env_utils import compiled_env_var_substitution_re
 from xorq.common.utils.inspect_utils import get_arguments
-from xorq.loader import _load_entry_points, load_backend
+from xorq.loader import _find_entry_point, _load_entry_points, load_backend
 from xorq.vendor.ibis.config import options
 
 
@@ -183,9 +183,12 @@ class Profile:
 
     @con_name.validator
     def validate_con_name(self, attr, value):
-        entry_points = _load_entry_points()
-        if not any(ep.name == value for ep in entry_points):
-            installed = sorted(ep.name for ep in entry_points)
+        # via _find_entry_point, so that a backend installed into a live process
+        # is accepted rather than rejected by an entry-point cache that predates
+        # it. On a miss that call has already refreshed the cache, so the names
+        # reported below are the fresh ones.
+        if _find_entry_point(value) is None:
+            installed = sorted(ep.name for ep in _load_entry_points())
             raise ValueError(
                 f"Unknown backend {value!r}; installed backends: {installed}"
             )
@@ -471,6 +474,12 @@ con_name_to_secret_keys = MappingProxyType(
 )
 
 
+# Checked for every backend, unconditionally, on top of whatever the mirror and
+# the dynamic hook contribute. A backend cannot declare that a kwarg literally
+# named `password` is not a secret.
+default_secret_keys = ("password",)
+
+
 def get_dynamic_secret_keys(
     con_name: str, kwargs: dict | None = None
 ) -> tuple[str, ...] | None:
@@ -494,6 +503,12 @@ def get_dynamic_secret_keys(
     not imported, has no entry point, declares no dynamic hook, or the hook
     raises.
 
+    A hook is handed the profile's kwargs with their values, i.e. the plaintext
+    credentials, at validation time. Name keys off of them; do not log, persist,
+    or send them anywhere. Names that aren't ``str`` are dropped with a warning
+    (they could never match a kwarg), and a return that isn't a sequence of
+    names drops this tier entirely rather than propagating out of the save.
+
     This tier is purely additive: ``check_for_exposed_secrets`` unions whatever
     is returned here with the unconditional ``("password",)`` default and the
     static ``con_name_to_secret_keys`` mirror. An unavailable or raising hook
@@ -506,7 +521,7 @@ def get_dynamic_secret_keys(
     must *always* be caught belongs in ``con_name_to_secret_keys`` as well; keep
     the hook for keys that only a kwargs-dependent rule can name.
     """
-    entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
+    entry_point = _find_entry_point(con_name)
     if entry_point is None:
         return None
     module = sys.modules.get(entry_point.module)
@@ -516,7 +531,7 @@ def get_dynamic_secret_keys(
     if not callable(getter):
         return None
     try:
-        keys = getter(kwargs)
+        keys = getter({} if kwargs is None else kwargs)
         if isinstance(keys, (str, bytes)):
             # A bare name is iterable, so tuple("api_key") would quietly become
             # ('a','p','i',...): the intended key dropped from this tier and
@@ -526,24 +541,37 @@ def get_dynamic_secret_keys(
                 "must return a sequence of names or None, not a bare "
                 f"{type(keys).__name__} ({keys!r})"
             )
+        # Materialize inside the try: a hook returning a non-iterable, or an
+        # iterable that raises partway through, must be reported like any other
+        # hook error rather than propagating out of a Profile.save().
+        keys = tuple(keys) if keys is not None else None
     except Exception as e:
         # Degrade to tiers 1+2 rather than crashing a save or skipping the check
         # entirely -- but say so, since an always-raising hook otherwise
-        # contributes nothing forever and silently.
+        # contributes nothing forever and silently. No stacklevel: every call
+        # comes from get_secret_keys, so no frame here names the backend that
+        # actually needs fixing -- the message does.
         warnings.warn(
             f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: {e}; "
             "ignoring its keys and checking only the default and static keys",
             RuntimeWarning,
-            stacklevel=2,
         )
         return None
-    return tuple(keys) if keys is not None else None
-
-
-# Checked for every backend, unconditionally, on top of whatever the mirror and
-# the dynamic hook contribute. A backend cannot declare that a kwarg literally
-# named `password` is not a secret.
-default_secret_keys = ("password",)
+    if keys is None:
+        return None
+    if not_str := tuple(key for key in keys if not isinstance(key, str)):
+        # A non-str name can never match a kwarg, so it would silently check
+        # nothing -- the same failure mode as the bare str above. Keep the
+        # well-formed names rather than dropping the tier: they are unambiguous,
+        # and checking them is strictly safer than not.
+        warnings.warn(
+            f"{con_name}: _get_secret_keys returned non-str names {not_str!r}; "
+            "ignoring them (a name that isn't a str cannot match a kwarg) and "
+            "checking the rest",
+            RuntimeWarning,
+        )
+        keys = tuple(key for key in keys if isinstance(key, str))
+    return keys
 
 
 def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...]:

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -485,12 +485,16 @@ con_name_to_secret_key_sources = MappingProxyType({})
 
 def _resolve_source(source: tuple[str, ...], kwargs: dict) -> tuple[str, ...] | None:
     """The names ``source`` points at inside ``kwargs``, or None when it doesn't
-    resolve. Resolution runs no code belonging to the values it walks: every read
-    is through an unbound builtin, so a subclass's ``get``/``__getitem__``/
-    ``__missing__``/``__iter__`` is bypassed and the true underlying data is read.
-    Anything that isn't a ``dict`` at a step, or a ``list``/``tuple`` at the leaf,
-    is unresolved rather than reached into -- ``secret_fields: null`` falls
-    through, while ``[]`` resolves to ``()``. A non-``str`` name is dropped.
+    resolve. Every read is through an unbound builtin, so a subclass's
+    ``get``/``__getitem__``/``__missing__``/``__iter__``/``__str__`` is bypassed
+    and the true underlying data is read; the names come back as exact ``str``
+    copies, since a ``str`` subclass reaching the caller could forge the ``__eq__``
+    that matches it against a kwarg or the ``__hash__`` that dedupes it. (Dict
+    probing can still run a *stored* key's ``__eq__`` on a hash collision; one
+    that raises is caught below, and one that lies can only redirect among values
+    already in the kwargs.) Anything that isn't a ``dict`` at a step, or a
+    ``list``/``tuple`` at the leaf, is unresolved rather than reached into --
+    ``secret_fields: null`` falls through, while ``[]`` resolves to ``()``.
     """
     value = kwargs
     for step in source:
@@ -499,7 +503,7 @@ def _resolve_source(source: tuple[str, ...], kwargs: dict) -> tuple[str, ...] | 
         value = dict.get(value, step)
     if isinstance(value, (list, tuple)):
         names = (tuple if isinstance(value, tuple) else list).__iter__(value)
-        return tuple(name for name in names if isinstance(name, str))
+        return tuple(str.__str__(name) for name in names if isinstance(name, str))
     return None
 
 
@@ -612,7 +616,9 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
 
     exposed_secrets = tuple(
         key
-        for key, value in kwargs.items()
+        # unbound, like the reads in _resolve_source: a subclass's items() could
+        # otherwise hide the very kwarg the resolver just named
+        for key, value in dict.items(kwargs)
         if key in relevant_keys
         and not (
             isinstance(value, str) and compiled_env_var_substitution_re.match(value)

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -517,6 +517,15 @@ def get_dynamic_secret_keys(
         return None
     try:
         keys = getter(kwargs)
+        if isinstance(keys, (str, bytes)):
+            # A bare name is iterable, so tuple("api_key") would quietly become
+            # ('a','p','i',...): the intended key dropped from this tier and
+            # junk single-character keys added. Raise so it is reported below
+            # instead of silently not checking the key the hook meant to name.
+            raise TypeError(
+                "must return a sequence of names or None, not a bare "
+                f"{type(keys).__name__} ({keys!r})"
+            )
     except Exception as e:
         # Degrade to tiers 1+2 rather than crashing a save or skipping the check
         # entirely -- but say so, since an always-raising hook otherwise

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import sys
 from pathlib import Path
 from types import MappingProxyType
 
@@ -469,11 +470,47 @@ con_name_to_secret_keys = MappingProxyType(
 )
 
 
+def get_dynamic_secret_keys(
+    con_name: str, kwargs: dict | None = None
+) -> tuple[str, ...] | None:
+    """Return secret keys from a backend's dynamic ``_get_secret_keys(kwargs)``
+    hook, or None.
+
+    A backend may declare a classmethod ``_get_secret_keys(kwargs)`` when its
+    secret keys depend on the connection kwargs themselves (e.g. keys nested
+    inside a ``config`` kwarg being checked) and so can't be captured in the
+    static ``con_name_to_secret_keys`` mirror.
+
+    Only an already-imported backend is inspected -- we never import a backend
+    purely to validate secrets (that would import a heavy backend, e.g.
+    snowflake, on every ``Profile.save()``). Returns None when the backend is
+    not imported, has no entry point, declares no dynamic hook, or the hook
+    raises (fail closed: the caller then falls back to the static mirror rather
+    than skipping the check).
+    """
+    entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
+    if entry_point is None:
+        return None
+    module = sys.modules.get(entry_point.module)
+    if module is None:
+        return None
+    getter = getattr(getattr(module, "Backend", None), "_get_secret_keys", None)
+    if not callable(getter):
+        return None
+    try:
+        keys = getter(kwargs)
+    except Exception:
+        return None
+    return tuple(keys) if keys is not None else None
+
+
 def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     """Check if profile contains exposed secret keys.
 
-    Secret keys come from the static `con_name_to_secret_keys` mirror,
-    defaulting to `("password",)` for backends not listed.
+    A backend may declare a dynamic `_get_secret_keys(kwargs)` hook, which
+    takes precedence when it yields keys; otherwise secret keys come from the
+    static `con_name_to_secret_keys` mirror, defaulting to `("password",)` for
+    backends not listed.
 
     Raises
     ------
@@ -481,10 +518,12 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
         If profile contains exposed secret keys not using environment variables
     """
 
-    relevant_keys = con_name_to_secret_keys.get(
-        con_name,
-        ("password",),  # default to just password
-    )
+    relevant_keys = get_dynamic_secret_keys(con_name, kwargs)
+    if relevant_keys is None:
+        relevant_keys = con_name_to_secret_keys.get(
+            con_name,
+            ("password",),  # default to just password
+        )
 
     exposed_secrets = tuple(
         key

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import sys
+import warnings
 from pathlib import Path
 from types import MappingProxyType
 
@@ -476,10 +477,16 @@ def get_dynamic_secret_keys(
     """Return secret keys from a backend's dynamic ``_get_secret_keys(kwargs)``
     hook, or None.
 
-    A backend may declare a classmethod ``_get_secret_keys(kwargs)`` when its
-    secret keys depend on the connection kwargs themselves (e.g. keys nested
-    inside a ``config`` kwarg being checked) and so can't be captured in the
-    static ``con_name_to_secret_keys`` mirror.
+    A backend may declare a classmethod ``_get_secret_keys(kwargs)`` when which
+    kwargs are secret depends on the kwargs themselves -- e.g. a backend whose
+    auth kwarg is named differently per configured mode -- and so can't be
+    captured in the static ``con_name_to_secret_keys`` mirror.
+
+    **Return top-level kwarg names only.** ``check_for_exposed_secrets`` matches
+    the returned names against the top level of ``kwargs``, so a hook cannot
+    reach inside a nested value: for ``kwargs={"config": {"token": ...}}``,
+    returning ``"token"`` matches nothing and returning ``"config"`` flags the
+    whole kwarg (a dict is not an env-var reference, so it is reported).
 
     Only an already-imported backend is inspected -- we never import a backend
     purely to validate secrets (that would import a heavy backend, e.g.
@@ -492,6 +499,12 @@ def get_dynamic_secret_keys(
     static ``con_name_to_secret_keys`` mirror. An unavailable or raising hook
     (None) therefore cannot weaken the check, and neither can a hook that
     returns fewer keys than the mirror declares.
+
+    The corollary for hook authors: because resolution is best-effort, this tier
+    is NOT a guarantee. A profile hand-authored and saved in a fresh process
+    where the backend was never imported gets tiers 1 and 2 only. Any key that
+    must *always* be caught belongs in ``con_name_to_secret_keys`` as well; keep
+    the hook for keys that only a kwargs-dependent rule can name.
     """
     entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
     if entry_point is None:
@@ -504,7 +517,16 @@ def get_dynamic_secret_keys(
         return None
     try:
         keys = getter(kwargs)
-    except Exception:
+    except Exception as e:
+        # Degrade to tiers 1+2 rather than crashing a save or skipping the check
+        # entirely -- but say so, since an always-raising hook otherwise
+        # contributes nothing forever and silently.
+        warnings.warn(
+            f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: {e}; "
+            "ignoring its keys and checking only the default and static keys",
+            RuntimeWarning,
+            stacklevel=2,
+        )
         return None
     return tuple(keys) if keys is not None else None
 

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -485,19 +485,21 @@ con_name_to_secret_key_sources = MappingProxyType({})
 
 def _resolve_source(source: tuple[str, ...], kwargs: dict) -> tuple[str, ...] | None:
     """The names ``source`` points at inside ``kwargs``, or None when it doesn't
-    resolve. Resolution runs no code belonging to the values it walks: a step reads
-    a plain ``dict`` through the unbound ``dict.get``, the leaf must be exactly a
-    ``list``/``tuple`` (a subclass can forge ``__iter__``), and anything else is
-    unresolved rather than reached into -- ``secret_fields: null`` falls through,
-    while ``[]`` resolves to ``()``. A non-``str`` name is dropped.
+    resolve. Resolution runs no code belonging to the values it walks: every read
+    is through an unbound builtin, so a subclass's ``get``/``__getitem__``/
+    ``__missing__``/``__iter__`` is bypassed and the true underlying data is read.
+    Anything that isn't a ``dict`` at a step, or a ``list``/``tuple`` at the leaf,
+    is unresolved rather than reached into -- ``secret_fields: null`` falls
+    through, while ``[]`` resolves to ``()``. A non-``str`` name is dropped.
     """
     value = kwargs
     for step in source:
         if not isinstance(value, dict):
             return None
         value = dict.get(value, step)
-    if type(value) in (list, tuple):
-        return tuple(name for name in value if isinstance(name, str))
+    if isinstance(value, (list, tuple)):
+        names = (tuple if isinstance(value, tuple) else list).__iter__(value)
+        return tuple(name for name in names if isinstance(name, str))
     return None
 
 

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -485,8 +485,13 @@ def get_dynamic_secret_keys(
     purely to validate secrets (that would import a heavy backend, e.g.
     snowflake, on every ``Profile.save()``). Returns None when the backend is
     not imported, has no entry point, declares no dynamic hook, or the hook
-    raises (fail closed: the caller then falls back to the static mirror rather
-    than skipping the check).
+    raises.
+
+    This tier is purely additive: ``check_for_exposed_secrets`` unions whatever
+    is returned here with the unconditional ``("password",)`` default and the
+    static ``con_name_to_secret_keys`` mirror. An unavailable or raising hook
+    (None) therefore cannot weaken the check, and neither can a hook that
+    returns fewer keys than the mirror declares.
     """
     entry_point = next((ep for ep in _load_entry_points() if ep.name == con_name), None)
     if entry_point is None:
@@ -504,13 +509,48 @@ def get_dynamic_secret_keys(
     return tuple(keys) if keys is not None else None
 
 
+# Checked for every backend, unconditionally, on top of whatever the mirror and
+# the dynamic hook contribute. A backend cannot declare that a kwarg literally
+# named `password` is not a secret.
+default_secret_keys = ("password",)
+
+
+def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...]:
+    """Return every secret key to check for ``con_name``.
+
+    The result is the *union* of three tiers, so the combination is monotone --
+    each tier can only widen the set, never shrink it:
+
+    1. the unconditional ``default_secret_keys`` (``("password",)``),
+    2. the static ``con_name_to_secret_keys`` mirror entry, if any,
+    3. the backend's dynamic ``_get_secret_keys(kwargs)`` hook, if resolvable.
+
+    Consequently a dynamic hook can only ADD keys. A hook returning ``()``, a
+    hook returning a subset of the mirror, a raising hook, and a backend that
+    isn't imported yet all leave tiers 1 and 2 intact.
+
+    Ordering is deterministic (first occurrence wins, tiers in the order above)
+    so error messages are reproducible.
+    """
+    return tuple(
+        dict.fromkeys(
+            (
+                *default_secret_keys,
+                *con_name_to_secret_keys.get(con_name, ()),
+                *(get_dynamic_secret_keys(con_name, kwargs) or ()),
+            )
+        )
+    )
+
+
 def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     """Check if profile contains exposed secret keys.
 
-    A backend may declare a dynamic `_get_secret_keys(kwargs)` hook, which
-    takes precedence when it yields keys; otherwise secret keys come from the
-    static `con_name_to_secret_keys` mirror, defaulting to `("password",)` for
-    backends not listed.
+    The keys checked are the union of the unconditional ``("password",)``
+    default, the static `con_name_to_secret_keys` mirror entry for `con_name`,
+    and the backend's dynamic `_get_secret_keys(kwargs)` hook -- see
+    `get_secret_keys`. The dynamic hook can only widen that set; a hook that is
+    unavailable, raises, or returns fewer keys cannot weaken the check.
 
     Raises
     ------
@@ -518,12 +558,7 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
         If profile contains exposed secret keys not using environment variables
     """
 
-    relevant_keys = get_dynamic_secret_keys(con_name, kwargs)
-    if relevant_keys is None:
-        relevant_keys = con_name_to_secret_keys.get(
-            con_name,
-            ("password",),  # default to just password
-        )
+    relevant_keys = get_secret_keys(con_name, kwargs)
 
     exposed_secrets = tuple(
         key

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -479,79 +479,103 @@ con_name_to_secret_keys = MappingProxyType(
 default_secret_keys = ("password",)
 
 
-# Values shorter than this are never masked: masking those mangles the message
-# without hiding anything, and it is also the shortest run of a value that gets
-# masked when the value appears truncated.
+# Runs shorter than this are never masked: masking those mangles the message
+# without hiding anything.
 _min_redacted_length = 4
 
 
-def _redaction_texts(value, depth=4):
+def _redaction_texts(value, seen=None):
     """Every text form of ``value``, and of anything nested in it, that could
     carry a secret into a warning.
 
-    Nested, because the kwarg a hook keys off of is typically a config mapping
-    holding the credentials, so a hook failing mid-parse quotes back something
-    that was never a top-level value. Both the plain and the ``repr``-escaped
-    form of a str, since an exception echoing a value that contains a newline or
-    a quote quotes the escaped one, which the plain form doesn't match. A
-    container too deep to walk falls through to its own ``str``, which contains
-    the nested values as one string.
+    Nested at any depth, because the kwarg a hook keys off of is typically a
+    config mapping holding the credentials, so a hook failing mid-parse quotes
+    back something that was never a top-level value. Both the plain and the
+    ``repr``-escaped form of a str, since an exception echoing a value that
+    contains a newline or a quote quotes the escaped one, which the plain form
+    doesn't match. Containers are tracked by identity, so a cycle terminates.
+
+    Mapping *keys* are deliberately not collected: unlike values they name things
+    and appear in messages legitimately, so masking them would blank out the
+    diagnostic without hiding a credential anyone would store as a key.
     """
     if isinstance(value, str):
         texts = (value, repr(value)[1:-1])
     elif isinstance(value, bytes):
         texts = (repr(value)[2:-1], value.decode("latin-1"))
-    elif depth and isinstance(value, Mapping):
+    elif isinstance(value, (Mapping, list, tuple, set, frozenset)):
+        seen = set() if seen is None else seen
+        if id(value) in seen:
+            return ()
+        seen.add(id(value))
+        nested = value.values() if isinstance(value, Mapping) else value
         return tuple(
-            itertools.chain.from_iterable(
-                _redaction_texts(v, depth - 1) for v in value.values()
-            )
-        )
-    elif depth and isinstance(value, (list, tuple, set, frozenset)):
-        return tuple(
-            itertools.chain.from_iterable(_redaction_texts(v, depth - 1) for v in value)
+            itertools.chain.from_iterable(_redaction_texts(v, seen) for v in nested)
         )
     else:
-        texts = (str(value),)
+        try:
+            texts = (str(value),)
+        except Exception:
+            # guarded separately from the whole detail, so one value whose str()
+            # raises costs its own masking and not the rest of the message
+            return ()
     return tuple(text for text in texts if len(text) >= _min_redacted_length)
 
 
-def _mask(text: str, secret: str) -> str:
-    """Replace every occurrence of ``secret``, or of a long enough prefix of it,
-    with ``***``.
-
-    Prefixes, because an exception truncates what it echoes -- ``int()`` on a
-    long credential quotes only its first ~50 characters -- and replacing the
-    whole value leaves that behind.
-    """
-    seed = secret[:_min_redacted_length]
-    parts = []
-    while (start := text.find(seed)) != -1:
-        stop = start + _min_redacted_length
-        while (
-            stop - start < len(secret)
-            and text[start : stop + 1] == secret[: stop - start + 1]
-        ):
-            stop += 1
-        parts.append(text[:start] + "***")
-        text = text[stop:]
-    return "".join(parts) + text
+def _secret_run_end(text: str, start: int, secrets: tuple[str, ...]) -> int | None:
+    """The end of the longest run of ``text`` starting at ``start`` that some
+    secret contains, or None when no run there is long enough to mask."""
+    stop = start + _min_redacted_length
+    if stop > len(text) or not any(text[start:stop] in s for s in secrets):
+        return None
+    while stop < len(text) and any(text[start : stop + 1] in s for s in secrets):
+        stop += 1
+    return stop
 
 
 def _redact_kwarg_values(text: str, kwargs: dict) -> str:
-    """Mask any kwarg value, including one nested inside a kwarg, appearing in
-    ``text``.
+    """Mask every run of ``text`` long enough to be part of a kwarg value, or of
+    a value nested inside one.
 
-    A hook that fails parsing a credential tends to quote it back, and the
-    warnings below reach stderr and CI logs. Longest first, so masking one value
-    can't strand a prefix of another.
+    A hook that fails while parsing a credential tends to quote it back, and
+    these warnings reach stderr and CI logs. Matching *substrings* rather than
+    whole values, because an exception rarely echoes a value intact: it truncates
+    what it echoes (``int()`` quotes ~200 characters of its input), quotes a
+    tail, or escapes it. Substrings also mean masking one value cannot strand
+    part of another that shares a prefix with it -- a real case, since
+    credentials in a family (``sk_live_...``) share one.
     """
-    secrets = set(
-        itertools.chain.from_iterable(_redaction_texts(v) for v in kwargs.values())
+    secrets = tuple(
+        set(itertools.chain.from_iterable(_redaction_texts(v) for v in kwargs.values()))
     )
-    for secret in sorted(secrets, key=len, reverse=True):
-        text = _mask(text, secret)
-    return text
+    if not secrets:
+        return text
+    parts = []
+    kept = index = 0
+    while index < len(text):
+        if (stop := _secret_run_end(text, index, secrets)) is None:
+            index += 1
+            continue
+        parts.append(text[kept:index] + "***")
+        # from `stop`, not `stop + 1`: a second run can start where one ended
+        kept = index = stop
+    return "".join(parts) + text[kept:]
+
+
+def _describe(render, value, kwargs: dict) -> str:
+    """Render ``value`` into warning detail with the kwarg values masked, falling
+    back to a placeholder when any part of that raises.
+
+    All of it is arbitrary code: ``str()`` on the exception a hook raised,
+    ``repr()`` of the names it returned, and the ``str()`` calls masking makes on
+    the kwarg values. One that raises would escape ``get_dynamic_secret_keys``
+    from inside the reporting and abort a save with nothing wrong with it, so the
+    detail is dropped rather than the warning.
+    """
+    try:
+        return _redact_kwarg_values(render(value), kwargs)
+    except Exception:
+        return "<unprintable>"
 
 
 def _copy_kwargs(kwargs: dict) -> dict:
@@ -618,9 +642,9 @@ def get_dynamic_secret_keys(
         if isinstance(keys, (str, bytes)):
             # tuple("api_key") would check 'a', 'p', 'i', ... and not api_key.
             # The value itself is left out of the message: a hook returning a
-            # credential rather than its name would put it in the warning, and
-            # `repr` escaping it defeats the redaction below. The type is what a
-            # hook author needs.
+            # credential rather than its name would put it in the warning, and a
+            # value the hook derived from a kwarg is one redaction cannot match.
+            # The type is what a hook author needs.
             raise TypeError(
                 "must return a sequence of names or None, not a bare "
                 f"{type(keys).__name__}"
@@ -632,8 +656,8 @@ def get_dynamic_secret_keys(
         # would otherwise contribute nothing forever
         warnings.warn(
             f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: "
-            f"{_redact_kwarg_values(str(e), kwargs)}; ignoring its keys and "
-            "checking only the default and static keys",
+            f"{_describe(str, e, kwargs)}; ignoring its keys and checking only "
+            "the default and static keys",
             RuntimeWarning,
         )
         return None
@@ -644,8 +668,8 @@ def get_dynamic_secret_keys(
         # are unambiguous
         warnings.warn(
             f"{con_name}: _get_secret_keys returned non-str names "
-            f"{_redact_kwarg_values(repr(not_str), kwargs)}; ignoring them (a "
-            "name that isn't a str cannot match a kwarg) and checking the rest",
+            f"{_describe(repr, not_str, kwargs)}; ignoring them (a name that "
+            "isn't a str cannot match a kwarg) and checking the rest",
             RuntimeWarning,
         )
         keys = tuple(key for key in keys if isinstance(key, str))

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -183,10 +183,8 @@ class Profile:
 
     @con_name.validator
     def validate_con_name(self, attr, value):
-        # via _find_entry_point, so that a backend installed into a live process
-        # is accepted rather than rejected by an entry-point cache that predates
-        # it. On a miss that call has already refreshed the cache, so the names
-        # reported below are the fresh ones.
+        # _find_entry_point, not a direct scan of the cache: see its docstring.
+        # On a miss it has refreshed, so the names below are the fresh ones.
         if _find_entry_point(value) is None:
             installed = sorted(ep.name for ep in _load_entry_points())
             raise ValueError(
@@ -474,25 +472,18 @@ con_name_to_secret_keys = MappingProxyType(
 )
 
 
-# Checked for every backend, unconditionally, on top of whatever the mirror and
-# the dynamic hook contribute. A backend cannot declare that a kwarg literally
-# named `password` is not a secret.
+# Checked for every backend, on top of the mirror and the hook: a backend cannot
+# declare that a kwarg literally named `password` is not a secret.
 default_secret_keys = ("password",)
 
 
 def _redact_kwarg_values(text: str, kwargs: dict) -> str:
-    """Mask any kwarg value that appears in ``text``.
+    """Mask any kwarg value appearing in ``text``.
 
-    A hook's exception is interpolated into the warning below, and a hook that
-    fails while parsing a credential tends to echo it -- ``int(kwargs["token"])``
-    raises ``invalid literal for int() with base 10: 'hunter2'``. This module
-    exists to keep secrets out of plaintext sinks, so it must not put them on
-    stderr (or in CI logs) itself.
-
-    Values shorter than 4 characters are left alone: masking those mangles
-    unrelated words in the message without hiding anything a value that short
-    could hide. Longest first, so masking one value can't strand a prefix of
-    another.
+    A hook that fails parsing a credential tends to quote it back, and the
+    warnings below reach stderr and CI logs. Values under 4 characters are left
+    alone: masking those mangles the message without hiding anything. Longest
+    first, so masking one can't strand a prefix of another.
     """
     for value in sorted(
         (v for v in kwargs.values() if isinstance(v, str) and len(v) >= 4),
@@ -509,45 +500,26 @@ def get_dynamic_secret_keys(
     """Return secret keys from a backend's dynamic ``_get_secret_keys(kwargs)``
     hook, or None.
 
-    A backend may declare a classmethod ``_get_secret_keys(kwargs)`` when which
-    kwargs are secret depends on the kwargs themselves -- e.g. a backend whose
-    auth kwarg is named differently per configured mode -- and so can't be
-    captured in the static ``con_name_to_secret_keys`` mirror.
+    A backend declares this classmethod when which kwargs are secret depends on
+    the kwargs themselves -- an auth kwarg named differently per configured mode,
+    say -- and so can't be captured in the static ``con_name_to_secret_keys``
+    mirror. ``get_secret_keys`` unions the result with the other tiers, so a hook
+    can only ADD keys.
 
-    **Return top-level kwarg names only.** ``check_for_exposed_secrets`` matches
-    the returned names against the top level of ``kwargs``, so a hook cannot
-    reach inside a nested value: for ``kwargs={"config": {"token": ...}}``,
-    returning ``"token"`` matches nothing and returning ``"config"`` flags the
-    whole kwarg (a dict is not an env-var reference, so it is reported).
+    **Return top-level kwarg names only**, and treat ``kwargs`` as read-only.
+    Names are matched against the top level, so for ``{"config": {"token": ...}}``
+    returning ``"token"`` matches nothing -- a hook that gets this wrong is a
+    silent no-op. The dict passed in is a (shallow) copy, since the caller scans
+    it after this returns; its values are as authored, i.e. plaintext for the
+    profile this check exists to reject, so don't log or forward them.
 
-    Only an already-imported backend is inspected -- we never import a backend
-    purely to validate secrets (that would import a heavy backend, e.g.
-    snowflake, on every ``Profile.save()``). Returns None when the backend is
-    not imported, has no entry point, declares no dynamic hook, or the hook
-    raises.
-
-    A hook is handed a *copy* of the kwargs, with their values as authored: an
-    env-var reference for a well-formed profile, the plaintext credential for the
-    profile this check exists to reject. Name keys off of them; do not log,
-    persist, or send them anywhere. The copy is what makes this tier additive --
-    a hook cannot delete or rewrite the entries the caller is about to scan --
-    and it is shallow, which is enough because only top-level names are matched.
-
-    Names that aren't ``str`` are dropped with a warning (they could never match
-    a kwarg), and a return that isn't a sequence of names drops this tier
-    entirely rather than propagating out of the save.
-
-    This tier is purely additive: ``check_for_exposed_secrets`` unions whatever
-    is returned here with the unconditional ``("password",)`` default and the
-    static ``con_name_to_secret_keys`` mirror. An unavailable or raising hook
-    (None) therefore cannot weaken the check, and neither can a hook that
-    returns fewer keys than the mirror declares.
-
-    The corollary for hook authors: because resolution is best-effort, this tier
-    is NOT a guarantee. A profile hand-authored and saved in a fresh process
-    where the backend was never imported gets tiers 1 and 2 only. Any key that
-    must *always* be caught belongs in ``con_name_to_secret_keys`` as well; keep
-    the hook for keys that only a kwargs-dependent rule can name.
+    Returns None when the backend has no entry point, isn't imported, declares no
+    hook, or the hook raises or returns something that isn't a sequence of names
+    (those last two warn). Only an already-imported backend is inspected, since
+    validating a profile must not import a heavy backend just to read its rule --
+    so this tier is best-effort, and any key that must *always* be caught belongs
+    in ``con_name_to_secret_keys`` too (enforced by
+    test_dynamic_hook_backends_also_mirror_static_keys).
     """
     entry_point = _find_entry_point(con_name)
     if entry_point is None:
@@ -560,31 +532,20 @@ def get_dynamic_secret_keys(
         return None
     kwargs = {} if kwargs is None else kwargs
     try:
-        # A copy: the caller scans this same dict *after* we return, so a hook
-        # that mutates what it is handed -- `kwargs.pop(...)` while walking a
-        # config, say -- would delete entries from the scan and let a plaintext
-        # secret save. That is the one way a hook could weaken rather than widen
-        # the check, and the union of tiers cannot protect against it.
+        # a copy: the caller scans this dict after we return, so a hook popping
+        # from it would delete entries from the scan
         keys = getter(dict(kwargs))
         if isinstance(keys, (str, bytes)):
-            # A bare name is iterable, so tuple("api_key") would quietly become
-            # ('a','p','i',...): the intended key dropped from this tier and
-            # junk single-character keys added. Raise so it is reported below
-            # instead of silently not checking the key the hook meant to name.
+            # tuple("api_key") would check 'a', 'p', 'i', ... and not api_key
             raise TypeError(
                 "must return a sequence of names or None, not a bare "
                 f"{type(keys).__name__} ({keys!r})"
             )
-        # Materialize inside the try: a hook returning a non-iterable, or an
-        # iterable that raises partway through, must be reported like any other
-        # hook error rather than propagating out of a Profile.save().
+        # inside the try, so a non-iterable return warns instead of raising
         keys = tuple(keys) if keys is not None else None
     except Exception as e:
-        # Degrade to tiers 1+2 rather than crashing a save or skipping the check
-        # entirely -- but say so, since an always-raising hook otherwise
-        # contributes nothing forever and silently. No stacklevel: every call
-        # comes from get_secret_keys, so no frame here names the backend that
-        # actually needs fixing -- the message does.
+        # degrade to the other tiers, but not silently: an always-broken hook
+        # would otherwise contribute nothing forever
         warnings.warn(
             f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: "
             f"{_redact_kwarg_values(str(e), kwargs)}; ignoring its keys and "
@@ -595,10 +556,8 @@ def get_dynamic_secret_keys(
     if keys is None:
         return None
     if not_str := tuple(key for key in keys if not isinstance(key, str)):
-        # A non-str name can never match a kwarg, so it would silently check
-        # nothing -- the same failure mode as the bare str above. Keep the
-        # well-formed names rather than dropping the tier: they are unambiguous,
-        # and checking them is strictly safer than not.
+        # a non-str name can't match a kwarg; keep the well-formed ones, which
+        # are unambiguous
         warnings.warn(
             f"{con_name}: _get_secret_keys returned non-str names "
             f"{_redact_kwarg_values(repr(not_str), kwargs)}; ignoring them (a "
@@ -610,23 +569,16 @@ def get_dynamic_secret_keys(
 
 
 def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...]:
-    """Return every secret key to check for ``con_name``.
-
-    The result is the *union* of three tiers, so the combination is monotone --
-    each tier can only widen the set, never shrink it:
+    """Return every secret key to check for ``con_name``: the *union* of
 
     1. the unconditional ``default_secret_keys`` (``("password",)``),
     2. the static ``con_name_to_secret_keys`` mirror entry, if any,
     3. the backend's dynamic ``_get_secret_keys(kwargs)`` hook, if resolvable.
 
-    Consequently a dynamic hook can only ADD keys. A hook returning ``()``, a
-    hook returning a subset of the mirror, a raising hook, and a backend that
-    isn't imported yet all leave tiers 1 and 2 intact. Nor can a hook shrink the
-    other side of the check: it is handed a copy of ``kwargs``, so it cannot
-    delete or rewrite the entries the caller goes on to scan.
-
-    Ordering is deterministic (first occurrence wins, tiers in the order above)
-    so error messages are reproducible.
+    Unioning is what keeps this monotone: an empty, narrower, raising, or
+    unresolvable tier 3 leaves tiers 1 and 2 intact, so a hook can only widen
+    what is checked. Ordering is deterministic (first occurrence wins, tiers in
+    the order above) so error messages are reproducible.
     """
     return tuple(
         dict.fromkeys(
@@ -642,11 +594,8 @@ def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...
 def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     """Check if profile contains exposed secret keys.
 
-    The keys checked are the union of the unconditional ``("password",)``
-    default, the static `con_name_to_secret_keys` mirror entry for `con_name`,
-    and the backend's dynamic `_get_secret_keys(kwargs)` hook -- see
-    `get_secret_keys`. The dynamic hook can only widen that set; a hook that is
-    unavailable, raises, or returns fewer keys cannot weaken the check.
+    The keys come from `get_secret_keys`, which unions the unconditional
+    default, the static mirror, and the backend's dynamic hook.
 
     Raises
     ------

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -1,7 +1,9 @@
+import copy
 import itertools
 import json
 import sys
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 
@@ -477,21 +479,100 @@ con_name_to_secret_keys = MappingProxyType(
 default_secret_keys = ("password",)
 
 
+# Values shorter than this are never masked: masking those mangles the message
+# without hiding anything, and it is also the shortest run of a value that gets
+# masked when the value appears truncated.
+_min_redacted_length = 4
+
+
+def _redaction_texts(value, depth=4):
+    """Every text form of ``value``, and of anything nested in it, that could
+    carry a secret into a warning.
+
+    Nested, because the kwarg a hook keys off of is typically a config mapping
+    holding the credentials, so a hook failing mid-parse quotes back something
+    that was never a top-level value. Both the plain and the ``repr``-escaped
+    form of a str, since an exception echoing a value that contains a newline or
+    a quote quotes the escaped one, which the plain form doesn't match. A
+    container too deep to walk falls through to its own ``str``, which contains
+    the nested values as one string.
+    """
+    if isinstance(value, str):
+        texts = (value, repr(value)[1:-1])
+    elif isinstance(value, bytes):
+        texts = (repr(value)[2:-1], value.decode("latin-1"))
+    elif depth and isinstance(value, Mapping):
+        return tuple(
+            itertools.chain.from_iterable(
+                _redaction_texts(v, depth - 1) for v in value.values()
+            )
+        )
+    elif depth and isinstance(value, (list, tuple, set, frozenset)):
+        return tuple(
+            itertools.chain.from_iterable(_redaction_texts(v, depth - 1) for v in value)
+        )
+    else:
+        texts = (str(value),)
+    return tuple(text for text in texts if len(text) >= _min_redacted_length)
+
+
+def _mask(text: str, secret: str) -> str:
+    """Replace every occurrence of ``secret``, or of a long enough prefix of it,
+    with ``***``.
+
+    Prefixes, because an exception truncates what it echoes -- ``int()`` on a
+    long credential quotes only its first ~50 characters -- and replacing the
+    whole value leaves that behind.
+    """
+    seed = secret[:_min_redacted_length]
+    parts = []
+    while (start := text.find(seed)) != -1:
+        stop = start + _min_redacted_length
+        while (
+            stop - start < len(secret)
+            and text[start : stop + 1] == secret[: stop - start + 1]
+        ):
+            stop += 1
+        parts.append(text[:start] + "***")
+        text = text[stop:]
+    return "".join(parts) + text
+
+
 def _redact_kwarg_values(text: str, kwargs: dict) -> str:
-    """Mask any kwarg value appearing in ``text``.
+    """Mask any kwarg value, including one nested inside a kwarg, appearing in
+    ``text``.
 
     A hook that fails parsing a credential tends to quote it back, and the
-    warnings below reach stderr and CI logs. Values under 4 characters are left
-    alone: masking those mangles the message without hiding anything. Longest
-    first, so masking one can't strand a prefix of another.
+    warnings below reach stderr and CI logs. Longest first, so masking one value
+    can't strand a prefix of another.
     """
-    for value in sorted(
-        (v for v in kwargs.values() if isinstance(v, str) and len(v) >= 4),
-        key=len,
-        reverse=True,
-    ):
-        text = text.replace(value, "***")
+    secrets = set(
+        itertools.chain.from_iterable(_redaction_texts(v) for v in kwargs.values())
+    )
+    for secret in sorted(secrets, key=len, reverse=True):
+        text = _mask(text, secret)
     return text
+
+
+def _copy_kwargs(kwargs: dict) -> dict:
+    """Deep-copy what the hook is handed.
+
+    The caller scans this dict after the hook returns, and `Profile.kwargs_dict`
+    shares nested objects with the `kwargs_tuple` that gets saved: a hook doing
+    `kwargs.pop(...)` while consuming a config would delete entries from the
+    scan, and one writing into a nested config would put tampered content on
+    disk under a check that passed. A value that can't be deep-copied is handed
+    over as it is -- a hook seeing the original is better than a copy failure
+    aborting the check.
+    """
+
+    def copied(value):
+        try:
+            return copy.deepcopy(value)
+        except Exception:
+            return value
+
+    return {key: copied(value) for key, value in kwargs.items()}
 
 
 def get_dynamic_secret_keys(
@@ -509,9 +590,10 @@ def get_dynamic_secret_keys(
     **Return top-level kwarg names only**, and treat ``kwargs`` as read-only.
     Names are matched against the top level, so for ``{"config": {"token": ...}}``
     returning ``"token"`` matches nothing -- a hook that gets this wrong is a
-    silent no-op. The dict passed in is a (shallow) copy, since the caller scans
-    it after this returns; its values are as authored, i.e. plaintext for the
-    profile this check exists to reject, so don't log or forward them.
+    silent no-op. The dict passed in is a deep copy, since the caller scans it
+    after this returns and shares its nested values with the profile it saves;
+    its values are as authored, i.e. plaintext for the profile this check exists
+    to reject, so don't log or forward them.
 
     Returns None when the backend has no entry point, isn't imported, declares no
     hook, or the hook raises or returns something that isn't a sequence of names
@@ -532,14 +614,16 @@ def get_dynamic_secret_keys(
         return None
     kwargs = {} if kwargs is None else kwargs
     try:
-        # a copy: the caller scans this dict after we return, so a hook popping
-        # from it would delete entries from the scan
-        keys = getter(dict(kwargs))
+        keys = getter(_copy_kwargs(kwargs))
         if isinstance(keys, (str, bytes)):
-            # tuple("api_key") would check 'a', 'p', 'i', ... and not api_key
+            # tuple("api_key") would check 'a', 'p', 'i', ... and not api_key.
+            # The value itself is left out of the message: a hook returning a
+            # credential rather than its name would put it in the warning, and
+            # `repr` escaping it defeats the redaction below. The type is what a
+            # hook author needs.
             raise TypeError(
                 "must return a sequence of names or None, not a bare "
-                f"{type(keys).__name__} ({keys!r})"
+                f"{type(keys).__name__}"
             )
         # inside the try, so a non-iterable return warns instead of raising
         keys = tuple(keys) if keys is not None else None

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -1,9 +1,7 @@
-import copy
+import inspect
 import itertools
 import json
 import sys
-import warnings
-from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 
@@ -474,206 +472,114 @@ con_name_to_secret_keys = MappingProxyType(
 )
 
 
-# Checked for every backend, on top of the mirror and the hook: a backend cannot
-# declare that a kwarg literally named `password` is not a secret.
+# Checked for every backend, on top of the mirror and the declared sources: a
+# backend cannot declare that a kwarg literally named `password` is not a secret.
 default_secret_keys = ("password",)
 
 
-# Runs shorter than this are never masked: masking those mangles the message
-# without hiding anything.
-_min_redacted_length = 4
+# Declarative secret-key sources by connection name, mirrored from each
+# backend's `Backend._secret_key_sources` declaration exactly as
+# `con_name_to_secret_keys` mirrors `_secret_keys`. Each source is a tuple of
+# steps naming where in the kwargs the secret kwarg *names* live; because the
+# declaration is data, mirroring it means resolution never needs the backend
+# imported. Empty until the first declaring backend lands.
+con_name_to_secret_key_sources = MappingProxyType({})
 
 
-def _redaction_texts(value, seen=None):
-    """Every text form of ``value``, and of anything nested in it, that could
-    carry a secret into a warning.
+def _resolve_source(source: tuple[str, ...], kwargs: dict) -> tuple[str, ...] | None:
+    """The names ``source`` points at inside ``kwargs``, or None when it
+    doesn't resolve.
 
-    Nested at any depth, because the kwarg a hook keys off of is typically a
-    config mapping holding the credentials, so a hook failing mid-parse quotes
-    back something that was never a top-level value. Both the plain and the
-    ``repr``-escaped form of a str, since an exception echoing a value that
-    contains a newline or a quote quotes the escaped one, which the plain form
-    doesn't match. Containers are tracked by identity, so a cycle terminates.
-
-    Mapping *keys* are deliberately not collected: unlike values they name things
-    and appear in messages legitimately, so masking them would blank out the
-    diagnostic without hiding a credential anyone would store as a key.
+    Every rule is a type check or a dict lookup, so no backend-authored code
+    runs: a step resolves only against a plain ``dict``, read through the
+    unbound ``dict.get`` so a subclass's ``get``/``__getitem__``/``__missing__``
+    overrides are bypassed. Anything else at an intermediate step -- an attrs
+    instance, a ``Mapping`` that isn't a ``dict``, ``None`` -- is unresolved
+    rather than reached into; profiles carry configs as plain dicts. A source
+    resolves iff every step lands and the final value is a ``list``/``tuple``:
+    its ``str`` members are the names (a non-``str`` member can never match a
+    kwarg, so it is dropped rather than costing the well-formed names beside
+    it). ``None`` is unresolved -- ``secret_fields: null`` falls through --
+    while ``[]`` resolves to ``()``: "none of the fields are secret".
     """
-    if isinstance(value, str):
-        texts = (value, repr(value)[1:-1])
-    elif isinstance(value, bytes):
-        texts = (repr(value)[2:-1], value.decode("latin-1"))
-    elif isinstance(value, (Mapping, list, tuple, set, frozenset)):
-        seen = set() if seen is None else seen
-        if id(value) in seen:
-            return ()
-        seen.add(id(value))
-        nested = value.values() if isinstance(value, Mapping) else value
-        return tuple(
-            itertools.chain.from_iterable(_redaction_texts(v, seen) for v in nested)
-        )
-    else:
-        try:
-            texts = (str(value),)
-        except Exception:
-            # guarded separately from the whole detail, so one value whose str()
-            # raises costs its own masking and not the rest of the message
-            return ()
-    return tuple(text for text in texts if len(text) >= _min_redacted_length)
+    value = kwargs
+    for step in source:
+        if not isinstance(value, dict):
+            return None
+        value = dict.get(value, step)
+    if isinstance(value, (list, tuple)):
+        return tuple(name for name in value if isinstance(name, str))
+    return None
 
 
-def _secret_run_end(text: str, start: int, secrets: tuple[str, ...]) -> int | None:
-    """The end of the longest run of ``text`` starting at ``start`` that some
-    secret contains, or None when no run there is long enough to mask."""
-    stop = start + _min_redacted_length
-    if stop > len(text) or not any(text[start:stop] in s for s in secrets):
-        return None
-    while stop < len(text) and any(text[start : stop + 1] in s for s in secrets):
-        stop += 1
-    return stop
-
-
-def _redact_kwarg_values(text: str, kwargs: dict) -> str:
-    """Mask every run of ``text`` long enough to be part of a kwarg value, or of
-    a value nested inside one.
-
-    A hook that fails while parsing a credential tends to quote it back, and
-    these warnings reach stderr and CI logs. Matching *substrings* rather than
-    whole values, because an exception rarely echoes a value intact: it truncates
-    what it echoes (``int()`` quotes ~200 characters of its input), quotes a
-    tail, or escapes it. Substrings also mean masking one value cannot strand
-    part of another that shares a prefix with it -- a real case, since
-    credentials in a family (``sk_live_...``) share one.
-    """
-    secrets = tuple(
-        set(itertools.chain.from_iterable(_redaction_texts(v) for v in kwargs.values()))
-    )
-    if not secrets:
-        return text
-    parts = []
-    kept = index = 0
-    while index < len(text):
-        if (stop := _secret_run_end(text, index, secrets)) is None:
-            index += 1
-            continue
-        parts.append(text[kept:index] + "***")
-        # from `stop`, not `stop + 1`: a second run can start where one ended
-        kept = index = stop
-    return "".join(parts) + text[kept:]
-
-
-def _describe(render, value, kwargs: dict) -> str:
-    """Render ``value`` into warning detail with the kwarg values masked, falling
-    back to a placeholder when any part of that raises.
-
-    All of it is arbitrary code: ``str()`` on the exception a hook raised,
-    ``repr()`` of the names it returned, and the ``str()`` calls masking makes on
-    the kwarg values. One that raises would escape ``get_dynamic_secret_keys``
-    from inside the reporting and abort a save with nothing wrong with it, so the
-    detail is dropped rather than the warning.
-    """
-    try:
-        return _redact_kwarg_values(render(value), kwargs)
-    except Exception:
-        return "<unprintable>"
-
-
-def _copy_kwargs(kwargs: dict) -> dict:
-    """Deep-copy what the hook is handed.
-
-    The caller scans this dict after the hook returns, and `Profile.kwargs_dict`
-    shares nested objects with the `kwargs_tuple` that gets saved: a hook doing
-    `kwargs.pop(...)` while consuming a config would delete entries from the
-    scan, and one writing into a nested config would put tampered content on
-    disk under a check that passed. A value that can't be deep-copied is handed
-    over as it is -- a hook seeing the original is better than a copy failure
-    aborting the check.
-    """
-
-    def copied(value):
-        try:
-            return copy.deepcopy(value)
-        except Exception:
-            return value
-
-    return {key: copied(value) for key, value in kwargs.items()}
-
-
-def get_dynamic_secret_keys(
-    con_name: str, kwargs: dict | None = None
-) -> tuple[str, ...] | None:
-    """Return secret keys from a backend's dynamic ``_get_secret_keys(kwargs)``
-    hook, or None.
-
-    A backend declares this classmethod when which kwargs are secret depends on
-    the kwargs themselves -- an auth kwarg named differently per configured mode,
-    say -- and so can't be captured in the static ``con_name_to_secret_keys``
-    mirror. ``get_secret_keys`` unions the result with the other tiers, so a hook
-    can only ADD keys.
-
-    **Return top-level kwarg names only**, and treat ``kwargs`` as read-only.
-    Names are matched against the top level, so for ``{"config": {"token": ...}}``
-    returning ``"token"`` matches nothing -- a hook that gets this wrong is a
-    silent no-op. The dict passed in is a deep copy, since the caller scans it
-    after this returns and shares its nested values with the profile it saves;
-    its values are as authored, i.e. plaintext for the profile this check exists
-    to reject, so don't log or forward them.
-
-    Returns None when the backend has no entry point, isn't imported, declares no
-    hook, or the hook raises or returns something that isn't a sequence of names
-    (those last two warn). Only an already-imported backend is inspected, since
-    validating a profile must not import a heavy backend just to read its rule --
-    so this tier is best-effort, and any key that must *always* be caught belongs
-    in ``con_name_to_secret_keys`` too (enforced by
-    test_dynamic_hook_backends_also_mirror_static_keys).
-    """
+def _imported_backend(con_name: str) -> type | None:
+    """The already-imported Backend class for ``con_name``, or None -- never
+    importing, since validating a profile must not import a heavy backend."""
     entry_point = _find_entry_point(con_name)
     if entry_point is None:
         return None
     module = sys.modules.get(entry_point.module)
     if module is None:
         return None
-    getter = getattr(getattr(module, "Backend", None), "_get_secret_keys", None)
-    if not callable(getter):
-        return None
-    kwargs = {} if kwargs is None else kwargs
-    try:
-        keys = getter(_copy_kwargs(kwargs))
-        if isinstance(keys, (str, bytes)):
-            # tuple("api_key") would check 'a', 'p', 'i', ... and not api_key.
-            # The value itself is left out of the message: a hook returning a
-            # credential rather than its name would put it in the warning, and a
-            # value the hook derived from a kwarg is one redaction cannot match.
-            # The type is what a hook author needs.
-            raise TypeError(
-                "must return a sequence of names or None, not a bare "
-                f"{type(keys).__name__}"
-            )
-        # inside the try, so a non-iterable return warns instead of raising
-        keys = tuple(keys) if keys is not None else None
-    except Exception as e:
-        # degrade to the other tiers, but not silently: an always-broken hook
-        # would otherwise contribute nothing forever
-        warnings.warn(
-            f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: "
-            f"{_describe(str, e, kwargs)}; ignoring its keys and checking only "
-            "the default and static keys",
-            RuntimeWarning,
+    backend = inspect.getattr_static(module, "Backend", None)
+    return backend if isinstance(backend, type) else None
+
+
+def _secret_key_sources_for(con_name: str) -> tuple[tuple[str, ...], ...]:
+    """Every declared secret-key source for ``con_name``: the mirror entry,
+    topped up from ``_secret_key_sources`` on an already-imported backend.
+
+    The mirror covers in-tree backends with no import at all; the class read
+    covers out-of-tree backends, which cannot add entries to the mirror.
+    ``inspect.getattr_static`` reads the class dict without firing descriptors,
+    so a ``_secret_key_sources`` declared as a ``property`` contributes nothing
+    instead of executing -- it returns the descriptor object, which the tuple
+    check discards.
+    """
+    sources = con_name_to_secret_key_sources.get(con_name, ())
+    if (backend := _imported_backend(con_name)) is not None:
+        declared = inspect.getattr_static(backend, "_secret_key_sources", ())
+        if isinstance(declared, tuple):
+            sources += declared
+    return tuple(dict.fromkeys(sources))
+
+
+def get_declared_secret_keys(
+    con_name: str, kwargs: dict | None = None
+) -> tuple[str, ...]:
+    """The first resolving declared source's names, or ``()`` -- the third
+    tier of ``get_secret_keys``, which unions it with the default and the
+    mirror so a declaration can only widen what is checked.
+
+    A backend whose secret kwarg names depend on the kwargs themselves -- an
+    auth kwarg named by a config passed as another kwarg, say -- declares
+    *where the names live*, as static class data::
+
+        _secret_key_sources = (
+            ("config", "auth", "secret_fields"),
+            ("config", "auth", "fields"),
         )
-        return None
-    if keys is None:
-        return None
-    if not_str := tuple(key for key in keys if not isinstance(key, str)):
-        # a non-str name can't match a kwarg; keep the well-formed ones, which
-        # are unambiguous
-        warnings.warn(
-            f"{con_name}: _get_secret_keys returned non-str names "
-            f"{_describe(repr, not_str, kwargs)}; ignoring them (a name that "
-            "isn't a str cannot match a kwarg) and checking the rest",
-            RuntimeWarning,
-        )
-        keys = tuple(key for key in keys if isinstance(key, str))
-    return keys
+
+    Sources are ordered fallback: the first that resolves wins. A source may
+    read from anywhere in the kwargs, but the names it yields are matched
+    against the **top level**, so for ``{"config": {"token": ...}}`` a source
+    yielding ``"token"`` matches nothing.
+    """
+    for source in _secret_key_sources_for(con_name):
+        try:
+            names = _resolve_source(source, kwargs or {})
+        except Exception as e:
+            # a hostile object inside kwargs (e.g. a lying __class__ passing
+            # the isinstance check), not a declaration bug: fail closed and
+            # loudly. Only our own declared source is interpolated, so there
+            # is nothing here to redact.
+            raise ValueError(
+                f"{con_name}: could not resolve secret-key source {source}: "
+                f"{type(e).__name__}"
+            ) from e
+        if names is not None:
+            return names
+    return ()
 
 
 def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...]:
@@ -681,19 +587,19 @@ def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...
 
     1. the unconditional ``default_secret_keys`` (``("password",)``),
     2. the static ``con_name_to_secret_keys`` mirror entry, if any,
-    3. the backend's dynamic ``_get_secret_keys(kwargs)`` hook, if resolvable.
+    3. the backend's declared ``_secret_key_sources``, resolved against kwargs.
 
-    Unioning is what keeps this monotone: an empty, narrower, raising, or
-    unresolvable tier 3 leaves tiers 1 and 2 intact, so a hook can only widen
-    what is checked. Ordering is deterministic (first occurrence wins, tiers in
-    the order above) so error messages are reproducible.
+    Unioning is what keeps this monotone: an empty, narrower, or unresolved
+    tier 3 leaves tiers 1 and 2 intact, so a declaration can only widen what
+    is checked. Ordering is deterministic (first occurrence wins, tiers in the
+    order above) so error messages are reproducible.
     """
     return tuple(
         dict.fromkeys(
             (
                 *default_secret_keys,
                 *con_name_to_secret_keys.get(con_name, ()),
-                *(get_dynamic_secret_keys(con_name, kwargs) or ()),
+                *get_declared_secret_keys(con_name, kwargs),
             )
         )
     )
@@ -703,7 +609,7 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     """Check if profile contains exposed secret keys.
 
     The keys come from `get_secret_keys`, which unions the unconditional
-    default, the static mirror, and the backend's dynamic hook.
+    default, the static mirror, and the backend's declared secret-key sources.
 
     Raises
     ------

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -480,6 +480,29 @@ con_name_to_secret_keys = MappingProxyType(
 default_secret_keys = ("password",)
 
 
+def _redact_kwarg_values(text: str, kwargs: dict) -> str:
+    """Mask any kwarg value that appears in ``text``.
+
+    A hook's exception is interpolated into the warning below, and a hook that
+    fails while parsing a credential tends to echo it -- ``int(kwargs["token"])``
+    raises ``invalid literal for int() with base 10: 'hunter2'``. This module
+    exists to keep secrets out of plaintext sinks, so it must not put them on
+    stderr (or in CI logs) itself.
+
+    Values shorter than 4 characters are left alone: masking those mangles
+    unrelated words in the message without hiding anything a value that short
+    could hide. Longest first, so masking one value can't strand a prefix of
+    another.
+    """
+    for value in sorted(
+        (v for v in kwargs.values() if isinstance(v, str) and len(v) >= 4),
+        key=len,
+        reverse=True,
+    ):
+        text = text.replace(value, "***")
+    return text
+
+
 def get_dynamic_secret_keys(
     con_name: str, kwargs: dict | None = None
 ) -> tuple[str, ...] | None:
@@ -503,11 +526,16 @@ def get_dynamic_secret_keys(
     not imported, has no entry point, declares no dynamic hook, or the hook
     raises.
 
-    A hook is handed the profile's kwargs with their values, i.e. the plaintext
-    credentials, at validation time. Name keys off of them; do not log, persist,
-    or send them anywhere. Names that aren't ``str`` are dropped with a warning
-    (they could never match a kwarg), and a return that isn't a sequence of
-    names drops this tier entirely rather than propagating out of the save.
+    A hook is handed a *copy* of the kwargs, with their values as authored: an
+    env-var reference for a well-formed profile, the plaintext credential for the
+    profile this check exists to reject. Name keys off of them; do not log,
+    persist, or send them anywhere. The copy is what makes this tier additive --
+    a hook cannot delete or rewrite the entries the caller is about to scan --
+    and it is shallow, which is enough because only top-level names are matched.
+
+    Names that aren't ``str`` are dropped with a warning (they could never match
+    a kwarg), and a return that isn't a sequence of names drops this tier
+    entirely rather than propagating out of the save.
 
     This tier is purely additive: ``check_for_exposed_secrets`` unions whatever
     is returned here with the unconditional ``("password",)`` default and the
@@ -530,8 +558,14 @@ def get_dynamic_secret_keys(
     getter = getattr(getattr(module, "Backend", None), "_get_secret_keys", None)
     if not callable(getter):
         return None
+    kwargs = {} if kwargs is None else kwargs
     try:
-        keys = getter({} if kwargs is None else kwargs)
+        # A copy: the caller scans this same dict *after* we return, so a hook
+        # that mutates what it is handed -- `kwargs.pop(...)` while walking a
+        # config, say -- would delete entries from the scan and let a plaintext
+        # secret save. That is the one way a hook could weaken rather than widen
+        # the check, and the union of tiers cannot protect against it.
+        keys = getter(dict(kwargs))
         if isinstance(keys, (str, bytes)):
             # A bare name is iterable, so tuple("api_key") would quietly become
             # ('a','p','i',...): the intended key dropped from this tier and
@@ -552,8 +586,9 @@ def get_dynamic_secret_keys(
         # comes from get_secret_keys, so no frame here names the backend that
         # actually needs fixing -- the message does.
         warnings.warn(
-            f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: {e}; "
-            "ignoring its keys and checking only the default and static keys",
+            f"{con_name}: _get_secret_keys hook raised {type(e).__name__}: "
+            f"{_redact_kwarg_values(str(e), kwargs)}; ignoring its keys and "
+            "checking only the default and static keys",
             RuntimeWarning,
         )
         return None
@@ -565,9 +600,9 @@ def get_dynamic_secret_keys(
         # well-formed names rather than dropping the tier: they are unambiguous,
         # and checking them is strictly safer than not.
         warnings.warn(
-            f"{con_name}: _get_secret_keys returned non-str names {not_str!r}; "
-            "ignoring them (a name that isn't a str cannot match a kwarg) and "
-            "checking the rest",
+            f"{con_name}: _get_secret_keys returned non-str names "
+            f"{_redact_kwarg_values(repr(not_str), kwargs)}; ignoring them (a "
+            "name that isn't a str cannot match a kwarg) and checking the rest",
             RuntimeWarning,
         )
         keys = tuple(key for key in keys if isinstance(key, str))
@@ -586,7 +621,9 @@ def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...
 
     Consequently a dynamic hook can only ADD keys. A hook returning ``()``, a
     hook returning a subset of the mirror, a raising hook, and a backend that
-    isn't imported yet all leave tiers 1 and 2 intact.
+    isn't imported yet all leave tiers 1 and 2 intact. Nor can a hook shrink the
+    other side of the check: it is handed a copy of ``kwargs``, so it cannot
+    delete or rewrite the entries the caller goes on to scan.
 
     Ordering is deterministic (first occurrence wins, tiers in the order above)
     so error messages are reproducible.

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -617,7 +617,10 @@ def check_for_exposed_secrets(con_name: str, kwargs: dict) -> None:
     exposed_secrets = tuple(
         key
         # unbound, like the reads in _resolve_source: a subclass's items() could
-        # otherwise hide the very kwarg the resolver just named
+        # otherwise hide the very kwarg the resolver just named. A str-subclass
+        # *key* forging __eq__ can still evade the membership test below --
+        # accepted: a hostile caller could as easily rename the kwarg, and the
+        # serialized profile carries the key's own str value either way.
         for key, value in dict.items(kwargs)
         if key in relevant_keys
         and not (

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -477,39 +477,40 @@ con_name_to_secret_keys = MappingProxyType(
 default_secret_keys = ("password",)
 
 
-# Declarative secret-key sources by connection name, mirrored from each
-# backend's `Backend._secret_key_sources` declaration exactly as
-# `con_name_to_secret_keys` mirrors `_secret_keys`. Each source is a tuple of
-# steps naming where in the kwargs the secret kwarg *names* live; because the
-# declaration is data, mirroring it means resolution never needs the backend
-# imported. Empty until the first declaring backend lands.
+# Declarative secret-key sources by connection name, mirrored from each backend's
+# `Backend._secret_key_sources` exactly as `con_name_to_secret_keys` mirrors
+# `_secret_keys`. Mirroring data means resolution never needs the backend imported.
 con_name_to_secret_key_sources = MappingProxyType({})
 
 
 def _resolve_source(source: tuple[str, ...], kwargs: dict) -> tuple[str, ...] | None:
-    """The names ``source`` points at inside ``kwargs``, or None when it
-    doesn't resolve.
-
-    Every rule is a type check or a dict lookup, so no backend-authored code
-    runs: a step resolves only against a plain ``dict``, read through the
-    unbound ``dict.get`` so a subclass's ``get``/``__getitem__``/``__missing__``
-    overrides are bypassed. Anything else at an intermediate step -- an attrs
-    instance, a ``Mapping`` that isn't a ``dict``, ``None`` -- is unresolved
-    rather than reached into; profiles carry configs as plain dicts. A source
-    resolves iff every step lands and the final value is a ``list``/``tuple``:
-    its ``str`` members are the names (a non-``str`` member can never match a
-    kwarg, so it is dropped rather than costing the well-formed names beside
-    it). ``None`` is unresolved -- ``secret_fields: null`` falls through --
-    while ``[]`` resolves to ``()``: "none of the fields are secret".
+    """The names ``source`` points at inside ``kwargs``, or None when it doesn't
+    resolve. Resolution runs no code belonging to the values it walks: a step reads
+    a plain ``dict`` through the unbound ``dict.get``, the leaf must be exactly a
+    ``list``/``tuple`` (a subclass can forge ``__iter__``), and anything else is
+    unresolved rather than reached into -- ``secret_fields: null`` falls through,
+    while ``[]`` resolves to ``()``. A non-``str`` name is dropped.
     """
     value = kwargs
     for step in source:
         if not isinstance(value, dict):
             return None
         value = dict.get(value, step)
-    if isinstance(value, (list, tuple)):
+    if type(value) in (list, tuple):
         return tuple(name for name in value if isinstance(name, str))
     return None
+
+
+def _well_formed_sources(sources) -> tuple[tuple[str, ...], ...]:
+    """The sources shaped like sources: a non-empty tuple of ``str`` steps. A
+    malformed one contributes nothing; shape is pinned by the mirror tests."""
+    return tuple(
+        source
+        for source in sources
+        if isinstance(source, tuple)
+        and source
+        and all(isinstance(step, str) for step in source)
+    )
 
 
 def _imported_backend(con_name: str) -> type | None:
@@ -526,53 +527,42 @@ def _imported_backend(con_name: str) -> type | None:
 
 
 def _secret_key_sources_for(con_name: str) -> tuple[tuple[str, ...], ...]:
-    """Every declared secret-key source for ``con_name``: the mirror entry,
-    topped up from ``_secret_key_sources`` on an already-imported backend.
-
-    The mirror covers in-tree backends with no import at all; the class read
-    covers out-of-tree backends, which cannot add entries to the mirror.
-    ``inspect.getattr_static`` reads the class dict without firing descriptors,
-    so a ``_secret_key_sources`` declared as a ``property`` contributes nothing
-    instead of executing -- it returns the descriptor object, which the tuple
-    check discards.
-    """
-    sources = con_name_to_secret_key_sources.get(con_name, ())
+    """Every declared source for ``con_name``: the mirror entry, topped up from
+    ``_secret_key_sources`` on an already-imported backend, which is how an
+    out-of-tree backend -- unable to add a mirror entry -- keeps the tier.
+    ``getattr_static`` cannot fire a descriptor, so a ``property`` declaration
+    contributes nothing instead of executing."""
+    sources = tuple(con_name_to_secret_key_sources.get(con_name, ()))
     if (backend := _imported_backend(con_name)) is not None:
         declared = inspect.getattr_static(backend, "_secret_key_sources", ())
         if isinstance(declared, tuple):
             sources += declared
-    return tuple(dict.fromkeys(sources))
+    return tuple(dict.fromkeys(_well_formed_sources(sources)))
 
 
 def get_declared_secret_keys(
     con_name: str, kwargs: dict | None = None
 ) -> tuple[str, ...]:
-    """The first resolving declared source's names, or ``()`` -- the third
-    tier of ``get_secret_keys``, which unions it with the default and the
-    mirror so a declaration can only widen what is checked.
-
-    A backend whose secret kwarg names depend on the kwargs themselves -- an
-    auth kwarg named by a config passed as another kwarg, say -- declares
-    *where the names live*, as static class data::
+    """The first resolving declared source's names, or ``()`` -- tier 3 of
+    ``get_secret_keys``. A backend whose secret kwarg names depend on the kwargs
+    themselves declares *where the names live*, as static class data::
 
         _secret_key_sources = (
             ("config", "auth", "secret_fields"),
             ("config", "auth", "fields"),
         )
 
-    Sources are ordered fallback: the first that resolves wins. A source may
-    read from anywhere in the kwargs, but the names it yields are matched
-    against the **top level**, so for ``{"config": {"token": ...}}`` a source
+    The first source that resolves wins, and the names it yields are matched against
+    the **top level** of the kwargs, so for ``{"config": {"token": ...}}`` a source
     yielding ``"token"`` matches nothing.
     """
+    kwargs = kwargs if kwargs is not None else {}
     for source in _secret_key_sources_for(con_name):
         try:
-            names = _resolve_source(source, kwargs or {})
+            names = _resolve_source(source, kwargs)
         except Exception as e:
-            # a hostile object inside kwargs (e.g. a lying __class__ passing
-            # the isinstance check), not a declaration bug: fail closed and
-            # loudly. Only our own declared source is interpolated, so there
-            # is nothing here to redact.
+            # a hostile object in kwargs, not a declaration bug: fail closed. Only
+            # our own source is interpolated, so no kwarg value can leak here.
             raise ValueError(
                 f"{con_name}: could not resolve secret-key source {source}: "
                 f"{type(e).__name__}"
@@ -589,10 +579,9 @@ def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...
     2. the static ``con_name_to_secret_keys`` mirror entry, if any,
     3. the backend's declared ``_secret_key_sources``, resolved against kwargs.
 
-    Unioning is what keeps this monotone: an empty, narrower, or unresolved
-    tier 3 leaves tiers 1 and 2 intact, so a declaration can only widen what
-    is checked. Ordering is deterministic (first occurrence wins, tiers in the
-    order above) so error messages are reproducible.
+    Unioning is what keeps this monotone: an empty, narrower, or unresolved tier 3
+    leaves tiers 1 and 2 intact, so a declaration can only widen what is checked.
+    Ordering is deterministic -- first occurrence wins, tiers in the order above.
     """
     return tuple(
         dict.fromkeys(


### PR DESCRIPTION
## Summary

Adds a declarative secret-key tier for connection profiles. A backend whose secret keys depend on the connection kwargs — e.g. the credential kwarg names are named by a config passed as another kwarg — declares **where the names live**, as static class data:

```python
class Backend(...):
    _secret_key_sources = (
        ("config", "auth", "secret_fields"),
        ("config", "auth", "fields"),
    )
```

A tuple of **sources**, each source a tuple of dict-lookup **steps**; ordered fallback, first source that resolves wins. Tuples of steps rather than dotted strings — no parser, and a kwarg name containing a dot stays unambiguous.

`check_for_exposed_secrets` checks the **union of three tiers**, via `get_secret_keys(con_name, kwargs)`:

1. the unconditional `default_secret_keys` (`("password",)`),
2. the static `con_name_to_secret_keys` mirror entry (from #2183), if any,
3. the backend's declared `_secret_key_sources`, resolved against the kwargs.

An earlier iteration of this branch implemented tier 3 as a callable hook (`Backend._get_secret_keys(kwargs)`). That contract put plugin-authored code inside a security check, handed it the exact data the check protects, and ran it where an exception is unacceptable and a warning is an exfiltration channel — and ~60% of the production lines ended up defending the contract (kwargs deep-copies, return-shape guards, a bespoke substring-redaction engine for the warnings) rather than implementing the feature, with one leak shape unclosable by construction. The declarative design deletes that entire surface.

Design choices:

- **No backend-authored code executes during resolution.** Every resolution rule is a type check or a dict lookup: a step resolves only against a plain `dict`, read through the **unbound** `dict.get`, so a `dict` subclass overriding `get`/`__getitem__`/`__missing__` has those overrides bypassed and the true underlying data is read. Anything else at an intermediate step — an attrs instance, a `Mapping` that isn't a `dict`, `None`, a list — makes the source unresolved: no attribute access, no method calls. The leaf is read the same way: a `list`/`tuple` subclass can override `__iter__`, so the names are read through the unbound `list.__iter__`/`tuple.__iter__`, which bypasses the override. Rejecting subclasses outright instead was tried and reverted — it fails *open*, since a benign `list` subclass carrying real field names would silently drop the tier and let the credential those names cover be written (verified against the REST port, which does block it). The **names** are values out of the kwargs too, so they come back as exact `str` copies via the unbound `str.__str__`: a `str` subclass handed onward carries its own `__eq__` into the membership test that matches it against a kwarg — the source resolves, the key is named in the error path, and the literal saves anyway — and its own `__hash__` into the dedupe in `get_secret_keys`, which runs outside the fail-closed guard. The enforcement loop reads `dict.items(kwargs)` unbound for the same reason, so a subclass cannot hide from the check the very kwarg the resolver just named. The declaration itself is read with `inspect.getattr_static`, which cannot fire a descriptor, so `_secret_key_sources` declared as a `property` contributes nothing instead of executing. Normalizing an absent `kwargs` tests for `None` rather than truthiness, so a subclass whose `__len__` reports empty cannot silently disable the tier either.
- **Monotone.** The union means each tier can only *widen* the checked key set. A source that doesn't resolve, a malformed declaration, or an unimported backend all leave tiers 1 and 2 intact — no key checked before this PR can be dropped. A source resolves iff every step lands and the leaf is a `list`/`tuple`: `secret_fields: []` resolves to `()` and wins the fallback ("none of the fields are secret" is different from the key being absent), but `()` cannot opt out of the default `password` check. `None` is unresolved, so `secret_fields: null` falls through to the next source. Ordering is deterministic (first occurrence wins, tiers in the order above) so error messages are reproducible.
- **The hazards the callable needed guards for stop existing.** A bare `str` leaf (`fields: "token"`) is not a `list`/`tuple`, so it is unresolved rather than iterated into `('t', 'o', 'k', ...)`. The resolver only reads, so there is no mutation vector to defend the caller's kwargs against and no deep copy. Nothing plugin-authored can raise mid-check and nothing plugin-controlled reaches a warning, so the redaction engine and the guarded reporting are deleted outright, not relocated. A non-`str` name in a leaf can never match a kwarg, so it is dropped silently while the well-formed names beside it are kept — the leaf is user config data, which a declaration test can't cover, and checking the good names is strictly safer than dropping the source.
- **One runtime failure remains, and it fails closed.** An adversarial object already inside the caller's kwargs (the same trust domain as the credentials themselves) whose `__class__` lies passes the `isinstance` check and makes the unbound `dict.get` raise `TypeError`; the guard converts that into a `ValueError` naming the con_name and the source — the save aborts, and the message interpolates only our own declared source, so there is no kwarg value in it to redact.
- **Mirrored, so tier 3 no longer depends on import history.** Because the declaration is data, it is mirrored into `con_name_to_secret_key_sources` beside `con_name_to_secret_keys`, enforced by the same bidirectional mirror tests — resolution for a mirrored backend never needs the backend imported. **Out-of-tree** backends, which cannot add mirror entries (the mirror is a `MappingProxyType` in vendored source), keep the tier via a `getattr_static` read of an already-imported backend's class — best-effort exactly as the callable tier was, and the compensating convention is enforced: a backend declaring `_secret_key_sources` must also declare static `_secret_keys` for its always-present names (`test_declaring_backends_also_mirror_static_keys`).
- **Top-level names only.** A source may read from anywhere in the kwargs, but the names it yields are matched against the top level, so for `{"config": {"token": ...}}` a source yielding `"token"` matches nothing. The docstring states this explicitly.
- **A malformed declaration contributes nothing, and cannot break the check.** Declaration shape is pinned by tests (`test_mirrored_secret_key_sources_are_tuples_of_str` and the mirror tests), but shape is checked at runtime too — per source, not just on the outer tuple — because an out-of-tree backend has no in-repo test to catch it: `_well_formed_sources` keeps only a non-empty tuple of `str` steps. Without it a source that isn't a tuple aborted every save for that backend, a source that is a *list* escaped as a bare `TypeError` from the dedupe (outside the fail-closed guard), and the likely authoring slip — a flat tuple of steps rather than a tuple of sources — walked single-character keys. There is still deliberately no *warning* for an unresolvable source: the declaration is static, so a test catches it once, and a warning would re-open a reporting path.
- **The entry-point cache refreshes on a miss, and every lookup goes through that path.** `_load_entry_points` is cached (returning a tuple) since resolution consults it per check, and scanning the installed distributions costs ~15ms while `validate_con_name` runs per `Profile` construction. But a cache held for the life of the process hides a backend installed into a live one (pip install in a Jupyter kernel), so resolution goes through `_find_entry_point`, which refreshes once on a miss: a name that resolves never pays for it, a name that doesn't pays a rescan instead of being wrong. `load_backend`, `validate_con_name`, and the declared-sources lookup all resolve through it.

## Testing

`python -m pytest python/xorq/tests/test_profile.py python/xorq/tests/test_loader.py` — the 3 failures in test_profile.py are pre-existing and need a live postgres on localhost:5432; they reproduce on `main`.

Declaration validity (static data, no fakes, no imports of heavy backends):

- `test_mirrored_secret_key_sources_are_tuples_of_str` — every mirror entry is a tuple of tuples of `str`.
- `test_secret_key_sources_mirror_matches_backend_declaration` / `test_declared_secret_key_sources_are_mirrored` — the mirror matches each installed backend's `_secret_key_sources`, both directions, parameterized like the existing `_secret_keys` mirror tests.
- `test_declaring_backends_also_mirror_static_keys` — a backend declaring sources must also declare static `_secret_keys`; checked against source (`find_spec` + `ast`, no import) when the extras aren't installed, searching the whole package so a re-exported `Backend` is still found.

Resolution:

- `test_get_declared_secret_keys_first_resolving_source_wins` / `_falls_back_in_order` — ordered fallback; absent and explicit `null` both fall through.
- `test_empty_secret_fields_resolves_and_wins` — `[]` resolves to `()` and wins, and the default `password` check still applies.
- `test_unresolved_sources_contribute_nothing` — missing step, non-dict intermediate (including an attrs-like instance), and non-list leaf (including the bare `str` and the dict) all leave tiers 1+2 enforcing.
- `test_mixed_leaf_keeps_the_str_names` — `["api_key", 3, None]` keeps `api_key`.
- `test_dict_subclass_overrides_are_bypassed` — a subclass forging results from `get`/`__getitem__`/`__missing__`, as kwargs itself and at every nested step, has the true data read.
- `test_a_mapping_that_is_not_a_dict_is_not_reached_into` — unresolved with zero lookup calls made.
- `test_a_lying_class_fails_closed` — the `TypeError` becomes a `ValueError` naming the con_name and source, the save writes nothing, and the message carries no kwarg value.
- `test_a_property_declaration_contributes_nothing` — the property lives on a metaclass, where a plain `getattr` *would* run it and would get back a well-formed tuple; only the `getattr_static` read keeps it out.
- `test_a_non_tuple_class_declaration_contributes_nothing` — a list-shaped declaration fails the tuple check.
- `test_a_leaf_subclass_has_its_true_names_read` — a `list` and a `tuple` subclass forging `__iter__` have the true names read, and the credential they name is enforced; `test_a_forged_empty_leaf_cannot_suppress_the_true_names` — a forgery cannot narrow the check by resolving to less, either.
- `test_malformed_sources_contribute_nothing` — a source that isn't a tuple, is a list, is empty, has a non-`str` step, or is a flat tuple of steps: each contributes nothing, without raising and without blocking an otherwise-clean save.
- `test_a_kwargs_subclass_lying_about_len_still_resolves` — a `__len__` that reports empty does not disable the tier.
- `test_a_forged_str_name_cannot_escape_the_match` — a `str` subclass name whose `__eq__` never matches is materialized, so the key is enforced and `Profile.save()` writes nothing; `test_a_name_whose_hash_raises_cannot_escape_the_guard` — nor does a name reach the dedupe with a `__hash__` left to raise outside the guard.
- `test_forged_items_cannot_hide_a_kwarg` — a kwargs subclass hiding an entry from `items()` cannot hide it from the check.
- `test_source_declares_searches_a_package_for_a_re_exported_name` — the no-import source read follows a `Backend` re-exported from a submodule, which is the common package layout; reading only the entry-point module's own source skipped the guardrail for exactly the backends CI cannot import.

That the union cannot be weakened:

- `test_get_secret_keys_unions_default_mirror_and_declared` — all three tiers together, deduped, deterministic order.
- `test_declared_sources_cannot_shrink_mirrored_keys` — a source resolving to a subset or to `()` leaves the mirror enforced.
- `test_mirrored_sources_resolve_without_import` — the capability the mirror adds: a mirrored backend's sources resolve with the backend never imported, where the callable tier silently contributed nothing.
- `test_unimported_backend_contributes_no_class_sources` — the class read alone stays best-effort, and the default still applies.

Enforcement end-to-end: `test_check_for_exposed_secrets_uses_declared_keys` (a key surfaced only by a declared source is enforced; an env-var reference is accepted) and `test_save_is_blocked_by_a_declared_key` (`Profile.save()` aborts and writes nothing).

Each of these was additionally verified to go **red** against a deliberately weakened resolver (subclass `.get`, subclass `__iter__` at the leaf, rejecting subclass leaves outright, handing back the leaf's `str` subclass rather than a copy, bound `kwargs.items()`, plain `getattr`, `tuple(value)` leaf coercion, no per-source shape check, `kwargs or {}`, no fail-closed guard, declared-tier-replaces-union, and a single-module source read), so none of them passes vacuously.

The loader change: `python/xorq/tests/test_loader.py` covers the tuple return and cache reuse, and that every declared entry point exposes a `Backend`. The stale-cache setup — warm the cache, then write a distribution onto `sys.path` — is a shared `installed_mid_process` context manager in `tests/util.py`, used by `test_find_entry_point_refreshes_a_stale_cache` and by `test_validate_con_name_sees_a_backend_installed_mid_process`.

## Verified against the real consumer

`RestBackend` on `land/4c-rest-declarative-contract` is the motivating case, and its rule is expressible as exactly the two sources above: `AuthConfig.effective_secret_fields` is a pure default-fill (`secret_fields if secret_fields is not None else fields`), and enumerating the constructible auth shapes against the real `AuthConfig` shows the data path agrees with the property on every one of them. The two divergences are both on coerced-malformed input, and both are fixed on the 4c port by tightening the `fields`/`secret_fields`/`optional_fields` converters to reject non-list/tuple values (a config that constructs is a config the resolver can read). Porting the REST family — declaring the sources, tightening the converters, and adding the `rest`/`mixpanel`/`github` entries to the CI backend matrix so the mirror tests stop skipping — lands on that branch, not here.

## Follow-ups considered and deferred

- **Extracting the secret policy out of vendored ibis.** `xorq/vendor/ibis/backends/profiles.py` is vendored in name only and now holds both mirrors, the default, and the three-tier resolution, plus two underscore-private imports from `xorq.loader`. A `xorq/backends/secrets.py` owning that policy is the right home, but doing it here would also relocate `con_name_to_secret_keys` from #2183; better as a focused follow-up.
- **A deps-free metadata entry-point group would delete the mirror outright.** ADR-0023 already owns this shape of problem (`xorq.identity_specs`, Proposed, not implemented); if that group is built, secret metadata should ride it rather than invent a parallel mechanism.
- **Expressiveness.** A rule that isn't "read names from a path" can't be stated — e.g. "if `mode == 'oauth'` then these names". No present consumer needs more (every REST-family auth kind sources its names from `fields`/`secret_fields`); the smallest extension if one appears is a discriminator mapping, still pure data. List indexing and wildcards are deliberate v1 non-goals.
- **Making the entry-point miss path free.** A miss costs ~20ms (measured), the same as *every* call cost before the cache — not a regression, but there is no negative caching, so a caller that repeatedly names a backend that doesn't exist pays it every time, plus an `importlib.invalidate_caches()` that taxes unrelated later imports. A `sys.path` + directory-mtime fingerprint would let a miss skip both when the environment demonstrably hasn't changed.

## Relationship to #2183

Follow-on to #2183 (static backend-declared secret keys), which has since merged; this branch is rebased on it and the tiers are unioned rather than the declared sources overriding the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

