### PR TITLE
feat(lineage): compact, boundary-aware lineage in expr metadata (XOR-363)

### DIFF
--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -38,9 +38,11 @@ from xorq.catalog.tests.testing import (
     wait_until,
 )
 from xorq.catalog.tui import (
+    BOUNDARY_STYLES,
     GIT_LOG_COLUMNS,
     KIND_ORDER,
     KIND_STYLES,
+    UNKNOWN_BOUNDARY_STYLE,
     AddAliasScreen,
     AddEntryScreen,
     CatalogRowData,
@@ -61,6 +63,7 @@ from xorq.catalog.tui import (
     _list_revisions_cached,
     _pygments_to_text,
     _pygments_tokens,
+    _render_lineage_rows,
     _render_sql_dag,
     _render_sql_text,
     _styled_branch_label,
@@ -72,6 +75,7 @@ from xorq.common.utils.env_utils import (
     EnvConfigable,
     env_templates_dir,
 )
+from xorq.common.utils.lineage_utils import LineageDAG, compact_lineage_rows
 from xorq.config import TUI, options
 from xorq.ibis_yaml.enums import ExprKind
 
@@ -254,6 +258,55 @@ def test_lineage_text_renders_compact_boundary_tree(entry_a):
 def test_lineage_text_shows_cache_boundary(entry_cached: CatalogEntry) -> None:
     row = CatalogRowData(entry=entry_cached)
     assert "Cache[" in row.lineage_text, row.lineage_text
+
+
+def test_lineage_rich_styles_each_boundary_kind(entry_udxf: CatalogEntry) -> None:
+    """Boundary kinds get an icon and a colour; the tree glyphs and the collapsed
+    `via` runs stay dim.  `lineage_text` is the same render's plain text."""
+    row = CatalogRowData(entry=entry_udxf)
+    rich = row.lineage_rich
+
+    assert row.lineage_text == rich.plain
+    assert BOUNDARY_STYLES["flight_udxf"].icon in rich.plain
+    assert BOUNDARY_STYLES["table"].icon in rich.plain
+
+    styles = {str(span.style) for span in rich.spans}
+    assert any(BOUNDARY_STYLES["flight_udxf"].color in s for s in styles), styles
+    assert any("dim" in s for s in styles), styles
+
+    # a kind we did not style would render with the unknown-boundary icon
+    assert UNKNOWN_BOUNDARY_STYLE.icon not in rich.plain
+
+
+def test_info_rich_labels_and_indents_the_lineage(entry_udxf: CatalogEntry) -> None:
+    row = CatalogRowData(entry=entry_udxf)
+    lines = row.info_rich.plain.splitlines()
+
+    assert lines[0] == "Lineage:"
+    assert all(line.startswith("  ") for line in lines[1:-2])
+    assert lines[-2].startswith("Cache: ")
+    assert lines[-1].startswith("Hash: ")
+    assert row.info_text == row.info_rich.plain
+
+
+def test_lineage_rich_of_a_legacy_sidecar_uses_the_unknown_style() -> None:
+    """A pre-boundary sidecar annotates nothing, so every row falls back to the
+    unknown-boundary style instead of raising or missing a style lookup."""
+    legacy = LineageDAG.from_dict(
+        {
+            "nodes": [
+                {"id": "0", "type": "Filter", "label": "Filter"},
+                {"id": "1", "type": "InMemoryTable", "label": "InMemoryTable"},
+            ],
+            "edges": [["0", "1"]],
+            "root": "0",
+        }
+    )
+
+    rendered = _render_lineage_rows(compact_lineage_rows(legacy))
+
+    assert rendered.plain == f"{UNKNOWN_BOUNDARY_STYLE.icon} Filter"
+    assert any(UNKNOWN_BOUNDARY_STYLE.color in str(s.style) for s in rendered.spans)
 
 
 def test_lineage_text_renders_udxf_identity_and_nested_input(

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from textual.containers import VerticalScroll
 from textual.widgets import DataTable, Input, Select, Static, Tree
 
 import xorq.api as xo
@@ -2189,7 +2190,35 @@ def test_tab_cycle_focus_no_crash(catalog):
     _run(_test())
 
 
-def test_h_l_with_datatable_focused(catalog):
+def test_info_panel_is_tab_reachable_and_scrollable(catalog: Catalog) -> None:
+    """The lineage tree is multi-line and taller than the panel: Info must be in
+    the tab cycle and must scroll like #sql-panel."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            info_panel = app.screen.query_one("#info-panel")
+            assert isinstance(info_panel, VerticalScroll)
+
+            for _ in range(len(CatalogScreen.FOCUS_CYCLE)):
+                if app.focused is info_panel:
+                    break
+                await pilot.press("tab")
+                await settle(pilot)
+            assert app.focused is info_panel, "tab never reaches the Info panel"
+
+            # j/k dispatch to the focused VerticalScroll
+            await pilot.press("j")
+            await settle(pilot)
+            await pilot.press("k")
+            await settle(pilot)
+            assert isinstance(app.screen, CatalogScreen)
+
+    _run(_test())
+
+
+def test_h_l_with_datatable_focused(catalog: Catalog) -> None:
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -222,6 +222,20 @@ def test_catalog_row_data_is_frozen(entry_a):
         row.aliases = ("new-name",)
 
 
+def test_lineage_text_renders_compact_boundary_tree(entry_a):
+    """lineage_text is the compact boundary view, not a flat arrow chain."""
+    row = CatalogRowData(entry=entry_a)
+    lines = row.lineage_text.splitlines()
+
+    assert "→" not in lines[0], "root should not be a flattened arrow chain"
+    assert any("InMemoryTable" in line for line in lines), row.lineage_text
+
+
+def test_lineage_text_shows_cache_boundary(entry_cached):
+    row = CatalogRowData(entry=entry_cached)
+    assert "Cache[" in row.lineage_text, row.lineage_text
+
+
 def test_revision_row_data_current():
     row = RevisionRowData(
         hash="abc123",

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -108,6 +108,25 @@ def entry_cached(catalog, tmp_path):
 
 
 @pytest.fixture
+def entry_udxf(catalog: Catalog) -> CatalogEntry:
+    """A FlightUDXF over an into_backend'd memtable: the UDXF appends one column.
+
+    Construction and build only -- no Flight server is started.
+    """
+    con = xo.connect()
+    inner = xo.memtable({"a": [1, 2, 3]}, name="t_udxf").into_backend(con, "inner")
+    expr = xo.expr.relations.flight_udxf(
+        inner,
+        process_df=lambda df: df.assign(b=1),
+        maybe_schema_in=inner.schema(),
+        maybe_schema_out=xo.schema(inner.schema() | {"b": "int64"}),
+        con=con,
+        make_udxf_kwargs={"name": "AddB"},
+    )
+    return catalog.add(expr)
+
+
+@pytest.fixture
 def alias_for_a(catalog, entry_a):
     """Add alias 'my-model' to entry_a and return the alias string."""
     alias = "my-model"
@@ -231,9 +250,26 @@ def test_lineage_text_renders_compact_boundary_tree(entry_a):
     assert any("InMemoryTable" in line for line in lines), row.lineage_text
 
 
-def test_lineage_text_shows_cache_boundary(entry_cached):
+def test_lineage_text_shows_cache_boundary(entry_cached: CatalogEntry) -> None:
     row = CatalogRowData(entry=entry_cached)
     assert "Cache[" in row.lineage_text, row.lineage_text
+
+
+def test_lineage_text_renders_udxf_identity_and_nested_input(
+    entry_udxf: CatalogEntry,
+) -> None:
+    """A FlightUDXF is the one boundary where the schema really changes: the TUI
+    must show the UDXF identity, the transition, and the nested input source."""
+    text = CatalogRowData(entry=entry_udxf).lineage_text
+    lines = text.splitlines()
+
+    assert "UDXF[AddB] : 1→2 cols" in text, text
+    assert "(+b)" in text, text
+    # the input lineage of the UDXF hangs underneath it, not in the outer chain
+    udxf_line = next(i for i, line in enumerate(lines) if "UDXF[" in line)
+    nested = lines[udxf_line + 1 :]
+    assert any("↳" in line for line in nested), text
+    assert any("t_udxf" in line or "InMemoryTable" in line for line in nested), text
 
 
 def test_revision_row_data_current():

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -9,6 +9,7 @@ from functools import cache, cached_property, lru_cache
 from itertools import groupby
 from operator import attrgetter
 from pathlib import Path
+from textwrap import indent
 from typing import Literal
 
 from attr import evolve, field, frozen
@@ -272,11 +273,14 @@ class CatalogRowData:
 
     @cached_property
     def lineage_text(self) -> str:
+        from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
+            format_compact_lineage,
+        )
+
         lineage = self.entry.metadata.lineage
-        if not lineage:
+        if not lineage or not lineage.nodes:
             return "(empty)"
-        labels = [n["label"] for n in lineage.nodes]
-        return " → ".join(labels) if labels else "(empty)"
+        return format_compact_lineage(lineage)
 
     @cached_property
     def cache_info_text(self) -> str:
@@ -291,8 +295,11 @@ class CatalogRowData:
 
     @cached_property
     def info_text(self) -> str:
+        # lineage_text is a multi-line tree: label it, then indent the tree under
+        # it so the branch glyphs stay aligned.
         parts = [
-            f"Lineage: {self.lineage_text}",
+            "Lineage:",
+            indent(self.lineage_text, "  "),
             f"Cache: {self.cache_info_text}",
             f"Hash: {self.hash}",
         ]

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -797,6 +797,7 @@ class CatalogScreen(Screen):
         "#catalog-tree",
         "#sql-panel",
         "#data-preview-panel",
+        "#info-panel",
         "#schema-preview-table",
     )
 
@@ -831,7 +832,9 @@ class CatalogScreen(Screen):
                 with Vertical(id="data-preview-panel"):
                     yield Static("", id="data-preview-status")
                     yield DataTable(id="data-preview-table")
-                with Vertical(id="info-panel"):
+                # Scrollable: the lineage tree is multi-line and unbounded in
+                # depth, so the panel cannot show all of it at any fixed height.
+                with VerticalScroll(id="info-panel"):
                     yield Static("", id="info-content")
                 with Vertical(id="schema-panel"):
                     with Horizontal(id="schema-split"):

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -9,8 +9,7 @@ from functools import cache, cached_property, lru_cache
 from itertools import groupby
 from operator import attrgetter
 from pathlib import Path
-from textwrap import indent
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from attr import evolve, field, frozen
 from attr.validators import instance_of, optional
@@ -54,6 +53,12 @@ from xorq.common.utils.caching_utils import CacheKey
 from xorq.common.utils.logging_utils import get_logger
 from xorq.config import options
 from xorq.ibis_yaml.enums import ExprKind
+
+
+if TYPE_CHECKING:
+    # Imported for annotations only: lineage_utils is loaded lazily at call
+    # sites so importing the TUI does not pull in the expression machinery.
+    from xorq.common.utils.lineage_utils import LineageRow
 
 
 logger = get_logger(__name__)
@@ -199,6 +204,43 @@ CACHE_STYLE: dict[bool | None, tuple[str, str]] = {
     None: ("—", "dim"),
 }
 
+# Icon + colour per lineage boundary kind. Keyed by the *base* kind, so
+# `tag:catalog-source` styles as a tag. Process boundaries (Flight) get the
+# loudest colour: they are the only hop that leaves the process.
+BOUNDARY_STYLES: dict[str, KindStyle] = {
+    "flight_udxf": KindStyle(icon="✈", color=XORQ_DARK.variables["flash-new"]),
+    "flight_expr": KindStyle(icon="✈", color=XORQ_DARK.variables["flash-new"]),
+    "engine_crossing": KindStyle(icon="⇄", color=XORQ_DARK.secondary),
+    "cache": KindStyle(icon="◈", color=XORQ_DARK.success),
+    "pin": KindStyle(icon="⊙", color=XORQ_DARK.success),
+    "ingestion": KindStyle(icon="⇤", color=XORQ_DARK.warning),
+    "udf": KindStyle(icon="ƒ", color=XORQ_DARK.variables["subdued"]),
+    "join": KindStyle(icon="⋈", color=XORQ_DARK.primary),
+    "table": KindStyle(icon="⊞", color=XORQ_DARK.primary),
+    "unbound": KindStyle(icon="⊘", color=XORQ_DARK.warning),
+    "tag": KindStyle(icon="⚑", color=XORQ_DARK.variables["subdued"]),
+}
+
+# A legacy sidecar has no boundary annotation at all, so every row lands here.
+UNKNOWN_BOUNDARY_STYLE = KindStyle(icon="·", color=XORQ_DARK.variables["panel-dim-fg"])
+
+
+def _render_lineage_rows(rows: "tuple[LineageRow, ...]", prefix: str = "") -> Text:
+    """Style a compact lineage tree: glyphs dim, icon+label per boundary kind,
+    collapsed `via [...]` runs dim.  Its `.plain` is the plain-text tree."""
+    text = Text(no_wrap=False, overflow="fold")
+    for i, row in enumerate(rows):
+        style = BOUNDARY_STYLES.get(row.kind, UNKNOWN_BOUNDARY_STYLE)
+        if i:
+            text.append("\n")
+        text.append(prefix + row.prefix, style="dim")
+        text.append(f"{style.icon} ", style=f"bold {style.color}")
+        text.append(row.label, style=style.color)
+        if row.via:
+            text.append(row.via_suffix, style="dim italic")
+    return text
+
+
 FLASH_NEW = XORQ_DARK.variables["flash-new"]
 SUBDUED = XORQ_DARK.variables["subdued"]
 
@@ -272,15 +314,20 @@ class CatalogRowData:
         return self.entry.metadata.sql_queries
 
     @cached_property
-    def lineage_text(self) -> str:
+    def lineage_rich(self) -> Text:
         from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
-            format_compact_lineage,
+            compact_lineage_rows,
         )
 
         lineage = self.entry.metadata.lineage
         if not lineage or not lineage.nodes:
-            return "(empty)"
-        return format_compact_lineage(lineage)
+            return Text("(empty)", style="dim")
+        return _render_lineage_rows(compact_lineage_rows(lineage))
+
+    @cached_property
+    def lineage_text(self) -> str:
+        # Plain form of the styled render, so the two can never drift.
+        return self.lineage_rich.plain
 
     @cached_property
     def cache_info_text(self) -> str:
@@ -294,16 +341,31 @@ class CatalogRowData:
                 return "○ uncached"
 
     @cached_property
+    def info_rich(self) -> Text:
+        from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
+            compact_lineage_rows,
+        )
+
+        lineage = self.entry.metadata.lineage
+        # The lineage is a multi-line tree: label it, then indent the tree under
+        # the label so the branch glyphs stay aligned.
+        tree = (
+            _render_lineage_rows(compact_lineage_rows(lineage), prefix="  ")
+            if lineage and lineage.nodes
+            else Text("  (empty)", style="dim")
+        )
+        text = Text(no_wrap=False, overflow="fold")
+        text.append("Lineage:\n", style="bold")
+        text.append_text(tree)
+        text.append("\nCache: ", style="bold")
+        text.append(self.cache_info_text)
+        text.append("\nHash: ", style="bold")
+        text.append(self.hash)
+        return text
+
+    @cached_property
     def info_text(self) -> str:
-        # lineage_text is a multi-line tree: label it, then indent the tree under
-        # it so the branch glyphs stay aligned.
-        parts = [
-            "Lineage:",
-            indent(self.lineage_text, "  "),
-            f"Cache: {self.cache_info_text}",
-            f"Hash: {self.hash}",
-        ]
-        return "\n".join(parts)
+        return self.info_rich.plain
 
     @property
     def row_key(self) -> str:
@@ -1013,7 +1075,7 @@ class CatalogScreen(Screen):
                 self._load_sql_preview(row_data.row_key, sqls)
 
         # Info panel
-        info_content.update(row_data.info_text)
+        info_content.update(row_data.info_rich)
 
         # Revisions preview
         match row_data.aliases:

--- a/python/xorq/common/utils/content_hash.py
+++ b/python/xorq/common/utils/content_hash.py
@@ -4,11 +4,11 @@ Single source of truth for a node's content-addressed identity. The hash is the
 dasher token of the node's *untagged*, snapshot-normalized representation, with
 per-type special-casing so structurally-equal nodes collapse to one identity.
 
-Currently consumed by ``ibis_yaml`` (expr.yaml node labels / ``snapshot_hash``).
-Planned second consumer is lineage extraction (XOR-363): once wired, a node will
-key identically in both artifacts and can be cross-referenced by hash. Lineage
-does not call this helper yet -- ``lineage_utils`` still computes an independent
-hash.
+Consumed by ``ibis_yaml`` (expr.yaml node labels / ``snapshot_hash``) and by
+lineage extraction (``lineage_utils``), so a relation keys identically in both
+artifacts and can be cross-referenced by hash. Lineage only calls this for
+relations; value ops (``Field``, ``SortKey``, …) never appear in expr.yaml and are
+not all normalizable, so they get a structural token instead.
 """
 
 from __future__ import annotations

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -63,7 +63,7 @@ class OpaqueSpec:
 # Single source of truth for opaque descent, consumed by both the read side
 # (``gen_children_of`` + policy variants) and the write side (``replace_nodes``).
 # Read-side descent policies are edge overrides of the derived ``OPAQUE_EDGES``
-# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``_gen_children_flight_leaf``).
+# (see ``_gen_children_exec``/``_gen_children_skip_pins``/``gen_children_flight_leaf``).
 OPAQUE_SPECS = MappingProxyType(
     {
         rel.RemoteTable: OpaqueSpec(("remote_expr",)),
@@ -559,13 +559,12 @@ def _gen_children_skip_pins(node: Node) -> Tuple[Node, ...]:
     return tuple(gen_children_of(node, opaque_edges=_SKIP_PINS_EDGES))
 
 
-def _gen_children_flight_leaf(node: Node) -> Tuple[Node, ...]:
+def gen_children_flight_leaf(node: Node) -> Tuple[Node, ...]:
     """Child enumeration treating ``FlightExpr``/``FlightUDXF`` as opaque leaves.
 
     So a Flight node's ``input_expr`` is not flattened into the outer graph; its
-    lineage is extracted separately as a nested sub-DAG (see XOR-363). Private
-    until XOR-363 lands its caller; covered by
-    ``test_gen_children_flight_leaf_treats_flight_as_leaf``.
+    lineage is extracted separately as a nested sub-DAG -- see
+    ``lineage_utils.extract_lineage_dag``, which passes this as ``bfs(children=)``.
     """
     return tuple(gen_children_of(node, opaque_edges=_FLIGHT_LEAF_EDGES))
 

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -27,9 +27,11 @@ from xorq.vendor.ibis.expr.operations.core import Node
 __all__ = [
     "CAPABILITY_REGISTRY",
     "LineageDAG",
+    "LineageRow",
     "base_kind",
     "build_column_trees",
     "build_tree",
+    "compact_lineage_rows",
     "extract_lineage_dag",
     "format_compact_lineage",
     "schema_diff",
@@ -497,6 +499,28 @@ _FLIGHT_TYPES = (rel.FlightExpr, rel.FlightUDXF)
 
 
 @frozen
+class LineageRow:
+    """One rendered line, in pieces: tree glyphs, label, boundary kind, ``via``.
+
+    A renderer (``catalog/tui.py``) styles the pieces separately; ``text`` is the
+    plain-text line, so ``str(TextTree)`` and a styled render never drift.
+    """
+
+    prefix: str = field(validator=instance_of(str))
+    label: str = field(validator=instance_of(str))
+    kind: str | None = field(default=None)
+    via: Tuple[str, ...] = field(factory=tuple, validator=instance_of(tuple))
+
+    @property
+    def via_suffix(self) -> str:
+        return _via_suffix(list(self.via))
+
+    @property
+    def text(self) -> str:
+        return self.prefix + self.label + self.via_suffix
+
+
+@frozen
 class TextTree:
     """Plain-text tree for displaying lineage."""
 
@@ -504,24 +528,34 @@ class TextTree:
     children: Tuple["TextTree", ...] = field(
         factory=tuple, validator=instance_of(tuple)
     )
+    # Only the compact lineage tree sets these; column trees leave them empty.
+    kind: str | None = field(default=None)
+    via: Tuple[str, ...] = field(factory=tuple, validator=instance_of(tuple))
+
+    def rows(
+        self, prefix: str = "", is_last: bool = True, is_root: bool = True
+    ) -> tuple[LineageRow, ...]:
+        if is_root:
+            line_prefix = ""
+            child_prefix = ""
+        else:
+            line_prefix = prefix + ("└── " if is_last else "├── ")
+            child_prefix = prefix + ("    " if is_last else "│   ")
+        row = LineageRow(
+            prefix=line_prefix, label=self.label, kind=self.kind, via=self.via
+        )
+        return (row,) + tuple(
+            descendant
+            for i, child in enumerate(self.children)
+            for descendant in child.rows(
+                child_prefix, i == len(self.children) - 1, False
+            )
+        )
 
     def _lines(
         self, prefix: str = "", is_last: bool = True, is_root: bool = True
     ) -> tuple[str, ...]:
-        if is_root:
-            line = self.label
-            child_prefix = ""
-        else:
-            connector = "└── " if is_last else "├── "
-            line = prefix + connector + self.label
-            child_prefix = prefix + ("    " if is_last else "│   ")
-        return (line,) + tuple(
-            grandchild_line
-            for i, child in enumerate(self.children)
-            for grandchild_line in child._lines(
-                child_prefix, i == len(self.children) - 1, False
-            )
-        )
+        return tuple(row.text for row in self.rows(prefix, is_last, is_root))
 
     def __str__(self) -> str:
         return "\n".join(self._lines())
@@ -795,12 +829,16 @@ class LineageDAG:
         edges = tuple(
             e for e in map(_norm_edge, self.edges) if e["scope"] == flight_label
         )
-        ids = {e["from"] for e in edges} | {e["to"] for e in edges}
+        root = self._scope_root(flight_label)
+        # Seed with the scope root: a nested lineage that is a *single* node (the
+        # Flight input is a bare table) has no edges at all, and deriving the id
+        # set from edges alone would drop the very node ``root`` points at.
+        ids = {e["from"] for e in edges} | {e["to"] for e in edges} | {root} - {None}
         by_id = self.by_id
         return {
             "nodes": tuple(by_id[i] for i in ids if i in by_id),
             "edges": edges,
-            "root": self._scope_root(flight_label),
+            "root": root,
             "scope": flight_label,
         }
 
@@ -1173,21 +1211,22 @@ def _via_suffix(via: list) -> str:
     return f"   via [{shown}]"
 
 
-def format_compact_lineage(dag: LineageDAG) -> str:
-    """Render a :class:`LineageDAG` as a compact boundary-only text tree.
+def _compact_lineage_tree(dag: LineageDAG) -> TextTree | None:
+    """Compact boundary tree, or ``None`` when there is nothing to render.
 
     Non-boundary runs collapse into ``via [...]`` on the surviving edges; Flight
-    boundaries carry their nested input lineage as an indented sub-tree.
+    boundaries carry their nested input lineage as an indented sub-tree. Each
+    node keeps its ``kind`` so a renderer can style per boundary kind without
+    re-parsing the label.
     """
     by_id = dag.by_id
 
-    def build(view: dict, nid: str, seen: frozenset, prefix: str = "") -> TextTree:
+    def build(view: dict, nid: str, seen: frozenset, marker: str = "") -> TextTree:
         node = by_id.get(nid, {"label": nid, "type": "?"})
         children_of: dict = defaultdict(list)
         for edge in view["edges"]:
             children_of[edge["from"]].append((edge["to"], edge.get("via", [])))
 
-        label = prefix + _compact_node_label(node)
         kids: list[TextTree] = []
 
         nested_root = node.get("nested_root")
@@ -1204,15 +1243,38 @@ def format_compact_lineage(dag: LineageDAG) -> str:
             )
 
         for child_id, via in children_of.get(nid, ()):
+            child = by_id[child_id]
             if child_id in seen:
-                kids.append(TextTree(f"↻ {_compact_node_label(by_id[child_id])}"))
+                kids.append(
+                    TextTree(
+                        f"↻ {_compact_node_label(child)}",
+                        kind=base_kind(child.get("boundary_kind")),
+                    )
+                )
                 continue
             subtree = build(view, child_id, seen | {child_id})
-            kids.append(TextTree(subtree.label + _via_suffix(via), subtree.children))
+            kids.append(evolve(subtree, via=tuple(via)))
 
-        return TextTree(label, tuple(kids))
+        return TextTree(
+            marker + _compact_node_label(node),
+            tuple(kids),
+            kind=base_kind(node.get("boundary_kind")),
+        )
 
     view = dag.compact()
     if not view["nodes"] or view["root"] is None:
-        return "(empty)"
-    return str(build(view, view["root"], frozenset({view["root"]})))
+        return None
+    return build(view, view["root"], frozenset({view["root"]}))
+
+
+def compact_lineage_rows(dag: LineageDAG) -> tuple[LineageRow, ...]:
+    """One row per rendered line, with the tree glyphs, label, kind and ``via``
+    kept apart so a renderer can style each piece (see ``catalog/tui.py``)."""
+    tree = _compact_lineage_tree(dag)
+    return () if tree is None else tree.rows()
+
+
+def format_compact_lineage(dag: LineageDAG) -> str:
+    """Render a :class:`LineageDAG` as a compact boundary-only text tree."""
+    tree = _compact_lineage_tree(dag)
+    return "(empty)" if tree is None else str(tree)

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping
 from functools import singledispatch
 from itertools import count
@@ -11,9 +12,11 @@ from attrs.validators import instance_of
 import xorq.expr.relations as rel
 import xorq.expr.udf as udf
 import xorq.vendor.ibis.expr.operations as ops
+from xorq.common.utils.content_hash import content_hash
 from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.graph_utils import (
     bfs,
+    gen_children_flight_leaf,
     gen_children_of,
     to_node,
 )
@@ -21,11 +24,223 @@ from xorq.vendor.ibis.expr.operations.core import Node
 
 
 __all__ = [
+    "CAPABILITY_REGISTRY",
     "LineageDAG",
     "build_column_trees",
     "build_tree",
     "extract_lineage_dag",
+    "format_compact_lineage",
 ]
+
+
+# ── Boundary taxonomy ──────────────────────────────────────────────────
+#
+# A "boundary" is a semantically-meaningful hinge in the lineage: an ingestion,
+# a cache, an engine crossing, a process crossing (Flight), a tag, or a table
+# source. ``compact()`` keeps exactly these and collapses everything between them
+# into a ``via`` run. ``_boundary_kind`` below is the single source of truth for
+# the set: every ``graph_utils.opaque_ops`` type (the descent boundaries) plus the
+# non-opaque display boundaries (tables, joins, tags) registers a kind.
+
+
+def _backend_label(node: Node) -> str | None:
+    source = getattr(node, "source", None)
+    if source is None:
+        return None
+    return getattr(source, "name", type(source).__name__)
+
+
+@singledispatch
+def _boundary_kind(node: Node) -> str | None:
+    """Taxonomy string for a boundary node, or ``None`` if not a boundary."""
+    return None
+
+
+@_boundary_kind.register
+def _(node: rel.CachedNode) -> str:
+    return "cache"
+
+
+@_boundary_kind.register
+def _(node: rel.CacheTag) -> str:
+    return "pin"
+
+
+@_boundary_kind.register
+def _(node: rel.RemoteTable) -> str:
+    return "engine_crossing"
+
+
+@_boundary_kind.register
+def _(node: rel.FlightUDXF) -> str:
+    return "flight_udxf"
+
+
+@_boundary_kind.register
+def _(node: rel.FlightExpr) -> str:
+    return "flight_expr"
+
+
+@_boundary_kind.register
+def _(node: udf.ExprScalarUDF) -> str:
+    return "udf"
+
+
+@_boundary_kind.register
+def _(node: rel.Read) -> str:
+    # Read subclasses DatabaseTable; register it first-class so it wins dispatch.
+    return "ingestion"
+
+
+@_boundary_kind.register
+def _(node: ops.DatabaseTable) -> str:
+    return "table"
+
+
+@_boundary_kind.register
+def _(node: ops.InMemoryTable) -> str:
+    return "table"
+
+
+@_boundary_kind.register
+def _(node: ops.UnboundTable) -> str:
+    return "unbound"
+
+
+@_boundary_kind.register
+def _(node: ops.JoinChain) -> str:
+    return "join"
+
+
+@_boundary_kind.register
+def _(node: rel.HashingTag) -> str:
+    return "tag"
+
+
+@_boundary_kind.register
+def _(node: rel.Tag) -> str:
+    # CacheTag subclasses Tag but registers its own "pin" kind above.
+    return "tag"
+
+
+def _schema_dict(schema: Any) -> dict[str, str] | None:
+    if schema is None:
+        return None
+    return {k: str(v) for k, v in schema.items()}
+
+
+@singledispatch
+def _boundary_extras(node: Node) -> dict[str, Any]:
+    """Per-kind inline facts stored on a boundary node (intrinsic 1:1 facts)."""
+    return {}
+
+
+@_boundary_extras.register
+def _(node: rel.CachedNode) -> dict[str, Any]:
+    cache = getattr(node, "cache", None)
+    extras: dict[str, Any] = {"backend": _backend_label(node)}
+    if cache is not None:
+        extras["cache_kind"] = type(cache).__name__
+    return extras
+
+
+@_boundary_extras.register
+def _(node: rel.CacheTag) -> dict[str, Any]:
+    # A pin's identity is its cache key: the frozen read's table name.
+    cache = getattr(node, "cache", None)
+    return {
+        "backend": _backend_label(node),
+        "cache_key": getattr(node.parent, "name", None),
+        "cache_kind": None if cache is None else type(cache).__name__,
+    }
+
+
+@_boundary_extras.register
+def _(node: rel.RemoteTable) -> dict[str, Any]:
+    return {"backend": _backend_label(node)}
+
+
+@_boundary_extras.register
+def _(node: rel.Read) -> dict[str, Any]:
+    kwargs = getattr(node, "read_kwargs", None)
+    extras: dict[str, Any] = {
+        "backend": _backend_label(node),
+        "read_kind": getattr(node, "method_name", None),
+    }
+    if kwargs:
+        extras["read_kwargs"] = _to_jsonable(dict(kwargs))
+    return extras
+
+
+@_boundary_extras.register
+def _(node: ops.DatabaseTable) -> dict[str, Any]:
+    return {"backend": _backend_label(node), "table_name": getattr(node, "name", None)}
+
+
+@_boundary_extras.register
+def _(node: ops.UnboundTable) -> dict[str, Any]:
+    return {"table_name": getattr(node, "name", None)}
+
+
+@_boundary_extras.register
+def _(node: ops.JoinChain) -> dict[str, Any]:
+    return {"n_inputs": 1 + len(getattr(node, "rest", ()) or ())}
+
+
+@_boundary_extras.register
+def _(node: udf.ExprScalarUDF) -> dict[str, Any]:
+    return {"udf_name": type(node).__name__}
+
+
+@_boundary_extras.register
+def _(node: rel.FlightUDXF) -> dict[str, Any]:
+    udxf = getattr(node, "udxf", None)
+    input_expr = getattr(node, "input_expr", None)
+    schema_in = input_expr.schema() if input_expr is not None else None
+    return {
+        "process_boundary": True,
+        "udxf_class": getattr(udxf, "__name__", type(udxf).__name__ if udxf else None),
+        "udxf_command": getattr(udxf, "command", None),
+        "schema_in_observed": _schema_dict(schema_in),
+        "schema_out": _schema_dict(getattr(node, "schema", None)),
+        "do_instrument_reader": getattr(node, "do_instrument_reader", None),
+    }
+
+
+@_boundary_extras.register
+def _(node: rel.FlightExpr) -> dict[str, Any]:
+    input_expr = getattr(node, "input_expr", None)
+    schema_in = input_expr.schema() if input_expr is not None else None
+    make_server = getattr(node, "make_server", None)
+    return {
+        "process_boundary": True,
+        "server_factory": getattr(make_server, "__name__", None),
+        "input_schema": _schema_dict(schema_in),
+        "output_schema": _schema_dict(getattr(node, "schema", None)),
+        "do_instrument_reader": getattr(node, "do_instrument_reader", None),
+    }
+
+
+# ── Capability registry (code, keyed by boundary_kind) ─────────────────
+#
+# ``capabilities(node) = CAPABILITY_REGISTRY[kind]`` is what a kind *can*
+# expose; ``available(node)`` scans ``overlays`` for what is actually present.
+# Nothing here is stored per node.
+CAPABILITY_REGISTRY: dict[str, tuple[str, ...]] = {
+    "ingestion": ("schema",),
+    "cache": ("schema",),
+    "pin": ("schema", "tag_metadata"),
+    "engine_crossing": ("schema",),
+    "table": ("schema",),
+    "unbound": ("schema",),
+    "join": ("schema",),
+    "udf": ("schema",),
+    "tag": ("tag_metadata",),
+    "flight_udxf": ("schema_in_observed", "schema_out", "nested"),
+    "flight_expr": ("input_schema", "output_schema", "nested"),
+}
+
+_FLIGHT_TYPES = (rel.FlightExpr, rel.FlightUDXF)
 
 
 @frozen
@@ -140,7 +355,15 @@ def _(node: rel.CachedNode) -> str:
 
 @format_node.register
 def _(node: rel.FlightExpr) -> str:
-    return f"FlightExpr ({node.input_expr})"
+    # Do NOT stringify input_expr (it is extracted as a nested sub-DAG); the old
+    # ``FlightExpr ({node.input_expr})`` label duplicated the whole sub-tree.
+    return f"FlightExpr:{getattr(node, 'name', '')}"
+
+
+@format_node.register
+def _(node: rel.FlightUDXF) -> str:
+    cls = getattr(getattr(node, "udxf", None), "__name__", "udxf")
+    return f"FlightUDXF[{cls}]"
 
 
 @format_node.register
@@ -171,30 +394,231 @@ def _(node: ops.Literal) -> str:
     return f"Literal: {node.value}"
 
 
+LINEAGE_VERSION = 2
+ROOT_SCOPE = "root"
+
+
+def _norm_edge(edge: Any) -> dict:
+    """Normalise a stored edge to ``{from, to, scope}``.
+
+    Tolerates legacy 2-tuples/lists (``[from, to]``) by defaulting the scope to
+    ``"root"``; a 3-tuple carries an explicit scope; a dict is taken as-is.
+    """
+    if isinstance(edge, Mapping):
+        return {
+            "from": edge["from"],
+            "to": edge["to"],
+            "scope": edge.get("scope", ROOT_SCOPE),
+        }
+    frm, to, *rest = edge
+    return {"from": frm, "to": to, "scope": rest[0] if rest else ROOT_SCOPE}
+
+
 @frozen
 class LineageDAG:
-    """Typed container for a serialisable lineage DAG."""
+    """Typed container for a serialisable, self-contained lineage DAG.
+
+    Storage model (a): ONE shared node table (outer + all nested Flight lineage),
+    deduped by ``snapshot_hash``; edges are scope-tagged ``{from, to, scope}``
+    (``"root"`` for the outer graph, the owning Flight label for nested edges).
+    ``compact()`` and ``scope()`` are computed *views* over this table, not
+    stored sub-documents.
+    """
 
     nodes: tuple[dict, ...] = field(validator=instance_of(tuple))
-    edges: tuple[tuple[str, str], ...] = field(validator=instance_of(tuple))
+    edges: tuple[dict, ...] = field(validator=instance_of(tuple))
     root: str = field(validator=instance_of(str))
+    overlays: dict = field(factory=dict, validator=instance_of(dict))
+    version: int = field(default=LINEAGE_VERSION, validator=instance_of(int))
+
+    @property
+    def by_id(self) -> dict[str, dict]:
+        return {n["id"]: n for n in self.nodes}
 
     def to_dict(self) -> dict:
         return {
-            "nodes": list(self.nodes),
-            "edges": [list(e) for e in self.edges],
+            "version": self.version,
             "root": self.root,
+            "nodes": list(self.nodes),
+            "edges": [dict(_norm_edge(e)) for e in self.edges],
+            "overlays": dict(self.overlays),
         }
 
     @classmethod
     def from_dict(cls, raw: dict) -> LineageDAG:
+        # Tolerate-and-degrade: legacy sidecars (integer ids, 2-tuple edges, no
+        # version/overlays) load without migration -- they render, just without
+        # the enriched dimensions.
         if "root" not in raw:
             raise KeyError("lineage dict missing required key 'root'")
         return cls(
             nodes=tuple(raw.get("nodes", ())),
-            edges=tuple(tuple(e) for e in raw.get("edges", ())),
+            edges=tuple(_norm_edge(e) for e in raw.get("edges", ())),
             root=raw["root"],
+            overlays=dict(raw.get("overlays", {})),
+            version=int(raw.get("version", 1)),
         )
+
+    # ── query API ──────────────────────────────────────────────────────
+
+    def resolve(self, handle: Any) -> tuple[dict, ...]:
+        """Resolve a handle to node dict(s).
+
+        Accepts a ``snapshot_hash``, an ``@label`` id, a tag string, a
+        ``boundary_kind``, or a predicate callable over node dicts.
+        """
+        by_id = self.by_id
+        if callable(handle):
+            return tuple(n for n in self.nodes if handle(n))
+        if isinstance(handle, str) and handle in by_id:
+            return (by_id[handle],)
+        matches = tuple(
+            n
+            for n in self.nodes
+            if n.get("snapshot_hash") == handle or n.get("boundary_kind") == handle
+        )
+        if matches:
+            return matches
+        return tuple(
+            n
+            for n in self.nodes
+            if isinstance(n.get("tag_metadata"), Mapping)
+            and n["tag_metadata"].get("tag") == handle
+        )
+
+    def boundaries(self, kind: str | None = None) -> tuple[dict, ...]:
+        return tuple(
+            n
+            for n in self.nodes
+            if n.get("is_boundary") and (kind is None or n.get("boundary_kind") == kind)
+        )
+
+    def capabilities(self, node: dict) -> tuple[str, ...]:
+        """What dimensions this node's kind *can* expose (code registry)."""
+        return CAPABILITY_REGISTRY.get(node.get("boundary_kind"), ())
+
+    def available(self, node: dict) -> tuple[str, ...]:
+        """What overlay dimensions actually reference this node (present)."""
+        nid = node["id"]
+        return tuple(
+            dim
+            for dim, payload in self.overlays.items()
+            if _overlay_touches(payload, nid)
+        )
+
+    def expand(self, selector: Any, *dims: str) -> dict:
+        """Filter stored overlays for the resolved node(s) along ``dims``.
+
+        Static: expand is a filter over what is already serialised, never a
+        recompute.  Returns ``{dim: payload}``.
+        """
+        targets = {n["id"] for n in self.resolve(selector)}
+        wanted = dims or tuple(self.overlays)
+        out: dict[str, Any] = {}
+        for dim in wanted:
+            payload = self.overlays.get(dim)
+            if payload is not None:
+                out[dim] = _overlay_filter(payload, targets)
+        return out
+
+    def _scope_root(self, scope: str) -> str | None:
+        """Root id of *scope*: the DAG root, or the Flight node's ``nested_root``."""
+        if scope == ROOT_SCOPE:
+            return self.root
+        return self.by_id.get(scope, {}).get("nested_root")
+
+    def scope(self, flight_label: str) -> dict:
+        """Nested subgraph view for a Flight boundary: nodes/edges in its scope."""
+        edges = tuple(
+            e for e in map(_norm_edge, self.edges) if e["scope"] == flight_label
+        )
+        ids = {e["from"] for e in edges} | {e["to"] for e in edges}
+        by_id = self.by_id
+        return {
+            "nodes": tuple(by_id[i] for i in ids if i in by_id),
+            "edges": edges,
+            "root": self._scope_root(flight_label),
+            "scope": flight_label,
+        }
+
+    def compact(self, scope: str = ROOT_SCOPE) -> dict:
+        """Boundary-only view: collapse non-boundary runs into ``via`` on the
+        surviving boundary→boundary edges.
+
+        A small generic adjacency BFS over the id-graph (stored labels + edges),
+        NOT the op-graph -- at render time there are no ops.
+        """
+        by_id = self.by_id
+        adj: dict[str, list[str]] = defaultdict(list)
+        in_scope: set[str] = set()
+        for e in self.edges:
+            e = _norm_edge(e)
+            if e["scope"] == scope:
+                adj[e["from"]].append(e["to"])
+                in_scope |= {e["from"], e["to"]}
+
+        # A legacy/partial sidecar can name a scope with no recorded root; the
+        # view then holds only what its edges reach.
+        scope_root = self._scope_root(scope)
+        kept = {i for i in in_scope if by_id.get(i, {}).get("is_boundary")}
+        if scope_root is not None:
+            kept.add(scope_root)
+
+        # (from, to) -> collapsed run. Two boundaries can be joined by several
+        # non-boundary paths (a Sort reaching its parent both directly and through
+        # its SortKey, say); keep the most direct one so the view stays one line
+        # per boundary pair.
+        runs: dict[tuple[str, str], tuple[str, ...]] = {}
+        for boundary in kept:
+            stack = [(child, ()) for child in adj.get(boundary, ())]
+            seen: set[str] = set()
+            while stack:
+                cur, via = stack.pop()
+                if cur in kept:
+                    key = (boundary, cur)
+                    if key not in runs or len(via) < len(runs[key]):
+                        runs[key] = via
+                    continue
+                if cur in seen:
+                    continue
+                seen.add(cur)
+                via_next = via + (by_id[cur].get("type", "?"),)
+                for child in adj.get(cur, ()):
+                    stack.append((child, via_next))
+
+        return {
+            "nodes": tuple(by_id[i] for i in sorted(kept) if i in by_id),
+            "edges": tuple(
+                {"from": frm, "to": to, "via": list(via), "scope": scope}
+                for (frm, to), via in sorted(runs.items())
+            ),
+            "root": scope_root,
+            "scope": scope,
+        }
+
+
+def _overlay_touches(payload: Any, node_id: str) -> bool:
+    if isinstance(payload, Mapping):
+        return node_id in payload or any(
+            _overlay_touches(v, node_id) for v in payload.values()
+        )
+    if isinstance(payload, (list, tuple)):
+        return node_id in payload or any(_overlay_touches(v, node_id) for v in payload)
+    return payload == node_id
+
+
+def _overlay_filter(payload: Any, targets: set[str]) -> Any:
+    """Restrict an overlay payload to entries touching ``targets``.
+
+    Overlays are a deferred scaffold (columns/engines/cost slot in here); this
+    keeps mapping payloads whose keys are target node ids and leaves other shapes
+    untouched.
+    """
+    if not targets:
+        return payload
+    if isinstance(payload, Mapping):
+        return {k: v for k, v in payload.items() if k in targets}
+    return payload
 
 
 def _to_jsonable(v: Any) -> Any:
@@ -216,42 +640,155 @@ def _to_jsonable(v: Any) -> Any:
     return str(v)
 
 
-def _node_dict(node: Node, node_ids: dict[Node, str]) -> dict:
+def _op_slug(node: Node) -> str:
+    name = type(node).__name__
+    return "".join(("_" + c.lower()) if c.isupper() else c for c in name).lstrip("_")
+
+
+def _arg_token(value: Any, node_hash: Callable[[Node], str]) -> Any:
+    """Hashable, address-free rendering of one op argument."""
+    if isinstance(value, Node):
+        return node_hash(value)
+    if isinstance(value, Mapping):
+        return tuple((str(k), _arg_token(v, node_hash)) for k, v in value.items())
+    if isinstance(value, (tuple, list)):
+        return tuple(_arg_token(v, node_hash) for v in value)
+    return str(value)
+
+
+def _structural_token(node: Node, node_hash: Callable[[Node], str]) -> str:
+    """Deterministic identity from an op's type and arguments.
+
+    ``repr()`` of an ibis op is address-based, so identity is rebuilt from
+    ``__argnames__``; child nodes contribute their own (memoized) hash, keeping
+    this linear in graph size.
+    """
+    return tokenize(
+        (type(node).__name__,)
+        + tuple(
+            (name, _arg_token(getattr(node, name, None), node_hash))
+            for name in getattr(node, "__argnames__", ())
+        )
+    )
+
+
+def make_node_hasher() -> Callable[[Node], str]:
+    """Return a memoized ``node -> hash`` function for one extraction pass.
+
+    Relations hash with :func:`content_hash` -- the identity ``ibis_yaml`` stores
+    as ``snapshot_hash``, so a relation cross-references between expr.yaml and the
+    sidecar by hash. Everything else (``Field``, ``Literal``, ``SortKey``,
+    ``JoinLink``, …) gets a structural token: ``content_hash`` snapshot-normalizes
+    and may compile to SQL, which is both wasted work and outright unsupported for
+    some value ops (a ``SortKey`` cannot be re-projected), and none of them appear
+    as expr.yaml nodes anyway. Both forms are deterministic, so dedup is stable
+    across runs.
+    """
+    memo: dict[Node, str] = {}
+
+    def node_hash(node: Node) -> str:
+        if (hashed := memo.get(node)) is not None:
+            return hashed
+        hashed = None
+        if isinstance(node, ops.Relation):
+            try:
+                hashed = content_hash(node)
+            except Exception:  # noqa: BLE001 - lineage must never break a build
+                hashed = None
+        if hashed is None:
+            hashed = _structural_token(node, node_hash)
+        memo[node] = hashed
+        return hashed
+
+    return node_hash
+
+
+def _node_dict(node: Node, label: str, snapshot_hash: str) -> dict:
     d: dict[str, Any] = {
-        "id": node_ids[node],
+        "id": label,
+        "snapshot_hash": snapshot_hash,
         "type": type(node).__name__,
         "label": format_node(node),
     }
-    schema = getattr(node, "schema", None)
+    kind = _boundary_kind(node)
+    if kind is not None:
+        d["is_boundary"] = True
+        d["boundary_kind"] = kind
+        for k, v in _boundary_extras(node).items():
+            if v is not None:
+                d[k] = v
+    else:
+        d["is_boundary"] = False
+    schema = _schema_dict(getattr(node, "schema", None))
     if schema is not None:
-        d["schema"] = {k: str(v) for k, v in schema.items()}
+        d["schema"] = schema
     if isinstance(node, rel.Tag):
         d["tag_metadata"] = _to_jsonable(node.metadata)
     return d
 
 
 def extract_lineage_dag(expr: Any) -> LineageDAG:
-    """Extract a full lineage DAG from an expression via BFS.
+    """Extract a compact, self-contained lineage DAG from an expression.
 
-    Traverses all children at each level (not just the first),
-    including opaque sub-expressions like ExprScalarUDF.computed_kwargs_expr
-    and RemoteTable.remote_expr.
-
-    Node IDs are deterministic sequential integers (BFS order) so that
-    the serialised DAG is stable across runs.
+    The outer walk treats ``FlightExpr``/``FlightUDXF`` as leaves
+    (``gen_children_flight_leaf``): a Flight node's ``input_expr`` is NOT
+    flattened into the outer graph but recursed as a *nested* sub-DAG whose nodes
+    live in the same shared table under a ``scope`` tag (the owning Flight
+    label).  Nodes are deduped across scopes by ``content_hash`` (the durable
+    ``snapshot_hash``, shared with expr.yaml); the ``@op_N`` label is a readable
+    within-doc handle.  BFS dedup guards nested-of-nested recursion.
     """
     root = to_node(expr)
-    graph = bfs(root)
 
-    # Deterministic IDs based on BFS insertion order.
-    node_ids = {node: str(i) for i, node in enumerate(graph)}
+    hash_to_label: dict[str, str] = {}
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
+    edge_seen: set[tuple[str, str, str]] = set()
+    expanded_flights: set[str] = set()
+    counter = count(1)
+    node_hash = make_node_hasher()
 
-    nodes = tuple(_node_dict(n, node_ids) for n in graph)
-    edges = tuple(
-        (node_ids[n], node_ids[c]) for n, children in graph.items() for c in children
+    def register(node: Node) -> str:
+        h = node_hash(node)
+        label = hash_to_label.get(h)
+        if label is None:
+            label = f"@{_op_slug(node)}_{next(counter)}"
+            hash_to_label[h] = label
+            nodes[label] = _node_dict(node, label, h)
+        return label
+
+    def add_edge(frm: str, to: str, scope: str) -> None:
+        key = (frm, to, scope)
+        if key not in edge_seen:
+            edge_seen.add(key)
+            edges.append({"from": frm, "to": to, "scope": scope})
+
+    def walk(subroot: Node, scope: str) -> str:
+        graph = bfs(subroot, children=gen_children_flight_leaf)
+        labels = {node: register(node) for node in graph}
+        for node, children in graph.items():
+            for child in children:
+                add_edge(labels[node], labels[child], scope)
+        # Expand each Flight node's input_expr as a nested sub-DAG (once).
+        for node, label in labels.items():
+            input_expr = getattr(node, "input_expr", None)
+            if not isinstance(node, _FLIGHT_TYPES) or input_expr is None:
+                continue
+            if label in expanded_flights:
+                continue
+            expanded_flights.add(label)
+            nodes[label]["nested_root"] = walk(to_node(input_expr), label)
+        return labels[subroot]
+
+    root_label = walk(root, ROOT_SCOPE)
+
+    return LineageDAG(
+        nodes=tuple(nodes.values()),
+        edges=tuple(edges),
+        root=root_label,
+        overlays={},
+        version=LINEAGE_VERSION,
     )
-
-    return LineageDAG(nodes=nodes, edges=edges, root=node_ids[root])
 
 
 def build_tree(
@@ -299,3 +836,94 @@ def build_tree(
         return TextTree(label, children=children)
 
     return _to_tree(node, 0)
+
+
+# ── compact-view rendering (TUI) ───────────────────────────────────────
+
+
+def _compact_node_label(node: dict) -> str:
+    """Per-kind one-line label for a boundary node in the compact view."""
+    kind = node.get("boundary_kind")
+    if kind == "flight_udxf":
+        cls = node.get("udxf_class", "udxf")
+        n_in = len(node.get("schema_in_observed") or {})
+        n_out = len(node.get("schema_out") or {})
+        return f"UDXF[{cls}] : {n_in}→{n_out} cols"
+    if kind == "flight_expr":
+        n_in = len(node.get("input_schema") or {})
+        n_out = len(node.get("output_schema") or {})
+        return f"FlightExpr : {n_in}→{n_out} cols"
+    if kind == "cache":
+        return f"Cache[{node.get('cache_kind', 'cache')}]"
+    if kind == "pin":
+        key = node.get("cache_key") or ""
+        return f"Pin[{key[:8]}]" if key else "Pin"
+    if kind == "engine_crossing":
+        return f"→ {node.get('backend', '?')}"
+    if kind == "ingestion":
+        backend = node.get("backend")
+        return f"Read[{backend}]" if backend else "Read"
+    if kind in ("table", "unbound"):
+        backend = node.get("backend")
+        name = node.get("table_name") or ""
+        return f"{backend}:{name}" if backend else (name or node.get("label", "table"))
+    if kind == "join":
+        return f"Join({node.get('n_inputs', '?')} inputs)"
+    if kind == "udf":
+        return f"UDF[{node.get('udf_name', '?')}]"
+    if kind == "tag":
+        tm = node.get("tag_metadata") or {}
+        return f"Tag[{tm.get('tag', '')}]" if isinstance(tm, Mapping) else "Tag"
+    return node.get("label", node.get("type", "?"))
+
+
+def _via_suffix(via: list) -> str:
+    if not via:
+        return ""
+    shown = ", ".join(via[:3]) + ("…" if len(via) > 3 else "")
+    return f"   via [{shown}]"
+
+
+def format_compact_lineage(dag: LineageDAG) -> str:
+    """Render a :class:`LineageDAG` as a compact boundary-only text tree.
+
+    Non-boundary runs collapse into ``via [...]`` on the surviving edges; Flight
+    boundaries carry their nested input lineage as an indented sub-tree.
+    """
+    by_id = dag.by_id
+
+    def build(view: dict, nid: str, seen: frozenset, prefix: str = "") -> TextTree:
+        node = by_id.get(nid, {"label": nid, "type": "?"})
+        children_of: dict = defaultdict(list)
+        for edge in view["edges"]:
+            children_of[edge["from"]].append((edge["to"], edge.get("via", [])))
+
+        label = prefix + _compact_node_label(node)
+        kids: list[TextTree] = []
+
+        nested_root = node.get("nested_root")
+        if nested_root is not None:
+            # A Flight boundary's input lineage lives in its own scope: render it
+            # as a sub-tree marked with the crossing arrow at its root.
+            kids.append(
+                build(
+                    dag.compact(scope=nid),
+                    nested_root,
+                    frozenset({nested_root}),
+                    "↳ ",
+                )
+            )
+
+        for child_id, via in children_of.get(nid, ()):
+            if child_id in seen:
+                kids.append(TextTree(f"↻ {_compact_node_label(by_id[child_id])}"))
+                continue
+            subtree = build(view, child_id, seen | {child_id})
+            kids.append(TextTree(subtree.label + _via_suffix(via), subtree.children))
+
+        return TextTree(label, tuple(kids))
+
+    view = dag.compact()
+    if not view["nodes"] or view["root"] is None:
+        return "(empty)"
+    return str(build(view, view["root"], frozenset({view["root"]})))

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -417,11 +417,24 @@ def _(node: ops.UnboundTable) -> dict[str, Any]:
     return {"table_name": getattr(node, "name", None), **_namespace_extras(node)}
 
 
+def _join_backend(node: ops.JoinChain) -> str | None:
+    """Backend a join executes on: its leftmost input's.
+
+    A ``JoinChain`` has no ``source`` of its own, and walking to the leaves is
+    the wrong answer -- a join over an ``into_backend`` reaches the *remote*
+    source too, so it would look multi-backend when it is not. The left input
+    (``first``, a ``JoinReference`` over the relation) is where it runs.
+    """
+    first = getattr(node, "first", None)
+    return _backend_label(getattr(first, "parent", None) or first)
+
+
 @_boundary_extras.register
 def _(node: ops.JoinChain) -> dict[str, Any]:
     return {
         "n_inputs": 1 + len(getattr(node, "rest", ()) or ()),
         "predicates_summary": _predicate_summary(node),
+        "backend": _join_backend(node),
     }
 
 
@@ -442,6 +455,7 @@ def _(node: rel.FlightUDXF) -> dict[str, Any]:
     schema_out = _schema_dict(getattr(node, "schema", None))
     return {
         "process_boundary": True,
+        "backend": _backend_label(node),
         "udxf_class": getattr(udxf, "__name__", type(udxf).__name__ if udxf else None),
         "udxf_command": getattr(udxf, "command", None),
         "server_factory": _server_factory_label(getattr(node, "make_server", None)),
@@ -462,6 +476,7 @@ def _(node: rel.FlightExpr) -> dict[str, Any]:
     make_server = getattr(node, "make_server", None)
     return {
         "process_boundary": True,
+        "backend": _backend_label(node),
         "server_factory": _server_factory_label(make_server),
         "flight_command": _flight_command(node),
         "input_schema": _schema_dict(schema_in),
@@ -1161,15 +1176,47 @@ def _schema_diff_suffix(diff: Mapping[str, Any] | None) -> str:
     return f"   ({shown})"
 
 
+# Kinds whose own label already carries the schema transition (`N→M cols`), so a
+# plain `(N cols)` on top would be redundant.
+_TRANSITION_KINDS = ("flight_udxf", "flight_expr")
+
+# Kinds whose label does NOT already name a backend: `duckdb:orders` and
+# `Read[duckdb]` and `RemoteTable[duckdb → xorq]` do, a bare `Join(...)` or
+# `Cache[...]` does not.
+_BACKEND_TAG_KINDS = (
+    "join",
+    "cache",
+    "pin",
+    "udf",
+    "tag",
+    "flight_udxf",
+    "flight_expr",
+)
+
+
 def _compact_node_label(node: dict) -> str:
-    """Per-kind one-line label for a boundary node in the compact view."""
+    """One-line label for a boundary node: what it is, how wide, and where.
+
+    ``<kind label> (<n> cols) [<backend>]``, dropping any piece the node cannot
+    supply. Flight kinds render their schema *transition* instead of a single
+    width, and the UDXF column delta stays last so the eye lands on it.
+    """
     kind = base_kind(node.get("boundary_kind"))
+    parts = [_kind_label(node, kind)]
+    n_cols = len(node.get("schema") or {})
+    if n_cols and kind not in _TRANSITION_KINDS:
+        parts.append(f"({n_cols} cols)")
+    if kind in _BACKEND_TAG_KINDS and (backend := node.get("backend")):
+        parts.append(f"[{backend}]")
+    return " ".join(parts) + _schema_diff_suffix(node.get("schema_diff"))
+
+
+def _kind_label(node: dict, kind: str | None) -> str:
     if kind == "flight_udxf":
         cls = node.get("udxf_class", "udxf")
         n_in = len(node.get("schema_in_observed") or {})
         n_out = len(node.get("schema_out") or {})
-        diff = _schema_diff_suffix(node.get("schema_diff"))
-        return f"UDXF[{cls}] : {n_in}→{n_out} cols{diff}"
+        return f"UDXF[{cls}] : {n_in}→{n_out} cols"
     if kind == "flight_expr":
         n_in = len(node.get("input_schema") or {})
         n_out = len(node.get("output_schema") or {})

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -16,6 +16,7 @@ from xorq.common.utils.content_hash import content_hash
 from xorq.common.utils.dasher import tokenize
 from xorq.common.utils.graph_utils import (
     bfs,
+    find_all_sources,
     gen_children_flight_leaf,
     gen_children_of,
     to_node,
@@ -26,10 +27,12 @@ from xorq.vendor.ibis.expr.operations.core import Node
 __all__ = [
     "CAPABILITY_REGISTRY",
     "LineageDAG",
+    "base_kind",
     "build_column_trees",
     "build_tree",
     "extract_lineage_dag",
     "format_compact_lineage",
+    "schema_diff",
 ]
 
 
@@ -114,7 +117,12 @@ def _(node: ops.JoinChain) -> str:
 
 @_boundary_kind.register
 def _(node: rel.HashingTag) -> str:
-    return "tag"
+    # Taxonomy: a catalog tag qualifies its kind with the tag value
+    # (``tag:catalog-source``). ``base_kind`` strips the qualifier for registry
+    # lookups and kind queries.
+    metadata = getattr(node, "metadata", None) or {}
+    tag = metadata.get("tag")
+    return f"tag:{tag}" if tag else "tag"
 
 
 @_boundary_kind.register
@@ -123,10 +131,185 @@ def _(node: rel.Tag) -> str:
     return "tag"
 
 
+def base_kind(kind: str | None) -> str | None:
+    """Taxonomy kind without its qualifier (``tag:catalog-source`` -> ``tag``)."""
+    return None if kind is None else kind.split(":", 1)[0]
+
+
 def _schema_dict(schema: Any) -> dict[str, str] | None:
     if schema is None:
         return None
     return {k: str(v) for k, v in schema.items()}
+
+
+_SECRET_HINTS = ("password", "passwd", "secret", "token", "credential", "api_key")
+
+
+def _redact(key: str, value: Any) -> Any:
+    """Drop credential-looking read kwargs; strip userinfo from URI values.
+
+    A ``Read``'s kwargs are stored verbatim in the sidecar, which is committed
+    next to the build -- a ``postgres://user:pw@host/db`` uri must not travel
+    with it.
+    """
+    if any(hint in key.lower() for hint in _SECRET_HINTS):
+        return "***"
+    if isinstance(value, str) and "://" in value:
+        scheme, _, rest = value.partition("://")
+        if "@" in rest:
+            return f"{scheme}://***@{rest.rpartition('@')[2]}"
+    return value
+
+
+_READ_PATH_KEYS = (
+    "path",
+    "hash_path",
+    "paths",
+    "source",
+    "source_list",
+    "uri",
+    "file",
+    "glob",
+)
+
+
+def _read_path_or_uri(kwargs: Mapping[str, Any]) -> Any:
+    for key in _READ_PATH_KEYS:
+        if (value := kwargs.get(key)) is not None:
+            return _redact(key, _to_jsonable(value))
+    return None
+
+
+def _read_format(method_name: str | None) -> str | None:
+    """``read_parquet`` -> ``parquet`` (the source kind for non-file readers)."""
+    if not method_name:
+        return None
+    return method_name.removeprefix("deferred_").removeprefix("read_") or None
+
+
+def _namespace_extras(node: Node) -> dict[str, Any]:
+    namespace = getattr(node, "namespace", None)
+    return {
+        "database": getattr(namespace, "database", None),
+        "catalog": getattr(namespace, "catalog", None),
+    }
+
+
+_PREDICATE_SYMBOLS = {
+    "Equals": "==",
+    "NotEquals": "!=",
+    "Less": "<",
+    "LessEqual": "<=",
+    "Greater": ">",
+    "GreaterEqual": ">=",
+}
+
+
+def _predicate_ref(value: Any) -> str:
+    """Column name for a field reference, op type name for anything else.
+
+    Deliberately never renders a literal's *value*: the summary is for display
+    and the sidecar is committed.
+    """
+    if isinstance(value, ops.Field):
+        return value.name
+    return type(value).__name__
+
+
+def _predicate_summary(node: ops.JoinChain) -> str | None:
+    parts = []
+    for link in getattr(node, "rest", ()) or ():
+        how = getattr(link, "how", "join")
+        refs = ", ".join(
+            f"{_predicate_ref(getattr(pred, 'left', pred))} "
+            f"{_PREDICATE_SYMBOLS.get(type(pred).__name__, type(pred).__name__)} "
+            f"{_predicate_ref(getattr(pred, 'right', pred))}"
+            if hasattr(pred, "left")
+            else type(pred).__name__
+            for pred in getattr(link, "predicates", ()) or ()
+        )
+        parts.append(f"{how}: {refs}" if refs else str(how))
+    return "; ".join(parts) or None
+
+
+def _udf_signature(node: Node) -> str | None:
+    dtypes = tuple(
+        str(getattr(getattr(node, name, None), "dtype", "?"))
+        for name in getattr(node, "__argnames__", ())
+    )
+    out = getattr(node, "dtype", None)
+    if not dtypes or out is None:
+        return None
+    return f"inputs: [{', '.join(dtypes)}] -> output: {out}"
+
+
+def schema_diff(
+    before: Mapping[str, str] | None, after: Mapping[str, str] | None
+) -> dict[str, Any] | None:
+    """Column-level delta between two ``{col: type}`` schemas.
+
+    Computed at extraction time and stored in the sidecar (rather than
+    recomputed per TUI open) so external readers get the transition for free.
+    A rename is only inferred when exactly one column was dropped and one added
+    *and* they share a dtype that is unique to the pair -- anything more
+    ambiguous stays reported as an add plus a drop.
+    """
+    if not before or not after:
+        return None
+    added = {k: v for k, v in after.items() if k not in before}
+    removed = {k: before[k] for k in before if k not in after}
+    retyped = {
+        k: [before[k], after[k]] for k in before if k in after and before[k] != after[k]
+    }
+    renamed: dict[str, str] = {}
+    if len(added) == 1 and len(removed) == 1:
+        ((new_col, new_type),) = added.items()
+        ((old_col, old_type),) = removed.items()
+        if new_type == old_type:
+            renamed = {old_col: new_col}
+            added, removed = {}, {}
+    if not (added or removed or retyped or renamed):
+        return None
+    return {
+        "added": added,
+        "removed": sorted(removed),
+        "retyped": retyped,
+        "renamed": renamed,
+    }
+
+
+def _server_factory_label(make_server: Any) -> str | None:
+    """Name of the factory that builds the Flight server.
+
+    The callable itself is never serialized and never *called* (that would start
+    a server); only its name travels. No attempt is made to infer a flavour
+    (``mtls``/``plain``) from that name: the defaults are a bare ``FlightServer``
+    class for ``FlightExpr`` and a ``make_mtls_server`` closure for
+    ``FlightUDXF``, so name-sniffing yields a class name as often as a flavour.
+    """
+    if make_server is None:
+        return None
+    return getattr(make_server, "__name__", None) or type(make_server).__name__
+
+
+def _flight_command(node: rel.FlightExpr) -> str | None:
+    """The command string the FlightExpr client sends on the wire.
+
+    ``FlightExpr.to_rbr`` registers an ``UnboundExprExchanger`` over
+    ``unbound_expr`` and exchanges on *its* ``command``, so the exchanger is the
+    only authority for the value -- recomputing the format string here would rot
+    silently. Constructing one is pure (walk + rename + tokenize, no server, no
+    connection); a failure degrades to no field rather than breaking extraction.
+    """
+    unbound_expr = getattr(node, "unbound_expr", None)
+    if unbound_expr is None:
+        return None
+    from xorq.flight.exchanger import UnboundExprExchanger  # noqa: PLC0415
+
+    try:
+        return UnboundExprExchanger(unbound_expr).command
+    except Exception:
+        return None
 
 
 @singledispatch
@@ -135,61 +318,117 @@ def _boundary_extras(node: Node) -> dict[str, Any]:
     return {}
 
 
+def _cache_extras(cache: Any) -> dict[str, Any]:
+    """Where a cache writes and how it keys, without touching the filesystem.
+
+    ``cache_path`` is the storage's *relative* path only. The resolved directory
+    is ``base_path / relative_path`` with ``base_path`` defaulting to the user's
+    cache dir -- an absolute, per-machine path that must not travel in a sidecar
+    committed next to the build. The per-entry parquet path is deliberately not
+    derived either: it needs ``cache.calc_key(expr)``, which stats the source
+    data under ``ModificationTimeStrategy``. Storages with no path
+    (``SourceStorage``) get none; their location is the ``backend``.
+    """
+    if cache is None:
+        return {}
+    storage = getattr(cache, "storage", None)
+    strategy = getattr(cache, "strategy", None)
+    relative_path = getattr(storage, "relative_path", None)
+    return {
+        "cache_kind": type(cache).__name__,
+        "cache_path": None if relative_path is None else str(relative_path),
+        "cache_key_prefix": getattr(strategy, "key_prefix", None),
+    }
+
+
 @_boundary_extras.register
 def _(node: rel.CachedNode) -> dict[str, Any]:
-    cache = getattr(node, "cache", None)
-    extras: dict[str, Any] = {"backend": _backend_label(node)}
-    if cache is not None:
-        extras["cache_kind"] = type(cache).__name__
-    return extras
+    return {"backend": _backend_label(node), **_cache_extras(node.cache)}
 
 
 @_boundary_extras.register
 def _(node: rel.CacheTag) -> dict[str, Any]:
     # A pin's identity is its cache key: the frozen read's table name.
-    cache = getattr(node, "cache", None)
     return {
         "backend": _backend_label(node),
         "cache_key": getattr(node.parent, "name", None),
-        "cache_kind": None if cache is None else type(cache).__name__,
+        **_cache_extras(getattr(node, "cache", None)),
     }
+
+
+def _source_backend(remote_expr: Any) -> str | None:
+    """Backend the data came from, for the visual ``duckdb → xorq`` hop.
+
+    ``remote_expr``'s *root* op usually has no ``source`` of its own (it is a
+    ``Project``/``Filter``), so the origin has to be resolved by walking to the
+    leaves. A multi-source input has no single origin to name: report none rather
+    than picking one arbitrarily.
+    """
+    if remote_expr is None:
+        return None
+    sources = find_all_sources(remote_expr, execution_only=True)
+    if len(sources) != 1:
+        return None
+    (source,) = sources
+    return getattr(source, "name", type(source).__name__)
 
 
 @_boundary_extras.register
 def _(node: rel.RemoteTable) -> dict[str, Any]:
-    return {"backend": _backend_label(node)}
+    # The crossing has two ends: ``source`` is where the data lands,
+    # ``remote_expr``'s backend is where it came from.
+    return {
+        "backend": _backend_label(node),
+        "remote_name": getattr(node, "name", None),
+        "source_backend": _source_backend(getattr(node, "remote_expr", None)),
+    }
 
 
 @_boundary_extras.register
 def _(node: rel.Read) -> dict[str, Any]:
-    kwargs = getattr(node, "read_kwargs", None)
+    kwargs = dict(getattr(node, "read_kwargs", None) or ())
+    method_name = getattr(node, "method_name", None)
     extras: dict[str, Any] = {
         "backend": _backend_label(node),
-        "read_kind": getattr(node, "method_name", None),
+        "read_kind": method_name,
+        "format": _read_format(method_name),
+        "path_or_uri": _read_path_or_uri(kwargs),
     }
     if kwargs:
-        extras["read_kwargs"] = _to_jsonable(dict(kwargs))
+        extras["read_kwargs"] = {
+            str(k): _redact(str(k), v) for k, v in _to_jsonable(kwargs).items()
+        }
     return extras
 
 
 @_boundary_extras.register
 def _(node: ops.DatabaseTable) -> dict[str, Any]:
-    return {"backend": _backend_label(node), "table_name": getattr(node, "name", None)}
+    return {
+        "backend": _backend_label(node),
+        "table_name": getattr(node, "name", None),
+        **_namespace_extras(node),
+    }
 
 
 @_boundary_extras.register
 def _(node: ops.UnboundTable) -> dict[str, Any]:
-    return {"table_name": getattr(node, "name", None)}
+    return {"table_name": getattr(node, "name", None), **_namespace_extras(node)}
 
 
 @_boundary_extras.register
 def _(node: ops.JoinChain) -> dict[str, Any]:
-    return {"n_inputs": 1 + len(getattr(node, "rest", ()) or ())}
+    return {
+        "n_inputs": 1 + len(getattr(node, "rest", ()) or ()),
+        "predicates_summary": _predicate_summary(node),
+    }
 
 
 @_boundary_extras.register
 def _(node: udf.ExprScalarUDF) -> dict[str, Any]:
-    return {"udf_name": type(node).__name__}
+    return {
+        "udf_name": getattr(node, "__func_name__", None) or type(node).__name__,
+        "udf_signature": _udf_signature(node),
+    }
 
 
 @_boundary_extras.register
@@ -197,12 +436,19 @@ def _(node: rel.FlightUDXF) -> dict[str, Any]:
     udxf = getattr(node, "udxf", None)
     input_expr = getattr(node, "input_expr", None)
     schema_in = input_expr.schema() if input_expr is not None else None
+    schema_in_observed = _schema_dict(schema_in)
+    schema_out = _schema_dict(getattr(node, "schema", None))
     return {
         "process_boundary": True,
         "udxf_class": getattr(udxf, "__name__", type(udxf).__name__ if udxf else None),
         "udxf_command": getattr(udxf, "command", None),
-        "schema_in_observed": _schema_dict(schema_in),
-        "schema_out": _schema_dict(getattr(node, "schema", None)),
+        "server_factory": _server_factory_label(getattr(node, "make_server", None)),
+        "schema_in_required": _schema_dict(getattr(udxf, "schema_in_required", None)),
+        "schema_in_observed": schema_in_observed,
+        "schema_out": schema_out,
+        # The UDXF is the one boundary where the schema actually changes; store
+        # the delta so readers (TUI, audit tools) do not recompute it.
+        "schema_diff": schema_diff(schema_in_observed, schema_out),
         "do_instrument_reader": getattr(node, "do_instrument_reader", None),
     }
 
@@ -214,7 +460,8 @@ def _(node: rel.FlightExpr) -> dict[str, Any]:
     make_server = getattr(node, "make_server", None)
     return {
         "process_boundary": True,
-        "server_factory": getattr(make_server, "__name__", None),
+        "server_factory": _server_factory_label(make_server),
+        "flight_command": _flight_command(node),
         "input_schema": _schema_dict(schema_in),
         "output_schema": _schema_dict(getattr(node, "schema", None)),
         "do_instrument_reader": getattr(node, "do_instrument_reader", None),
@@ -228,16 +475,22 @@ def _(node: rel.FlightExpr) -> dict[str, Any]:
 # Nothing here is stored per node.
 CAPABILITY_REGISTRY: dict[str, tuple[str, ...]] = {
     "ingestion": ("schema",),
-    "cache": ("schema",),
-    "pin": ("schema", "tag_metadata"),
+    "cache": ("schema", "cache_path"),
+    "pin": ("schema", "tag_metadata", "cache_key"),
     "engine_crossing": ("schema",),
     "table": ("schema",),
     "unbound": ("schema",),
     "join": ("schema",),
     "udf": ("schema",),
     "tag": ("tag_metadata",),
-    "flight_udxf": ("schema_in_observed", "schema_out", "nested"),
-    "flight_expr": ("input_schema", "output_schema", "nested"),
+    "flight_udxf": (
+        "schema_in_required",
+        "schema_in_observed",
+        "schema_out",
+        "schema_diff",
+        "nested",
+    ),
+    "flight_expr": ("input_schema", "output_schema", "flight_command", "nested"),
 }
 
 _FLIGHT_TYPES = (rel.FlightExpr, rel.FlightUDXF)
@@ -475,7 +728,8 @@ class LineageDAG:
         matches = tuple(
             n
             for n in self.nodes
-            if n.get("snapshot_hash") == handle or n.get("boundary_kind") == handle
+            if n.get("snapshot_hash") == handle
+            or handle in (n.get("boundary_kind"), base_kind(n.get("boundary_kind")))
         )
         if matches:
             return matches
@@ -487,15 +741,24 @@ class LineageDAG:
         )
 
     def boundaries(self, kind: str | None = None) -> tuple[dict, ...]:
+        """Boundary nodes, optionally of one *kind*.
+
+        A qualified kind matches on either form: ``kind="tag"`` selects
+        ``tag:catalog-source`` too, ``kind="tag:catalog-source"`` only that one.
+        """
         return tuple(
             n
             for n in self.nodes
-            if n.get("is_boundary") and (kind is None or n.get("boundary_kind") == kind)
+            if n.get("is_boundary")
+            and (
+                kind is None
+                or kind in (n.get("boundary_kind"), base_kind(n.get("boundary_kind")))
+            )
         )
 
     def capabilities(self, node: dict) -> tuple[str, ...]:
         """What dimensions this node's kind *can* expose (code registry)."""
-        return CAPABILITY_REGISTRY.get(node.get("boundary_kind"), ())
+        return CAPABILITY_REGISTRY.get(base_kind(node.get("boundary_kind")), ())
 
     def available(self, node: dict) -> tuple[str, ...]:
         """What overlay dimensions actually reference this node (present)."""
@@ -841,14 +1104,34 @@ def build_tree(
 # ── compact-view rendering (TUI) ───────────────────────────────────────
 
 
+def _schema_diff_suffix(diff: Mapping[str, Any] | None) -> str:
+    """One-line column delta: ``(+score, -raw, b→c, a: int64→float64)``."""
+    if not diff:
+        return ""
+    parts = (
+        [f"+{col}" for col in diff.get("added") or ()]
+        + [f"-{col}" for col in diff.get("removed") or ()]
+        + [f"{old}→{new}" for old, new in (diff.get("renamed") or {}).items()]
+        + [
+            f"{col}: {before}→{after}"
+            for col, (before, after) in (diff.get("retyped") or {}).items()
+        ]
+    )
+    if not parts:
+        return ""
+    shown = ", ".join(parts[:3]) + ("…" if len(parts) > 3 else "")
+    return f"   ({shown})"
+
+
 def _compact_node_label(node: dict) -> str:
     """Per-kind one-line label for a boundary node in the compact view."""
-    kind = node.get("boundary_kind")
+    kind = base_kind(node.get("boundary_kind"))
     if kind == "flight_udxf":
         cls = node.get("udxf_class", "udxf")
         n_in = len(node.get("schema_in_observed") or {})
         n_out = len(node.get("schema_out") or {})
-        return f"UDXF[{cls}] : {n_in}→{n_out} cols"
+        diff = _schema_diff_suffix(node.get("schema_diff"))
+        return f"UDXF[{cls}] : {n_in}→{n_out} cols{diff}"
     if kind == "flight_expr":
         n_in = len(node.get("input_schema") or {})
         n_out = len(node.get("output_schema") or {})
@@ -859,7 +1142,13 @@ def _compact_node_label(node: dict) -> str:
         key = node.get("cache_key") or ""
         return f"Pin[{key[:8]}]" if key else "Pin"
     if kind == "engine_crossing":
-        return f"→ {node.get('backend', '?')}"
+        target = node.get("backend", "?")
+        source = node.get("source_backend")
+        # A same-backend crossing (into_backend onto its own source) has no hop
+        # to show; rendering "duckdb → duckdb" would be noise.
+        if source and source != target:
+            return f"RemoteTable[{source} → {target}]"
+        return f"→ {target}"
     if kind == "ingestion":
         backend = node.get("backend")
         return f"Read[{backend}]" if backend else "Read"

--- a/python/xorq/common/utils/tests/test_graph_utils.py
+++ b/python/xorq/common/utils/tests/test_graph_utils.py
@@ -15,8 +15,8 @@ from xorq.caching import SourceCache
 from xorq.common.utils.graph_utils import (
     OPAQUE_EDGES,
     OpaqueSpec,
-    _gen_children_flight_leaf,
     find_all_sources,
+    gen_children_flight_leaf,
     gen_children_of,
     opaque_ops,
     walk_nodes,
@@ -195,9 +195,9 @@ def test_gen_children_flight_leaf_treats_flight_as_leaf() -> None:
     expr = make_flight_expr()
     node = expr.op()
     assert tuple(gen_children_of(node)) == (node.input_expr.op(),)
-    assert _gen_children_flight_leaf(node) == ()
+    assert gen_children_flight_leaf(node) == ()
     # the outer graph no longer reaches the input_expr's leaves
     assert walk_nodes(ops.DatabaseTable, node)
     assert walk_nodes(
-        (ops.DatabaseTable,), node, gen_children=_gen_children_flight_leaf
+        (ops.DatabaseTable,), node, gen_children=gen_children_flight_leaf
     ) == (node,)

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -23,6 +23,7 @@ from xorq.common.utils.lineage_utils import (
     base_kind,
     build_column_trees,
     build_tree,
+    compact_lineage_rows,
     extract_lineage_dag,
     format_compact_lineage,
     schema_diff,
@@ -1116,6 +1117,66 @@ def test_new_boundary_fields_round_trip(
         for name in fields:
             assert after[name] == before[name]
             assert after[name] is not None
+
+
+def test_scope_of_a_single_node_nested_lineage_keeps_its_root() -> None:
+    """A Flight whose input is a bare table has a nested lineage of one node and
+    zero edges: deriving the scope's ids from edges alone dropped that node while
+    `root` still pointed at it."""
+    con = xo.connect()
+    table = con.create_table(
+        "t_bare", xo.memtable({"a": [1, 2]}, name="src").to_pyarrow()
+    )
+
+    dag = extract_lineage_dag(_udxf(table, con, "add_c"))
+    [udxf] = dag.boundaries(kind="flight_udxf")
+    nested = dag.scope(udxf["id"])
+
+    assert nested["edges"] == ()
+    assert nested["root"] == udxf["nested_root"]
+    assert [n["id"] for n in nested["nodes"]] == [nested["root"]]
+    # and the derived compact view agrees with the raw scope view
+    assert {n["id"] for n in dag.compact(scope=udxf["id"])["nodes"]} == {nested["root"]}
+
+
+def test_compact_lineage_rows_split_glyphs_label_kind_and_via(
+    udxf_expression: Expr,
+) -> None:
+    """The rows carry each piece separately so a renderer can style them; their
+    concatenation is exactly the plain-text tree."""
+    dag = extract_lineage_dag(udxf_expression)
+    rows = compact_lineage_rows(dag)
+
+    assert "\n".join(row.text for row in rows) == format_compact_lineage(dag)
+    assert rows[0].prefix == "" and rows[0].via == ()
+    assert all(set(row.prefix) <= set("│├└─ ") for row in rows)
+    assert all("via [" not in row.label for row in rows)
+
+    [udxf_row] = [r for r in rows if r.kind == "flight_udxf"]
+    assert udxf_row.label.startswith("UDXF[add_c]")
+    # every kind on a row is a base kind, ready for a style lookup; a
+    # non-boundary root (Sort here) carries None
+    assert all(row.kind == base_kind(row.kind) for row in rows)
+    assert rows[0].kind is None
+
+
+def test_compact_lineage_rows_carry_via_off_the_label(
+    multi_join_expression: Expr,
+) -> None:
+    """A collapsed run is a row field, not text baked into the label, so a
+    renderer can dim it separately."""
+    rows = compact_lineage_rows(extract_lineage_dag(multi_join_expression))
+
+    via_rows = [r for r in rows if r.via]
+    assert via_rows
+    for row in via_rows:
+        assert all(isinstance(t, str) for t in row.via)
+        assert row.via_suffix.startswith("   via [")
+        assert row.text == row.prefix + row.label + row.via_suffix
+
+
+def test_compact_lineage_rows_of_an_empty_dag() -> None:
+    assert compact_lineage_rows(LineageDAG(nodes=(), edges=(), root="")) == ()
 
 
 def test_compact_of_unknown_scope_is_empty() -> None:

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -10,7 +10,7 @@ from attrs import evolve as attr_evolve
 import xorq.api as xo
 import xorq.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.caching import ParquetCache
+from xorq.caching import ParquetCache, SourceCache
 from xorq.common.utils.graph_utils import gen_children_of, opaque_ops, to_node
 from xorq.common.utils.lineage_utils import (
     ROOT_SCOPE,
@@ -19,15 +19,20 @@ from xorq.common.utils.lineage_utils import (
     TextTree,
     _boundary_kind,
     _build_column_tree,
+    _redact,
+    base_kind,
     build_column_trees,
     build_tree,
     extract_lineage_dag,
     format_compact_lineage,
+    schema_diff,
 )
+from xorq.expr.udf import make_pandas_expr_udf
+from xorq.flight.exchanger import UnboundExprExchanger
 from xorq.ibis_yaml.compiler import build_expr, load_expr
 from xorq.vendor.ibis.expr.operations.core import Node
 from xorq.vendor.ibis.expr.operations.reductions import Sum
-from xorq.vendor.ibis.expr.types.core import ExprMetadata
+from xorq.vendor.ibis.expr.types.core import Expr, ExprMetadata
 
 
 @xo.udf.make_pandas_udf(
@@ -811,7 +816,309 @@ def test_cache_and_pin_boundaries(tmp_path, parquet_dir):
     assert "Pin[" in format_compact_lineage(pinned_dag)
 
 
-def test_compact_of_unknown_scope_is_empty():
+# ── per-kind boundary facts (XOR-363 ticket field table) ───────────────
+
+
+def test_hashing_tag_kind_is_qualified_by_tag_value() -> None:
+    """``tag:<value>`` per the taxonomy; ``base_kind`` strips the qualifier so
+    registry lookups and kind queries keep working."""
+    tagged = xo.memtable({"x": [1]}, name="sales").hashing_tag(tag="catalog-source")
+
+    dag = extract_lineage_dag(tagged)
+    [tag_node] = [n for n in dag.nodes if n["type"] == "HashingTag"]
+
+    assert tag_node["boundary_kind"] == "tag:catalog-source"
+    assert base_kind(tag_node["boundary_kind"]) == "tag"
+    assert dag.capabilities(tag_node) == ("tag_metadata",)
+    # both the qualified and the base form select it
+    assert dag.boundaries(kind="tag:catalog-source") == (tag_node,)
+    assert tag_node in dag.boundaries(kind="tag")
+    assert dag.resolve("tag") == (tag_node,)
+    assert "Tag[catalog-source]" in format_compact_lineage(dag)
+
+
+def test_plain_tag_kind_is_unqualified() -> None:
+    tagged = xo.memtable({"x": [1]}, name="sales").tag(tag="bsl")
+
+    dag = extract_lineage_dag(tagged)
+    [tag_node] = [n for n in dag.nodes if n["type"] == "Tag"]
+
+    assert tag_node["boundary_kind"] == "tag"
+    assert base_kind("tag") == "tag"
+    assert base_kind(None) is None
+
+
+def test_ingestion_carries_format_and_path(parquet_dir: Path) -> None:
+    con = xo.connect()
+    path = parquet_dir / "awards_players.parquet"
+    expr = xo.deferred_read_parquet(path, con=con)
+
+    dag = extract_lineage_dag(expr)
+    [read] = dag.boundaries(kind="ingestion")
+
+    assert read["format"] == "parquet"
+    assert read["read_kind"] == "read_parquet"
+    assert str(path) in str(read["path_or_uri"])
+    assert read["backend"]
+
+
+def test_read_kwargs_are_redacted() -> None:
+    """The sidecar is committed next to the build: credentials must not travel."""
+    assert _redact("password", "hunter2") == "***"
+    assert _redact("aws_secret_key", "abc") == "***"
+    assert _redact("API_KEY", "abc") == "***"
+    assert _redact("uri", "postgres://user:pw@host:5432/db") == (
+        "postgres://***@host:5432/db"
+    )
+    # non-credential values pass through untouched
+    assert _redact("path", "/data/x.parquet") == "/data/x.parquet"
+    assert _redact("uri", "s3://bucket/key.parquet") == "s3://bucket/key.parquet"
+    assert _redact("n_rows", 10) == 10
+
+
+def test_table_boundary_carries_namespace() -> None:
+    """A namespaced backend (duckdb) fills database/catalog; a backend whose
+    Namespace is empty (xorq) simply omits them."""
+    con = xo.duckdb.connect()
+    table = con.create_table("t_ns", xo.memtable({"a": [1]}, name="src").to_pyarrow())
+
+    dag = extract_lineage_dag(table)
+    [node] = dag.boundaries(kind="table")
+
+    assert node["table_name"] == "t_ns"
+    assert node["database"] == table.op().namespace.database
+    assert node["catalog"] == table.op().namespace.catalog
+    assert f"{node['backend']}:t_ns" in format_compact_lineage(dag)
+
+    xorq_table = xo.connect().create_table(
+        "t_no_ns", xo.memtable({"a": [1]}, name="src").to_pyarrow()
+    )
+    [plain] = extract_lineage_dag(xorq_table).boundaries(kind="table")
+    assert plain["table_name"] == "t_no_ns"
+    assert "database" not in plain and "catalog" not in plain
+
+
+def test_udf_boundary_carries_name_and_signature() -> None:
+    base = xo.memtable({"a": [1.0, 2.0]}, name="base")
+    scaled = make_pandas_expr_udf(
+        computed_kwargs_expr=base.a.sum(),
+        fn=lambda computed, df: df.a * computed,
+        schema=xo.schema({"a": "float64"}),
+        return_type=dt.float64,
+        name="scaled",
+        post_process_fn=lambda x: x,
+    )
+
+    dag = extract_lineage_dag(base.mutate(out=scaled.on_expr(base)))
+    [udf_node] = dag.boundaries(kind="udf")
+
+    assert udf_node["udf_name"] == "scaled"
+    assert udf_node["udf_signature"] == "inputs: [float64] -> output: float64"
+    assert "UDF[scaled]" in format_compact_lineage(dag)
+
+
+def test_join_boundary_summarises_predicates(multi_join_expression: Expr) -> None:
+    dag = extract_lineage_dag(multi_join_expression)
+    joins = dag.boundaries(kind="join")
+
+    assert joins
+    for join in joins:
+        assert join["n_inputs"] >= 2
+        summary = join["predicates_summary"]
+        assert summary
+        # column refs and operators only -- never a literal's value
+        assert "==" in summary
+        assert "Literal" not in summary
+
+
+def test_engine_crossing_carries_both_ends() -> None:
+    """The hop needs both ends: source is where the data lands, source_backend
+    where it came from."""
+    duck = xo.duckdb.connect()
+    con = xo.connect()
+    remote = duck.create_table("t_x", xo.memtable({"a": [1]}, name="src").to_pyarrow())
+
+    dag = extract_lineage_dag(remote.into_backend(con, "crossed"))
+    [crossing] = dag.boundaries(kind="engine_crossing")
+
+    assert crossing["remote_name"] == "crossed"
+    assert crossing["source_backend"] == duck.name
+    assert crossing["backend"] == con.name
+    assert f"RemoteTable[{duck.name} → {con.name}]" in format_compact_lineage(dag)
+
+
+def test_engine_crossing_without_a_resolvable_origin_omits_it(
+    multi_join_expression: Expr,
+) -> None:
+    """A crossing whose input bottoms out in a memtable has no origin backend to
+    name; the field is omitted rather than guessed."""
+    dag = extract_lineage_dag(multi_join_expression)
+    crossings = dag.boundaries(kind="engine_crossing")
+
+    assert crossings
+    for crossing in crossings:
+        assert crossing["remote_name"]
+        assert crossing["backend"]
+        assert "source_backend" not in crossing
+    assert "RemoteTable[" not in format_compact_lineage(dag)
+
+
+def test_engine_crossing_label_omits_a_same_backend_hop() -> None:
+    """into_backend onto the expression's own backend has no hop to render."""
+    con = xo.connect()
+    t = con.create_table("t_same", xo.memtable({"a": [1]}, name="src").to_pyarrow())
+    dag = extract_lineage_dag(t.into_backend(con, "same"))
+    [crossing] = dag.boundaries(kind="engine_crossing")
+
+    assert crossing["source_backend"] == crossing["backend"]
+    text = format_compact_lineage(dag)
+    assert "RemoteTable[" not in text
+    assert f"→ {crossing['backend']}" in text
+
+
+def test_flight_udxf_carries_required_schema_and_server_factory(
+    udxf_expression: Expr,
+) -> None:
+    dag = extract_lineage_dag(udxf_expression)
+    [node] = dag.boundaries(kind="flight_udxf")
+
+    assert set(node["schema_in_required"]) == {"a", "b"}
+    assert node["server_factory"]
+    assert node["udxf_command"]
+    assert "schema_in_required" in dag.capabilities(node)
+
+
+def test_flight_udxf_stores_the_schema_diff(udxf_expression: Expr) -> None:
+    """Open question #3 resolved in favour of the sidecar: the transition is
+    stored, so external readers do not recompute it."""
+    dag = extract_lineage_dag(udxf_expression)
+    [node] = dag.boundaries(kind="flight_udxf")
+
+    assert node["schema_diff"] == {
+        "added": {"c": "int64"},
+        "removed": [],
+        "retyped": {},
+        "renamed": {},
+    }
+    assert "(+c)" in format_compact_lineage(dag)
+
+
+def test_schema_diff_reports_adds_drops_retypes_and_renames() -> None:
+    assert schema_diff({"a": "int64"}, {"a": "int64", "b": "int64"}) == {
+        "added": {"b": "int64"},
+        "removed": [],
+        "retyped": {},
+        "renamed": {},
+    }
+    assert schema_diff({"a": "int64", "b": "int64"}, {"a": "int64"}) == {
+        "added": {},
+        "removed": ["b"],
+        "retyped": {},
+        "renamed": {},
+    }
+    assert schema_diff({"a": "int64"}, {"a": "float64"}) == {
+        "added": {},
+        "removed": [],
+        "retyped": {"a": ["int64", "float64"]},
+        "renamed": {},
+    }
+    # one drop + one add of the same dtype is the only rename we infer
+    assert schema_diff({"a": "int64"}, {"b": "int64"}) == {
+        "added": {},
+        "removed": [],
+        "retyped": {},
+        "renamed": {"a": "b"},
+    }
+    # ambiguous (two drops, two adds) stays reported as adds plus drops
+    ambiguous = schema_diff({"a": "int64", "b": "int64"}, {"c": "int64", "d": "int64"})
+    assert ambiguous["renamed"] == {}
+    assert set(ambiguous["added"]) == {"c", "d"}
+    assert ambiguous["removed"] == ["a", "b"]
+    # no delta, or nothing to compare against
+    assert schema_diff({"a": "int64"}, {"a": "int64"}) is None
+    assert schema_diff(None, {"a": "int64"}) is None
+    assert schema_diff({"a": "int64"}, None) is None
+
+
+def test_flight_expr_carries_the_wire_command(flight_expr_expression: Expr) -> None:
+    """``flight_command`` must be the command the client actually exchanges on:
+    the ``UnboundExprExchanger``'s, not a locally invented string."""
+    dag = extract_lineage_dag(flight_expr_expression)
+    [flight] = dag.boundaries(kind="flight_expr")
+
+    node = to_node(flight_expr_expression)
+    (flight_op,) = [
+        n for n in (node, *gen_children_of(node)) if type(n).__name__ == "FlightExpr"
+    ] or [None]
+    expected = UnboundExprExchanger(flight_op.unbound_expr).command
+
+    assert flight["flight_command"] == expected
+    assert flight["flight_command"].startswith("execute-unbound-expr-")
+    assert "flight_command" in dag.capabilities(flight)
+
+
+def test_cache_boundary_carries_portable_path_and_key_prefix(
+    tmp_path: Path, parquet_dir: Path
+) -> None:
+    """``cache_path`` is the storage's *relative* path: an absolute
+    ``base_path``-resolved path would leak the developer's home dir into a
+    committed sidecar and differ per machine."""
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con, relative_path="xorq-cache")
+    cached = (
+        xo.deferred_read_parquet(parquet_dir / "awards_players.parquet", con=con)
+        .filter(xo._.playerID == "bondto01")
+        .cache(cache=cache)
+    )
+
+    dag = extract_lineage_dag(cached)
+    [cache_node] = dag.boundaries(kind="cache")
+
+    assert cache_node["cache_path"] == "xorq-cache"
+    assert cache_node["cache_key_prefix"] == cache.strategy.key_prefix
+    assert "cache_path" in dag.capabilities(cache_node)
+    # the resolved cache dir (base_path / relative_path) must not travel
+    assert str(cache.storage.path) not in str(cache_node)
+    assert str(Path.home()) not in str(cache_node)
+
+
+def test_source_cache_has_no_path() -> None:
+    """A SourceCache lives in a backend, not on a path: its location is already
+    the ``backend`` field."""
+    con = xo.connect()
+    cache = SourceCache.from_kwargs(source=con)
+    cached = xo.memtable({"a": [1, 2]}, name="t_src").into_backend(con).cache(cache)
+
+    dag = extract_lineage_dag(cached)
+    [cache_node] = dag.boundaries(kind="cache")
+
+    assert "cache_path" not in cache_node
+    assert cache_node["cache_kind"] == "SourceCache"
+    assert cache_node["cache_key_prefix"] == cache.strategy.key_prefix
+    assert cache_node["backend"]
+
+
+def test_new_boundary_fields_round_trip(
+    udxf_expression: Expr, flight_expr_expression: Expr
+) -> None:
+    for expr, kind, fields in (
+        (
+            udxf_expression,
+            "flight_udxf",
+            ("schema_in_required", "schema_diff", "server_factory"),
+        ),
+        (flight_expr_expression, "flight_expr", ("flight_command", "server_factory")),
+    ):
+        dag = extract_lineage_dag(expr)
+        restored = LineageDAG.from_dict(dag.to_dict())
+        [before] = dag.boundaries(kind=kind)
+        [after] = restored.boundaries(kind=kind)
+        for name in fields:
+            assert after[name] == before[name]
+            assert after[name] is not None
+
+
+def test_compact_of_unknown_scope_is_empty() -> None:
     """A scope with no recorded nested_root degrades to an empty view."""
     dag = LineageDAG.from_dict(
         {"nodes": [{"id": "0", "type": "Filter"}], "edges": [], "root": "0"}

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -1119,6 +1119,79 @@ def test_new_boundary_fields_round_trip(
             assert after[name] is not None
 
 
+def test_labels_carry_column_counts_and_a_backend_tag() -> None:
+    """`<what> (<n> cols) [<backend>]`, per the ticket's target render. Kinds that
+    already name the backend (`duckdb:orders`, `Read[..]`, `RemoteTable[a → b]`)
+    do not repeat it; Flight kinds show their transition instead of one width."""
+    duck = xo.duckdb.connect()
+    con = xo.connect()
+    customers = duck.create_table(
+        "raw_customers",
+        xo.memtable({"id": [1], "name": ["a"]}, name="c_src").to_pyarrow(),
+    )
+    orders = con.create_table(
+        "raw_orders",
+        xo.memtable({"id": [1], "amount": [1.0]}, name="o_src").to_pyarrow(),
+    )
+    enriched = _udxf(orders, con, "OrderEnricher", extra_col="score")
+    expr = customers.into_backend(con, "customers_in").join(enriched, "id")
+
+    text = format_compact_lineage(extract_lineage_dag(expr))
+
+    # 4 cols: the join keeps both `id` columns plus name and amount
+    assert f"Join(2 inputs) (4 cols) [{con.name}]" in text
+    assert f"UDXF[OrderEnricher] : 2→3 cols [{con.name}]   (+score)" in text
+    assert f"RemoteTable[{duck.name} → {con.name}] (2 cols)" in text
+    assert f"{duck.name}:raw_customers (2 cols)" in text
+    # the backend is named once per label, never twice
+    for line in text.splitlines():
+        assert line.count(con.name) <= 1 or "RemoteTable[" in line
+
+
+def test_join_backend_is_its_left_input_not_the_remote_source() -> None:
+    """Walking to the leaves would reach the *remote* side of an into_backend and
+    make a single-backend join look multi-backend."""
+    duck = xo.duckdb.connect()
+    con = xo.connect()
+    left = con.create_table(
+        "left_t", xo.memtable({"id": [1]}, name="l_src").to_pyarrow()
+    )
+    right = duck.create_table(
+        "right_t", xo.memtable({"id": [1]}, name="r_src").to_pyarrow()
+    )
+    expr = left.join(right.into_backend(con, "right_in"), "id")
+
+    dag = extract_lineage_dag(expr)
+    [join] = dag.boundaries(kind="join")
+
+    assert join["backend"] == con.name
+    assert {c["source_backend"] for c in dag.boundaries(kind="engine_crossing")} == {
+        duck.name
+    }
+
+
+def test_cache_and_pin_labels_carry_no_column_count_when_schema_is_absent() -> None:
+    """A node with no schema recorded (legacy sidecar) renders bare."""
+    legacy = LineageDAG.from_dict(
+        {
+            "nodes": [
+                {
+                    "id": "0",
+                    "type": "CachedNode",
+                    "label": "CachedNode",
+                    "is_boundary": True,
+                    "boundary_kind": "cache",
+                    "cache_kind": "ParquetCache",
+                }
+            ],
+            "edges": [],
+            "root": "0",
+        }
+    )
+
+    assert format_compact_lineage(legacy) == "Cache[ParquetCache]"
+
+
 def test_scope_of_a_single_node_nested_lineage_keeps_its_root() -> None:
     """A Flight whose input is a bare table has a nested lineage of one node and
     zero edges: deriving the scope's ids from edges alone dropped that node while

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import operator
 import tempfile
 from pathlib import Path
 
@@ -7,15 +10,19 @@ from attrs import evolve as attr_evolve
 import xorq.api as xo
 import xorq.expr.datatypes as dt
 import xorq.vendor.ibis.expr.operations as ops
-from xorq.common.utils.graph_utils import gen_children_of, to_node
+from xorq.caching import ParquetCache
+from xorq.common.utils.graph_utils import gen_children_of, opaque_ops, to_node
 from xorq.common.utils.lineage_utils import (
+    ROOT_SCOPE,
     GenericNode,
     LineageDAG,
     TextTree,
+    _boundary_kind,
     _build_column_tree,
     build_column_trees,
     build_tree,
     extract_lineage_dag,
+    format_compact_lineage,
 )
 from xorq.ibis_yaml.compiler import build_expr, load_expr
 from xorq.vendor.ibis.expr.operations.core import Node
@@ -403,13 +410,14 @@ def test_lineage_dag_relation_schema(sample_expression):
 
 
 def test_lineage_dag_edge_validity(sample_expression):
-    """Every edge (source, target) must reference existing node ids."""
+    """Every {from, to, scope} edge must reference existing node ids."""
     dag = extract_lineage_dag(sample_expression)
 
     node_ids = {n["id"] for n in dag.nodes}
-    for source, target in dag.edges:
-        assert source in node_ids, f"Edge source {source} not in node ids"
-        assert target in node_ids, f"Edge target {target} not in node ids"
+    for edge in dag.edges:
+        assert edge["from"] in node_ids, f"Edge source {edge['from']} not in node ids"
+        assert edge["to"] in node_ids, f"Edge target {edge['to']} not in node ids"
+        assert isinstance(edge["scope"], str)
 
 
 def test_lineage_dag_root_validity(sample_expression):
@@ -419,7 +427,7 @@ def test_lineage_dag_root_validity(sample_expression):
     node_ids = {n["id"] for n in dag.nodes}
     assert dag.root in node_ids, "Root id not found in nodes"
 
-    target_ids = {target for _, target in dag.edges}
+    target_ids = {edge["to"] for edge in dag.edges}
     assert dag.root not in target_ids, "Root node should not be targeted by any edge"
 
 
@@ -448,28 +456,57 @@ def test_lineage_dag_round_trip_via_expr_metadata(sample_expression):
     serialized = metadata.to_dict()
     assert "lineage" in serialized
     assert isinstance(serialized["lineage"], dict)
-    # Serialized edges should be lists (JSON-safe)
+    assert serialized["lineage"]["version"] == 2
+    # Serialized edges should be JSON-safe {from, to, scope} dicts
     assert isinstance(serialized["lineage"]["edges"], list)
-    assert isinstance(serialized["lineage"]["edges"][0], list)
+    assert set(serialized["lineage"]["edges"][0]) == {"from", "to", "scope"}
 
     restored = ExprMetadata.from_dict(serialized)
     assert isinstance(restored.lineage, LineageDAG)
-    assert restored.lineage.root == dag.root
-    assert len(restored.lineage.nodes) == len(dag.nodes)
-    assert len(restored.lineage.edges) == len(dag.edges)
-    # Restored edges should be tuples again
+    assert restored.lineage.to_dict() == dag.to_dict()
+    # Restored collections should be tuples again
+    assert isinstance(restored.lineage.nodes, tuple)
     assert isinstance(restored.lineage.edges, tuple)
-    assert isinstance(restored.lineage.edges[0], tuple)
 
 
 def test_lineage_dag_backward_compat_from_dict():
-    """LineageDAG.from_dict should convert JSON-deserialized lists back to tuples."""
-    json_lineage = {"nodes": [{"id": "1"}], "edges": [["a", "b"]], "root": "1"}
+    """A legacy sidecar (integer ids, 2-tuple edges, no version) still loads."""
+    json_lineage = {
+        "nodes": [{"id": "0", "type": "Filter", "label": "Filter"}, {"id": "1"}],
+        "edges": [["0", "1"]],
+        "root": "0",
+    }
     result = LineageDAG.from_dict(json_lineage)
+
     assert isinstance(result, LineageDAG)
     assert isinstance(result.nodes, tuple)
     assert isinstance(result.edges, tuple)
-    assert result.edges[0] == ("a", "b")
+    assert result.version == 1
+    assert result.overlays == {}
+    # 2-tuples are normalised to root-scoped structured edges
+    assert result.edges[0] == {"from": "0", "to": "1", "scope": ROOT_SCOPE}
+
+
+def test_legacy_lineage_compacts_and_renders():
+    """Legacy sidecars have no boundary annotation: they degrade to the root
+    node alone rather than raising."""
+    legacy = LineageDAG.from_dict(
+        {
+            "nodes": [
+                {"id": "0", "type": "Filter", "label": "Filter"},
+                {"id": "1", "type": "InMemoryTable", "label": "InMemoryTable"},
+            ],
+            "edges": [["0", "1"]],
+            "root": "0",
+        }
+    )
+
+    view = legacy.compact()
+    assert view["root"] == "0"
+    assert {n["id"] for n in view["nodes"]} == {"0"}
+    assert view["edges"] == ()
+    assert format_compact_lineage(legacy) == "Filter"
+    assert legacy.boundaries() == ()
 
 
 def test_lineage_dag_tag_metadata_preserves_structure():
@@ -502,3 +539,282 @@ def test_lineage_dag_tag_metadata_preserves_structure():
 
     assert isinstance(tm["measures"], list)
     assert [m[0] for m in tm["measures"]] == ["flight_count"]
+
+
+# ── boundary taxonomy / compact view (XOR-363) ─────────────────────────
+
+
+def _add_column(name, value=1):
+    return operator.methodcaller("assign", **{name: value})
+
+
+def _udxf(input_expr, con, name, extra_col="c"):
+    """A FlightUDXF over *input_expr* that appends one column.
+
+    Construction only -- no server is started, so this is safe in unit tests.
+    """
+    return xo.expr.relations.flight_udxf(
+        input_expr,
+        process_df=_add_column(extra_col),
+        maybe_schema_in=input_expr.schema(),
+        maybe_schema_out=xo.schema(input_expr.schema() | {extra_col: "int64"}),
+        con=con,
+        make_udxf_kwargs={"name": name},
+    )
+
+
+@pytest.fixture
+def udxf_expression():
+    """memtable -> into_backend -> filter -> FlightUDXF -> order_by."""
+    con = xo.connect()
+    t = xo.memtable({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, name="t")
+    inner = t.into_backend(con, "inner").filter(xo._.a > 1)
+    return _udxf(inner, con, "add_c").order_by("a")
+
+
+@pytest.fixture
+def flight_expr_expression():
+    """A FlightExpr running a filter+aggregate remotely over a joined input."""
+    con = xo.connect()
+    left = xo.memtable({"a": [1, 2], "b": [1.0, 2.0]}, name="left")
+    right = xo.memtable({"a": [1, 2], "c": ["x", "y"]}, name="right")
+    joined = left.join(right.into_backend(con, "right_in"), "a")
+    unbound = xo.table(joined.schema()).filter(xo._.a > 0)
+    return xo.expr.relations.flight_expr(joined, unbound, con=con)
+
+
+def test_boundary_kind_registered_for_every_opaque_op():
+    """Every opaque (descent-boundary) op type must map to a taxonomy kind, else
+    compact() would collapse a real boundary into a via run."""
+    registered = tuple(t for t in _boundary_kind.registry if t is not object)
+    for op_type in opaque_ops:
+        assert any(issubclass(op_type, t) for t in registered), (
+            f"{op_type.__name__} has no _boundary_kind registration"
+        )
+
+
+def test_boundaries_annotated_by_kind(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+
+    kinds = {n["boundary_kind"] for n in dag.boundaries()}
+    assert {"table", "engine_crossing", "flight_udxf"} <= kinds
+
+    for node in dag.nodes:
+        assert node["is_boundary"] == (node.get("boundary_kind") is not None)
+    for node in dag.boundaries():
+        assert dag.capabilities(node), f"no capabilities for {node['boundary_kind']}"
+
+
+def test_flight_udxf_node_carries_schema_transition(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+
+    [udxf] = dag.boundaries(kind="flight_udxf")
+    assert udxf["process_boundary"] is True
+    assert udxf["udxf_class"] == "add_c"
+    assert udxf["udxf_command"]
+    assert set(udxf["schema_in_observed"]) == {"a", "b"}
+    assert set(udxf["schema_out"]) == {"a", "b", "c"}
+
+
+def test_flight_input_expr_is_leaf_of_outer_walk(udxf_expression):
+    """The outer walk must NOT flatten input_expr: its nodes belong to the
+    Flight node's own scope only, or they would be double-counted."""
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    root_ids = {e["from"] for e in dag.edges if e["scope"] == ROOT_SCOPE} | {
+        e["to"] for e in dag.edges if e["scope"] == ROOT_SCOPE
+    }
+    nested = dag.scope(udxf["id"])
+    nested_ids = {n["id"] for n in nested["nodes"]}
+
+    assert nested_ids, "nested lineage should be populated"
+    assert udxf["id"] in root_ids
+    assert udxf["id"] not in nested_ids
+    # the Flight node is a leaf of the outer graph
+    assert not [
+        e for e in dag.edges if e["scope"] == ROOT_SCOPE and e["from"] == udxf["id"]
+    ]
+    # input_expr's own nodes live only under the nested scope
+    assert nested_ids.isdisjoint(root_ids)
+    assert nested["root"] == udxf["nested_root"]
+    assert nested["root"] in nested_ids
+
+
+def test_nested_lineage_nodes_share_the_one_node_table(udxf_expression):
+    """Storage model (a): nested nodes live in the shared table, deduped by
+    snapshot_hash -- scope() is a view, not a sub-document."""
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    ids = [n["id"] for n in dag.nodes]
+    hashes = [n["snapshot_hash"] for n in dag.nodes]
+    assert len(ids) == len(set(ids))
+    assert len(hashes) == len(set(hashes))
+    assert {n["id"] for n in dag.scope(udxf["id"])["nodes"]} <= set(ids)
+
+
+def test_nested_of_nested_terminates():
+    con = xo.connect()
+    t = xo.memtable({"a": [1, 2, 3]}, name="t")
+    inner = _udxf(t.into_backend(con, "inner"), con, "add_c", extra_col="c")
+    outer = _udxf(inner, con, "add_d", extra_col="d")
+
+    dag = extract_lineage_dag(outer)
+    udxfs = dag.boundaries(kind="flight_udxf")
+
+    assert len(udxfs) == 2
+    scopes = {e["scope"] for e in dag.edges}
+    assert scopes == {ROOT_SCOPE} | {u["id"] for u in udxfs}
+    for u in udxfs:
+        assert dag.scope(u["id"])["nodes"]
+
+
+def test_compact_keeps_boundaries_and_collects_via(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+    view = dag.compact()
+
+    kept = {n["id"] for n in view["nodes"]}
+    assert view["root"] == dag.root
+    assert view["root"] in kept
+    assert all(n["is_boundary"] or n["id"] == dag.root for n in view["nodes"]), (
+        "compact() must keep only boundaries (plus the root)"
+    )
+
+    # every compacted edge joins two kept nodes and records what it collapsed
+    for edge in view["edges"]:
+        assert edge["from"] in kept and edge["to"] in kept
+        assert isinstance(edge["via"], list)
+        assert all(isinstance(t, str) for t in edge["via"])
+
+    # a boundary reachable only through non-boundary ops is still connected
+    [udxf] = dag.boundaries(kind="flight_udxf")
+    assert any(e["to"] == udxf["id"] for e in view["edges"])
+
+
+def test_compact_of_flight_scope_is_rooted_in_the_nested_input(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    nested = dag.compact(scope=udxf["id"])
+
+    assert nested["scope"] == udxf["id"]
+    assert nested["root"] == udxf["nested_root"]
+    # the outer graph must not leak into the nested view
+    outer_only = {n["id"] for n in dag.compact()["nodes"]}
+    assert not ({n["id"] for n in nested["nodes"]} & outer_only)
+
+
+def test_format_compact_lineage_renders_udxf_and_nested_tree(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+    text = format_compact_lineage(dag)
+
+    assert "UDXF[add_c] : 2→3 cols" in text
+    # the nested input lineage hangs off the Flight node, marked with ↳
+    udxf_line = next(i for i, line in enumerate(text.splitlines()) if "UDXF[" in line)
+    nested_lines = text.splitlines()[udxf_line + 1 :]
+    assert nested_lines and any("↳" in line for line in nested_lines)
+    assert "InMemoryTable" in text
+
+
+def test_resolve_accepts_hash_label_kind_and_predicate(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    assert dag.resolve(udxf["id"]) == (udxf,)
+    assert dag.resolve(udxf["snapshot_hash"]) == (udxf,)
+    assert dag.resolve("flight_udxf") == (udxf,)
+    assert dag.resolve(lambda n: n["id"] == udxf["id"]) == (udxf,)
+    assert dag.resolve("nope") == ()
+
+
+def test_overlays_scaffold_is_empty_but_queryable(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    assert dag.overlays == {}
+    assert dag.available(udxf) == ()
+    assert dag.expand(udxf["id"]) == {}
+
+    with_overlay = attr_evolve(
+        dag, overlays={"columns": {udxf["id"]: ["a"], "other": ["z"]}}
+    )
+    assert with_overlay.available(udxf) == ("columns",)
+    assert with_overlay.expand(udxf["id"], "columns") == {
+        "columns": {udxf["id"]: ["a"]}
+    }
+
+
+def test_lineage_round_trip_preserves_nested_scopes(udxf_expression):
+    dag = extract_lineage_dag(udxf_expression)
+
+    restored = LineageDAG.from_dict(dag.to_dict())
+
+    assert restored.to_dict() == dag.to_dict()
+    assert restored.version == 2
+    [udxf] = restored.boundaries(kind="flight_udxf")
+    assert restored.scope(udxf["id"])["nodes"]
+    assert format_compact_lineage(restored) == format_compact_lineage(dag)
+
+
+def test_lineage_is_stable_across_extractions(udxf_expression):
+    first = extract_lineage_dag(udxf_expression)
+    second = extract_lineage_dag(udxf_expression)
+    assert first.to_dict() == second.to_dict()
+
+
+def test_flight_expr_nested_lineage_over_multi_source_join(flight_expr_expression):
+    """A Flight boundary whose input is a multi-source join: the outer view keeps
+    the Flight node, the join lives in the nested scope."""
+    dag = extract_lineage_dag(flight_expr_expression)
+
+    [flight] = dag.boundaries(kind="flight_expr")
+    assert flight["process_boundary"] is True
+    assert set(flight["input_schema"]) == {"a", "b", "c"}
+    assert set(flight["output_schema"]) == {"a", "b", "c"}
+    assert flight["server_factory"]
+
+    nested = dag.compact(scope=flight["id"])
+    nested_kinds = {
+        n["boundary_kind"] for n in nested["nodes"] if n.get("boundary_kind")
+    }
+    assert "join" in nested_kinds
+    assert "engine_crossing" in nested_kinds
+    assert {n["id"] for n in dag.compact()["nodes"]} == {dag.root, flight["id"]}
+
+    text = format_compact_lineage(dag)
+    assert "FlightExpr : 3→3 cols" in text
+    assert "Join(" in text
+
+
+def test_cache_and_pin_boundaries(tmp_path, parquet_dir):
+    con = xo.connect()
+    cache = ParquetCache.from_kwargs(source=con, relative_path=tmp_path)
+    cached = (
+        xo.deferred_read_parquet(parquet_dir / "awards_players.parquet", con=con)
+        .filter(xo._.playerID == "bondto01")
+        .cache(cache=cache)
+    )
+
+    dag = extract_lineage_dag(cached)
+    assert dag.boundaries(kind="ingestion")
+    [cache_node] = dag.boundaries(kind="cache")
+    assert cache_node["cache_kind"] == "ParquetCache"
+    assert "Cache[" in format_compact_lineage(dag)
+
+    pinned_dag = extract_lineage_dag(cached.ls.pin(ensure_materialized=True))
+    [pin_node] = pinned_dag.boundaries(kind="pin")
+
+    assert pin_node["cache_key"]
+    assert pin_node["cache_kind"] == "ParquetCache"
+    assert not pinned_dag.boundaries(kind="cache")
+    assert "Pin[" in format_compact_lineage(pinned_dag)
+
+
+def test_compact_of_unknown_scope_is_empty():
+    """A scope with no recorded nested_root degrades to an empty view."""
+    dag = LineageDAG.from_dict(
+        {"nodes": [{"id": "0", "type": "Filter"}], "edges": [], "root": "0"}
+    )
+    view = dag.compact(scope="@no_such_flight")
+    assert view == {"nodes": (), "edges": (), "root": None, "scope": "@no_such_flight"}

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "00c36ffbdac0",
   "expr.yaml": "0476a75f1b20c040c4625105c10f6f93",
-  "expr_metadata.json": "4761ea1a8209fdb1139b1386cd301163",
+  "expr_metadata.json": "812287881c6d729034da6c6339590282",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
   "build_dir_name": "00c36ffbdac0",
   "expr.yaml": "0476a75f1b20c040c4625105c10f6f93",
-  "expr_metadata.json": "646bd83bb82ee155b98353e18b973ff9",
+  "expr_metadata.json": "4761ea1a8209fdb1139b1386cd301163",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -5,7 +5,7 @@
   "deferred_reads.yaml": "1569fa2c7c9f512176a545e521dd79f6",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "expr.yaml": "1f2feefe679834bdf31db4038900e4b8",
-  "expr_metadata.json": "c9eb65dfe6384c17f31e7d54b70c340d",
+  "expr_metadata.json": "3728e0d0543ee554b636dfea0b54d2e3",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -5,7 +5,7 @@
   "deferred_reads.yaml": "1569fa2c7c9f512176a545e521dd79f6",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "expr.yaml": "1f2feefe679834bdf31db4038900e4b8",
-  "expr_metadata.json": "2a49e8f5f74f3c5bd2a4dac4c5fc0ad7",
+  "expr_metadata.json": "ca2b874805977ff835b41573c7f2fe43",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -5,7 +5,7 @@
   "deferred_reads.yaml": "1569fa2c7c9f512176a545e521dd79f6",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "expr.yaml": "1f2feefe679834bdf31db4038900e4b8",
-  "expr_metadata.json": "ca2b874805977ff835b41573c7f2fe43",
+  "expr_metadata.json": "c9eb65dfe6384c17f31e7d54b70c340d",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -5,7 +5,7 @@
   "deferred_reads.yaml": "d2ba95a6587082eb55386c11f201e398",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "expr.yaml": "5a037e3af6cacd794609a74ec29d9985",
-  "expr_metadata.json": "f508e800657c2612c48ae4b26a858d6a",
+  "expr_metadata.json": "db709a546abda2ffa83742ad384fa1fe",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -5,7 +5,7 @@
   "deferred_reads.yaml": "d2ba95a6587082eb55386c11f201e398",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "expr.yaml": "5a037e3af6cacd794609a74ec29d9985",
-  "expr_metadata.json": "db709a546abda2ffa83742ad384fa1fe",
+  "expr_metadata.json": "b9d909af614e9066869b8aa287120844",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -5,7 +5,7 @@
   "deferred_reads.yaml": "d2ba95a6587082eb55386c11f201e398",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
   "expr.yaml": "5a037e3af6cacd794609a74ec29d9985",
-  "expr_metadata.json": "b9d909af614e9066869b8aa287120844",
+  "expr_metadata.json": "e366873b55dcfe2ae044f9026adba614",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }


### PR DESCRIPTION
> **Stacked on #2177.** Based on `main`, so the diff includes #2177's four `graph_utils` refactor commits (already under review there — `d160a240`, `e1e31381`, `73fab4bb`, `d64e247c`). Review and merge #2177 first; this diff shrinks to the lineage work once it lands. The only `graph_utils` change *owned by this PR* is the `gen_children_flight_leaf` visibility flip described below.

## What

Enrich the sidecar `LineageDAG` with a semantic boundary taxonomy, and make the compact and nested views **derived** rather than stored.

## Why

XOR-363. The sidecar recorded a flat node list with `" -> ".join(labels)` rendering: no notion of which nodes are semantically meaningful, no way to expand or collapse, and Flight `input_expr` nodes flattened into the outer graph so they appeared twice with wrong edges.

## How

- **Boundary taxonomy** via singledispatch — `_boundary_kind` (`ingestion`, `cache`, `pin`, `engine_crossing`, `flight_udxf`, `flight_expr`, `udf`, `table`, `unbound`, `join`, `tag`/`tag:<value>`) and `_boundary_extras` for per-kind intrinsic facts. The dispatch registry is the single source of truth; a test asserts every `opaque_ops` type registers. `base_kind()` strips a tag's qualifier so kind queries and registry lookups match either form.
- **Node identity from `content_hash`** for relations, so a relation keys identically in `expr.yaml` and the sidecar (`snapshot_hash`); `@op_N` stays the doc-local readable label. Value ops (`Field`, `SortKey`, `Literal`, …) use a memoized structural token instead — `content_hash` snapshot-normalizes and compiles to SQL, which fails outright on `SortKey` and is wasted work for nodes that never reach `expr.yaml`.
- **Flight-leaf outer walk** — `bfs(root, children=gen_children_flight_leaf)`, the policy landed in #2177. A Flight node's `input_expr` is no longer flattened into the outer graph; it is recursed as a *nested* sub-DAG whose nodes live in the one shared node table under a `scope: <flight label>` tag. BFS dedup guards nested-of-nested recursion.
- Structured `{from, to, scope}` edges, `version: 2`, an `overlays` scaffold for future dimensions (columns, engines), and a code-side `CAPABILITY_REGISTRY` keyed by `boundary_kind`.
- **Query API** on `LineageDAG`: `resolve` (hash | label | tag | kind | predicate), `boundaries`, `capabilities`, `available`, `expand`, `scope`, `compact`, `by_id`.
- `compact()` is an adjacency BFS over the **id-graph** (stored labels + edges, not the op-graph — at render time there are no ops), collapsing non-boundary runs into `via: [types]` and keeping one edge per boundary pair (the most direct run).
- `from_dict` tolerates legacy sidecars (integer ids, 2-tuple edges, no version).
- **TUI**: `lineage_text` renders the compact tree instead of `" -> ".join(labels)`. `FlightUDXF` shows as `UDXF[class] : N->M cols` with its schema delta and nested input sub-tree; `FlightExpr`'s label no longer stringifies `input_expr`.
- **TUI panel** (`25adf622`): the Info panel becomes a `VerticalScroll` and joins `FOCUS_CYCLE` -- the old single-line lineage fit in `max-height: 6`, a tree of unbounded depth does not, and a plain `Vertical` outside the focus cycle had no scrollbar, no keys and no wheel target. Same treatment `#sql-panel` already has; `j`/`k` needed no change because `action_cursor_down`/`_up` already dispatch to a focused `VerticalScroll`.
- **TUI colours** (`802fdc81`): `BOUNDARY_STYLES` gives each base kind an icon and a theme colour, loudest for the Flight boundaries (the only hop that leaves the process); tree glyphs dim, collapsed `via [...]` runs dim italic.

```
  Join(2 inputs) (6 cols) [xorq_datafusion]
  |-- Cache[ParquetCache] (4 cols) [xorq_datafusion]   via [Field, JoinReference]
  |   `-- -> xorq_datafusion (4 cols)
  |       `-- UDXF[OrderEnricher] : 3->4 cols [xorq_datafusion]   (+order_score)
  |           `-- xorq_datafusion:raw_orders (3 cols)     <- nested input scope
  `-- RemoteTable[duckdb -> xorq_datafusion] (3 cols)   via [Field, JoinReference]
      `-- duckdb:raw_customers (3 cols)
```

  Styling reads `LineageRow.kind`, never the rendered label: `Cache[...]`, `UDXF[...]` and `via [...]` all contain brackets, so Rich markup would misparse them. `lineage_rich`/`info_rich` are the renders and `lineage_text`/`info_text` are their `.plain`, so the two forms cannot drift. Icons live in the renderer, so `expr_metadata.json` is untouched by this.
- **Label widths + backend tag** (`7e07cd41`): every boundary label is now `<what> (<n> cols) [<backend>]`, matching the ticket's target render. Pieces drop out when the node cannot supply them (a legacy sidecar with no schema renders bare); Flight kinds keep their schema *transition* instead of one width; the tag is appended only for kinds whose label does not already name a backend, so `duckdb:orders`, `Read[duckdb]` and `RemoteTable[duckdb -> xorq]` are untouched. Two extras were needed: `backend` on the Flight nodes (they have a `source` and never reported it) and `backend` on `JoinChain`, which has none -- a join's is its *left input's* (`first.parent`), because walking to the leaves reaches the remote side of an `into_backend` and would report a single-backend join as multi-backend.
- **`LineageRow`** (`fed211c2`): `compact_lineage_rows(dag)` returns the compact tree with the glyph prefix, label, boundary kind and `via` kept apart, which is what makes the styling above possible without label parsing. `TextTree._lines` is derived from the same rows; the plain-text output is unchanged.
- **`scope()` fix** (`fed211c2`): the view derived its id set from the scope's edges alone, so a Flight node whose `input_expr` is a bare table (one node, zero edges) came back with `nodes: ()` while `root` still pointed at that node. Found by exercising the sidecar-inspection recipes on a real build; the existing tests missed it because their UDXF input was a filter over an `into_backend`.
- One `graph_utils` change: `_gen_children_flight_leaf` → `gen_children_flight_leaf`. #2177 left it private with a "private until XOR-363 lands its caller" note; this branch is that caller.

## Per-kind boundary facts (`31013717`)

Every field in the ticket's per-kind table is stored:

- **tags** — `tag:<tag-value>` for `HashingTag`, full sanitized `tag_metadata`.
- **RemoteTable** — `remote_name`, `source_backend`, resolved with `find_all_sources(remote_expr, execution_only=True)` rather than off the node: the remote expr's root is usually a `Project`/`Filter` with no `source` of its own. A multi-source or memtable-rooted input has no single origin, so the field is omitted rather than guessed.
- **Read** — `format`, `path_or_uri`, `read_kwargs`, with credential-looking keys redacted to `***` and URI userinfo collapsed to `scheme://***@host`. The sidecar is committed next to the build, so a `postgres://user:pw@host/db` must not travel with it.
- **DatabaseTable / UnboundTable** — `table_name`, `database`, `catalog`.
- **JoinChain** — `n_inputs`, `predicates_summary` (column refs and operators only, never a literal's value).
- **ExprScalarUDF** — `udf_name`, `udf_signature`.
- **FlightUDXF** — `udxf_class`, `udxf_command`, `schema_in_required`, `schema_in_observed`, `schema_out`, `process_boundary`, `server_factory`, `do_instrument_reader`, and a stored `schema_diff` (ticket open question #3, resolved in favour of the sidecar so external readers get the transition for free).
- **FlightExpr** — `flight_command`, `input_schema`, `output_schema`, `server_factory`. The command is built from `UnboundExprExchanger`: `FlightExpr.to_rbr` registers one and exchanges on *its* `command`, so the exchanger is the only authority and recomputing the format string here would rot silently. Construction is pure (walk + rename + tokenize — no server, no connection) and a failure degrades to no field.
- **CachedNode / CacheTag** — `cache_kind`, `cache_key_prefix`, `cache_key` (pins), and `cache_path` as the storage's **relative** path only. The resolved directory is `base_path / relative_path` with `base_path` defaulting to the user's cache dir — an absolute per-machine path that must not enter a committed sidecar. The per-entry parquet path is also excluded: it needs `cache.calc_key(expr)`, which stats the source data under `ModificationTimeStrategy`. `SourceCache` has no path at all; its location is the `backend`.

No `server_kind` flavour is inferred: the `FlightExpr` default factory is the bare `FlightServer` class and the `FlightUDXF` default is a `make_mtls_server` closure, so name-sniffing yields a class name as often as a flavour. `server_factory` alone carries it.

## Deviations from the ticket text

- **No `BOUNDARY_TYPES` constant.** The `_boundary_kind` dispatch registry is the single source of truth; a parallel tuple would drift. A test asserts every `opaque_ops` type has a registration.
- **`read_options` is stored as `read_kwargs`** — the op's own attribute name.
- **Nested lineage is not a per-node `nested_input_lineage` sub-document.** One shared node table (deduped by `snapshot_hash`) plus `scope`-tagged edges and a `nested_root` pointer; `scope(label)` returns the nested view by filtering. This keeps global hash-addressing and lets a future overlay span a Flight boundary.
- **`via` lives on the derived `compact()` edges, not on a stored `compact_edges`** (ticket open question #1). Nothing about the compact view is serialized.
- **TUI is a plain-text tree** — no icons or colour; `Cache[...]`, `UDXF[...]`, `RemoteTable[a -> b]`, `↳`, `↻` carry the signal.

## Build hash

Build-stability snapshots move **only** in `expr_metadata.json`. `build_dir_name` and `expr.yaml` are unchanged, so the richer sidecar does not affect the build hash.

## Verification

`test_lineage_utils.py` + `test_graph_utils.py` + `test_content_hash.py` + `test_tui.py` + `test_compiler.py` — **526 passed, 1 skipped**; the full `test_tui.py` again after the Info-panel change — **355 passed**; `test_lineage_utils.py` + `test_tui.py` + `test_compiler.py` + `test_graph_utils.py` after the colour and `scope()` work — **530 passed, 1 skipped** with no snapshot movement; and again after the label widths — **543 passed, 1 skipped**, where two `expr_metadata.json` hashes move (the new `backend` field) and nothing else. The three `expected.json` stability snapshots move as described above (verified field-by-field against the failure diff before regenerating).

Coverage added for every new field, plus the behaviours that are easy to get wrong: kwarg/URI redaction, `schema_diff` add/drop/retype/unambiguous-rename/ambiguous/no-delta cases, `flight_command` compared against the exchanger itself rather than a hard-coded string, no resolved cache dir or `$HOME` in a cache node, `source_backend` present for duckdb → xorq and omitted when unresolvable, and a catalog entry containing a `FlightUDXF` rendering `UDXF[AddB] : 1->2 cols` with `(+b)` and its nested input source. Further tests assert the Info panel is a `VerticalScroll` that `tab` lands on and `j`/`k` scroll; that `LineageRow`s concatenate back to exactly the plain tree and keep `via` off the label; that a single-node nested scope keeps its root; that each boundary kind renders with its own icon and colour while a legacy sidecar falls back to a neutral one; that labels carry the width and the backend exactly once; and that a join's backend is its left input's rather than the remote side of an `into_backend`.

## Scope

Draft. Third and last link of the XOR-363 chain: Prep #1 `content_hash` → Prep #2 graph refactor (#2177) → **this**.

Refs XOR-363

🤖 Generated with [Claude Code](https://claude.com/claude-code)
