### PR TITLE
build: use commit.remote in git-cliff template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,9 +370,9 @@ body = """
     #### {{ group | upper_first }}
     {%- for commit in commits %}
         - {{ commit.message | upper_first | trim }}\
-            {% if commit.github.username %} by @{{ commit.github.username }}{%- endif -%}
-            {% if commit.github.pr_number %} in \
-              [#{{ commit.github.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.github.pr_number }}) \
+            {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}
+            {% if commit.remote.pr_number %} in \
+              [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}) \
             {%- endif -%}
     {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## What

Replace the deprecated `commit.github.*` template variables in the `[tool.git-cliff.changelog]` body with `commit.remote.*`.

## Why

Every changelog render — including `scripts/build-release.sh` step 5 — emitted:

```
WARN  git_cliff_core::changelog > Variables ["commit.github", "commit.gitea", "commit.gitlab", "commit.bitbucket", "commit.azure_devops"] are deprecated and will be removed in the future. Use `commit.remote` instead.
```

git-cliff 2.x deprecated the per-platform `commit.<platform>` objects in favor of the platform-agnostic `commit.remote`. Only the `commit.*` accessors are deprecated; top-level `github.contributors` and `remote.github.owner`/`repo` are untouched.

## Verification

`git cliff --github-repo xorq-labs/xorq --tag v9.9.9 -u` before and after:

- Warning gone.
- Rendered changelog output byte-identical (author attribution and PR links still present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)