### PR TITLE
feat(catalog): add `xorq catalog lineage` (--level, --node, --format)

### DIFF
--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -97,6 +97,7 @@ CATALOG_GROUPS = (
             "list",
             "show",
             "schema",
+            "lineage",
             "get",
             "add-alias",
             "remove-alias",
@@ -212,11 +213,18 @@ SEE_ALSO = {
     ),
     "catalog/show": (
         "[`catalog schema`](schema.qmd)—schema-only view",
+        "[`catalog lineage`](lineage.qmd)—lineage-only view",
         "[`catalog list`](list.qmd)—list entries",
     ),
     "catalog/schema": (
         "[`catalog show`](show.qmd)—full metadata for an entry",
+        "[`catalog lineage`](lineage.qmd)—where an entry's data comes from",
         "[`catalog list`](list.qmd)—list available entries",
+    ),
+    "catalog/lineage": (
+        "[`catalog show`](show.qmd)—the rest of an entry's metadata",
+        "[`catalog schema`](schema.qmd)—input and output schemas only",
+        "[`catalog tui`](tui.qmd)—browse the same lineage tree interactively",
     ),
     "catalog/get": (
         "[`catalog add`](add.qmd)—re-add an exported archive to another catalog",

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -23,6 +23,7 @@ from xorq.catalog import constants as catalog_constants
 
 if TYPE_CHECKING:
     from xorq.catalog.content_store import ContentStoreConfig
+    from xorq.common.utils.lineage_utils import LineageDAG
 
 from xorq.cli import (
     _get_cache_dir,
@@ -1018,6 +1019,88 @@ def schema(ctx, name, as_json):
                     click.echo(f"  {col:<24} {dtype}")
 
 
+def _lineage_boundaries_lines(dag: LineageDAG) -> Iterator[str]:
+    """One line per boundary: id, kind, and the compact label's facts."""
+    from xorq.common.utils.lineage_utils import compact_node_label  # noqa: PLC0415
+
+    for node in dag.boundaries():
+        yield f"{node['id']}\t{node['boundary_kind']}\t{compact_node_label(node)}"
+
+
+def _lineage_scope_lines(dag: LineageDAG) -> Iterator[str]:
+    """Nested Flight scopes, rendered under the boundary that owns them."""
+    for node in dag.boundaries():
+        if (nested_root := node.get("nested_root")) is None:
+            continue
+        n_nodes = len(dag.compact(scope=node["id"])["nodes"])
+        plural = "" if n_nodes == 1 else "s"
+        yield f"{node['id']}\t{n_nodes} node{plural}\troot={nested_root}"
+
+
+@cli.command()
+@click.argument("name", shell_complete=_complete_entry_or_alias_names)
+@click.option(
+    "-l",
+    "--level",
+    type=click.Choice(("compact", "boundaries", "raw")),
+    default="compact",
+    show_default=True,
+    help="How much lineage detail to print.",
+)
+@click.pass_context
+def lineage(ctx: click.Context, name: str, level: str) -> None:
+    """Show the lineage recorded in an entry's metadata sidecar.
+
+    The sidecar stores one node table with scope-tagged edges; the compact
+    boundary tree is derived from it, so no level re-walks the expression.
+
+    \b
+    Levels:
+      compact     Boundary-only tree, as the TUI renders it (default).
+      boundaries  One tab-separated line per boundary: id, kind, label.
+      raw         The stored lineage as JSON — pipe it to `jq`.
+
+    \b
+    Arguments:
+      NAME  Entry name or alias.
+
+    \b
+    Examples:
+      # The tree the TUI shows
+      xorq catalog lineage penguins-prod
+      # Grep-able boundary list
+      xorq catalog lineage penguins-prod --level boundaries
+      # Every stored field, for jq
+      xorq catalog lineage penguins-prod --level raw | jq '.nodes[0]'
+    """
+    from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
+        format_compact_lineage,
+    )
+
+    with click_context_catalog(ctx):
+        catalog = ctx.obj.make_catalog(init=False)
+        entry = _get_catalog_entry(catalog, name)
+
+    dag = entry.metadata.lineage
+    if dag is None or not dag.nodes:
+        # A sidecar written before lineage existed, or an expression with none.
+        raise click.ClickException(
+            f"Entry {name!r} has no lineage in its metadata sidecar — "
+            f"rebuild it with a current xorq to record one."
+        )
+
+    match level:
+        case "raw":
+            click.echo(json.dumps(dag.to_dict(), indent=2, default=str))
+        case "boundaries":
+            for line in _lineage_boundaries_lines(dag):
+                click.echo(line)
+            for line in _lineage_scope_lines(dag):
+                click.echo(f"# nested\t{line}")
+        case _:
+            click.echo(format_compact_lineage(dag))
+
+
 @cli.command()
 @click.argument("name", shell_complete=_complete_entry_or_alias_names)
 @json_option
@@ -1029,7 +1112,7 @@ def schema(ctx, name, as_json):
     help="Print the metadata sidecar file as-is (YAML).",
 )
 @click.pass_context
-def show(ctx, name, as_json, as_raw):
+def show(ctx: click.Context, name: str, as_json: bool, as_raw: bool) -> None:
     """Show full metadata for a catalog entry.
 
     Prints name, aliases, kind, backends, schemas, parameters, builders,

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1064,8 +1064,19 @@ def _lineage_boundaries_lines(
     help="Expand one node: a snapshot hash, an @label, a tag value, or a "
     "boundary kind. Scopes every level to the match(es).",
 )
+@click.option(
+    "-f",
+    "--format",
+    "fmt",
+    type=click.Choice(("text", "mermaid")),
+    default="text",
+    show_default=True,
+    help="Render the compact level as a text tree or a mermaid flowchart.",
+)
 @click.pass_context
-def lineage(ctx: click.Context, name: str, level: str, handle: str | None) -> None:
+def lineage(
+    ctx: click.Context, name: str, level: str, handle: str | None, fmt: str
+) -> None:
     """Show the lineage recorded in an entry's metadata sidecar.
 
     The sidecar stores one node table with scope-tagged edges; the compact
@@ -1081,6 +1092,13 @@ def lineage(ctx: click.Context, name: str, level: str, handle: str | None) -> No
       compact     Boundary-only tree, as the TUI renders it (default).
       boundaries  One tab-separated line per boundary: id, kind, label.
       raw         The stored lineage as JSON — pipe it to `jq`.
+
+    \b
+    Formats (compact level only):
+      text     Indented tree (default).
+      mermaid  A `flowchart TD` to paste into docs or an issue. Edges point
+               downstream, so sources sit at the top; a Flight boundary's
+               nested input lineage becomes a `subgraph`.
 
     \b
     Arguments:
@@ -1100,10 +1118,21 @@ def lineage(ctx: click.Context, name: str, level: str, handle: str | None) -> No
       xorq catalog lineage penguins-prod --node flight_udxf --level raw
       # A catalog-tagged source, addressed by tag value
       xorq catalog lineage penguins-prod --node catalog-source
+      # A mermaid diagram, whole graph or one node's upstream
+      xorq catalog lineage penguins-prod --format mermaid
+      xorq catalog lineage penguins-prod --node flight_udxf -f mermaid
     """
     from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
         format_compact_lineage,
+        format_mermaid_lineage,
     )
+
+    if fmt == "mermaid" and level != "compact":
+        raise click.UsageError(
+            f"--format mermaid renders the graph, which only the compact level "
+            f"is; {level!r} is a listing. Drop --level or pass --level compact."
+        )
+    render = format_mermaid_lineage if fmt == "mermaid" else format_compact_lineage
 
     with click_context_catalog(ctx):
         catalog = ctx.obj.make_catalog(init=False)
@@ -1137,13 +1166,13 @@ def lineage(ctx: click.Context, name: str, level: str, handle: str | None) -> No
             for line in _lineage_boundaries_lines(dag, selected, capabilities=True):
                 click.echo(line)
         case (_, None):
-            click.echo(format_compact_lineage(dag))
+            click.echo(render(dag))
         case _:
             # One subtree per match, blank-line separated.
             for i, node in enumerate(selected):
                 if i:
                     click.echo()
-                click.echo(format_compact_lineage(dag, root=node["id"]))
+                click.echo(render(dag, root=node["id"]))
 
 
 @cli.command()

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1019,6 +1019,17 @@ def schema(ctx, name, as_json):
                     click.echo(f"  {col:<24} {dtype}")
 
 
+def _resolve_lineage(dag: LineageDAG, handle: str, name: str) -> tuple[dict, ...]:
+    """Nodes a `--node`/`--expand` handle names, or a pointer to the listing."""
+    if matches := dag.resolve(handle):
+        return matches
+    raise click.ClickException(
+        f"No lineage node matches {handle!r} — run "
+        f"'xorq catalog lineage {name} --level boundaries' to see the "
+        f"available ids, kinds and hashes."
+    )
+
+
 def _lineage_boundary_line(node: dict) -> str:
     from xorq.common.utils.lineage_utils import compact_node_label  # noqa: PLC0415
 
@@ -1071,21 +1082,36 @@ def _lineage_boundaries_lines(
     type=click.Choice(("text", "mermaid")),
     default="text",
     show_default=True,
-    help="Render the compact level as a text tree or a mermaid flowchart.",
+    help="Render the graph as a text tree or a mermaid flowchart.",
+)
+@click.option(
+    "--expand",
+    "expand_handle",
+    default=None,
+    help="Keep the whole graph compact but draw this node raw: every op on a "
+    "path into it, plus everything under it. Same handle forms as --node. "
+    "Mermaid only.",
 )
 @click.pass_context
 def lineage(
-    ctx: click.Context, name: str, level: str, handle: str | None, fmt: str
+    ctx: click.Context,
+    name: str,
+    level: str,
+    handle: str | None,
+    fmt: str,
+    expand_handle: str | None,
 ) -> None:
     """Show the lineage recorded in an entry's metadata sidecar.
 
     The sidecar stores one node table with scope-tagged edges; the compact
     boundary tree is derived from it, so no level re-walks the expression.
 
-    `--level` picks how much detail, `--node` picks how much of the graph. With
-    `--node`, the compact level prints the subtree feeding that node — including
-    a Flight boundary's nested input lineage — and a handle matching several
-    nodes (a kind, a tag) prints each match in turn.
+    `--level` picks how much detail, `--node` picks how much of the graph,
+    `--format` picks the rendering, and `--expand` mixes detail: the whole graph
+    stays compact except for one node, drawn raw. With `--node`, the compact
+    level prints the subtree feeding that node — including a Flight boundary's
+    nested input lineage — and a handle matching several nodes (a kind, a tag)
+    prints each match in turn.
 
     \b
     Levels:
@@ -1094,11 +1120,14 @@ def lineage(
     - `raw`—the stored lineage as JSON; pipe it to `jq`.
 
     \b
-    Formats (compact level only):
-    - `text` (default)—an indented tree.
+    Formats:
+    - `text` (default)—the level's own format: a tree, a listing, or JSON.
     - `mermaid`—a `flowchart TD` to paste into docs or an issue. Edges point
       downstream, so sources sit at the top, and a Flight boundary's nested
-      input lineage becomes a `subgraph`.
+      input lineage becomes a `subgraph`. With `--level compact` it draws the
+      boundary graph; with `--level raw`, the expanded one, where the runs
+      collapsed into `via` become real nodes. `--level boundaries` has no graph
+      to draw and is rejected.
 
     \b
     Arguments:
@@ -1121,18 +1150,32 @@ def lineage(
       # A mermaid diagram, whole graph or one node's upstream
       xorq catalog lineage penguins-prod --format mermaid
       xorq catalog lineage penguins-prod --node flight_udxf -f mermaid
+      # The same diagram expanded to every op, not just the boundaries
+      xorq catalog lineage penguins-prod --level raw --format mermaid
+      # The whole graph compact, with one node drawn raw
+      xorq catalog lineage penguins-prod -f mermaid --expand @cached_node_14
     """
     from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
         format_compact_lineage,
         format_mermaid_lineage,
     )
 
-    if fmt == "mermaid" and level != "compact":
+    if fmt == "mermaid" and level == "boundaries":
         raise click.UsageError(
-            f"--format mermaid renders the graph, which only the compact level "
-            f"is; {level!r} is a listing. Drop --level or pass --level compact."
+            "--format mermaid renders a graph; 'boundaries' is a flat listing. "
+            "Use --level compact for the boundary graph or --level raw for the "
+            "expanded one."
         )
-    render = format_mermaid_lineage if fmt == "mermaid" else format_compact_lineage
+    if expand_handle is not None and fmt != "mermaid":
+        raise click.UsageError(
+            "--expand needs --format mermaid: the text tree has no way to show "
+            "one region in more detail than the rest."
+        )
+    if expand_handle is not None and level == "raw":
+        raise click.UsageError(
+            "--expand is redundant with --level raw, which already draws every "
+            "op. Drop one of them."
+        )
 
     with click_context_catalog(ctx):
         catalog = ctx.obj.make_catalog(init=False)
@@ -1146,15 +1189,27 @@ def lineage(
                 f"rebuild it with a current xorq to record one."
             )
 
-        selected = dag.nodes if handle is None else dag.resolve(handle)
-        if handle is not None and not selected:
-            raise click.ClickException(
-                f"No lineage node matches {handle!r} — run "
-                f"'xorq catalog lineage {name} --level boundaries' to see the "
-                f"available ids, kinds and hashes."
-            )
+        selected = dag.nodes if handle is None else _resolve_lineage(dag, handle, name)
+        expand_ids = (
+            ()
+            if expand_handle is None
+            else tuple(n["id"] for n in _resolve_lineage(dag, expand_handle, name))
+        )
 
-        match (level, handle):
+        if fmt == "mermaid":
+            # raw is the stored graph: the same diagram with the runs that
+            # compact() folds into `via` drawn as real nodes. --expand does that
+            # for one region instead of the whole graph.
+            def render(dag: LineageDAG, root: str | None = None) -> str:
+                return format_mermaid_lineage(
+                    dag, root=root, expand=level == "raw", expand_from=expand_ids
+                )
+        else:
+            render = format_compact_lineage
+
+        # `--format mermaid` renders a graph at every level it accepts, so it
+        # takes precedence over the level's own listing format.
+        match (level if fmt == "text" else "graph", handle):
             case ("raw", None):
                 click.echo(json.dumps(dag.to_dict(), indent=2, default=str))
             case ("raw", _):

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1089,16 +1089,16 @@ def lineage(
 
     \b
     Levels:
-      compact     Boundary-only tree, as the TUI renders it (default).
-      boundaries  One tab-separated line per boundary: id, kind, label.
-      raw         The stored lineage as JSON — pipe it to `jq`.
+    - `compact` (default)—the boundary-only tree, as the TUI renders it.
+    - `boundaries`—one tab-separated line per boundary: id, kind, label.
+    - `raw`—the stored lineage as JSON; pipe it to `jq`.
 
     \b
     Formats (compact level only):
-      text     Indented tree (default).
-      mermaid  A `flowchart TD` to paste into docs or an issue. Edges point
-               downstream, so sources sit at the top; a Flight boundary's
-               nested input lineage becomes a `subgraph`.
+    - `text` (default)—an indented tree.
+    - `mermaid`—a `flowchart TD` to paste into docs or an issue. Edges point
+      downstream, so sources sit at the top, and a Flight boundary's nested
+      input lineage becomes a `subgraph`.
 
     \b
     Arguments:
@@ -1138,41 +1138,41 @@ def lineage(
         catalog = ctx.obj.make_catalog(init=False)
         entry = _get_catalog_entry(catalog, name)
 
-    dag = entry.metadata.lineage
-    if dag is None or not dag.nodes:
-        # A sidecar written before lineage existed, or an expression with none.
-        raise click.ClickException(
-            f"Entry {name!r} has no lineage in its metadata sidecar — "
-            f"rebuild it with a current xorq to record one."
-        )
+        dag = entry.metadata.lineage
+        if dag is None or not dag.nodes:
+            # A sidecar written before lineage existed, or an expression with none.
+            raise click.ClickException(
+                f"Entry {name!r} has no lineage in its metadata sidecar — "
+                f"rebuild it with a current xorq to record one."
+            )
 
-    selected = dag.nodes if handle is None else dag.resolve(handle)
-    if handle is not None and not selected:
-        raise click.ClickException(
-            f"No lineage node matches {handle!r} — run "
-            f"'xorq catalog lineage {name} --level boundaries' to see the "
-            f"available ids, kinds and hashes."
-        )
+        selected = dag.nodes if handle is None else dag.resolve(handle)
+        if handle is not None and not selected:
+            raise click.ClickException(
+                f"No lineage node matches {handle!r} — run "
+                f"'xorq catalog lineage {name} --level boundaries' to see the "
+                f"available ids, kinds and hashes."
+            )
 
-    match (level, handle):
-        case ("raw", None):
-            click.echo(json.dumps(dag.to_dict(), indent=2, default=str))
-        case ("raw", _):
-            click.echo(json.dumps(list(selected), indent=2, default=str))
-        case ("boundaries", None):
-            for line in _lineage_boundaries_lines(dag, dag.boundaries()):
-                click.echo(line)
-        case ("boundaries", _):
-            for line in _lineage_boundaries_lines(dag, selected, capabilities=True):
-                click.echo(line)
-        case (_, None):
-            click.echo(render(dag))
-        case _:
-            # One subtree per match, blank-line separated.
-            for i, node in enumerate(selected):
-                if i:
-                    click.echo()
-                click.echo(render(dag, root=node["id"]))
+        match (level, handle):
+            case ("raw", None):
+                click.echo(json.dumps(dag.to_dict(), indent=2, default=str))
+            case ("raw", _):
+                click.echo(json.dumps(list(selected), indent=2, default=str))
+            case ("boundaries", None):
+                for line in _lineage_boundaries_lines(dag, dag.boundaries()):
+                    click.echo(line)
+            case ("boundaries", _):
+                for line in _lineage_boundaries_lines(dag, selected, capabilities=True):
+                    click.echo(line)
+            case (_, None):
+                click.echo(render(dag))
+            case _:
+                # One subtree per match, blank-line separated.
+                for i, node in enumerate(selected):
+                    if i:
+                        click.echo()
+                    click.echo(render(dag, root=node["id"]))
 
 
 @cli.command()

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1088,9 +1088,8 @@ def _lineage_boundaries_lines(
     "--expand",
     "expand_handle",
     default=None,
-    help="Keep the whole graph compact but draw this node raw: every op on a "
-    "path into it, plus everything under it. Same handle forms as --node. "
-    "Mermaid only.",
+    help="List this node's columns under it: name and type per field, and both "
+    "sides of a Flight boundary's schema change. Same handle forms as --node.",
 )
 @click.pass_context
 def lineage(
@@ -1107,11 +1106,14 @@ def lineage(
     boundary tree is derived from it, so no level re-walks the expression.
 
     `--level` picks how much detail, `--node` picks how much of the graph,
-    `--format` picks the rendering, and `--expand` mixes detail: the whole graph
-    stays compact except for one node, drawn raw. With `--node`, the compact
-    level prints the subtree feeding that node — including a Flight boundary's
-    nested input lineage — and a handle matching several nodes (a kind, a tag)
-    prints each match in turn.
+    `--format` picks the rendering, and `--expand` opens a node up: its columns
+    are listed under it in the tree, or inside it in the diagram. With `--node`,
+    the compact level prints the subtree feeding that node — including a Flight
+    boundary's nested input lineage — and a handle matching several nodes (a
+    kind, a tag) prints each match in turn.
+
+    The TUI's Lineage panel expands the same way, with `]` and `[` on the node
+    under its cursor.
 
     \b
     Levels:
@@ -1152,7 +1154,8 @@ def lineage(
       xorq catalog lineage penguins-prod --node flight_udxf -f mermaid
       # The same diagram expanded to every op, not just the boundaries
       xorq catalog lineage penguins-prod --level raw --format mermaid
-      # The whole graph compact, with one node drawn raw
+      # What flows through one node: its columns, in the tree or in the diagram
+      xorq catalog lineage penguins-prod --expand @cached_node_14
       xorq catalog lineage penguins-prod -f mermaid --expand @cached_node_14
     """
     from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
@@ -1166,15 +1169,14 @@ def lineage(
             "Use --level compact for the boundary graph or --level raw for the "
             "expanded one."
         )
-    if expand_handle is not None and fmt != "mermaid":
+    # --expand lists a node's columns inside a rendered tree or diagram. The flat
+    # listing and the raw JSON already carry every stored schema, so there is
+    # nothing there for it to add.
+    if expand_handle is not None and not (fmt == "mermaid" or level == "compact"):
         raise click.UsageError(
-            "--expand needs --format mermaid: the text tree has no way to show "
-            "one region in more detail than the rest."
-        )
-    if expand_handle is not None and level == "raw":
-        raise click.UsageError(
-            "--expand is redundant with --level raw, which already draws every "
-            "op. Drop one of them."
+            f"--expand lists a node's columns in the tree or the diagram, and "
+            f"--level {level} with --format text already prints every stored "
+            f"field. Use --level compact, or --format mermaid."
         )
 
     with click_context_catalog(ctx):
@@ -1197,15 +1199,17 @@ def lineage(
         )
 
         if fmt == "mermaid":
-            # raw is the stored graph: the same diagram with the runs that
-            # compact() folds into `via` drawn as real nodes. --expand does that
-            # for one region instead of the whole graph.
+            # `--level raw` is the stored graph: the same diagram with the runs
+            # that compact() folds into `via` drawn as real nodes. --expand is the
+            # other axis -- what flows through a node, not what surrounds it.
             def render(dag: LineageDAG, root: str | None = None) -> str:
                 return format_mermaid_lineage(
-                    dag, root=root, expand=level == "raw", expand_from=expand_ids
+                    dag, root=root, raw=level == "raw", expand_columns=expand_ids
                 )
         else:
-            render = format_compact_lineage
+
+            def render(dag: LineageDAG, root: str | None = None) -> str:
+                return format_compact_lineage(dag, root=root, expand_columns=expand_ids)
 
         # `--format mermaid` renders a graph at every level it accepts, so it
         # takes precedence over the level's own listing format.

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1129,7 +1129,8 @@ def lineage(
       input lineage becomes a `subgraph`. With `--level compact` it draws the
       boundary graph; with `--level raw`, the expanded one, where the runs
       collapsed into `via` become real nodes. `--level boundaries` has no graph
-      to draw and is rejected.
+      to draw and is rejected. A `--node` handle matching several nodes emits
+      one `flowchart` block per match—paste them one at a time.
 
     \b
     Arguments:
@@ -1174,9 +1175,10 @@ def lineage(
     # nothing there for it to add.
     if expand_handle is not None and not (fmt == "mermaid" or level == "compact"):
         raise click.UsageError(
-            f"--expand lists a node's columns in the tree or the diagram, and "
-            f"--level {level} with --format text already prints every stored "
-            f"field. Use --level compact, or --format mermaid."
+            f"--expand lists a node's columns in the rendered tree or diagram, "
+            f"which --level {level} with --format text does not draw "
+            f"(--level raw already prints every stored field as JSON). "
+            f"Use --level compact, or --format mermaid."
         )
 
     with click_context_catalog(ctx):

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1019,22 +1019,32 @@ def schema(ctx, name, as_json):
                     click.echo(f"  {col:<24} {dtype}")
 
 
-def _lineage_boundaries_lines(dag: LineageDAG) -> Iterator[str]:
-    """One line per boundary: id, kind, and the compact label's facts."""
+def _lineage_boundary_line(node: dict) -> str:
     from xorq.common.utils.lineage_utils import compact_node_label  # noqa: PLC0415
 
-    for node in dag.boundaries():
-        yield f"{node['id']}\t{node['boundary_kind']}\t{compact_node_label(node)}"
+    return f"{node['id']}\t{node['boundary_kind']}\t{compact_node_label(node)}"
 
 
-def _lineage_scope_lines(dag: LineageDAG) -> Iterator[str]:
-    """Nested Flight scopes, rendered under the boundary that owns them."""
-    for node in dag.boundaries():
-        if (nested_root := node.get("nested_root")) is None:
-            continue
-        n_nodes = len(dag.compact(scope=node["id"])["nodes"])
-        plural = "" if n_nodes == 1 else "s"
-        yield f"{node['id']}\t{n_nodes} node{plural}\troot={nested_root}"
+def _lineage_boundaries_lines(
+    dag: LineageDAG, nodes: tuple[dict, ...], *, capabilities: bool = False
+) -> Iterator[str]:
+    """One line per boundary: id, kind, and the compact label's facts.
+
+    Non-boundary nodes appear too when selected by handle -- a `--node` query
+    should never answer with nothing for a node that exists. Capability lines are
+    for that expansion case only: on the full listing they would double the
+    output with what the kind column already implies.
+    """
+    for node in nodes:
+        yield _lineage_boundary_line(
+            node if node.get("boundary_kind") else {**node, "boundary_kind": "-"}
+        )
+        if capabilities and (dims := dag.capabilities(node)):
+            yield f"# capabilities\t{node['id']}\t{','.join(dims)}"
+        if (nested_root := node.get("nested_root")) is not None:
+            n_nodes = len(dag.compact(scope=node["id"])["nodes"])
+            plural = "" if n_nodes == 1 else "s"
+            yield f"# nested\t{node['id']}\t{n_nodes} node{plural}\troot={nested_root}"
 
 
 @cli.command()
@@ -1047,12 +1057,24 @@ def _lineage_scope_lines(dag: LineageDAG) -> Iterator[str]:
     show_default=True,
     help="How much lineage detail to print.",
 )
+@click.option(
+    "--node",
+    "handle",
+    default=None,
+    help="Expand one node: a snapshot hash, an @label, a tag value, or a "
+    "boundary kind. Scopes every level to the match(es).",
+)
 @click.pass_context
-def lineage(ctx: click.Context, name: str, level: str) -> None:
+def lineage(ctx: click.Context, name: str, level: str, handle: str | None) -> None:
     """Show the lineage recorded in an entry's metadata sidecar.
 
     The sidecar stores one node table with scope-tagged edges; the compact
     boundary tree is derived from it, so no level re-walks the expression.
+
+    `--level` picks how much detail, `--node` picks how much of the graph. With
+    `--node`, the compact level prints the subtree feeding that node — including
+    a Flight boundary's nested input lineage — and a handle matching several
+    nodes (a kind, a tag) prints each match in turn.
 
     \b
     Levels:
@@ -1072,6 +1094,12 @@ def lineage(ctx: click.Context, name: str, level: str) -> None:
       xorq catalog lineage penguins-prod --level boundaries
       # Every stored field, for jq
       xorq catalog lineage penguins-prod --level raw | jq '.nodes[0]'
+      # What feeds one node, addressed by its content hash
+      xorq catalog lineage penguins-prod --node 8f3a91c2e4
+      # Every UDXF's stored facts, addressed by kind
+      xorq catalog lineage penguins-prod --node flight_udxf --level raw
+      # A catalog-tagged source, addressed by tag value
+      xorq catalog lineage penguins-prod --node catalog-source
     """
     from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
         format_compact_lineage,
@@ -1089,16 +1117,33 @@ def lineage(ctx: click.Context, name: str, level: str) -> None:
             f"rebuild it with a current xorq to record one."
         )
 
-    match level:
-        case "raw":
+    selected = dag.nodes if handle is None else dag.resolve(handle)
+    if handle is not None and not selected:
+        raise click.ClickException(
+            f"No lineage node matches {handle!r} — run "
+            f"'xorq catalog lineage {name} --level boundaries' to see the "
+            f"available ids, kinds and hashes."
+        )
+
+    match (level, handle):
+        case ("raw", None):
             click.echo(json.dumps(dag.to_dict(), indent=2, default=str))
-        case "boundaries":
-            for line in _lineage_boundaries_lines(dag):
+        case ("raw", _):
+            click.echo(json.dumps(list(selected), indent=2, default=str))
+        case ("boundaries", None):
+            for line in _lineage_boundaries_lines(dag, dag.boundaries()):
                 click.echo(line)
-            for line in _lineage_scope_lines(dag):
-                click.echo(f"# nested\t{line}")
-        case _:
+        case ("boundaries", _):
+            for line in _lineage_boundaries_lines(dag, selected, capabilities=True):
+                click.echo(line)
+        case (_, None):
             click.echo(format_compact_lineage(dag))
+        case _:
+            # One subtree per match, blank-line separated.
+            for i, node in enumerate(selected):
+                if i:
+                    click.echo()
+                click.echo(format_compact_lineage(dag, root=node["id"]))
 
 
 @cli.command()

--- a/python/xorq/catalog/tests/test_cli_lineage.py
+++ b/python/xorq/catalog/tests/test_cli_lineage.py
@@ -1,0 +1,175 @@
+"""`xorq catalog lineage` -- the three detail levels over a stored sidecar.
+
+The command never re-walks the expression: every level is read or derived from
+the `LineageDAG` in `expr_metadata.json`, so these tests build entries once and
+assert on what the sidecar carries.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml12
+from click.testing import CliRunner
+
+import xorq.api as xo
+from xorq.catalog.catalog import Catalog
+from xorq.catalog.cli import cli
+
+
+@pytest.fixture
+def catalog_with_udxf(catalog_path: str) -> tuple[str, str]:
+    """A catalog holding one duckdb -> xorq join over a FlightUDXF.
+
+    Construction and build only -- no Flight server is started.
+    """
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    duck = xo.duckdb.connect()
+    con = xo.connect()
+
+    customers = duck.create_table(
+        "raw_customers",
+        xo.memtable({"id": [1, 2], "name": ["a", "b"]}, name="c_src").to_pyarrow(),
+    )
+    orders = con.create_table(
+        "raw_orders",
+        xo.memtable({"id": [1, 2], "amount": [1.0, 2.0]}, name="o_src").to_pyarrow(),
+    )
+    enriched = xo.expr.relations.flight_udxf(
+        orders,
+        process_df=lambda df: df.assign(score=df.amount * 2),
+        maybe_schema_in=orders.schema(),
+        maybe_schema_out=xo.schema(orders.schema() | {"score": "float64"}),
+        con=con,
+        make_udxf_kwargs={"name": "OrderEnricher"},
+    )
+    expr = customers.into_backend(con, "customers_in").join(enriched, "id")
+
+    entry = catalog.add(expr, aliases=("udxf-demo",))
+    return catalog_path, entry.name
+
+
+def test_lineage_compact_is_the_default_level(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(cli, ["--path", catalog_path, "lineage", name])
+
+    assert result.exit_code == 0, result.output
+    assert "UDXF[OrderEnricher] : 2→3 cols" in result.output
+    assert "(+score)" in result.output
+    # a tree, not a flat chain, with the nested input under the UDXF
+    assert "└── " in result.output
+    assert "↳ " in result.output
+    # and the same output as asking for it explicitly
+    explicit = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--level", "compact"]
+    )
+    assert explicit.output == result.output
+
+
+def test_lineage_accepts_an_alias(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    by_alias = runner.invoke(cli, ["--path", catalog_path, "lineage", "udxf-demo"])
+    by_name = runner.invoke(cli, ["--path", catalog_path, "lineage", name])
+
+    assert by_alias.exit_code == 0, by_alias.output
+    assert by_alias.output == by_name.output
+
+
+def test_lineage_boundaries_is_one_tab_separated_line_per_boundary(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-l", "boundaries"]
+    )
+
+    assert result.exit_code == 0, result.output
+    rows = [
+        line.split("\t")
+        for line in result.output.splitlines()
+        if line and not line.startswith("# nested")
+    ]
+    assert rows
+    assert all(len(row) == 3 for row in rows), rows
+
+    kinds = {kind for _, kind, _ in rows}
+    assert {"join", "engine_crossing", "table", "flight_udxf"} <= kinds
+    assert all(node_id.startswith("@") for node_id, _, _ in rows)
+    # no tree glyphs: this level is for grep and cut
+    assert "└──" not in result.output
+
+    # the Flight boundary reports its nested scope on a comment line
+    [nested] = [
+        line for line in result.output.splitlines() if line.startswith("# nested")
+    ]
+    assert "root=@" in nested
+    assert "node" in nested
+
+
+def test_lineage_raw_is_the_stored_dag_as_json(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(cli, ["--path", catalog_path, "lineage", name, "-l", "raw"])
+
+    assert result.exit_code == 0, result.output
+    raw = json.loads(result.output)
+
+    assert raw["version"] == 2
+    assert raw["root"].startswith("@")
+    # every node, not just the boundaries the compact view keeps
+    assert len(raw["nodes"]) > len([n for n in raw["nodes"] if n.get("is_boundary")])
+    assert set(raw["edges"][0]) == {"from", "to", "scope"}
+
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    stored = catalog.get_catalog_entry(name).metadata.lineage
+    assert raw == json.loads(json.dumps(stored.to_dict(), default=str))
+
+
+def test_lineage_rejects_an_unknown_level(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-l", "verbose"]
+    )
+
+    assert result.exit_code != 0
+    assert "'compact', 'boundaries', 'raw'" in result.output
+
+
+def test_lineage_of_an_unknown_entry_points_at_list(
+    runner: CliRunner, catalog_path: str
+) -> None:
+    result = runner.invoke(cli, ["--path", catalog_path, "lineage", "no-such-entry"])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "xorq catalog list" in result.output
+
+
+def test_lineage_of_a_sidecar_without_lineage_explains_itself(
+    runner: CliRunner, catalog_path: str
+) -> None:
+    """A sidecar written before lineage existed has `lineage: None`; the command
+    says how to get one rather than printing an empty tree."""
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    entry = catalog.add(xo.memtable({"a": [1]}, name="no_lineage"))
+    sidecar = yaml12.parse_yaml(entry.metadata_path.read_text())
+    sidecar["expr_metadata"]["lineage"] = None
+    entry.metadata_path.write_text(yaml12.format_yaml(sidecar))
+
+    result = runner.invoke(cli, ["--path", catalog_path, "lineage", entry.name])
+
+    assert result.exit_code != 0
+    assert "no lineage in its metadata sidecar" in result.output

--- a/python/xorq/catalog/tests/test_cli_lineage.py
+++ b/python/xorq/catalog/tests/test_cli_lineage.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 import xorq.api as xo
 from xorq.catalog.catalog import Catalog
 from xorq.catalog.cli import cli
-from xorq.common.utils.lineage_utils import LineageDAG
+from xorq.common.utils.lineage_utils import LineageDAG, _mermaid_id
 
 
 @pytest.fixture
@@ -342,19 +342,190 @@ def test_lineage_format_mermaid_honours_node(
     assert "Join(" not in result.output
 
 
-def test_lineage_format_mermaid_rejects_the_listing_levels(
+def test_lineage_format_mermaid_rejects_the_boundaries_level(
     runner: CliRunner, catalog_with_udxf: tuple[str, str]
 ) -> None:
-    """mermaid renders the graph; `raw` and `boundaries` are listings."""
+    """`boundaries` is a flat listing: keeping the edges would just re-spell the
+    compact graph, dropping them would draw node soup."""
     catalog_path, name = catalog_with_udxf
 
-    for level in ("raw", "boundaries"):
-        result = runner.invoke(
+    result = runner.invoke(
+        cli,
+        ["--path", catalog_path, "lineage", name, "-f", "mermaid", "-l", "boundaries"],
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "'boundaries' is a flat listing" in result.output
+
+
+def test_lineage_raw_mermaid_expands_the_collapsed_runs(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """`raw` is the stored graph, so mermaid draws it un-collapsed: the ops that
+    the compact view folds into `via` become real nodes."""
+    catalog_path, name = catalog_with_udxf
+
+    compact = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid"]
+    )
+    expanded = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid", "-l", "raw"]
+    )
+
+    assert expanded.exit_code == 0, expanded.output
+    assert expanded.output.splitlines()[0] == "flowchart TD"
+    # not JSON: --format wins over the level's own listing format
+    assert not expanded.output.lstrip().startswith("{")
+
+    def declared(output: str) -> set[str]:
+        return {
+            line.strip().split("[", 1)[0]
+            for line in output.splitlines()
+            if "[" in line and not line.strip().startswith(("subgraph", "class"))
+        }
+
+    assert declared(compact.output) < declared(expanded.output)
+    # the plumbing the compact view hides behind `via`
+    assert "Field:" in expanded.output
+    assert "|via " in compact.output
+    assert "|via " not in expanded.output
+    # and it carries a receding class of its own
+    assert "classDef unknown " in expanded.output
+
+
+def test_lineage_raw_mermaid_honours_node(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """Expanding one node: the ops under it, nothing above it."""
+    catalog_path, name = catalog_with_udxf
+    dag = _lineage_dag(catalog_path, name)
+    crossing, *_ = dag.boundaries(kind="engine_crossing")
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "lineage",
+            name,
+            "--node",
+            crossing["id"],
+            "-l",
+            "raw",
+            "-f",
+            "mermaid",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _mermaid_id(crossing["id"]) in result.output
+    assert _mermaid_id(dag.root) not in result.output
+
+
+def test_lineage_expand_keeps_the_whole_graph(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """`--expand` is the mixed-detail dial: everything stays compact except from
+    the matched node downward, which is what `--node` cannot do (it narrows)."""
+    catalog_path, name = catalog_with_udxf
+    dag = _lineage_dag(catalog_path, name)
+
+    compact = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid"]
+    )
+    expanded = runner.invoke(
+        cli,
+        ["--path", catalog_path, "lineage", name, "-f", "mermaid", "--expand", "join"],
+    )
+
+    assert expanded.exit_code == 0, expanded.output
+    # the root and the far side of the graph survive, unlike with --node
+    assert _mermaid_id(dag.root) in expanded.output
+    assert "raw_customers" in expanded.output
+    # and the expanded region gained the ops the compact view folded into `via`
+    assert "Field:" not in compact.output
+    assert "Field:" in expanded.output
+    assert "|via " in compact.output
+    assert "|via " not in expanded.output
+
+
+def test_lineage_expand_reaches_the_run_above_the_node(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """Expanding a node whose own subtree has no intermediates still shows
+    something: the run collapsed onto its consumer's edge."""
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "lineage",
+            name,
+            "-f",
+            "mermaid",
+            "--expand",
+            "flight_udxf",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Field:" in result.output or "JoinReference" in result.output
+
+
+def test_lineage_expand_accepts_the_same_handles_as_node(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+    dag = _lineage_dag(catalog_path, name)
+    [join] = dag.boundaries(kind="join")
+
+    by_kind, by_label, by_hash = (
+        runner.invoke(
             cli,
-            ["--path", catalog_path, "lineage", name, "-f", "mermaid", "-l", level],
+            ["--path", catalog_path, "lineage", name, "-f", "mermaid", "--expand", h],
         )
-        assert result.exit_code != 0, result.output
-        assert "--format mermaid renders the graph" in result.output
+        for h in ("join", join["id"], join["snapshot_hash"])
+    )
+
+    assert by_kind.exit_code == 0, by_kind.output
+    assert by_kind.output == by_label.output == by_hash.output
+
+
+def test_lineage_expand_needs_mermaid_and_conflicts_with_raw(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    text = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--expand", "join"]
+    )
+    with_raw = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "lineage",
+            name,
+            "-f",
+            "mermaid",
+            "-l",
+            "raw",
+            "--expand",
+            "join",
+        ],
+    )
+    unknown = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid", "--expand", "x"]
+    )
+
+    assert text.exit_code != 0
+    assert "--expand needs --format mermaid" in text.output
+    assert with_raw.exit_code != 0
+    assert "redundant with --level raw" in with_raw.output
+    assert unknown.exit_code != 0
+    assert "No lineage node matches 'x'" in unknown.output
 
 
 def test_lineage_rejects_an_unknown_level(

--- a/python/xorq/catalog/tests/test_cli_lineage.py
+++ b/python/xorq/catalog/tests/test_cli_lineage.py
@@ -422,13 +422,14 @@ def test_lineage_raw_mermaid_honours_node(
     assert _mermaid_id(dag.root) not in result.output
 
 
-def test_lineage_expand_keeps_the_whole_graph(
+def test_lineage_expand_lists_a_nodes_columns_in_the_diagram(
     runner: CliRunner, catalog_with_udxf: tuple[str, str]
 ) -> None:
-    """`--expand` is the mixed-detail dial: everything stays compact except from
-    the matched node downward, which is what `--node` cannot do (it narrows)."""
+    """`--expand` opens one node up: its columns are listed inside it, and the
+    graph around it keeps its shape."""
     catalog_path, name = catalog_with_udxf
     dag = _lineage_dag(catalog_path, name)
+    [join] = dag.boundaries(kind="join")
 
     compact = runner.invoke(
         cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid"]
@@ -439,74 +440,58 @@ def test_lineage_expand_keeps_the_whole_graph(
     )
 
     assert expanded.exit_code == 0, expanded.output
-    # the root and the far side of the graph survive, unlike with --node
+    # same nodes and edges: only the join's label grew
+    assert len(expanded.output.splitlines()) == len(compact.output.splitlines())
     assert _mermaid_id(dag.root) in expanded.output
-    assert "raw_customers" in expanded.output
-    # and the expanded region gained the ops the compact view folded into `via`
-    assert "Field:" not in compact.output
-    assert "Field:" in expanded.output
-    assert "|via " in compact.output
-    assert "|via " not in expanded.output
+    [label] = [
+        line
+        for line in expanded.output.splitlines()
+        if _mermaid_id(join["id"]) + "[" in line
+    ]
+    for column in dag.by_id[join["id"]]["schema"]:
+        assert column in label
+    assert "<br/>" in label
 
 
-def test_lineage_expand_reaches_the_run_above_the_node(
+def test_lineage_expand_lists_a_nodes_columns_in_the_text_tree(
     runner: CliRunner, catalog_with_udxf: tuple[str, str]
 ) -> None:
-    """Expanding a node whose own subtree has no intermediates still shows
-    something: the run collapsed onto its consumer's edge."""
-    catalog_path, name = catalog_with_udxf
-
-    result = runner.invoke(
-        cli,
-        [
-            "--path",
-            catalog_path,
-            "lineage",
-            name,
-            "-f",
-            "mermaid",
-            "--expand",
-            "flight_udxf",
-        ],
-    )
-
-    assert result.exit_code == 0, result.output
-    assert "Field:" in result.output or "JoinReference" in result.output
-
-
-def test_lineage_node_bounds_expand(
-    runner: CliRunner, catalog_with_udxf: tuple[str, str]
-) -> None:
-    """`--node` narrows; an `--expand` outside that subtree must not drag the rest
-    of the graph back in."""
+    """The tree expands the same way the TUI's Lineage panel does: one row per
+    column under the node, with the rest of the tree untouched."""
     catalog_path, name = catalog_with_udxf
     dag = _lineage_dag(catalog_path, name)
-    [duck_table] = [
-        n for n in dag.boundaries(kind="table") if n.get("backend") == "duckdb"
-    ]
+    [join] = dag.boundaries(kind="join")
+    schema = dag.by_id[join["id"]]["schema"]
+
+    compact = runner.invoke(cli, ["--path", catalog_path, "lineage", name])
+    expanded = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--expand", "join"]
+    )
+
+    assert expanded.exit_code == 0, expanded.output
+    assert not expanded.output.lstrip().startswith("flowchart")
+    added = len(expanded.output.splitlines()) - len(compact.output.splitlines())
+    assert added == len(schema)
+    for column in schema:
+        assert column in expanded.output
+    # the collapsed runs are still collapsed: expanding says nothing about them
+    assert ("via [" in compact.output) == ("via [" in expanded.output)
+
+
+def test_lineage_expand_of_a_flight_boundary_shows_the_transition(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """A Flight boundary changes the schema across it, so both sides are listed."""
+    catalog_path, name = catalog_with_udxf
 
     result = runner.invoke(
         cli,
-        [
-            "--path",
-            catalog_path,
-            "lineage",
-            name,
-            "-f",
-            "mermaid",
-            "--node",
-            duck_table["id"],
-            "--expand",
-            "flight_udxf",
-        ],
+        ["--path", catalog_path, "lineage", name, "--expand", "flight_udxf"],
     )
 
     assert result.exit_code == 0, result.output
-    assert _mermaid_id(duck_table["id"]) in result.output
-    # nothing above or beside the selected leaf
-    assert _mermaid_id(dag.root) not in result.output
-    assert "UDXF[" not in result.output
-    assert "Cache[" not in result.output
+    assert "in " in result.output
+    assert "out " in result.output
 
 
 def test_lineage_expand_accepts_the_same_handles_as_node(
@@ -528,14 +513,11 @@ def test_lineage_expand_accepts_the_same_handles_as_node(
     assert by_kind.output == by_label.output == by_hash.output
 
 
-def test_lineage_expand_needs_mermaid_and_conflicts_with_raw(
+def test_lineage_expand_needs_a_tree_or_a_diagram(
     runner: CliRunner, catalog_with_udxf: tuple[str, str]
 ) -> None:
     catalog_path, name = catalog_with_udxf
 
-    text = runner.invoke(
-        cli, ["--path", catalog_path, "lineage", name, "--expand", "join"]
-    )
     with_raw = runner.invoke(
         cli,
         [
@@ -543,8 +525,6 @@ def test_lineage_expand_needs_mermaid_and_conflicts_with_raw(
             catalog_path,
             "lineage",
             name,
-            "-f",
-            "mermaid",
             "-l",
             "raw",
             "--expand",
@@ -555,10 +535,8 @@ def test_lineage_expand_needs_mermaid_and_conflicts_with_raw(
         cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid", "--expand", "x"]
     )
 
-    assert text.exit_code != 0
-    assert "--expand needs --format mermaid" in text.output
     assert with_raw.exit_code != 0
-    assert "redundant with --level raw" in with_raw.output
+    assert "already prints every stored field" in with_raw.output
     assert unknown.exit_code != 0
     assert "No lineage node matches 'x'" in unknown.output
 

--- a/python/xorq/catalog/tests/test_cli_lineage.py
+++ b/python/xorq/catalog/tests/test_cli_lineage.py
@@ -282,6 +282,81 @@ def test_lineage_node_of_an_unknown_handle_points_at_boundaries(
     assert "--level boundaries" in result.output
 
 
+def test_lineage_format_defaults_to_text(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    default = runner.invoke(cli, ["--path", catalog_path, "lineage", name])
+    explicit = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--format", "text"]
+    )
+
+    assert default.exit_code == 0, default.output
+    assert default.output == explicit.output
+    assert "flowchart" not in default.output
+
+
+def test_lineage_format_mermaid_emits_a_flowchart(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-f", "mermaid"]
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    assert lines[0] == "flowchart TD"
+    assert any("UDXF[OrderEnricher]" in line for line in lines)
+    assert any(line.strip().startswith("subgraph ") for line in lines)
+    assert any("-->" in line for line in lines)
+    assert any(line.strip().startswith("classDef ") for line in lines)
+    # tree glyphs belong to the text renderer only
+    assert "└──" not in result.output
+
+
+def test_lineage_format_mermaid_honours_node(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "lineage",
+            name,
+            "--node",
+            "flight_udxf",
+            "-f",
+            "mermaid",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.splitlines()[0] == "flowchart TD"
+    assert "UDXF[OrderEnricher]" in result.output
+    assert "Join(" not in result.output
+
+
+def test_lineage_format_mermaid_rejects_the_listing_levels(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """mermaid renders the graph; `raw` and `boundaries` are listings."""
+    catalog_path, name = catalog_with_udxf
+
+    for level in ("raw", "boundaries"):
+        result = runner.invoke(
+            cli,
+            ["--path", catalog_path, "lineage", name, "-f", "mermaid", "-l", level],
+        )
+        assert result.exit_code != 0, result.output
+        assert "--format mermaid renders the graph" in result.output
+
+
 def test_lineage_rejects_an_unknown_level(
     runner: CliRunner, catalog_with_udxf: tuple[str, str]
 ) -> None:

--- a/python/xorq/catalog/tests/test_cli_lineage.py
+++ b/python/xorq/catalog/tests/test_cli_lineage.py
@@ -474,6 +474,41 @@ def test_lineage_expand_reaches_the_run_above_the_node(
     assert "Field:" in result.output or "JoinReference" in result.output
 
 
+def test_lineage_node_bounds_expand(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """`--node` narrows; an `--expand` outside that subtree must not drag the rest
+    of the graph back in."""
+    catalog_path, name = catalog_with_udxf
+    dag = _lineage_dag(catalog_path, name)
+    [duck_table] = [
+        n for n in dag.boundaries(kind="table") if n.get("backend") == "duckdb"
+    ]
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "lineage",
+            name,
+            "-f",
+            "mermaid",
+            "--node",
+            duck_table["id"],
+            "--expand",
+            "flight_udxf",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _mermaid_id(duck_table["id"]) in result.output
+    # nothing above or beside the selected leaf
+    assert _mermaid_id(dag.root) not in result.output
+    assert "UDXF[" not in result.output
+    assert "Cache[" not in result.output
+
+
 def test_lineage_expand_accepts_the_same_handles_as_node(
     runner: CliRunner, catalog_with_udxf: tuple[str, str]
 ) -> None:

--- a/python/xorq/catalog/tests/test_cli_lineage.py
+++ b/python/xorq/catalog/tests/test_cli_lineage.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 import xorq.api as xo
 from xorq.catalog.catalog import Catalog
 from xorq.catalog.cli import cli
+from xorq.common.utils.lineage_utils import LineageDAG
 
 
 @pytest.fixture
@@ -95,7 +96,7 @@ def test_lineage_boundaries_is_one_tab_separated_line_per_boundary(
     rows = [
         line.split("\t")
         for line in result.output.splitlines()
-        if line and not line.startswith("# nested")
+        if line and not line.startswith("#")
     ]
     assert rows
     assert all(len(row) == 3 for row in rows), rows
@@ -133,6 +134,152 @@ def test_lineage_raw_is_the_stored_dag_as_json(
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     stored = catalog.get_catalog_entry(name).metadata.lineage
     assert raw == json.loads(json.dumps(stored.to_dict(), default=str))
+
+
+def _lineage_dag(catalog_path: str, name: str) -> LineageDAG:
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    return catalog.get_catalog_entry(name).metadata.lineage
+
+
+def test_lineage_node_by_kind_prints_the_subtree_feeding_it(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """`--node` scopes the compact tree to what feeds that node -- including the
+    UDXF's nested input lineage, which lives in its own scope."""
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--node", "flight_udxf"]
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    assert lines[0].startswith("UDXF[OrderEnricher] : 2→3 cols")
+    assert "↳ " in lines[1]
+    # scoped: the join and the duckdb side of the graph are not in this subtree
+    assert "Join(" not in result.output
+    assert "raw_customers" not in result.output
+
+
+def test_lineage_node_by_hash_and_by_label_agree(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """The content hash is the durable handle; the @label is the doc-local one."""
+    catalog_path, name = catalog_with_udxf
+    dag = _lineage_dag(catalog_path, name)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    by_hash = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--node", udxf["snapshot_hash"]]
+    )
+    by_label = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--node", udxf["id"]]
+    )
+
+    assert by_hash.exit_code == 0, by_hash.output
+    assert by_hash.output == by_label.output
+    assert "UDXF[OrderEnricher]" in by_hash.output
+
+
+def test_lineage_node_by_tag_value(runner: CliRunner, catalog_path: str) -> None:
+    """A tag resolves by its *value*, not just by the `tag:<value>` kind."""
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    tagged = xo.memtable({"x": [1, 2]}, name="sales").tag(tag="bsl", name="flights")
+    entry = catalog.add(tagged)
+
+    by_value = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", entry.name, "--node", "bsl"]
+    )
+    by_kind = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", entry.name, "--node", "tag"]
+    )
+
+    assert by_value.exit_code == 0, by_value.output
+    assert "Tag[bsl]" in by_value.output
+    assert by_value.output == by_kind.output
+
+
+def test_lineage_node_prints_every_match(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    """A kind handle resolves to several nodes; each gets its own subtree."""
+    catalog_path, name = catalog_with_udxf
+    dag = _lineage_dag(catalog_path, name)
+    tables = dag.boundaries(kind="table")
+    assert len(tables) > 1
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--node", "table"]
+    )
+
+    assert result.exit_code == 0, result.output
+    blocks = [b for b in result.output.split("\n\n") if b.strip()]
+    assert len(blocks) == len(tables)
+    assert "raw_customers" in result.output
+    assert "raw_orders" in result.output
+
+
+def test_lineage_node_with_raw_prints_only_the_matched_nodes(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli,
+        ["--path", catalog_path, "lineage", name, "--node", "flight_udxf", "-l", "raw"],
+    )
+
+    assert result.exit_code == 0, result.output
+    [node] = json.loads(result.output)
+    assert node["boundary_kind"] == "flight_udxf"
+    assert node["udxf_class"] == "OrderEnricher"
+    # the whole DAG's keys are absent: this is a node list, not the document
+    assert "nodes" not in node and "edges" not in node
+
+
+def test_lineage_node_with_boundaries_reports_capabilities_and_scope(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "lineage",
+            name,
+            "--node",
+            "flight_udxf",
+            "-l",
+            "boundaries",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    assert lines[0].split("\t")[1] == "flight_udxf"
+    assert any(line.startswith("# capabilities\t") for line in lines)
+    assert any(line.startswith("# nested\t") for line in lines)
+    # capability lines are for the expansion case only
+    listing = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "-l", "boundaries"]
+    )
+    assert "# capabilities" not in listing.output
+
+
+def test_lineage_node_of_an_unknown_handle_points_at_boundaries(
+    runner: CliRunner, catalog_with_udxf: tuple[str, str]
+) -> None:
+    catalog_path, name = catalog_with_udxf
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "lineage", name, "--node", "no-such-node"]
+    )
+
+    assert result.exit_code != 0
+    assert "No lineage node matches 'no-such-node'" in result.output
+    assert "--level boundaries" in result.output
 
 
 def test_lineage_rejects_an_unknown_level(

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 import pytest
 from textual.containers import VerticalScroll
+from textual.pilot import Pilot
 from textual.widgets import DataTable, Input, Select, Static, Tree
 
 import xorq.api as xo
@@ -39,9 +40,13 @@ from xorq.catalog.tests.testing import (
 )
 from xorq.catalog.tui import (
     BOUNDARY_STYLES,
+    EXPANDABLE_MARKER,
+    EXPANDED_MARKER,
     GIT_LOG_COLUMNS,
     KIND_ORDER,
     KIND_STYLES,
+    LINEAGE_TREE_OFFSET,
+    NO_MARKER,
     UNKNOWN_BOUNDARY_STYLE,
     AddAliasScreen,
     AddEntryScreen,
@@ -75,7 +80,12 @@ from xorq.common.utils.env_utils import (
     EnvConfigable,
     env_templates_dir,
 )
-from xorq.common.utils.lineage_utils import LineageDAG, compact_lineage_rows
+from xorq.common.utils.lineage_utils import (
+    COLUMN_KIND,
+    LineageDAG,
+    LineageRow,
+    compact_lineage_rows,
+)
 from xorq.config import TUI, options
 from xorq.ibis_yaml.enums import ExprKind
 
@@ -102,6 +112,21 @@ def entry_b(catalog):
     """A single-column bound expression: value (int)."""
     expr = xo.memtable({"value": [10, 20, 30]})
     return catalog.add(expr)
+
+
+@pytest.fixture
+def entry_columns(catalog: Catalog) -> CatalogEntry:
+    """An expression whose root node stores a schema worth expanding."""
+    t = xo.memtable({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    expr = t.filter(t.a > 1).mutate(c=t.a * 2).group_by("b").agg(n=xo._.a.sum())
+    return catalog.add(expr)
+
+
+@pytest.fixture
+def entry_wide(catalog: Catalog) -> CatalogEntry:
+    """Enough columns that one expansion overflows a short panel."""
+    t = xo.memtable({f"c{i}": [1, 2] for i in range(24)})
+    return catalog.add(t.filter(t.c0 > 0))
 
 
 @pytest.fixture
@@ -282,16 +307,23 @@ def test_lineage_panel_rich_puts_cache_and_hash_above_the_tree(
     entry_udxf: CatalogEntry,
 ) -> None:
     row = CatalogRowData(entry=entry_udxf)
-    lines = row.lineage_panel_rich.plain.splitlines()
+    lines = row.lineage_panel_rich().plain.splitlines()
 
     assert lines[0].startswith("Cache: ")
     assert lines[1].startswith("Hash: ")
     assert lines[2] == ""
-    # The tree renders unindented: the panel's border title labels it.
-    tree_lines = lines[3:]
+    # The tree renders with no header and no indent beyond the fold gutter: the
+    # panel's border title labels it.
+    tree_lines = lines[LINEAGE_TREE_OFFSET:]
     assert tree_lines == row.lineage_rich.plain.splitlines()
-    assert not tree_lines[0].startswith(" ")
-    assert row.lineage_panel_text == row.lineage_panel_rich.plain
+    # every row opens with the two-column fold gutter, so the labels line up
+    assert all(
+        line[:2] in (NO_MARKER, EXPANDABLE_MARKER, EXPANDED_MARKER)
+        or line[:2].strip("│├└─ ") == ""
+        for line in tree_lines
+    )
+    assert tree_lines[0][:2] == EXPANDABLE_MARKER, "the root stores a schema"
+    assert row.lineage_panel_text() == row.lineage_panel_rich().plain
 
 
 def test_lineage_rich_of_a_legacy_sidecar_uses_the_unknown_style() -> None:
@@ -310,7 +342,8 @@ def test_lineage_rich_of_a_legacy_sidecar_uses_the_unknown_style() -> None:
 
     rendered = _render_lineage_rows(compact_lineage_rows(legacy))
 
-    assert rendered.plain == f"{UNKNOWN_BOUNDARY_STYLE.icon} Filter"
+    # nothing is folded here, so the fold gutter is blank
+    assert rendered.plain == f"{NO_MARKER}{UNKNOWN_BOUNDARY_STYLE.icon} Filter"
     assert any(UNKNOWN_BOUNDARY_STYLE.color in str(s.style) for s in rendered.spans)
 
 
@@ -2315,7 +2348,10 @@ def test_tab_cycle_focus_no_crash(catalog):
 
 def test_lineage_panel_is_tab_reachable_and_scrollable(catalog: Catalog) -> None:
     """The lineage tree is multi-line and unbounded in depth: the panel must be in
-    the tab cycle and must scroll like #sql-panel."""
+    the tab cycle and must scroll like #sql-panel.
+
+    With no entry selected there are no rows, so `j`/`k` fall through to the
+    scroll container rather than moving a row cursor."""
 
     async def _test():
         app = _make_tui(catalog)
@@ -2337,6 +2373,330 @@ def test_lineage_panel_is_tab_reachable_and_scrollable(catalog: Catalog) -> None
             await pilot.press("k")
             await settle(pilot)
             assert isinstance(app.screen, CatalogScreen)
+
+    _run(_test())
+
+
+def _lineage_body(screen: CatalogScreen) -> str:
+    """The panel's rendered text, markers and all."""
+    return screen.query_one("#lineage-content", Static).render().plain
+
+
+def _cursor_row(screen: CatalogScreen) -> LineageRow | None:
+    """The lineage row the fold keys currently act on."""
+    return screen._lineage_cursor_row()
+
+
+async def _move_cursor_to(pilot: Pilot, node_id: str) -> None:
+    """Walk the lineage cursor down onto *node_id*'s row."""
+    screen = pilot.app.screen
+    for _ in range(len(screen._lineage_rows) + 1):
+        row = _cursor_row(screen)
+        if row is not None and row.node_id == node_id:
+            return
+        await pilot.press("j")
+        await settle(pilot)
+    raise AssertionError(f"the lineage cursor never reached {node_id}")
+
+
+async def _focus_lineage_panel(pilot: Pilot) -> None:
+    """Tab until the lineage panel owns focus, so the fold keys are live."""
+    panel = pilot.app.screen.query_one("#lineage-panel")
+    for _ in range(len(CatalogScreen.FOCUS_CYCLE)):
+        if pilot.app.focused is panel:
+            return
+        await pilot.press("tab")
+        await settle(pilot)
+    raise AssertionError("tab never reaches the Lineage panel")
+
+
+async def _await_lineage_rows(pilot: Pilot) -> None:
+    """Wait out the panel's render debounce, which `settle` does not cover."""
+    screen = pilot.app.screen
+    for _ in range(40):
+        await settle(pilot)
+        if screen._lineage_rows:
+            return
+        await pilot.pause()
+    raise AssertionError("the lineage panel never rendered any rows")
+
+
+async def _move_off_entry(pilot: Pilot) -> str:
+    """Move the entries-tree cursor off its current line; return the key pressed.
+
+    Which direction is available depends on where the entry sits in the tree, and
+    a step can land on a kind branch as well as another entry -- so this watches
+    the tree's own cursor rather than the selected row.
+    """
+    tree = pilot.app.screen.query_one("#catalog-tree", Tree)
+    start = tree.cursor_line
+    for key in ("j", "k"):
+        await pilot.press(key)
+        await settle(pilot)
+        if tree.cursor_line != start:
+            return key
+    raise AssertionError("the entries-tree cursor never moved")
+
+
+async def _select_lineage_entry(
+    pilot: Pilot, catalog: Catalog, *entries: CatalogEntry
+) -> CatalogScreen:
+    """Populate the tree and land on *entries[0]*'s leaf, rows rendered.
+
+    Leaves are grouped by kind and ordered by hash, not by insertion, so the
+    cursor is walked to the wanted entry rather than assumed to start on it.
+    """
+    screen = pilot.app.screen
+    rows = tuple(CatalogRowData(entry=entry) for entry in entries)
+    screen._row_cache = {row.row_key: row for row in rows}
+    screen._render_refresh(catalog.repo.working_dir, rows)
+    await settle(pilot)
+    wanted = rows[0].row_key
+    for _ in range(2 * len(rows) + 2):
+        await pilot.press("j")
+        await settle(pilot)
+        selected = screen._selected_row_data()
+        if selected is not None and selected.row_key == wanted:
+            await _await_lineage_rows(pilot)
+            return screen
+    raise AssertionError(f"never reached the leaf for {wanted}")
+
+
+def test_lineage_bracket_keys_expand_and_fold_the_cursor_node(
+    catalog: Catalog, entry_columns: CatalogEntry
+) -> None:
+    """`]` lists the columns of the node under the cursor and `[` folds them back,
+    the same thing `xorq catalog lineage --expand` prints."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = await _select_lineage_entry(pilot, catalog, entry_columns)
+            await _focus_lineage_panel(pilot)
+
+            row_data = screen._selected_row_data()
+            key = row_data.row_key
+            compact_rows = screen._lineage_rows
+            target = compact_rows[0]
+            assert target.node_id in row_data.lineage_expandable
+            assert EXPANDABLE_MARKER in _lineage_body(screen)
+
+            await _move_cursor_to(pilot, target.node_id)
+            await pilot.press("]")
+            await settle(pilot)
+
+            assert screen._lineage_expanded[key] == frozenset({target.node_id})
+            columns = [r for r in screen._lineage_rows if r.kind == COLUMN_KIND]
+            schema = row_data.entry.metadata.lineage.by_id[target.node_id]["schema"]
+            assert len(columns) == len(schema)
+            body = _lineage_body(screen)
+            for column in schema:
+                assert column in body
+            assert EXPANDED_MARKER in body
+            # the cursor stayed on the node it expanded
+            assert _cursor_row(screen).node_id == target.node_id
+
+            await pilot.press("[")
+            await settle(pilot)
+
+            assert screen._lineage_expanded[key] == frozenset()
+            assert screen._lineage_rows == compact_rows
+            assert EXPANDED_MARKER not in _lineage_body(screen)
+
+    _run(_test())
+
+
+def test_lineage_fold_keys_belong_to_the_panel_alone(
+    catalog: Catalog, entry_columns: CatalogEntry
+) -> None:
+    """`h`/`l` keep folding the entries tree, and the bracket keys are offered
+    only while the Lineage panel has focus."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = await _select_lineage_entry(pilot, catalog, entry_columns)
+            key = screen._selected_row_data().row_key
+
+            # entries tree focused: the fold bindings are hidden and inert
+            assert screen.check_action("lineage_expand", ()) is None
+            await pilot.press("]")
+            await settle(pilot)
+            assert screen._lineage_expanded.get(key, frozenset()) == frozenset()
+
+            await _focus_lineage_panel(pilot)
+            assert screen.check_action("lineage_expand", ()) is True
+
+            # `l` here is the tree's key, not the panel's: it folds nothing
+            await pilot.press("l")
+            await settle(pilot)
+            assert screen._lineage_expanded.get(key, frozenset()) == frozenset()
+
+            await pilot.press("]")
+            await settle(pilot)
+            assert screen._lineage_expanded[key]
+
+    _run(_test())
+
+
+def test_lineage_fold_on_a_column_row_folds_the_node_it_came_from(
+    catalog: Catalog, entry_columns: CatalogEntry
+) -> None:
+    """A column row belongs to the node above it, so `[` there folds that node --
+    the alternative is a cursor sitting on a row no key can act on."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = await _select_lineage_entry(pilot, catalog, entry_columns)
+            await _focus_lineage_panel(pilot)
+
+            key = screen._selected_row_data().row_key
+            target = screen._lineage_rows[0]
+            await _move_cursor_to(pilot, target.node_id)
+            await pilot.press("]")
+            await settle(pilot)
+
+            # step onto the first column row, which carries the same node id
+            await pilot.press("j")
+            await settle(pilot)
+            assert _cursor_row(screen).kind == COLUMN_KIND
+
+            await pilot.press("[")
+            await settle(pilot)
+
+            assert screen._lineage_expanded[key] == frozenset()
+            assert not [r for r in screen._lineage_rows if r.kind == COLUMN_KIND]
+
+    _run(_test())
+
+
+def test_lineage_expansion_is_kept_per_entry(
+    catalog: Catalog, entry_columns: CatalogEntry, entry_a: CatalogEntry
+) -> None:
+    """Fold state is keyed by entry, so browsing to a neighbour and back keeps
+    what you expanded."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = await _select_lineage_entry(pilot, catalog, entry_columns, entry_a)
+            await _focus_lineage_panel(pilot)
+
+            key = screen._selected_row_data().row_key
+            target = screen._lineage_rows[0]
+            await _move_cursor_to(pilot, target.node_id)
+            await pilot.press("]")
+            await settle(pilot)
+            expanded_rows = len(screen._lineage_rows)
+            assert screen._lineage_expanded[key]
+
+            # to the other entry and back: the fold keys are the panel's, so the
+            # entries tree has to take focus before j/k move the selection
+            await pilot.press("shift+tab")
+            await settle(pilot)
+            away = await _move_off_entry(pilot)
+            selected = screen._selected_row_data()
+            assert selected is None or selected.row_key != key
+
+            await pilot.press("k" if away == "j" else "j")
+            await _await_lineage_rows(pilot)
+
+            assert screen._selected_row_data().row_key == key
+            assert screen._lineage_expanded[key] == frozenset({target.node_id})
+            assert len(screen._lineage_rows) == expanded_rows
+
+    _run(_test())
+
+
+def test_lineage_cursor_walks_every_row_and_scrolls_to_follow(
+    catalog: Catalog, entry_wide: CatalogEntry
+) -> None:
+    """`j` advances one row at a time, scrolling to keep the cursor visible.
+
+    The cursor is a row index and not a node id because a node owns more than one
+    row once expanded -- its columns carry its id too, so an id-keyed cursor would
+    snap back to the node's own row.
+    """
+
+    async def _test():
+        app = _make_tui(catalog)
+        # a terminal too short for the expanded tree, so the panel has to scroll
+        async with app.run_test(size=(100, 24)) as pilot:
+            await settle(pilot)
+            screen = await _select_lineage_entry(pilot, catalog, entry_wide)
+            await _focus_lineage_panel(pilot)
+
+            key = screen._selected_row_data().row_key
+            target = screen._lineage_rows[0]
+            await _move_cursor_to(pilot, target.node_id)
+            await pilot.press("]")
+            await settle(pilot)
+
+            panel = screen.query_one("#lineage-panel", VerticalScroll)
+            rows = screen._lineage_rows
+            assert len(rows) > panel.content_size.height, "tree fits: nothing to scroll"
+            # the node and its columns share an id, which is what breaks an
+            # id-keyed cursor
+            assert len({r.node_id for r in rows}) < len(rows)
+
+            seen = [screen._lineage_cursor[key]]
+            for _ in range(len(rows)):
+                await pilot.press("j")
+                await settle(pilot)
+                seen.append(screen._lineage_cursor[key])
+
+            assert seen[-1] == len(rows) - 1, "the cursor never reached the last row"
+            assert all(b - a in (0, 1) for a, b in zip(seen, seen[1:])), seen
+            assert panel.scroll_offset.y > 0, "the panel never scrolled to follow"
+
+    _run(_test())
+
+
+def test_lineage_expand_on_a_column_row_does_nothing(
+    catalog: Catalog, entry_columns: CatalogEntry
+) -> None:
+    """A column row's node is already expanded, so `]` there is a silent no-op --
+    and the row carries no marker, which is the whole message.
+
+    (Every row a compact tree draws is a boundary or the root, and those all store
+    a schema, so this is the only unexpandable row the panel can show.)
+    """
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = await _select_lineage_entry(pilot, catalog, entry_columns)
+            await _focus_lineage_panel(pilot)
+
+            key = screen._selected_row_data().row_key
+            target = screen._lineage_rows[0]
+            await _move_cursor_to(pilot, target.node_id)
+            await pilot.press("]")
+            await settle(pilot)
+            expanded = screen._lineage_expanded[key]
+
+            await pilot.press("j")
+            await settle(pilot)
+            column_row = _cursor_row(screen)
+            assert column_row.kind == COLUMN_KIND
+            rows_before = screen._lineage_rows
+
+            await pilot.press("]")
+            await settle(pilot)
+
+            assert screen._lineage_expanded[key] == expanded
+            assert screen._lineage_rows == rows_before
+            # the column row itself is not offered as expandable
+            body_line = _lineage_body(screen).splitlines()[
+                LINEAGE_TREE_OFFSET + rows_before.index(column_row)
+            ]
+            assert EXPANDABLE_MARKER not in body_line
 
     _run(_test())
 

--- a/python/xorq/catalog/tests/test_tui.py
+++ b/python/xorq/catalog/tests/test_tui.py
@@ -278,15 +278,20 @@ def test_lineage_rich_styles_each_boundary_kind(entry_udxf: CatalogEntry) -> Non
     assert UNKNOWN_BOUNDARY_STYLE.icon not in rich.plain
 
 
-def test_info_rich_labels_and_indents_the_lineage(entry_udxf: CatalogEntry) -> None:
+def test_lineage_panel_rich_puts_cache_and_hash_above_the_tree(
+    entry_udxf: CatalogEntry,
+) -> None:
     row = CatalogRowData(entry=entry_udxf)
-    lines = row.info_rich.plain.splitlines()
+    lines = row.lineage_panel_rich.plain.splitlines()
 
-    assert lines[0] == "Lineage:"
-    assert all(line.startswith("  ") for line in lines[1:-2])
-    assert lines[-2].startswith("Cache: ")
-    assert lines[-1].startswith("Hash: ")
-    assert row.info_text == row.info_rich.plain
+    assert lines[0].startswith("Cache: ")
+    assert lines[1].startswith("Hash: ")
+    assert lines[2] == ""
+    # The tree renders unindented: the panel's border title labels it.
+    tree_lines = lines[3:]
+    assert tree_lines == row.lineage_rich.plain.splitlines()
+    assert not tree_lines[0].startswith(" ")
+    assert row.lineage_panel_text == row.lineage_panel_rich.plain
 
 
 def test_lineage_rich_of_a_legacy_sidecar_uses_the_unknown_style() -> None:
@@ -872,13 +877,29 @@ def test_data_preview_hidden_by_default(catalog):
     _run(_test())
 
 
-def test_info_panel_exists(catalog):
+def test_lineage_panel_exists(catalog: Catalog) -> None:
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:
             await settle(pilot)
-            info = app.screen.query_one("#info-panel")
-            assert info.border_title == "Info"
+            lineage = app.screen.query_one("#lineage-panel")
+            assert lineage.border_title == "Lineage"
+
+    _run(_test())
+
+
+def test_lineage_is_the_default_view(catalog: Catalog) -> None:
+    """1/2/3 swap one panel into the right column; lineage is what you land on."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = app.screen
+            assert screen._active_view == "lineage"
+            assert screen.query_one("#lineage-panel").display is True
+            assert screen.query_one("#sql-panel").display is False
+            assert screen.query_one("#data-preview-panel").display is False
 
     _run(_test())
 
@@ -1174,35 +1195,84 @@ def test_schema_preview_empty_before_selection(catalog):
     _run(_test())
 
 
-def test_view_switching_1_2(catalog):
+def test_view_switching_1_2_3(catalog: Catalog) -> None:
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:
             await settle(pilot)
             screen = app.screen
 
+            lineage_panel = screen.query_one("#lineage-panel")
             sql_panel = screen.query_one("#sql-panel")
             data_panel = screen.query_one("#data-preview-panel")
 
             await run_script(
                 pilot,
-                # Default: SQL visible, data hidden
+                # Default: lineage visible, sql and data hidden
+                Assert(lambda p: lineage_panel.display is True),
+                Assert(lambda p: sql_panel.display is False),
+                Assert(lambda p: data_panel.display is False),
+                # Switch to SQL
+                Press(("2",)),
+                Assert(lambda p: lineage_panel.display is False),
                 Assert(lambda p: sql_panel.display is True),
                 Assert(lambda p: data_panel.display is False),
                 # Switch to data
-                Press(("2",)),
+                Press(("3",)),
+                Assert(lambda p: lineage_panel.display is False),
                 Assert(lambda p: sql_panel.display is False),
                 Assert(lambda p: data_panel.display is True),
-                # Switch back to SQL
+                # Switch back to lineage
                 Press(("1",)),
-                Assert(lambda p: sql_panel.display is True),
+                Assert(lambda p: lineage_panel.display is True),
+                Assert(lambda p: sql_panel.display is False),
                 Assert(lambda p: data_panel.display is False),
             )
 
     _run(_test())
 
 
-def test_v_toggles_revisions(catalog):
+def test_sql_preview_renders_only_while_the_sql_view_is_active(
+    catalog: Catalog, entry_a: CatalogEntry, entry_b: CatalogEntry
+) -> None:
+    """SQL highlighting costs a worker per selection, so browsing lineage must
+    not render it; switching to the SQL view renders the current selection."""
+
+    async def _test():
+        app = _make_tui(catalog)
+        rows = (
+            CatalogRowData(entry=entry_a, aliases=("a",)),
+            CatalogRowData(entry=entry_b, aliases=("b",)),
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settle(pilot)
+            screen = app.screen
+            assert isinstance(screen, CatalogScreen)
+
+            screen._row_cache = {r.row_key: r for r in rows}
+            screen._render_refresh(catalog.repo.working_dir, rows)
+            await settle(pilot)
+
+            schema_table = screen.query_one("#schema-preview-table", DataTable)
+
+            await run_script(
+                pilot,
+                # Move past branch to first leaf: schema renders, SQL does not.
+                Press(("j",)),
+                WaitUntil(lambda: schema_table.row_count == 3),
+                Assert(lambda p: screen._current_sql_hash is None),
+                # Switching to the SQL view renders the selection on demand.
+                Press(("2",)),
+                Assert(lambda p: screen._current_sql_hash == rows[0].row_key),
+                # Leaving the view clears the guard so re-entry re-renders.
+                Press(("1",)),
+                Assert(lambda p: screen._current_sql_hash is None),
+            )
+
+    _run(_test())
+
+
+def test_v_toggles_revisions(catalog: Catalog) -> None:
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:
@@ -2243,23 +2313,23 @@ def test_tab_cycle_focus_no_crash(catalog):
     _run(_test())
 
 
-def test_info_panel_is_tab_reachable_and_scrollable(catalog: Catalog) -> None:
-    """The lineage tree is multi-line and taller than the panel: Info must be in
+def test_lineage_panel_is_tab_reachable_and_scrollable(catalog: Catalog) -> None:
+    """The lineage tree is multi-line and unbounded in depth: the panel must be in
     the tab cycle and must scroll like #sql-panel."""
 
     async def _test():
         app = _make_tui(catalog)
         async with app.run_test(size=(120, 40)) as pilot:
             await settle(pilot)
-            info_panel = app.screen.query_one("#info-panel")
-            assert isinstance(info_panel, VerticalScroll)
+            lineage_panel = app.screen.query_one("#lineage-panel")
+            assert isinstance(lineage_panel, VerticalScroll)
 
             for _ in range(len(CatalogScreen.FOCUS_CYCLE)):
-                if app.focused is info_panel:
+                if app.focused is lineage_panel:
                     break
                 await pilot.press("tab")
                 await settle(pilot)
-            assert app.focused is info_panel, "tab never reaches the Info panel"
+            assert app.focused is lineage_panel, "tab never reaches the Lineage panel"
 
             # j/k dispatch to the focused VerticalScroll
             await pilot.press("j")

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -225,7 +225,7 @@ BOUNDARY_STYLES: dict[str, KindStyle] = {
 UNKNOWN_BOUNDARY_STYLE = KindStyle(icon="·", color=XORQ_DARK.variables["panel-dim-fg"])
 
 
-def _render_lineage_rows(rows: "tuple[LineageRow, ...]", prefix: str = "") -> Text:
+def _render_lineage_rows(rows: "tuple[LineageRow, ...]") -> Text:
     """Style a compact lineage tree: glyphs dim, icon+label per boundary kind,
     collapsed `via [...]` runs dim.  Its `.plain` is the plain-text tree."""
     text = Text(no_wrap=False, overflow="fold")
@@ -233,7 +233,7 @@ def _render_lineage_rows(rows: "tuple[LineageRow, ...]", prefix: str = "") -> Te
         style = BOUNDARY_STYLES.get(row.kind, UNKNOWN_BOUNDARY_STYLE)
         if i:
             text.append("\n")
-        text.append(prefix + row.prefix, style="dim")
+        text.append(row.prefix, style="dim")
         text.append(f"{style.icon} ", style=f"bold {style.color}")
         text.append(row.label, style=style.color)
         if row.via:
@@ -341,31 +341,21 @@ class CatalogRowData:
                 return "○ uncached"
 
     @cached_property
-    def info_rich(self) -> Text:
-        from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
-            compact_lineage_rows,
-        )
-
-        lineage = self.entry.metadata.lineage
-        # The lineage is a multi-line tree: label it, then indent the tree under
-        # the label so the branch glyphs stay aligned.
-        tree = (
-            _render_lineage_rows(compact_lineage_rows(lineage), prefix="  ")
-            if lineage and lineage.nodes
-            else Text("  (empty)", style="dim")
-        )
+    def lineage_panel_rich(self) -> Text:
+        # Cache/Hash first: the lineage tree is unbounded in depth, so rendering
+        # it last would push the entry's identity off the top of the panel.
         text = Text(no_wrap=False, overflow="fold")
-        text.append("Lineage:\n", style="bold")
-        text.append_text(tree)
-        text.append("\nCache: ", style="bold")
+        text.append("Cache: ", style="bold")
         text.append(self.cache_info_text)
         text.append("\nHash: ", style="bold")
         text.append(self.hash)
+        text.append("\n\n")
+        text.append_text(self.lineage_rich)
         return text
 
     @cached_property
-    def info_text(self) -> str:
-        return self.info_rich.plain
+    def lineage_panel_text(self) -> str:
+        return self.lineage_panel_rich.plain
 
     @property
     def row_key(self) -> str:
@@ -851,15 +841,16 @@ class CatalogScreen(Screen):
         Binding("d", "delete_entry", "Delete"),
         Binding("v", "toggle_revisions", "Revisions"),
         Binding("g", "toggle_git_log", "Git Log"),
-        Binding("1", "view_sql", "SQL", priority=True),
-        Binding("2", "view_data", "Data", priority=True),
+        Binding("1", "view_lineage", "Lineage", priority=True),
+        Binding("2", "view_sql", "SQL", priority=True),
+        Binding("3", "view_data", "Data", priority=True),
     )
 
     FOCUS_CYCLE = (
         "#catalog-tree",
+        "#lineage-panel",
         "#sql-panel",
         "#data-preview-panel",
-        "#info-panel",
         "#schema-preview-table",
     )
 
@@ -873,7 +864,7 @@ class CatalogScreen(Screen):
         self._git_log_visible = options.tui.git_log_open
         self._git_log_loaded = False
         self._refresh_lock = threading.Lock()
-        self._active_view: Literal["sql", "data"] = "sql"
+        self._active_view: Literal["lineage", "sql", "data"] = "lineage"
         self._data_preview_hash: str | None = None
         self._current_sql_hash: str | None = None
         self._highlight_timer = None
@@ -889,15 +880,15 @@ class CatalogScreen(Screen):
                 with Vertical(id="git-log-panel"):
                     yield DataTable(id="git-log-table")
             with Vertical(id="right-column"):
+                # Scrollable: the lineage tree is multi-line and unbounded in
+                # depth, so the panel cannot show all of it at any fixed height.
+                with VerticalScroll(id="lineage-panel"):
+                    yield Static("", id="lineage-content")
                 with VerticalScroll(id="sql-panel"):
                     yield Static("", id="sql-preview")
                 with Vertical(id="data-preview-panel"):
                     yield Static("", id="data-preview-status")
                     yield DataTable(id="data-preview-table")
-                # Scrollable: the lineage tree is multi-line and unbounded in
-                # depth, so the panel cannot show all of it at any fixed height.
-                with VerticalScroll(id="info-panel"):
-                    yield Static("", id="info-content")
                 with Vertical(id="schema-panel"):
                     with Horizontal(id="schema-split"):
                         with Vertical(id="schema-in-half"):
@@ -944,12 +935,14 @@ class CatalogScreen(Screen):
         self.query_one("#catalog-panel").border_title = "Expressions"
         self.query_one("#schema-panel").border_title = "Schema"
         self.query_one("#schema-in-half").display = False
-        self.query_one("#sql-panel").border_title = "SQL"
+        sql_panel = self.query_one("#sql-panel")
+        sql_panel.border_title = "SQL"
+        sql_panel.display = False
         self.query_one("#sql-preview", Static).update(
             Text("← Select an expression to view its SQL", style="dim")
         )
-        self.query_one("#info-panel").border_title = "Info"
-        self.query_one("#info-content", Static).update(
+        self.query_one("#lineage-panel").border_title = "Lineage"
+        self.query_one("#lineage-content", Static).update(
             Text("← Select an expression", style="dim")
         )
         self.query_one("#revisions-panel").border_title = "Revisions"
@@ -1013,8 +1006,7 @@ class CatalogScreen(Screen):
         schema_in_table.clear()
         schema_out_table = self.query_one("#schema-preview-table", DataTable)
         schema_out_table.clear()
-        sql_preview = self.query_one("#sql-preview", Static)
-        info_content = self.query_one("#info-content", Static)
+        lineage_content = self.query_one("#lineage-content", Static)
         rev_table = self.query_one("#revisions-preview-table", DataTable)
         rev_table.clear()
 
@@ -1029,8 +1021,8 @@ class CatalogScreen(Screen):
         )
         if row_data is None:
             self._current_sql_hash = None
-            sql_preview.update("")
-            info_content.update("")
+            self.query_one("#sql-preview", Static).update("")
+            lineage_content.update("")
             self.query_one("#schema-in-half").display = False
             self.query_one("#revisions-panel").border_title = "Revisions"
             return
@@ -1053,29 +1045,18 @@ class CatalogScreen(Screen):
         for name, dtype in row_data.schema_out:
             schema_out_table.add_row(name, dtype)
 
-        # SQL preview
-        sql_panel = self.query_one("#sql-panel")
-        match row_data.sqls:
-            case ():
-                self._current_sql_hash = None
-                sql_preview.update("(SQL unavailable)")
-                sql_panel.border_subtitle = ""
-            case ((_, engine, sql),):
-                sql_panel.border_subtitle = engine
-                self._current_sql_hash = row_data.row_key
-                sql_preview.update(Text("Rendering SQL Query…", style="dim"))
-                self._load_sql_preview(row_data.row_key, sql)
-            case sqls:
-                engines = sorted({engine for _, engine, _ in sqls})
-                sql_panel.border_subtitle = (
-                    f"{len(sqls)} queries · {', '.join(engines)}"
-                )
-                self._current_sql_hash = row_data.row_key
-                sql_preview.update(Text("Rendering SQL Query…", style="dim"))
-                self._load_sql_preview(row_data.row_key, sqls)
+        # Lineage panel: cheap (metadata only), so render regardless of view.
+        lineage_content.update(row_data.lineage_panel_rich)
 
-        # Info panel
-        info_content.update(row_data.info_rich)
+        # SQL and data previews both cost a worker, so only the active view pays
+        # for them; switching views renders the current selection on demand.
+        match self._active_view:
+            case "sql":
+                self._refresh_sql_preview(row_data)
+            case "data":
+                self._refresh_data_preview(row_data)
+            case _:
+                pass
 
         # Revisions preview
         match row_data.aliases:
@@ -1098,10 +1079,6 @@ class CatalogScreen(Screen):
                 self.query_one(
                     "#revisions-panel"
                 ).border_title = "Revisions — (no alias)"
-
-        # Update data preview if data view is active
-        if self._active_view == "data":
-            self._refresh_data_preview(row_data)
 
     def _tree_entry_hashes(self) -> set[str]:
         """Return set of entry hashes currently in the tree."""
@@ -1293,7 +1270,7 @@ class CatalogScreen(Screen):
     def _apply_alias_changes(self, keys: set[str]) -> None:
         self._relabel_leaves(keys)
         # If the cursor sits on an affected entry, the side panels (Revisions
-        # title, Info) were rendered from the stale aliases; re-render them.
+        # title, Lineage) were rendered from the stale aliases; re-render them.
         tree = self.query_one("#catalog-tree", Tree)
         node = tree.cursor_node
         if node is not None and node.data in keys:
@@ -1362,22 +1339,33 @@ class CatalogScreen(Screen):
             for i, row_data in enumerate(rows):
                 table.add_row(*row_data.row, key=str(i))
 
-    # --- View switching (1/2) ---
+    # --- View switching (1/2/3) ---
 
-    def _set_active_view(self, view: Literal["sql", "data"]) -> None:
+    def _set_active_view(self, view: Literal["lineage", "sql", "data"]) -> None:
         self._active_view = view
+        self.query_one("#lineage-panel").display = view == "lineage"
         self.query_one("#sql-panel").display = view == "sql"
         self.query_one("#data-preview-panel").display = view == "data"
 
-        if view == "data":
-            tree = self.query_one("#catalog-tree", Tree)
-            node = tree.cursor_node
-            if node is not None and node.data is not None:
-                row_data = self._row_cache.get(node.data)
-                if row_data is not None:
-                    self._refresh_data_preview(row_data)
-        else:
+        # The inactive views' dedup guards are cleared so re-entering a view
+        # re-renders the selection that changed while it was hidden.
+        if view != "data":
             self._data_preview_hash = None
+        if view != "sql":
+            self._current_sql_hash = None
+        if view == "lineage":
+            return
+
+        row_data = self._selected_row_data()
+        if row_data is None:
+            return
+        if view == "sql":
+            self._refresh_sql_preview(row_data)
+        else:
+            self._refresh_data_preview(row_data)
+
+    def action_view_lineage(self) -> None:
+        self._set_active_view("lineage")
 
     def action_view_sql(self) -> None:
         self._set_active_view("sql")
@@ -1385,7 +1373,31 @@ class CatalogScreen(Screen):
     def action_view_data(self) -> None:
         self._set_active_view("data")
 
-    def _refresh_data_preview(self, row_data) -> None:
+    def _refresh_sql_preview(self, row_data: CatalogRowData) -> None:
+        if self._current_sql_hash == row_data.row_key:
+            return
+        sql_preview = self.query_one("#sql-preview", Static)
+        sql_panel = self.query_one("#sql-panel")
+        match row_data.sqls:
+            case ():
+                self._current_sql_hash = None
+                sql_preview.update("(SQL unavailable)")
+                sql_panel.border_subtitle = ""
+            case ((_, engine, sql),):
+                sql_panel.border_subtitle = engine
+                self._current_sql_hash = row_data.row_key
+                sql_preview.update(Text("Rendering SQL Query…", style="dim"))
+                self._load_sql_preview(row_data.row_key, sql)
+            case sqls:
+                engines = sorted({engine for _, engine, _ in sqls})
+                sql_panel.border_subtitle = (
+                    f"{len(sqls)} queries · {', '.join(engines)}"
+                )
+                self._current_sql_hash = row_data.row_key
+                sql_preview.update(Text("Rendering SQL Query…", style="dim"))
+                self._load_sql_preview(row_data.row_key, sqls)
+
+    def _refresh_data_preview(self, row_data: CatalogRowData) -> None:
         entry_hash = row_data.row_key
         if self._data_preview_hash == entry_hash:
             return
@@ -2206,7 +2218,7 @@ class CatalogTUI(App):
     #revisions-panel,
     #git-log-panel,
     #sql-panel,
-    #info-panel,
+    #lineage-panel,
     #schema-panel,
     #data-preview-panel,
     DataViewScreen #stack-browser-panel {
@@ -2218,7 +2230,7 @@ class CatalogTUI(App):
     #revisions-panel:focus-within,
     #git-log-panel:focus-within,
     #sql-panel:focus-within,
-    #info-panel:focus-within,
+    #lineage-panel:focus-within,
     #schema-panel:focus-within,
     #data-preview-panel:focus-within,
     DataViewScreen #stack-browser-panel:focus-within {
@@ -2242,8 +2254,7 @@ class CatalogTUI(App):
     DataTable:focus { border: none; }
     Tree:focus { border: none; }
 
-    #info-panel { height: auto; max-height: 6; padding: 0 1; }
-    #info-content { height: auto; }
+    #lineage-panel { height: 2fr; padding: 0 1; }
 
     #schema-panel { height: 1fr; }
     #schema-split { height: 1fr; }

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -26,6 +26,7 @@ from pygments.token import (
     String,
     Token,
 )
+from rich.cells import cell_len
 from rich.text import Text
 from textual import on, work
 from textual.app import App, ComposeResult
@@ -226,8 +227,8 @@ UNKNOWN_BOUNDARY_STYLE = KindStyle(icon="·", color=XORQ_DARK.variables["panel-d
 
 
 # Fold gutter, two columns wide on every row so the labels stay aligned: a node
-# that stores a schema can be expanded with `l` to list its columns, and folded
-# back with `h`.
+# that stores a schema can be expanded with `]` to list its columns, and folded
+# back with `[`.
 EXPANDABLE_MARKER = "▸ "
 EXPANDED_MARKER = "▾ "
 NO_MARKER = "  "
@@ -283,7 +284,8 @@ def _render_lineage_rows(
         if row.via:
             text.append(row.via_suffix, style=f"dim italic{cursor}")
         elif on_cursor:
-            # extend the highlight to the full panel width, as a cursor should
+            # one reversed trailing cell, so the cursor reads as a cursor even
+            # when the label ends the line (Rich pads with unstyled cells)
             text.append(" ", style="reverse")
     return text
 
@@ -387,7 +389,7 @@ class CatalogRowData:
 
     @cached_property
     def lineage_expandable(self) -> frozenset[str]:
-        """Ids of the nodes that store a schema, so `l` has columns to show."""
+        """Ids of the nodes that store a schema, so `]` has columns to show."""
         from xorq.common.utils.lineage_utils import node_columns  # noqa: PLC0415
 
         lineage = self.entry.metadata.lineage
@@ -1539,21 +1541,28 @@ class CatalogScreen(Screen):
         target = min(max(cursor + direction, 0), len(rows) - 1)
         self._lineage_cursor[row_data.row_key] = target
         self._render_lineage_panel(row_data)
-        self._scroll_lineage_cursor(target)
+        self._scroll_lineage_cursor(row_data, target)
 
-    def _scroll_lineage_cursor(self, row_index: int) -> None:
+    def _scroll_lineage_cursor(self, row_data: CatalogRowData, row_index: int) -> None:
         """Keep the cursor row inside the panel's viewport.
 
         The panel is one Static, so Textual has no per-row region to scroll to:
-        the row index *is* the y offset of the tree, which starts after the
-        Cache/Hash lines and the blank one.
+        the y offset is counted off the rendered lines above the cursor row.
+        The content folds (`overflow="fold"`), so a long Hash or label takes one
+        display line per panel-width of cells, not one per source line.
         """
         panel = self.query_one("#lineage-panel", VerticalScroll)
-        y = row_index + LINEAGE_TREE_OFFSET
-        top = panel.scroll_offset.y
         height = panel.content_size.height
         if height <= 0:
             return
+        expanded = self._lineage_expanded.get(row_data.row_key, frozenset())
+        lines = row_data.lineage_panel_text(expanded).split("\n")
+        width = self.query_one("#lineage-content", Static).content_size.width
+        y = sum(
+            max(1, math.ceil(cell_len(line) / width)) if width > 0 else 1
+            for line in lines[: row_index + LINEAGE_TREE_OFFSET]
+        )
+        top = panel.scroll_offset.y
         if y < top:
             panel.scroll_to(y=y, animate=False)
         elif y >= top + height:
@@ -1575,12 +1584,12 @@ class CatalogScreen(Screen):
         if row_data is None or row is None or row.node_id is None:
             return
         key = row_data.row_key
-        # A column row carries its owner's id, so `h` on one folds the node it
+        # A column row carries its owner's id, so `[` on one folds the node it
         # came from -- which is the node the user is looking at.
         node_id = row.node_id
         expanded = self._lineage_expanded.get(key, frozenset())
         if expand:
-            # No schema stored at this node: `l` is a no-op, as the missing marker
+            # No schema stored at this node: `]` is a no-op, as the missing marker
             # already says.
             if node_id not in row_data.lineage_expandable or node_id in expanded:
                 return

--- a/python/xorq/catalog/tui.py
+++ b/python/xorq/catalog/tui.py
@@ -225,19 +225,66 @@ BOUNDARY_STYLES: dict[str, KindStyle] = {
 UNKNOWN_BOUNDARY_STYLE = KindStyle(icon="·", color=XORQ_DARK.variables["panel-dim-fg"])
 
 
-def _render_lineage_rows(rows: "tuple[LineageRow, ...]") -> Text:
+# Fold gutter, two columns wide on every row so the labels stay aligned: a node
+# that stores a schema can be expanded with `l` to list its columns, and folded
+# back with `h`.
+EXPANDABLE_MARKER = "▸ "
+EXPANDED_MARKER = "▾ "
+NO_MARKER = "  "
+
+# Lines the panel prints above the tree: Cache, Hash, and the blank between.
+LINEAGE_TREE_OFFSET = 3
+
+# Columns are the expansion itself, not something to expand further, so they get
+# no icon and no gutter marker -- just a dim, indented row.
+COLUMN_ROW_STYLE = "dim italic"
+
+
+def _render_lineage_rows(
+    rows: "tuple[LineageRow, ...]",
+    expanded: frozenset[str] = frozenset(),
+    cursor_row: int | None = None,
+    expandable: frozenset[str] = frozenset(),
+) -> Text:
     """Style a compact lineage tree: glyphs dim, icon+label per boundary kind,
-    collapsed `via [...]` runs dim.  Its `.plain` is the plain-text tree."""
+    collapsed `via [...]` runs dim.  Its `.plain` is the plain-text tree.
+
+    *expanded* is the set of node ids whose columns are listed, which marks their
+    rows `▾`; *expandable* is the set that could be, marked `▸`; *cursor_row* is
+    the index of the row the fold keys act on, rendered reversed.
+    """
+    from xorq.common.utils.lineage_utils import COLUMN_KIND  # noqa: PLC0415
+
     text = Text(no_wrap=False, overflow="fold")
     for i, row in enumerate(rows):
-        style = BOUNDARY_STYLES.get(row.kind, UNKNOWN_BOUNDARY_STYLE)
         if i:
             text.append("\n")
-        text.append(row.prefix, style="dim")
-        text.append(f"{style.icon} ", style=f"bold {style.color}")
-        text.append(row.label, style=style.color)
+        on_cursor = i == cursor_row
+        # The cursor is a whole-line reverse, so every span on the line carries it.
+        cursor = " reverse" if on_cursor else ""
+        if row.kind == COLUMN_KIND:
+            text.append(row.prefix, style=f"dim{cursor}")
+            text.append(NO_MARKER, style=f"dim{cursor}")
+            text.append(row.label, style=f"{COLUMN_ROW_STYLE}{cursor}")
+            if on_cursor:
+                text.append(" ", style="reverse")
+            continue
+        style = BOUNDARY_STYLES.get(row.kind, UNKNOWN_BOUNDARY_STYLE)
+        if row.node_id in expanded:
+            marker = EXPANDED_MARKER
+        elif row.node_id in expandable:
+            marker = EXPANDABLE_MARKER
+        else:
+            marker = NO_MARKER
+        text.append(row.prefix, style=f"dim{cursor}")
+        text.append(marker, style=f"dim{cursor}")
+        text.append(f"{style.icon} ", style=f"bold {style.color}{cursor}")
+        text.append(row.label, style=f"{style.color}{cursor}")
         if row.via:
-            text.append(row.via_suffix, style="dim italic")
+            text.append(row.via_suffix, style=f"dim italic{cursor}")
+        elif on_cursor:
+            # extend the highlight to the full panel width, as a cursor should
+            text.append(" ", style="reverse")
     return text
 
 
@@ -314,15 +361,50 @@ class CatalogRowData:
         return self.entry.metadata.sql_queries
 
     @cached_property
-    def lineage_rich(self) -> Text:
+    def _lineage_line_cache(self) -> dict:
+        # The TUI re-renders the panel on every keypress, so the walk is done once
+        # per fold state rather than once per key.
+        return {}
+
+    def lineage_lines(
+        self, expand_columns: frozenset[str] = frozenset()
+    ) -> "tuple[LineageRow, ...]":
+        """The tree's rows, listing the columns of every node in *expand_columns*."""
         from xorq.common.utils.lineage_utils import (  # noqa: PLC0415
             compact_lineage_rows,
         )
 
+        if expand_columns in self._lineage_line_cache:
+            return self._lineage_line_cache[expand_columns]
+        lineage = self.entry.metadata.lineage
+        rows = (
+            ()
+            if not lineage or not lineage.nodes
+            else compact_lineage_rows(lineage, expand_columns=expand_columns)
+        )
+        self._lineage_line_cache[expand_columns] = rows
+        return rows
+
+    @cached_property
+    def lineage_expandable(self) -> frozenset[str]:
+        """Ids of the nodes that store a schema, so `l` has columns to show."""
+        from xorq.common.utils.lineage_utils import node_columns  # noqa: PLC0415
+
         lineage = self.entry.metadata.lineage
         if not lineage or not lineage.nodes:
-            return Text("(empty)", style="dim")
-        return _render_lineage_rows(compact_lineage_rows(lineage))
+            return frozenset()
+        return frozenset(
+            nid for nid, node in lineage.by_id.items() if node_columns(node)
+        )
+
+    @cached_property
+    def lineage_rich(self) -> Text:
+        rows = self.lineage_lines()
+        return (
+            Text("(empty)", style="dim")
+            if not rows
+            else _render_lineage_rows(rows, expandable=self.lineage_expandable)
+        )
 
     @cached_property
     def lineage_text(self) -> str:
@@ -340,8 +422,11 @@ class CatalogRowData:
             case _:
                 return "○ uncached"
 
-    @cached_property
-    def lineage_panel_rich(self) -> Text:
+    def lineage_panel_rich(
+        self,
+        expand_columns: frozenset[str] = frozenset(),
+        cursor_row: int | None = None,
+    ) -> Text:
         # Cache/Hash first: the lineage tree is unbounded in depth, so rendering
         # it last would push the entry's identity off the top of the panel.
         text = Text(no_wrap=False, overflow="fold")
@@ -350,12 +435,26 @@ class CatalogRowData:
         text.append("\nHash: ", style="bold")
         text.append(self.hash)
         text.append("\n\n")
-        text.append_text(self.lineage_rich)
+        rows = self.lineage_lines(expand_columns)
+        if not rows:
+            text.append("(empty)", style="dim")
+        else:
+            text.append_text(
+                _render_lineage_rows(
+                    rows,
+                    expanded=expand_columns,
+                    cursor_row=cursor_row,
+                    expandable=self.lineage_expandable,
+                )
+            )
         return text
 
-    @cached_property
-    def lineage_panel_text(self) -> str:
-        return self.lineage_panel_rich.plain
+    def lineage_panel_text(
+        self,
+        expand_columns: frozenset[str] = frozenset(),
+        cursor_row: int | None = None,
+    ) -> str:
+        return self.lineage_panel_rich(expand_columns, cursor_row).plain
 
     @property
     def row_key(self) -> str:
@@ -830,6 +929,13 @@ class CatalogScreen(Screen):
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
         Binding("l", "tree_expand", "Expand", show=False),
+        # Fold a lineage node's columns. Separate keys from the tree's h/l so the
+        # two folds never depend on which panel happens to hold focus; shown in
+        # the footer only while the Lineage panel does (see check_action).
+        Binding("]", "lineage_expand", "Columns", key_display="]"),
+        Binding("[", "lineage_collapse", "Fold", key_display="["),
+        Binding("right_square_bracket", "lineage_expand", "Columns", show=False),
+        Binding("left_square_bracket", "lineage_collapse", "Fold", show=False),
         Binding("tab", "focus_next_panel", "Next", show=False),
         Binding("shift+tab", "focus_prev_panel", "Prev", show=False),
         Binding("e", "open_data_view", "Explore"),
@@ -868,6 +974,13 @@ class CatalogScreen(Screen):
         self._data_preview_hash: str | None = None
         self._current_sql_hash: str | None = None
         self._highlight_timer = None
+        # Lineage fold state, per entry: which nodes are drawn raw, and the node
+        # the fold keys act on. Keyed by entry hash so browsing away and back
+        # keeps each entry's expansions, and a refresh re-render preserves them.
+        self._lineage_expanded: dict[str, frozenset[str]] = {}
+        self._lineage_cursor: dict[str, str] = {}
+        # Rows of the entry rendered last, so cursor moves need no re-walk.
+        self._lineage_rows: "tuple[LineageRow, ...]" = ()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -1023,6 +1136,7 @@ class CatalogScreen(Screen):
             self._current_sql_hash = None
             self.query_one("#sql-preview", Static).update("")
             lineage_content.update("")
+            self._lineage_rows = ()
             self.query_one("#schema-in-half").display = False
             self.query_one("#revisions-panel").border_title = "Revisions"
             return
@@ -1046,7 +1160,7 @@ class CatalogScreen(Screen):
             schema_out_table.add_row(name, dtype)
 
         # Lineage panel: cheap (metadata only), so render regardless of view.
-        lineage_content.update(row_data.lineage_panel_rich)
+        self._render_lineage_panel(row_data)
 
         # SQL and data previews both cost a worker, so only the active view pays
         # for them; switching views renders the current selection on demand.
@@ -1367,6 +1481,117 @@ class CatalogScreen(Screen):
     def action_view_lineage(self) -> None:
         self._set_active_view("lineage")
 
+    # --- Lineage panel: fold state and cursor (l / h / j / k) ---
+
+    def _lineage_focused(self) -> bool:
+        """Whether the fold keys and the row cursor are live.
+
+        Gated on focus because `h`/`l`/`j`/`k` already drive the entries tree:
+        the panel has to own them before it can fold anything.
+        """
+        return self.is_mounted and self.app.focused is self.query_one("#lineage-panel")
+
+    def _render_lineage_panel(
+        self, row_data: CatalogRowData, keep_node: str | None = None
+    ) -> None:
+        """Draw the panel for *row_data* and remember its rows for the cursor.
+
+        *keep_node* re-seats the cursor on that node's row after a fold changed
+        the row set: expanding a node inserts the ops above it, so the row the
+        cursor sat on moves down, and the user expects to still be on it.
+        """
+        expanded = self._lineage_expanded.get(row_data.row_key, frozenset())
+        rows = row_data.lineage_lines(expanded)
+        self._lineage_rows = rows
+        cursor = self._lineage_cursor.get(row_data.row_key, 0)
+        if keep_node is not None:
+            # First occurrence: a node repeated as `↻` renders in full only once.
+            cursor = next(
+                (i for i, row in enumerate(rows) if row.node_id == keep_node), cursor
+            )
+        cursor = min(max(cursor, 0), max(len(rows) - 1, 0))
+        self._lineage_cursor[row_data.row_key] = cursor
+        self.query_one("#lineage-content", Static).update(
+            row_data.lineage_panel_rich(
+                expanded, cursor if self._lineage_focused() else None
+            )
+        )
+
+    def _lineage_cursor_row(self) -> "LineageRow | None":
+        """The row the fold keys act on, or None when the panel has no rows."""
+        row_data = self._selected_row_data()
+        if row_data is None or not self._lineage_rows:
+            return None
+        cursor = self._lineage_cursor.get(row_data.row_key, 0)
+        if not 0 <= cursor < len(self._lineage_rows):
+            return None
+        return self._lineage_rows[cursor]
+
+    def _move_lineage_cursor(self, direction: int) -> None:
+        # The cursor is a row, not a node: a node can render on more than one row
+        # (`↻` pointers, a shared node in the compact tree), so an id would be
+        # ambiguous here and the cursor would jump back to the first occurrence.
+        row_data = self._selected_row_data()
+        rows = self._lineage_rows
+        if row_data is None or not rows:
+            return
+        cursor = self._lineage_cursor.get(row_data.row_key, 0)
+        target = min(max(cursor + direction, 0), len(rows) - 1)
+        self._lineage_cursor[row_data.row_key] = target
+        self._render_lineage_panel(row_data)
+        self._scroll_lineage_cursor(target)
+
+    def _scroll_lineage_cursor(self, row_index: int) -> None:
+        """Keep the cursor row inside the panel's viewport.
+
+        The panel is one Static, so Textual has no per-row region to scroll to:
+        the row index *is* the y offset of the tree, which starts after the
+        Cache/Hash lines and the blank one.
+        """
+        panel = self.query_one("#lineage-panel", VerticalScroll)
+        y = row_index + LINEAGE_TREE_OFFSET
+        top = panel.scroll_offset.y
+        height = panel.content_size.height
+        if height <= 0:
+            return
+        if y < top:
+            panel.scroll_to(y=y, animate=False)
+        elif y >= top + height:
+            panel.scroll_to(y=y - height + 1, animate=False)
+
+    def action_lineage_expand(self) -> None:
+        """`]`: list the columns of the node under the lineage cursor."""
+        if self._lineage_focused():
+            self._toggle_lineage_expand(True)
+
+    def action_lineage_collapse(self) -> None:
+        """`[`: fold those columns away again."""
+        if self._lineage_focused():
+            self._toggle_lineage_expand(False)
+
+    def _toggle_lineage_expand(self, expand: bool) -> None:
+        row_data = self._selected_row_data()
+        row = self._lineage_cursor_row()
+        if row_data is None or row is None or row.node_id is None:
+            return
+        key = row_data.row_key
+        # A column row carries its owner's id, so `h` on one folds the node it
+        # came from -- which is the node the user is looking at.
+        node_id = row.node_id
+        expanded = self._lineage_expanded.get(key, frozenset())
+        if expand:
+            # No schema stored at this node: `l` is a no-op, as the missing marker
+            # already says.
+            if node_id not in row_data.lineage_expandable or node_id in expanded:
+                return
+            expanded = expanded | {node_id}
+        else:
+            if node_id not in expanded:
+                return
+            expanded = expanded - {node_id}
+        self._lineage_expanded[key] = expanded
+        self._render_lineage_panel(row_data, keep_node=node_id)
+
     def action_view_sql(self) -> None:
         self._set_active_view("sql")
 
@@ -1486,7 +1711,7 @@ class CatalogScreen(Screen):
     # --- Navigation ---
 
     def action_tree_collapse(self) -> None:
-        """h: collapse branch in tree, scroll left in DataTable."""
+        """h: collapse branch in tree, scroll left in a DataTable."""
         focused = self.app.focused
         tree = self.query_one("#catalog-tree", Tree)
         if focused is tree:
@@ -1507,6 +1732,8 @@ class CatalogScreen(Screen):
             tree.action_cursor_down()
         elif isinstance(focused, DataTable):
             focused.action_cursor_down()
+        elif self._lineage_focused():
+            self._move_lineage_cursor(1)
         elif isinstance(focused, VerticalScroll):
             focused.scroll_down()
 
@@ -1517,11 +1744,13 @@ class CatalogScreen(Screen):
             tree.action_cursor_up()
         elif isinstance(focused, DataTable):
             focused.action_cursor_up()
+        elif self._lineage_focused():
+            self._move_lineage_cursor(-1)
         elif isinstance(focused, VerticalScroll):
             focused.scroll_up()
 
     def action_tree_expand(self) -> None:
-        """l: expand branch in tree, scroll right in DataTable."""
+        """l: expand branch in tree, scroll right in a DataTable."""
         focused = self.app.focused
         tree = self.query_one("#catalog-tree", Tree)
         if focused is tree:
@@ -1595,10 +1824,19 @@ class CatalogScreen(Screen):
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         if action in ("add_alias", "remove_alias", "delete_entry"):
             return self._tree_action_available()
+        if action in ("lineage_expand", "lineage_collapse"):
+            # None hides the binding: the fold keys only mean anything while the
+            # Lineage panel has focus, so that is the only time they are offered.
+            return True if self._lineage_focused() else None
         return super().check_action(action, parameters)
 
     def on_descendant_focus(self) -> None:
         self.refresh_bindings()
+        # The lineage cursor is only drawn while its panel holds focus, so the
+        # panel is re-rendered whenever focus lands on or leaves it.
+        row_data = self._selected_row_data()
+        if row_data is not None and self._lineage_rows:
+            self._render_lineage_panel(row_data)
 
     def action_delete_entry(self) -> None:
         row_data = self._tree_action_row()

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1260,19 +1260,28 @@ def _via_suffix(via: list) -> str:
     return f"   via [{shown}]"
 
 
-def _view_containing(dag: LineageDAG, nid: str) -> dict | None:
-    """The compact view *nid* lives in: the root graph, or a Flight's own scope.
+def _view_containing(
+    dag: LineageDAG, nid: str, view_of: Callable[[str], dict] | None = None
+) -> dict | None:
+    """The view *nid* lives in: the root graph, or a Flight's own scope.
 
     A node reached only inside a Flight's nested lineage is absent from the root
-    view, so rooting a subtree at it means finding its scope first.
+    view, so rooting a subtree at it means finding its scope first. *view_of*
+    selects the flavour of view (compact by default, ``dag.scope`` for the
+    stored graph).
     """
-    view = dag.compact()
+    if view_of is None:
+
+        def view_of(scope: str) -> dict:
+            return dag.compact(scope=scope)
+
+    view = view_of(ROOT_SCOPE)
     if any(n["id"] == nid for n in view["nodes"]):
         return view
     for boundary in dag.boundaries():
         if boundary.get("nested_root") is None:
             continue
-        nested = dag.compact(scope=boundary["id"])
+        nested = view_of(boundary["id"])
         if any(n["id"] == nid for n in nested["nodes"]):
             return nested
     return None
@@ -1381,13 +1390,21 @@ _MERMAID_STYLES: dict[str, str] = {
     "table": "fill:#f5f5f5,stroke:#616161,color:#111",
     "unbound": "fill:#fff3e0,stroke:#ef6c00,color:#111",
     "tag": "fill:#f5f5f5,stroke:#9e9e9e,color:#111",
+    # Non-boundary plumbing, only drawn in the expanded graph: recede visually so
+    # the boundaries still read as the structure.
+    "unknown": "fill:#fafafa,stroke:#bdbdbd,stroke-dasharray:3 3,color:#555",
 }
 _MERMAID_UNKNOWN = "unknown"
 
 
+def _mermaid_slug(text: str) -> str:
+    """Anything -> a bare word, which is all a mermaid id may contain."""
+    return "".join(c if c.isalnum() or c == "_" else "_" for c in text)
+
+
 def _mermaid_id(node_id: str) -> str:
     """`@flight_u_d_x_f_17` -> `n_flight_u_d_x_f_17` (mermaid ids are bare words)."""
-    return "n_" + "".join(c if c.isalnum() or c == "_" else "_" for c in node_id)
+    return "n_" + _mermaid_slug(node_id)
 
 
 def _mermaid_text(label: str) -> str:
@@ -1409,29 +1426,45 @@ def _mermaid_scope_title(node: dict) -> str:
     return f"input of {label}"
 
 
-def _mermaid_reachable(
-    view: dict, root: str
-) -> tuple[tuple[str, ...], tuple[dict, ...]]:
-    """Ids and edges of the sub-DAG under *root* within one compact view.
+def _stored_expansion(
+    dag: LineageDAG, target: str
+) -> tuple[set[str], tuple[dict, ...]]:
+    """Stored nodes and edges to draw so *target* is rendered raw.
 
-    Ids come back in BFS discovery order, not as a set: the rendered diagram has
-    to be byte-stable across processes (set iteration is not).
+    Both directions matter. `compact()` folds a run of non-boundary ops onto the
+    edge *above* a node as much as below it -- a cache reached through
+    `JoinReference`/`Field` has those ops on its consumer's edge -- so rendering
+    one node raw means every stored node on a path into it, plus its whole stored
+    subtree. Unrelated branches are untouched, which is what keeps the rest of the
+    diagram compact.
     """
-    children: dict[str, list[dict]] = defaultdict(list)
-    for edge in view["edges"]:
-        children[edge["from"]].append(edge)
-    ids, edges, queue = [root], [], [root]
-    while queue:
-        nid, queue = queue[0], queue[1:]
-        for edge in children.get(nid, ()):
-            edges.append(edge)
-            if edge["to"] not in ids:
-                ids.append(edge["to"])
-                queue.append(edge["to"])
-    return tuple(ids), tuple(edges)
+    view = _view_containing(dag, target, dag.scope) or {"edges": ()}
+    edges = tuple(view["edges"])
+    consumers: dict[str, list[str]] = defaultdict(list)
+    upstreams: dict[str, list[str]] = defaultdict(list)
+    for edge in edges:
+        consumers[edge["to"]].append(edge["from"])
+        upstreams[edge["from"]].append(edge["to"])
+
+    def reach(adjacency: dict[str, list[str]]) -> set[str]:
+        found, queue = {target}, [target]
+        while queue:
+            for nxt in adjacency.get(queue.pop(), ()):
+                if nxt not in found:
+                    found.add(nxt)
+                    queue.append(nxt)
+        return found
+
+    keep = reach(consumers) | reach(upstreams)
+    return keep, tuple(e for e in edges if e["from"] in keep and e["to"] in keep)
 
 
-def format_mermaid_lineage(dag: LineageDAG, root: str | None = None) -> str:
+def format_mermaid_lineage(
+    dag: LineageDAG,
+    root: str | None = None,
+    expand: bool = False,
+    expand_from: str | tuple[str, ...] | None = None,
+) -> str:
     """Render a :class:`LineageDAG` as a mermaid `flowchart`.
 
     Edges point **downstream** (a source to its consumer), the reverse of the
@@ -1440,11 +1473,46 @@ def format_mermaid_lineage(dag: LineageDAG, root: str | None = None) -> str:
     boundary's nested input lineage becomes a `subgraph`, which is what the
     stored `scope` tag means.
 
-    Pass *root* (a node id) to render only what feeds that node.
+    Three dials, which compose:
+
+    - *root* — render only what feeds that node.
+    - *expand* — draw the *stored* graph instead of the compact one: every node,
+      with the runs that `compact()` folds into `via` drawn as real nodes.
+    - *expand_from* — keep the graph compact but switch to the stored one at that
+      node, so one region is detailed in an otherwise compact diagram.
+
+    The walk is a DFS that carries its own mode, which is what lets the detail
+    change part-way down: a node is declared once, edges once, and a per-path
+    ``seen`` set stops a cycle.
     """
     by_id = dag.by_id
     lines = ["flowchart TD"]
     kinds: dict[str, set[str]] = defaultdict(set)
+    declared: set[str] = set()
+    drawn: set[tuple[str, str]] = set()
+    expand_ids = frozenset(
+        (expand_from,) if isinstance(expand_from, str) else (expand_from or ())
+    )
+    expansions = {
+        target: _stored_expansion(dag, target)
+        for target in sorted(expand_ids)
+        if target in by_id
+    }
+    expansion_scope = {
+        target: (_view_containing(dag, target, dag.scope) or {}).get(
+            "scope", ROOT_SCOPE
+        )
+        for target in expansions
+    }
+    expanded_keep = (
+        frozenset().union(*(keep for keep, _ in expansions.values()))
+        if (expansions)
+        else frozenset()
+    )
+
+    def view_for(scope: str, expanded: bool) -> dict:
+        # dag.scope() is the stored graph for one scope; dag.compact() collapses it.
+        return dag.scope(scope) if expanded else dag.compact(scope=scope)
 
     def declare(nid: str, indent: str) -> None:
         node = by_id.get(nid, {})
@@ -1453,43 +1521,74 @@ def format_mermaid_lineage(dag: LineageDAG, root: str | None = None) -> str:
         label = _mermaid_text(compact_node_label(node) if node else nid)
         lines.append(f'{indent}{_mermaid_id(nid)}["{label}"]')
 
-    def emit(
-        view: dict, ids: tuple[str, ...], edges: tuple[dict, ...], indent: str
-    ) -> None:
-        for nid in ids:
-            nested_root = by_id.get(nid, {}).get("nested_root")
-            if nested_root is None:
-                declare(nid, indent)
+    def draw_edge(upstream: str, downstream: str, via: tuple, indent: str) -> None:
+        if (upstream, downstream) in drawn:
+            return
+        drawn.add((upstream, downstream))
+        # reversed: data flows from the upstream node into its consumer
+        arrow = f"-->|via {', '.join(via[:3])}|" if via else "-->"
+        lines.append(
+            f"{indent}{_mermaid_id(upstream)} {arrow} {_mermaid_id(downstream)}"
+        )
+
+    def emit_expansion(scope: str, indent: str) -> None:
+        """Draw the stored graph around each expanded node in *scope*.
+
+        Additive: the compact walk has already drawn the rest. What gets drawn is
+        every node on a stored path *into* the expanded node plus its whole stored
+        subtree -- so the runs `compact()` folded into `via` both above and below
+        it become real nodes, while unrelated branches stay collapsed.
+        """
+        for target, (keep, edges) in expansions.items():
+            if expansion_scope[target] != scope:
                 continue
-            # the Flight node itself sits outside its own input subgraph
+            for nid in keep:
+                if nid not in declared:
+                    declared.add(nid)
+                    declare(nid, indent)
+            for edge in edges:
+                draw_edge(edge["to"], edge["from"], (), indent)
+
+    def walk(
+        nid: str, scope: str, expanded: bool, indent: str, seen: frozenset
+    ) -> None:
+        expanded = expanded or nid in expand_ids
+        if nid not in declared:
+            declared.add(nid)
             declare(nid, indent)
-            nested_view = dag.compact(scope=nid)
-            nested_ids, nested_edges = _mermaid_reachable(nested_view, nested_root)
-            title = _mermaid_text(_mermaid_scope_title(by_id[nid]))
-            lines.append(f'{indent}subgraph {_mermaid_id(nid)}_scope["{title}"]')
-            emit(nested_view, nested_ids, nested_edges, indent + "  ")
-            lines.append(f"{indent}end")
-            lines.append(f"{indent}{_mermaid_id(nested_root)} --> {_mermaid_id(nid)}")
-        for edge in edges:
-            # reversed: data flows from the upstream node into its consumer
-            arrow = (
-                f"-->|via {', '.join(edge['via'][:3])}|" if edge.get("via") else "-->"
-            )
-            lines.append(
-                f"{indent}{_mermaid_id(edge['to'])} {arrow} {_mermaid_id(edge['from'])}"
-            )
+            nested_root = by_id.get(nid, {}).get("nested_root")
+            if nested_root is not None:
+                # the Flight node itself sits outside its own input subgraph
+                title = _mermaid_text(_mermaid_scope_title(by_id[nid]))
+                lines.append(f'{indent}subgraph {_mermaid_id(nid)}_scope["{title}"]')
+                walk(
+                    nested_root, nid, expanded, indent + "  ", frozenset({nested_root})
+                )
+                emit_expansion(nid, indent + "  ")
+                lines.append(f"{indent}end")
+                draw_edge(nested_root, nid, (), indent)
+        for edge in view_for(scope, expanded)["edges"]:
+            if edge["from"] != nid or edge["to"] in seen:
+                continue
+            walk(edge["to"], scope, expanded, indent, seen | {edge["to"]})
+            # a compact edge whose both ends are inside an expansion is replaced
+            # by the stored run between them
+            if not (edge["from"] in expanded_keep and edge["to"] in expanded_keep):
+                draw_edge(edge["to"], nid, tuple(edge.get("via") or ()), indent)
 
     if root is None:
-        view = dag.compact()
-        start = view["root"]
+        start = view_for(ROOT_SCOPE, expand)["root"]
+        scope = ROOT_SCOPE
     else:
-        view = _view_containing(dag, root) or {"nodes": (), "edges": ()}
-        start = root
+        view = _view_containing(dag, root, lambda s: view_for(s, expand)) or {
+            "scope": ROOT_SCOPE
+        }
+        start, scope = root, view.get("scope", ROOT_SCOPE)
     if start is None or start not in by_id:
         return 'flowchart TD\n  empty["(empty)"]'
 
-    ids, edges = _mermaid_reachable(view, start)
-    emit(view, ids, edges, "  ")
+    walk(start, scope, expand, "  ", frozenset({start}))
+    emit_expansion(scope, "  ")
     for kind, members in sorted(kinds.items()):
         if style := _MERMAID_STYLES.get(kind):
             lines.append(f"  classDef {kind} {style}")

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -35,6 +35,7 @@ __all__ = [
     "compact_node_label",
     "extract_lineage_dag",
     "format_compact_lineage",
+    "format_mermaid_lineage",
     "schema_diff",
 ]
 
@@ -1358,3 +1359,139 @@ def format_compact_lineage(dag: LineageDAG, root: str | None = None) -> str:
     """
     tree = _compact_lineage_tree(dag, root=root)
     return "(empty)" if tree is None else str(tree)
+
+
+# ── mermaid rendering ──────────────────────────────────────────────────
+#
+# A second renderer over the same compact views. Unlike the text tree this keeps
+# the *graph*: a node shared by two consumers is one mermaid node with two
+# inbound edges, where the tree has to repeat it (or mark it `↻`).
+
+# Fill/stroke per boundary kind. Deliberately not the TUI's theme colours: a
+# mermaid diagram is pasted into docs and issues with their own background.
+_MERMAID_STYLES: dict[str, str] = {
+    "flight_udxf": "fill:#ffe0f0,stroke:#c2185b,color:#111",
+    "flight_expr": "fill:#ffe0f0,stroke:#c2185b,color:#111",
+    "engine_crossing": "fill:#e3f2fd,stroke:#1976d2,color:#111",
+    "cache": "fill:#e8f5e9,stroke:#2e7d32,color:#111",
+    "pin": "fill:#e8f5e9,stroke:#1b5e20,color:#111",
+    "ingestion": "fill:#fff8e1,stroke:#f9a825,color:#111",
+    "udf": "fill:#f3e5f5,stroke:#7b1fa2,color:#111",
+    "join": "fill:#eceff1,stroke:#455a64,color:#111",
+    "table": "fill:#f5f5f5,stroke:#616161,color:#111",
+    "unbound": "fill:#fff3e0,stroke:#ef6c00,color:#111",
+    "tag": "fill:#f5f5f5,stroke:#9e9e9e,color:#111",
+}
+_MERMAID_UNKNOWN = "unknown"
+
+
+def _mermaid_id(node_id: str) -> str:
+    """`@flight_u_d_x_f_17` -> `n_flight_u_d_x_f_17` (mermaid ids are bare words)."""
+    return "n_" + "".join(c if c.isalnum() or c == "_" else "_" for c in node_id)
+
+
+def _mermaid_text(label: str) -> str:
+    """Escape a label for a mermaid `["..."]` node."""
+    return (
+        label.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _mermaid_scope_title(node: dict) -> str:
+    """`UDXF[OrderEnricher]` out of the full label: a subgraph title wants the
+    node's identity, not its widths and column delta."""
+    label = compact_node_label(node)
+    for separator in ("   ", " : ", " ("):
+        label = label.split(separator, 1)[0]
+    return f"input of {label}"
+
+
+def _mermaid_reachable(
+    view: dict, root: str
+) -> tuple[tuple[str, ...], tuple[dict, ...]]:
+    """Ids and edges of the sub-DAG under *root* within one compact view.
+
+    Ids come back in BFS discovery order, not as a set: the rendered diagram has
+    to be byte-stable across processes (set iteration is not).
+    """
+    children: dict[str, list[dict]] = defaultdict(list)
+    for edge in view["edges"]:
+        children[edge["from"]].append(edge)
+    ids, edges, queue = [root], [], [root]
+    while queue:
+        nid, queue = queue[0], queue[1:]
+        for edge in children.get(nid, ()):
+            edges.append(edge)
+            if edge["to"] not in ids:
+                ids.append(edge["to"])
+                queue.append(edge["to"])
+    return tuple(ids), tuple(edges)
+
+
+def format_mermaid_lineage(dag: LineageDAG, root: str | None = None) -> str:
+    """Render a :class:`LineageDAG` as a mermaid `flowchart`.
+
+    Edges point **downstream** (a source to its consumer), the reverse of the
+    stored depends-on direction, so `TD` lays the diagram out as the pipeline
+    reads: sources at the top, the final expression at the bottom. A Flight
+    boundary's nested input lineage becomes a `subgraph`, which is what the
+    stored `scope` tag means.
+
+    Pass *root* (a node id) to render only what feeds that node.
+    """
+    by_id = dag.by_id
+    lines = ["flowchart TD"]
+    kinds: dict[str, set[str]] = defaultdict(set)
+
+    def declare(nid: str, indent: str) -> None:
+        node = by_id.get(nid, {})
+        kind = base_kind(node.get("boundary_kind")) or _MERMAID_UNKNOWN
+        kinds[kind].add(_mermaid_id(nid))
+        label = _mermaid_text(compact_node_label(node) if node else nid)
+        lines.append(f'{indent}{_mermaid_id(nid)}["{label}"]')
+
+    def emit(
+        view: dict, ids: tuple[str, ...], edges: tuple[dict, ...], indent: str
+    ) -> None:
+        for nid in ids:
+            nested_root = by_id.get(nid, {}).get("nested_root")
+            if nested_root is None:
+                declare(nid, indent)
+                continue
+            # the Flight node itself sits outside its own input subgraph
+            declare(nid, indent)
+            nested_view = dag.compact(scope=nid)
+            nested_ids, nested_edges = _mermaid_reachable(nested_view, nested_root)
+            title = _mermaid_text(_mermaid_scope_title(by_id[nid]))
+            lines.append(f'{indent}subgraph {_mermaid_id(nid)}_scope["{title}"]')
+            emit(nested_view, nested_ids, nested_edges, indent + "  ")
+            lines.append(f"{indent}end")
+            lines.append(f"{indent}{_mermaid_id(nested_root)} --> {_mermaid_id(nid)}")
+        for edge in edges:
+            # reversed: data flows from the upstream node into its consumer
+            arrow = (
+                f"-->|via {', '.join(edge['via'][:3])}|" if edge.get("via") else "-->"
+            )
+            lines.append(
+                f"{indent}{_mermaid_id(edge['to'])} {arrow} {_mermaid_id(edge['from'])}"
+            )
+
+    if root is None:
+        view = dag.compact()
+        start = view["root"]
+    else:
+        view = _view_containing(dag, root) or {"nodes": (), "edges": ()}
+        start = root
+    if start is None or start not in by_id:
+        return 'flowchart TD\n  empty["(empty)"]'
+
+    ids, edges = _mermaid_reachable(view, start)
+    emit(view, ids, edges, "  ")
+    for kind, members in sorted(kinds.items()):
+        if style := _MERMAID_STYLES.get(kind):
+            lines.append(f"  classDef {kind} {style}")
+            lines.append(f"  class {','.join(sorted(members))} {kind}")
+    return "\n".join(lines)

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1560,10 +1560,25 @@ def format_mermaid_lineage(
     declared: set[str] = set()
     drawn: set[tuple[str, str]] = set()
     expand_ids = _expand_ids(expand_columns)
+    # Views and their child indexes are built once per scope, not once per node,
+    # as in `_compact_lineage_tree`: the walk visits every node, and a raw view
+    # of a large graph re-derived per visit would make the render quadratic.
+    views: dict[str, dict] = {}
+    child_index: dict[str, dict[str, list]] = {}
 
     def view_for(scope: str) -> dict:
         # dag.scope() is the stored graph for one scope; dag.compact() collapses it.
-        return dag.scope(scope) if raw else dag.compact(scope=scope)
+        if scope not in views:
+            views[scope] = dag.scope(scope) if raw else dag.compact(scope=scope)
+        return views[scope]
+
+    def children_of(scope: str) -> dict[str, list]:
+        if scope not in child_index:
+            index: dict[str, list] = defaultdict(list)
+            for edge in view_for(scope)["edges"]:
+                index[edge["from"]].append((edge["to"], tuple(edge.get("via") or ())))
+            child_index[scope] = index
+        return child_index[scope]
 
     def declare(nid: str, indent: str) -> None:
         node = by_id.get(nid, {})
@@ -1582,7 +1597,12 @@ def format_mermaid_lineage(
             return
         drawn.add((upstream, downstream))
         # reversed: data flows from the upstream node into its consumer
-        arrow = f"-->|via {', '.join(via[:3])}|" if via else "-->"
+        if via:
+            # truncate as the text renderer's `_via_suffix` does, ellipsis and all
+            shown = ", ".join(via[:3]) + ("…" if len(via) > 3 else "")
+            arrow = f"-->|via {shown}|"
+        else:
+            arrow = "-->"
         lines.append(
             f"{indent}{_mermaid_id(upstream)} {arrow} {_mermaid_id(downstream)}"
         )
@@ -1599,11 +1619,11 @@ def format_mermaid_lineage(
                 walk(nested_root, nid, indent + "  ", frozenset({nested_root}))
                 lines.append(f"{indent}end")
                 draw_edge(nested_root, nid, (), indent)
-        for edge in view_for(scope)["edges"]:
-            if edge["from"] != nid or edge["to"] in seen:
+        for child_id, via in children_of(scope).get(nid, ()):
+            if child_id in seen:
                 continue
-            walk(edge["to"], scope, indent, seen | {edge["to"]})
-            draw_edge(edge["to"], nid, tuple(edge.get("via") or ()), indent)
+            walk(child_id, scope, indent, seen | {child_id})
+            draw_edge(child_id, nid, via, indent)
 
     if root is None:
         start = view_for(ROOT_SCOPE)["root"]

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1427,9 +1427,9 @@ def _mermaid_scope_title(node: dict) -> str:
 
 
 def _stored_expansion(
-    dag: LineageDAG, target: str
-) -> tuple[set[str], tuple[dict, ...]]:
-    """Stored nodes and edges to draw so *target* is rendered raw.
+    dag: LineageDAG, target: str, bound: str | None = None
+) -> tuple[str, tuple[str, ...], tuple[dict, ...]]:
+    """Scope, nodes and edges to draw so *target* is rendered raw.
 
     Both directions matter. `compact()` folds a run of non-boundary ops onto the
     edge *above* a node as much as below it -- a cache reached through
@@ -1437,8 +1437,18 @@ def _stored_expansion(
     one node raw means every stored node on a path into it, plus its whole stored
     subtree. Unrelated branches are untouched, which is what keeps the rest of the
     diagram compact.
+
+    *bound*, when given, is the id the diagram is rooted at: the expansion is
+    clipped to what that root reaches, so `--expand` cannot drag back the graph
+    above a `--node` selection.
+
+    Nodes come back in BFS order, never as a set: the rendered diagram has to be
+    byte-stable across processes, and set iteration is not.
     """
-    view = _view_containing(dag, target, dag.scope) or {"edges": ()}
+    view = _view_containing(dag, target, dag.scope) or {
+        "edges": (),
+        "scope": ROOT_SCOPE,
+    }
     edges = tuple(view["edges"])
     consumers: dict[str, list[str]] = defaultdict(list)
     upstreams: dict[str, list[str]] = defaultdict(list)
@@ -1446,17 +1456,28 @@ def _stored_expansion(
         consumers[edge["to"]].append(edge["from"])
         upstreams[edge["from"]].append(edge["to"])
 
-    def reach(adjacency: dict[str, list[str]]) -> set[str]:
-        found, queue = {target}, [target]
+    def reach(adjacency: dict[str, list[str]], start: str) -> list[str]:
+        # order comes from the list, membership from the set
+        found, seen, queue = [start], {start}, [start]
         while queue:
-            for nxt in adjacency.get(queue.pop(), ()):
-                if nxt not in found:
-                    found.add(nxt)
+            node, queue = queue[0], queue[1:]
+            for nxt in adjacency.get(node, ()):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    found.append(nxt)
                     queue.append(nxt)
         return found
 
-    keep = reach(consumers) | reach(upstreams)
-    return keep, tuple(e for e in edges if e["from"] in keep and e["to"] in keep)
+    keep = list(dict.fromkeys(reach(consumers, target) + reach(upstreams, target)))
+    if bound is not None:
+        reachable = set(reach(upstreams, bound))
+        keep = [nid for nid in keep if nid in reachable]
+    kept = set(keep)
+    return (
+        view.get("scope", ROOT_SCOPE),
+        tuple(keep),
+        tuple(e for e in edges if e["from"] in kept and e["to"] in kept),
+    )
 
 
 def format_mermaid_lineage(
@@ -1493,22 +1514,14 @@ def format_mermaid_lineage(
     expand_ids = frozenset(
         (expand_from,) if isinstance(expand_from, str) else (expand_from or ())
     )
-    expansions = {
-        target: _stored_expansion(dag, target)
+    # `root` bounds every expansion: `--node` narrows the diagram, and an
+    # `--expand` outside that subtree must not drag the rest of the graph back in.
+    expansions = tuple(
+        _stored_expansion(dag, target, bound=root)
         for target in sorted(expand_ids)
         if target in by_id
-    }
-    expansion_scope = {
-        target: (_view_containing(dag, target, dag.scope) or {}).get(
-            "scope", ROOT_SCOPE
-        )
-        for target in expansions
-    }
-    expanded_keep = (
-        frozenset().union(*(keep for keep, _ in expansions.values()))
-        if (expansions)
-        else frozenset()
     )
+    expanded_keep = frozenset(nid for _, keep, _ in expansions for nid in keep)
 
     def view_for(scope: str, expanded: bool) -> dict:
         # dag.scope() is the stored graph for one scope; dag.compact() collapses it.
@@ -1539,8 +1552,8 @@ def format_mermaid_lineage(
         subtree -- so the runs `compact()` folded into `via` both above and below
         it become real nodes, while unrelated branches stay collapsed.
         """
-        for target, (keep, edges) in expansions.items():
-            if expansion_scope[target] != scope:
+        for expansion_scope, keep, edges in expansions:
+            if expansion_scope != scope:
                 continue
             for nid in keep:
                 if nid not in declared:

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -32,6 +32,7 @@ __all__ = [
     "build_column_trees",
     "build_tree",
     "compact_lineage_rows",
+    "compact_node_label",
     "extract_lineage_dag",
     "format_compact_lineage",
     "schema_diff",
@@ -1194,7 +1195,7 @@ _BACKEND_TAG_KINDS = (
 )
 
 
-def _compact_node_label(node: dict) -> str:
+def compact_node_label(node: dict) -> str:
     """One-line label for a boundary node: what it is, how wide, and where.
 
     ``<kind label> (<n> cols) [<backend>]``, dropping any piece the node cannot
@@ -1294,7 +1295,7 @@ def _compact_lineage_tree(dag: LineageDAG) -> TextTree | None:
             if child_id in seen:
                 kids.append(
                     TextTree(
-                        f"↻ {_compact_node_label(child)}",
+                        f"↻ {compact_node_label(child)}",
                         kind=base_kind(child.get("boundary_kind")),
                     )
                 )
@@ -1303,7 +1304,7 @@ def _compact_lineage_tree(dag: LineageDAG) -> TextTree | None:
             kids.append(evolve(subtree, via=tuple(via)))
 
         return TextTree(
-            marker + _compact_node_label(node),
+            marker + compact_node_label(node),
             tuple(kids),
             kind=base_kind(node.get("boundary_kind")),
         )

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from functools import singledispatch
 from itertools import count
 from typing import Any, Callable, Tuple
@@ -26,6 +26,7 @@ from xorq.vendor.ibis.expr.operations.core import Node
 
 __all__ = [
     "CAPABILITY_REGISTRY",
+    "COLUMN_KIND",
     "LineageDAG",
     "LineageRow",
     "base_kind",
@@ -36,6 +37,7 @@ __all__ = [
     "extract_lineage_dag",
     "format_compact_lineage",
     "format_mermaid_lineage",
+    "node_columns",
     "schema_diff",
 ]
 
@@ -527,6 +529,10 @@ class LineageRow:
     label: str = field(validator=instance_of(str))
     kind: str | None = field(default=None)
     via: Tuple[str, ...] = field(factory=tuple, validator=instance_of(tuple))
+    # The graph node this line renders, so a caller that lets the user point at a
+    # line (``catalog/tui.py``) can address the node behind it. Column trees have
+    # no lineage node, so they leave it None.
+    node_id: str | None = field(default=None)
 
     @property
     def via_suffix(self) -> str:
@@ -548,6 +554,7 @@ class TextTree:
     # Only the compact lineage tree sets these; column trees leave them empty.
     kind: str | None = field(default=None)
     via: Tuple[str, ...] = field(factory=tuple, validator=instance_of(tuple))
+    node_id: str | None = field(default=None)
 
     def rows(
         self, prefix: str = "", is_last: bool = True, is_root: bool = True
@@ -559,7 +566,11 @@ class TextTree:
             line_prefix = prefix + ("└── " if is_last else "├── ")
             child_prefix = prefix + ("    " if is_last else "│   ")
         row = LineageRow(
-            prefix=line_prefix, label=self.label, kind=self.kind, via=self.via
+            prefix=line_prefix,
+            label=self.label,
+            kind=self.kind,
+            via=self.via,
+            node_id=self.node_id,
         )
         return (row,) + tuple(
             descendant
@@ -1287,86 +1298,178 @@ def _view_containing(
     return None
 
 
-def _compact_lineage_tree(dag: LineageDAG, root: str | None = None) -> TextTree | None:
+def _expand_ids(expand_columns: str | Iterable[str] | None) -> frozenset[str]:
+    """One node id, several, or none, as a set. Shared by both renderers."""
+    return frozenset(
+        (expand_columns,) if isinstance(expand_columns, str) else (expand_columns or ())
+    )
+
+
+COLUMN_KIND = "column"
+
+# Schemas a node stores, in the order they read, and how a column row labels the
+# side it came from. A Flight boundary is the one kind whose schema changes across
+# it, so both sides are drawn; everything else has the one schema.
+_COLUMN_SCHEMAS: dict[str, tuple[tuple[str, str], ...]] = {
+    "flight_udxf": (("schema_in_observed", "in "), ("schema_out", "out ")),
+    "flight_expr": (("input_schema", "in "), ("output_schema", "out ")),
+}
+_DEFAULT_COLUMN_SCHEMAS = (("schema", ""),)
+
+
+def node_columns(node: dict) -> tuple[str, ...]:
+    """One label per column the node stores: ``name  dtype``, names padded.
+
+    A Flight boundary labels each side (``in``/``out``) and marks what its stored
+    ``schema_diff`` says changed, so the transition reads off the rows themselves.
+    Returns ``()`` for a node that stores no schema -- there is nothing to expand.
+    """
+    kind = base_kind(node.get("boundary_kind"))
+    diff = node.get("schema_diff") or {}
+    added = set(diff.get("added") or ())
+    removed = set(diff.get("removed") or ())
+    retyped = set(diff.get("retyped") or ())
+    rows: list[tuple[str, str]] = []
+    for key, side in _COLUMN_SCHEMAS.get(kind, _DEFAULT_COLUMN_SCHEMAS):
+        schema = node.get(key) or {}
+        for name, dtype in schema.items():
+            # `+`/`~` come from the stored diff; a column the diff calls renamed
+            # is a plain row on both sides, which is what the rename says it is.
+            if name in added:
+                mark = "+ "
+            elif name in retyped:
+                mark = "~ "
+            else:
+                mark = ""
+            rows.append((f"{side}{mark}{name}", str(dtype)))
+        # A dropped column is gone from `after`, so it only shows on the in side.
+        if side == "out ":
+            for name in sorted(removed):
+                rows.append((f"{side}- {name}", ""))
+    if not rows:
+        return ()
+    width = max(len(label) for label, _ in rows) + 2
+    return tuple(f"{label:<{width}}{dtype}".rstrip() for label, dtype in rows)
+
+
+def _compact_lineage_tree(
+    dag: LineageDAG,
+    root: str | None = None,
+    expand_columns: str | Iterable[str] | None = None,
+) -> TextTree | None:
     """Compact boundary tree, or ``None`` when there is nothing to render.
 
     Non-boundary runs collapse into ``via [...]`` on the surviving edges; Flight
     boundaries carry their nested input lineage as an indented sub-tree. Each
     node keeps its ``kind`` so a renderer can style per boundary kind without
-    re-parsing the label.
+    re-parsing the label, and its ``node_id`` so a renderer can address it.
 
-    Pass *root* to render the subtree feeding one node instead of the whole
-    expression.
+    Two dials:
+
+    - *root* — render the subtree feeding one node instead of the whole expression.
+    - *expand_columns* — node ids to expand: their columns become child rows,
+      tagged ``kind="column"`` and carrying the node's id, so a renderer can style
+      them apart and a caller can fold them back.
     """
     by_id = dag.by_id
+    expand_ids = _expand_ids(expand_columns)
+    # Views and their child indexes are built once per scope, not once per node,
+    # so the walk stays O(V+E) however often a caller re-renders (the TUI does it
+    # on every keypress).
+    views: dict[str, dict] = {}
+    child_index: dict[str, dict[str, list]] = {}
 
-    def build(view: dict, nid: str, seen: frozenset, marker: str = "") -> TextTree:
+    def view_for(scope: str) -> dict:
+        if scope not in views:
+            views[scope] = dag.compact(scope=scope)
+        return views[scope]
+
+    def children_of(scope: str) -> dict[str, list]:
+        if scope not in child_index:
+            index: dict[str, list] = defaultdict(list)
+            for edge in view_for(scope)["edges"]:
+                index[edge["from"]].append((edge["to"], tuple(edge.get("via") or ())))
+            child_index[scope] = index
+        return child_index[scope]
+
+    def column_kids(nid: str, node: dict) -> list[TextTree]:
+        if nid not in expand_ids:
+            return []
+        return [
+            TextTree(label, kind=COLUMN_KIND, node_id=nid)
+            for label in node_columns(node)
+        ]
+
+    def build(scope: str, nid: str, seen: frozenset, marker: str = "") -> TextTree:
         node = by_id.get(nid, {"label": nid, "type": "?"})
-        children_of: dict = defaultdict(list)
-        for edge in view["edges"]:
-            children_of[edge["from"]].append((edge["to"], edge.get("via", [])))
-
-        kids: list[TextTree] = []
+        # Columns first: they describe this node, where the rest are its inputs.
+        kids: list[TextTree] = column_kids(nid, node)
 
         nested_root = node.get("nested_root")
         if nested_root is not None:
             # A Flight boundary's input lineage lives in its own scope: render it
             # as a sub-tree marked with the crossing arrow at its root.
-            kids.append(
-                build(
-                    dag.compact(scope=nid),
-                    nested_root,
-                    frozenset({nested_root}),
-                    "↳ ",
-                )
-            )
+            kids.append(build(nid, nested_root, frozenset({nested_root}), "↳ "))
 
-        for child_id, via in children_of.get(nid, ()):
+        for child_id, via in children_of(scope).get(nid, ()):
             child = by_id[child_id]
             if child_id in seen:
                 kids.append(
                     TextTree(
                         f"↻ {compact_node_label(child)}",
                         kind=base_kind(child.get("boundary_kind")),
+                        node_id=child_id,
                     )
                 )
                 continue
-            subtree = build(view, child_id, seen | {child_id})
-            kids.append(evolve(subtree, via=tuple(via)))
+            subtree = build(scope, child_id, seen | {child_id})
+            kids.append(evolve(subtree, via=via))
 
         return TextTree(
             marker + compact_node_label(node),
             tuple(kids),
             kind=base_kind(node.get("boundary_kind")),
+            node_id=nid,
         )
 
     if root is None:
-        view = dag.compact()
-        root = view["root"]
+        root, scope = view_for(ROOT_SCOPE)["root"], ROOT_SCOPE
     else:
         # A node the compact view dropped (non-boundary, or unreachable) still
         # renders as its own one-line tree rather than nothing.
-        view = _view_containing(dag, root) or {"nodes": (), "edges": ()}
+        view = _view_containing(dag, root, view_for) or {"scope": ROOT_SCOPE}
+        scope = view.get("scope", ROOT_SCOPE)
     if root is None or root not in by_id:
         return None
-    return build(view, root, frozenset({root}))
+    return build(scope, root, frozenset({root}))
 
 
 def compact_lineage_rows(
-    dag: LineageDAG, root: str | None = None
+    dag: LineageDAG,
+    root: str | None = None,
+    expand_columns: str | Iterable[str] | None = None,
 ) -> tuple[LineageRow, ...]:
-    """One row per rendered line, with the tree glyphs, label, kind and ``via``
-    kept apart so a renderer can style each piece (see ``catalog/tui.py``)."""
-    tree = _compact_lineage_tree(dag, root=root)
+    """One row per rendered line, with the tree glyphs, label, kind, ``via`` and
+    node id kept apart so a renderer can style or address each piece (see
+    ``catalog/tui.py``).
+
+    *root* and *expand_columns* are :func:`_compact_lineage_tree`'s dials.
+    """
+    tree = _compact_lineage_tree(dag, root=root, expand_columns=expand_columns)
     return () if tree is None else tree.rows()
 
 
-def format_compact_lineage(dag: LineageDAG, root: str | None = None) -> str:
+def format_compact_lineage(
+    dag: LineageDAG,
+    root: str | None = None,
+    expand_columns: str | Iterable[str] | None = None,
+) -> str:
     """Render a :class:`LineageDAG` as a compact boundary-only text tree.
 
-    Pass *root* (a node id) to render only what feeds that node.
+    Pass *root* (a node id) to render only what feeds that node, or
+    *expand_columns* (node ids) to list those nodes' columns under them.
     """
-    tree = _compact_lineage_tree(dag, root=root)
+    tree = _compact_lineage_tree(dag, root=root, expand_columns=expand_columns)
     return "(empty)" if tree is None else str(tree)
 
 
@@ -1426,65 +1529,11 @@ def _mermaid_scope_title(node: dict) -> str:
     return f"input of {label}"
 
 
-def _stored_expansion(
-    dag: LineageDAG, target: str, bound: str | None = None
-) -> tuple[str, tuple[str, ...], tuple[dict, ...]]:
-    """Scope, nodes and edges to draw so *target* is rendered raw.
-
-    Both directions matter. `compact()` folds a run of non-boundary ops onto the
-    edge *above* a node as much as below it -- a cache reached through
-    `JoinReference`/`Field` has those ops on its consumer's edge -- so rendering
-    one node raw means every stored node on a path into it, plus its whole stored
-    subtree. Unrelated branches are untouched, which is what keeps the rest of the
-    diagram compact.
-
-    *bound*, when given, is the id the diagram is rooted at: the expansion is
-    clipped to what that root reaches, so `--expand` cannot drag back the graph
-    above a `--node` selection.
-
-    Nodes come back in BFS order, never as a set: the rendered diagram has to be
-    byte-stable across processes, and set iteration is not.
-    """
-    view = _view_containing(dag, target, dag.scope) or {
-        "edges": (),
-        "scope": ROOT_SCOPE,
-    }
-    edges = tuple(view["edges"])
-    consumers: dict[str, list[str]] = defaultdict(list)
-    upstreams: dict[str, list[str]] = defaultdict(list)
-    for edge in edges:
-        consumers[edge["to"]].append(edge["from"])
-        upstreams[edge["from"]].append(edge["to"])
-
-    def reach(adjacency: dict[str, list[str]], start: str) -> list[str]:
-        # order comes from the list, membership from the set
-        found, seen, queue = [start], {start}, [start]
-        while queue:
-            node, queue = queue[0], queue[1:]
-            for nxt in adjacency.get(node, ()):
-                if nxt not in seen:
-                    seen.add(nxt)
-                    found.append(nxt)
-                    queue.append(nxt)
-        return found
-
-    keep = list(dict.fromkeys(reach(consumers, target) + reach(upstreams, target)))
-    if bound is not None:
-        reachable = set(reach(upstreams, bound))
-        keep = [nid for nid in keep if nid in reachable]
-    kept = set(keep)
-    return (
-        view.get("scope", ROOT_SCOPE),
-        tuple(keep),
-        tuple(e for e in edges if e["from"] in kept and e["to"] in kept),
-    )
-
-
 def format_mermaid_lineage(
     dag: LineageDAG,
     root: str | None = None,
-    expand: bool = False,
-    expand_from: str | tuple[str, ...] | None = None,
+    raw: bool = False,
+    expand_columns: str | Iterable[str] | None = None,
 ) -> str:
     """Render a :class:`LineageDAG` as a mermaid `flowchart`.
 
@@ -1497,13 +1546,12 @@ def format_mermaid_lineage(
     Three dials, which compose:
 
     - *root* — render only what feeds that node.
-    - *expand* — draw the *stored* graph instead of the compact one: every node,
-      with the runs that `compact()` folds into `via` drawn as real nodes.
-    - *expand_from* — keep the graph compact but switch to the stored one at that
-      node, so one region is detailed in an otherwise compact diagram.
+    - *raw* — draw the *stored* graph instead of the compact one: every node, with
+      the runs that `compact()` folds into `via` drawn as real nodes.
+    - *expand_columns* — node ids to expand: their columns are listed inside the
+      node, leaving the shape of the graph alone.
 
-    The walk is a DFS that carries its own mode, which is what lets the detail
-    change part-way down: a node is declared once, edges once, and a per-path
+    The walk is a DFS: a node is declared once, edges once, and a per-path
     ``seen`` set stops a cycle.
     """
     by_id = dag.by_id
@@ -1511,27 +1559,22 @@ def format_mermaid_lineage(
     kinds: dict[str, set[str]] = defaultdict(set)
     declared: set[str] = set()
     drawn: set[tuple[str, str]] = set()
-    expand_ids = frozenset(
-        (expand_from,) if isinstance(expand_from, str) else (expand_from or ())
-    )
-    # `root` bounds every expansion: `--node` narrows the diagram, and an
-    # `--expand` outside that subtree must not drag the rest of the graph back in.
-    expansions = tuple(
-        _stored_expansion(dag, target, bound=root)
-        for target in sorted(expand_ids)
-        if target in by_id
-    )
-    expanded_keep = frozenset(nid for _, keep, _ in expansions for nid in keep)
+    expand_ids = _expand_ids(expand_columns)
 
-    def view_for(scope: str, expanded: bool) -> dict:
+    def view_for(scope: str) -> dict:
         # dag.scope() is the stored graph for one scope; dag.compact() collapses it.
-        return dag.scope(scope) if expanded else dag.compact(scope=scope)
+        return dag.scope(scope) if raw else dag.compact(scope=scope)
 
     def declare(nid: str, indent: str) -> None:
         node = by_id.get(nid, {})
         kind = base_kind(node.get("boundary_kind")) or _MERMAID_UNKNOWN
         kinds[kind].add(_mermaid_id(nid))
-        label = _mermaid_text(compact_node_label(node) if node else nid)
+        parts = [compact_node_label(node) if node else nid]
+        if nid in expand_ids:
+            # `<br/>` keeps the columns inside the node: expanding says what flows
+            # through it, not what the graph around it looks like.
+            parts.extend(node_columns(node))
+        label = "<br/>".join(_mermaid_text(part) for part in parts)
         lines.append(f'{indent}{_mermaid_id(nid)}["{label}"]')
 
     def draw_edge(upstream: str, downstream: str, via: tuple, indent: str) -> None:
@@ -1544,28 +1587,7 @@ def format_mermaid_lineage(
             f"{indent}{_mermaid_id(upstream)} {arrow} {_mermaid_id(downstream)}"
         )
 
-    def emit_expansion(scope: str, indent: str) -> None:
-        """Draw the stored graph around each expanded node in *scope*.
-
-        Additive: the compact walk has already drawn the rest. What gets drawn is
-        every node on a stored path *into* the expanded node plus its whole stored
-        subtree -- so the runs `compact()` folded into `via` both above and below
-        it become real nodes, while unrelated branches stay collapsed.
-        """
-        for expansion_scope, keep, edges in expansions:
-            if expansion_scope != scope:
-                continue
-            for nid in keep:
-                if nid not in declared:
-                    declared.add(nid)
-                    declare(nid, indent)
-            for edge in edges:
-                draw_edge(edge["to"], edge["from"], (), indent)
-
-    def walk(
-        nid: str, scope: str, expanded: bool, indent: str, seen: frozenset
-    ) -> None:
-        expanded = expanded or nid in expand_ids
+    def walk(nid: str, scope: str, indent: str, seen: frozenset) -> None:
         if nid not in declared:
             declared.add(nid)
             declare(nid, indent)
@@ -1574,34 +1596,25 @@ def format_mermaid_lineage(
                 # the Flight node itself sits outside its own input subgraph
                 title = _mermaid_text(_mermaid_scope_title(by_id[nid]))
                 lines.append(f'{indent}subgraph {_mermaid_id(nid)}_scope["{title}"]')
-                walk(
-                    nested_root, nid, expanded, indent + "  ", frozenset({nested_root})
-                )
-                emit_expansion(nid, indent + "  ")
+                walk(nested_root, nid, indent + "  ", frozenset({nested_root}))
                 lines.append(f"{indent}end")
                 draw_edge(nested_root, nid, (), indent)
-        for edge in view_for(scope, expanded)["edges"]:
+        for edge in view_for(scope)["edges"]:
             if edge["from"] != nid or edge["to"] in seen:
                 continue
-            walk(edge["to"], scope, expanded, indent, seen | {edge["to"]})
-            # a compact edge whose both ends are inside an expansion is replaced
-            # by the stored run between them
-            if not (edge["from"] in expanded_keep and edge["to"] in expanded_keep):
-                draw_edge(edge["to"], nid, tuple(edge.get("via") or ()), indent)
+            walk(edge["to"], scope, indent, seen | {edge["to"]})
+            draw_edge(edge["to"], nid, tuple(edge.get("via") or ()), indent)
 
     if root is None:
-        start = view_for(ROOT_SCOPE, expand)["root"]
+        start = view_for(ROOT_SCOPE)["root"]
         scope = ROOT_SCOPE
     else:
-        view = _view_containing(dag, root, lambda s: view_for(s, expand)) or {
-            "scope": ROOT_SCOPE
-        }
+        view = _view_containing(dag, root, view_for) or {"scope": ROOT_SCOPE}
         start, scope = root, view.get("scope", ROOT_SCOPE)
     if start is None or start not in by_id:
         return 'flowchart TD\n  empty["(empty)"]'
 
-    walk(start, scope, expand, "  ", frozenset({start}))
-    emit_expansion(scope, "  ")
+    walk(start, scope, "  ", frozenset({start}))
     for kind, members in sorted(kinds.items()):
         if style := _MERMAID_STYLES.get(kind):
             lines.append(f"  classDef {kind} {style}")

--- a/python/xorq/common/utils/lineage_utils.py
+++ b/python/xorq/common/utils/lineage_utils.py
@@ -1259,13 +1259,34 @@ def _via_suffix(via: list) -> str:
     return f"   via [{shown}]"
 
 
-def _compact_lineage_tree(dag: LineageDAG) -> TextTree | None:
+def _view_containing(dag: LineageDAG, nid: str) -> dict | None:
+    """The compact view *nid* lives in: the root graph, or a Flight's own scope.
+
+    A node reached only inside a Flight's nested lineage is absent from the root
+    view, so rooting a subtree at it means finding its scope first.
+    """
+    view = dag.compact()
+    if any(n["id"] == nid for n in view["nodes"]):
+        return view
+    for boundary in dag.boundaries():
+        if boundary.get("nested_root") is None:
+            continue
+        nested = dag.compact(scope=boundary["id"])
+        if any(n["id"] == nid for n in nested["nodes"]):
+            return nested
+    return None
+
+
+def _compact_lineage_tree(dag: LineageDAG, root: str | None = None) -> TextTree | None:
     """Compact boundary tree, or ``None`` when there is nothing to render.
 
     Non-boundary runs collapse into ``via [...]`` on the surviving edges; Flight
     boundaries carry their nested input lineage as an indented sub-tree. Each
     node keeps its ``kind`` so a renderer can style per boundary kind without
     re-parsing the label.
+
+    Pass *root* to render the subtree feeding one node instead of the whole
+    expression.
     """
     by_id = dag.by_id
 
@@ -1309,20 +1330,31 @@ def _compact_lineage_tree(dag: LineageDAG) -> TextTree | None:
             kind=base_kind(node.get("boundary_kind")),
         )
 
-    view = dag.compact()
-    if not view["nodes"] or view["root"] is None:
+    if root is None:
+        view = dag.compact()
+        root = view["root"]
+    else:
+        # A node the compact view dropped (non-boundary, or unreachable) still
+        # renders as its own one-line tree rather than nothing.
+        view = _view_containing(dag, root) or {"nodes": (), "edges": ()}
+    if root is None or root not in by_id:
         return None
-    return build(view, view["root"], frozenset({view["root"]}))
+    return build(view, root, frozenset({root}))
 
 
-def compact_lineage_rows(dag: LineageDAG) -> tuple[LineageRow, ...]:
+def compact_lineage_rows(
+    dag: LineageDAG, root: str | None = None
+) -> tuple[LineageRow, ...]:
     """One row per rendered line, with the tree glyphs, label, kind and ``via``
     kept apart so a renderer can style each piece (see ``catalog/tui.py``)."""
-    tree = _compact_lineage_tree(dag)
+    tree = _compact_lineage_tree(dag, root=root)
     return () if tree is None else tree.rows()
 
 
-def format_compact_lineage(dag: LineageDAG) -> str:
-    """Render a :class:`LineageDAG` as a compact boundary-only text tree."""
-    tree = _compact_lineage_tree(dag)
+def format_compact_lineage(dag: LineageDAG, root: str | None = None) -> str:
+    """Render a :class:`LineageDAG` as a compact boundary-only text tree.
+
+    Pass *root* (a node id) to render only what feeds that node.
+    """
+    tree = _compact_lineage_tree(dag, root=root)
     return "(empty)" if tree is None else str(tree)

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -19,6 +19,8 @@ from xorq.common.utils.lineage_utils import (
     TextTree,
     _boundary_kind,
     _build_column_tree,
+    _mermaid_id,
+    _mermaid_text,
     _redact,
     base_kind,
     build_column_trees,
@@ -27,6 +29,7 @@ from xorq.common.utils.lineage_utils import (
     compact_node_label,
     extract_lineage_dag,
     format_compact_lineage,
+    format_mermaid_lineage,
     schema_diff,
 )
 from xorq.expr.udf import make_pandas_expr_udf
@@ -1283,6 +1286,80 @@ def test_compact_lineage_rooted_at_an_unknown_node_is_empty(
     assert format_compact_lineage(
         extract_lineage_dag(udxf_expression), root="@nope"
     ) == ("(empty)")
+
+
+def test_mermaid_lineage_is_a_flowchart_of_the_compact_graph(
+    udxf_expression: Expr,
+) -> None:
+    """Same views as the text tree, emitted as mermaid: downstream edges, a
+    subgraph per Flight scope, one classDef per boundary kind."""
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    diagram = format_mermaid_lineage(dag)
+    lines = diagram.splitlines()
+
+    assert lines[0] == "flowchart TD"
+    # ids are mermaid-safe: no '@'
+    assert "@" not in diagram
+    assert f'{_mermaid_id(udxf["id"])}["UDXF[add_c]' in diagram
+    # the nested input lineage is a subgraph, per its stored scope
+    stripped = [line.strip() for line in lines]
+    assert (
+        f'subgraph {_mermaid_id(udxf["id"])}_scope["input of UDXF[add_c]"]' in stripped
+    )
+    assert "end" in stripped
+    # kinds carry a class, and every classed node was declared
+    assert any(line.startswith("  classDef flight_udxf ") for line in lines)
+    for line in lines:
+        if line.startswith("  class "):
+            for member in line.split()[1].split(","):
+                assert f"{member}[" in diagram
+
+
+def test_mermaid_lineage_edges_point_downstream(udxf_expression: Expr) -> None:
+    """The stored edges are depends-on; the diagram reverses them so `TD` reads
+    sources-to-output."""
+    dag = extract_lineage_dag(udxf_expression)
+    diagram = format_mermaid_lineage(dag)
+
+    root = _mermaid_id(dag.root)
+    arrows = [line.strip() for line in diagram.splitlines() if "-->" in line]
+    assert arrows
+    # nothing flows out of the final expression; something flows into it
+    assert not any(line.startswith(f"{root} -->") for line in arrows)
+    assert any(line.endswith(f"> {root}") for line in arrows)
+    # a collapsed run keeps its `via` as the edge label
+    if any(e["via"] for e in dag.compact()["edges"]):
+        assert any("|via " in line for line in arrows)
+
+
+def test_mermaid_lineage_is_byte_stable(udxf_expression: Expr) -> None:
+    """Node order comes from a BFS, not set iteration: a diagram pasted into docs
+    must not churn between processes."""
+    dag = extract_lineage_dag(udxf_expression)
+    assert format_mermaid_lineage(dag) == format_mermaid_lineage(
+        LineageDAG.from_dict(dag.to_dict())
+    )
+
+
+def test_mermaid_lineage_rooted_at_a_node_and_of_nothing(
+    udxf_expression: Expr,
+) -> None:
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    subtree = format_mermaid_lineage(dag, root=udxf["id"])
+
+    assert subtree.splitlines()[0] == "flowchart TD"
+    assert _mermaid_id(udxf["id"]) in subtree
+    assert _mermaid_id(dag.root) not in subtree
+    assert "(empty)" in format_mermaid_lineage(dag, root="@nope")
+
+
+def test_mermaid_label_escaping() -> None:
+    """A label reaching mermaid must not break out of its quoted node."""
+    assert _mermaid_text('a "b" <c> & d') == "a &quot;b&quot; &lt;c&gt; &amp; d"
 
 
 def test_compact_lineage_rows_of_an_empty_dag() -> None:

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 import operator
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -1332,6 +1335,83 @@ def test_mermaid_lineage_edges_point_downstream(udxf_expression: Expr) -> None:
     # a collapsed run keeps its `via` as the edge label
     if any(e["via"] for e in dag.compact()["edges"]):
         assert any("|via " in line for line in arrows)
+
+
+_STABILITY_SCRIPT = """
+import hashlib, json, sys
+from xorq.common.utils.lineage_utils import LineageDAG, format_mermaid_lineage
+
+dag = LineageDAG.from_dict(json.load(sys.stdin))
+for kwargs in ({}, {"expand": True}, {"expand_from": "@cache"}):
+    print(hashlib.md5(format_mermaid_lineage(dag, **kwargs).encode()).hexdigest())
+"""
+
+
+def _stability_dag() -> dict:
+    """A graph with a run of non-boundary ops between two boundaries, so the
+    compact, expanded and expand_from renders all differ."""
+    nodes = [
+        {
+            "id": "@join",
+            "type": "JoinChain",
+            "is_boundary": True,
+            "boundary_kind": "join",
+            "n_inputs": 2,
+        },
+        {
+            "id": "@cache",
+            "type": "CachedNode",
+            "is_boundary": True,
+            "boundary_kind": "cache",
+            "cache_kind": "ParquetCache",
+        },
+        {
+            "id": "@table",
+            "type": "DatabaseTable",
+            "is_boundary": True,
+            "boundary_kind": "table",
+            "table_name": "t",
+        },
+    ] + [
+        {"id": f"@field_{i}", "type": "Field", "label": f"Field:c{i}"} for i in range(8)
+    ]
+    edges = [
+        {"from": "@join", "to": f"@field_{i}", "scope": ROOT_SCOPE} for i in range(8)
+    ]
+    edges += [
+        {"from": f"@field_{i}", "to": "@cache", "scope": ROOT_SCOPE} for i in range(8)
+    ]
+    edges += [{"from": "@cache", "to": "@table", "scope": ROOT_SCOPE}]
+    return {"version": 2, "root": "@join", "nodes": nodes, "edges": edges}
+
+
+@pytest.mark.parametrize(
+    "index",
+    (
+        pytest.param(0, id="compact"),
+        pytest.param(1, id="expand"),
+        pytest.param(2, id="expand_from"),
+    ),
+)
+def test_mermaid_lineage_is_byte_stable_across_processes(
+    index: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A diagram pasted into docs must not churn between runs. Set iteration order
+    is only stable *within* a process, so this has to fork rather than render
+    twice in-process."""
+    payload = json.dumps(_stability_dag())
+    digests = set()
+    for seed in (1, 2, 3, 4):
+        monkeypatch.setenv("PYTHONHASHSEED", str(seed))
+        result = subprocess.run(
+            [sys.executable, "-c", _STABILITY_SCRIPT],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        digests.add(result.stdout.splitlines()[index])
+    assert len(digests) == 1, digests
 
 
 def test_mermaid_lineage_is_byte_stable(udxf_expression: Expr) -> None:

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -1357,6 +1357,100 @@ def test_mermaid_lineage_rooted_at_a_node_and_of_nothing(
     assert "(empty)" in format_mermaid_lineage(dag, root="@nope")
 
 
+def test_mermaid_expand_draws_the_stored_graph(udxf_expression: Expr) -> None:
+    """`expand=True` renders `dag.scope()` -- the stored graph -- instead of the
+    compact one, so the runs folded into `via` become real nodes."""
+    dag = extract_lineage_dag(udxf_expression)
+
+    compact = format_mermaid_lineage(dag)
+    expanded = format_mermaid_lineage(dag, expand=True)
+
+    def declared(diagram: str) -> set[str]:
+        return {
+            line.strip().split("[", 1)[0]
+            for line in diagram.splitlines()
+            if "[" in line and not line.strip().startswith(("subgraph", "class"))
+        }
+
+    assert declared(compact) < declared(expanded)
+    assert len(declared(expanded)) == len(dag.nodes)
+    # nothing is collapsed any more, so no edge carries a `via` label
+    assert "|via " not in expanded
+    assert "classDef unknown " in expanded
+    # nested Flight scopes are expanded too, not just the outer graph
+    [udxf] = dag.boundaries(kind="flight_udxf")
+    nested_ids = {n["id"] for n in dag.scope(udxf["id"])["nodes"]}
+    assert len(nested_ids) > 1
+    for nid in nested_ids:
+        assert _mermaid_id(nid) in expanded
+
+
+def test_mermaid_expand_from_switches_detail_part_way_down(
+    multi_join_expression: Expr,
+) -> None:
+    """`expand_from` keeps the compact graph but draws the stored one from that
+    node downward -- the walk carries its own mode, so detail changes mid-graph."""
+    dag = extract_lineage_dag(multi_join_expression)
+    [crossing, *_] = dag.boundaries(kind="engine_crossing")
+
+    compact = format_mermaid_lineage(dag)
+    mixed = format_mermaid_lineage(dag, expand_from=crossing["id"])
+    everything = format_mermaid_lineage(dag, expand=True)
+
+    def declared(diagram: str) -> set[str]:
+        """Op nodes only: column nodes are drawn for the expanded node alone, so
+        they are not part of the compact-vs-expanded comparison."""
+        return {
+            line.strip().split("[", 1)[0]
+            for line in diagram.splitlines()
+            if "[" in line
+            and "_col_" not in line
+            and not line.strip().startswith(("subgraph", "class"))
+        }
+
+    # strictly between the two extremes
+    assert declared(compact) < declared(mixed) < declared(everything)
+    # the root stays in the picture, unlike root=
+    assert _mermaid_id(dag.root) in mixed
+    # a node is declared once even when several paths reach it
+    for nid in declared(mixed):
+        assert mixed.count(f"{nid}[") == 1
+
+
+def test_mermaid_expand_from_expands_the_run_above_the_node(
+    multi_join_expression: Expr,
+) -> None:
+    """`compact()` folds runs onto the edge *above* a node as much as below it, so
+    rendering one node raw has to reach upward too -- otherwise expanding a node
+    whose own subtree has no intermediates draws nothing new."""
+    dag = extract_lineage_dag(multi_join_expression)
+    [crossing, *_] = dag.boundaries(kind="engine_crossing")
+    (incoming,) = [
+        e for e in dag.compact()["edges"] if e["to"] == crossing["id"] and e["via"]
+    ]
+
+    diagram = format_mermaid_lineage(dag, expand_from=crossing["id"])
+
+    # the ops that were folded into that edge's `via` are now nodes of their own
+    for op_type in incoming["via"]:
+        assert op_type in diagram
+    # and the edge itself is gone, replaced by the stored run
+    assert f"{_mermaid_id(crossing['id'])} -->|via" not in diagram, (
+        "the collapsed edge should be replaced, not drawn alongside"
+    )
+
+
+def test_mermaid_expand_from_accepts_several_nodes(multi_join_expression: Expr) -> None:
+    dag = extract_lineage_dag(multi_join_expression)
+    crossings = tuple(n["id"] for n in dag.boundaries(kind="engine_crossing"))
+    assert len(crossings) > 1
+
+    one = format_mermaid_lineage(dag, expand_from=crossings[:1])
+    several = format_mermaid_lineage(dag, expand_from=crossings)
+
+    assert len(several.splitlines()) > len(one.splitlines())
+
+
 def test_mermaid_label_escaping() -> None:
     """A label reaching mermaid must not break out of its quoted node."""
     assert _mermaid_text('a "b" <c> & d') == "a &quot;b&quot; &lt;c&gt; &amp; d"

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -16,6 +16,7 @@ import xorq.vendor.ibis.expr.operations as ops
 from xorq.caching import ParquetCache, SourceCache
 from xorq.common.utils.graph_utils import gen_children_of, opaque_ops, to_node
 from xorq.common.utils.lineage_utils import (
+    COLUMN_KIND,
     ROOT_SCOPE,
     GenericNode,
     LineageDAG,
@@ -33,6 +34,7 @@ from xorq.common.utils.lineage_utils import (
     extract_lineage_dag,
     format_compact_lineage,
     format_mermaid_lineage,
+    node_columns,
     schema_diff,
 )
 from xorq.expr.udf import make_pandas_expr_udf
@@ -1283,6 +1285,90 @@ def test_compact_lineage_rooted_at_a_node_is_the_subtree_feeding_it(
     assert compact_lineage_rows(dag, root=udxf["id"])[0].kind == "flight_udxf"
 
 
+def test_compact_lineage_rows_carry_the_node_they_render(
+    udxf_expression: Expr,
+) -> None:
+    """A row names its graph node, so a caller that lets the user point at a line
+    can address the node behind it (the TUI's fold keys)."""
+    dag = extract_lineage_dag(udxf_expression)
+    rows = compact_lineage_rows(dag)
+
+    assert rows[0].node_id == dag.root
+    assert all(row.node_id in dag.by_id for row in rows)
+    [udxf_row] = [r for r in rows if r.kind == "flight_udxf"]
+    assert udxf_row.node_id == dag.boundaries(kind="flight_udxf")[0]["id"]
+    # a column tree has no lineage node to name
+    assert all(
+        row.node_id is None
+        for column_tree in build_column_trees(udxf_expression).values()
+        for row in build_tree(column_tree).rows()
+    )
+
+
+def test_expand_columns_lists_a_nodes_fields_under_it(
+    multi_join_expression: Expr,
+) -> None:
+    """Expanding a node means showing what flows through it: one row per column,
+    tagged so a renderer can style them apart, and only under that node."""
+    dag = extract_lineage_dag(multi_join_expression)
+    compact = compact_lineage_rows(dag)
+    target = compact[0].node_id
+    schema = dag.by_id[target]["schema"]
+    assert schema
+
+    expanded = compact_lineage_rows(dag, expand_columns=target)
+
+    columns = [r for r in expanded if r.kind == COLUMN_KIND]
+    assert len(columns) == len(schema)
+    # every column reads as `name  dtype`, and belongs to the node it expanded
+    for (name, dtype), row in zip(schema.items(), columns):
+        assert row.label.split() == [name, str(dtype)]
+        assert row.node_id == target
+    # the graph itself is untouched: same nodes, same collapsed runs
+    assert [r.node_id for r in expanded if r.kind != COLUMN_KIND] == [
+        r.node_id for r in compact
+    ]
+    assert [r.via for r in expanded if r.kind != COLUMN_KIND] == [
+        r.via for r in compact
+    ]
+    # a string and a set of ids are the same request
+    assert compact_lineage_rows(dag, expand_columns={target}) == expanded
+
+
+def test_expand_columns_of_a_flight_boundary_shows_both_sides(
+    udxf_expression: Expr,
+) -> None:
+    """A Flight boundary is the one kind whose schema changes across it, so its
+    columns are drawn per side and the stored diff marks what it added."""
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    rows = compact_lineage_rows(dag, expand_columns=udxf["id"])
+
+    columns = [r.label for r in rows if r.kind == COLUMN_KIND]
+    assert columns
+    assert any(label.startswith("in ") for label in columns)
+    assert any(label.startswith("out ") for label in columns)
+    # the udxf appends one column, which the stored schema_diff calls added
+    added = tuple(udxf["schema_diff"]["added"])
+    assert added
+    assert any(label.startswith(f"out + {added[0]}") for label in columns)
+
+
+def test_expand_columns_of_a_node_without_a_schema_adds_nothing(
+    multi_join_expression: Expr,
+) -> None:
+    """Not every stored node carries a schema (a Field, a Literal): there is
+    nothing to expand there, and asking is not an error."""
+    dag = extract_lineage_dag(multi_join_expression)
+    schemaless = [nid for nid, node in dag.by_id.items() if not node_columns(node)]
+    assert schemaless
+
+    assert compact_lineage_rows(
+        dag, expand_columns=frozenset(schemaless)
+    ) == compact_lineage_rows(dag)
+
+
 def test_compact_lineage_rooted_at_an_unknown_node_is_empty(
     udxf_expression: Expr,
 ) -> None:
@@ -1342,14 +1428,14 @@ import hashlib, json, sys
 from xorq.common.utils.lineage_utils import LineageDAG, format_mermaid_lineage
 
 dag = LineageDAG.from_dict(json.load(sys.stdin))
-for kwargs in ({}, {"expand": True}, {"expand_from": "@cache"}):
+for kwargs in ({}, {"raw": True}, {"expand_columns": "@cache"}):
     print(hashlib.md5(format_mermaid_lineage(dag, **kwargs).encode()).hexdigest())
 """
 
 
 def _stability_dag() -> dict:
     """A graph with a run of non-boundary ops between two boundaries, so the
-    compact, expanded and expand_from renders all differ."""
+    compact, raw and expand_columns renders all differ."""
     nodes = [
         {
             "id": "@join",
@@ -1389,8 +1475,8 @@ def _stability_dag() -> dict:
     "index",
     (
         pytest.param(0, id="compact"),
-        pytest.param(1, id="expand"),
-        pytest.param(2, id="expand_from"),
+        pytest.param(1, id="raw"),
+        pytest.param(2, id="expand_columns"),
     ),
 )
 def test_mermaid_lineage_is_byte_stable_across_processes(
@@ -1437,13 +1523,13 @@ def test_mermaid_lineage_rooted_at_a_node_and_of_nothing(
     assert "(empty)" in format_mermaid_lineage(dag, root="@nope")
 
 
-def test_mermaid_expand_draws_the_stored_graph(udxf_expression: Expr) -> None:
-    """`expand=True` renders `dag.scope()` -- the stored graph -- instead of the
+def test_mermaid_raw_draws_the_stored_graph(udxf_expression: Expr) -> None:
+    """`raw=True` renders `dag.scope()` -- the stored graph -- instead of the
     compact one, so the runs folded into `via` become real nodes."""
     dag = extract_lineage_dag(udxf_expression)
 
     compact = format_mermaid_lineage(dag)
-    expanded = format_mermaid_lineage(dag, expand=True)
+    expanded = format_mermaid_lineage(dag, raw=True)
 
     def declared(diagram: str) -> set[str]:
         return {
@@ -1465,70 +1551,50 @@ def test_mermaid_expand_draws_the_stored_graph(udxf_expression: Expr) -> None:
         assert _mermaid_id(nid) in expanded
 
 
-def test_mermaid_expand_from_switches_detail_part_way_down(
+def test_mermaid_expand_columns_lists_them_inside_the_node(
     multi_join_expression: Expr,
 ) -> None:
-    """`expand_from` keeps the compact graph but draws the stored one from that
-    node downward -- the walk carries its own mode, so detail changes mid-graph."""
+    """Expanding in a diagram puts the columns inside the node, so the graph keeps
+    its shape: same nodes, same edges, one label grown."""
     dag = extract_lineage_dag(multi_join_expression)
     [crossing, *_] = dag.boundaries(kind="engine_crossing")
 
     compact = format_mermaid_lineage(dag)
-    mixed = format_mermaid_lineage(dag, expand_from=crossing["id"])
-    everything = format_mermaid_lineage(dag, expand=True)
+    expanded = format_mermaid_lineage(dag, expand_columns=crossing["id"])
 
-    def declared(diagram: str) -> set[str]:
-        """Op nodes only: column nodes are drawn for the expanded node alone, so
-        they are not part of the compact-vs-expanded comparison."""
-        return {
-            line.strip().split("[", 1)[0]
+    def structure(diagram: str) -> list[str]:
+        return [
+            line.strip().split("[", 1)[0] if "[" in line else line.strip()
             for line in diagram.splitlines()
-            if "[" in line
-            and "_col_" not in line
-            and not line.strip().startswith(("subgraph", "class"))
-        }
+        ]
 
-    # strictly between the two extremes
-    assert declared(compact) < declared(mixed) < declared(everything)
-    # the root stays in the picture, unlike root=
-    assert _mermaid_id(dag.root) in mixed
-    # a node is declared once even when several paths reach it
-    for nid in declared(mixed):
-        assert mixed.count(f"{nid}[") == 1
+    assert structure(compact) == structure(expanded)
+    [label] = [
+        line
+        for line in expanded.splitlines()
+        if _mermaid_id(crossing["id"]) + "[" in line
+    ]
+    for name in dag.by_id[crossing["id"]]["schema"]:
+        assert name in label
+    assert "<br/>" in label
 
 
-def test_mermaid_expand_from_expands_the_run_above_the_node(
+def test_mermaid_expand_columns_accepts_several_nodes(
     multi_join_expression: Expr,
 ) -> None:
-    """`compact()` folds runs onto the edge *above* a node as much as below it, so
-    rendering one node raw has to reach upward too -- otherwise expanding a node
-    whose own subtree has no intermediates draws nothing new."""
-    dag = extract_lineage_dag(multi_join_expression)
-    [crossing, *_] = dag.boundaries(kind="engine_crossing")
-    (incoming,) = [
-        e for e in dag.compact()["edges"] if e["to"] == crossing["id"] and e["via"]
-    ]
-
-    diagram = format_mermaid_lineage(dag, expand_from=crossing["id"])
-
-    # the ops that were folded into that edge's `via` are now nodes of their own
-    for op_type in incoming["via"]:
-        assert op_type in diagram
-    # and the edge itself is gone, replaced by the stored run
-    assert f"{_mermaid_id(crossing['id'])} -->|via" not in diagram, (
-        "the collapsed edge should be replaced, not drawn alongside"
-    )
-
-
-def test_mermaid_expand_from_accepts_several_nodes(multi_join_expression: Expr) -> None:
     dag = extract_lineage_dag(multi_join_expression)
     crossings = tuple(n["id"] for n in dag.boundaries(kind="engine_crossing"))
     assert len(crossings) > 1
 
-    one = format_mermaid_lineage(dag, expand_from=crossings[:1])
-    several = format_mermaid_lineage(dag, expand_from=crossings)
+    one = format_mermaid_lineage(dag, expand_columns=crossings[:1])
+    several = format_mermaid_lineage(dag, expand_columns=crossings)
 
-    assert len(several.splitlines()) > len(one.splitlines())
+    assert several != one
+    for nid in crossings:
+        [label] = [
+            line for line in several.splitlines() if _mermaid_id(nid) + "[" in line
+        ]
+        assert "<br/>" in label
 
 
 def test_mermaid_label_escaping() -> None:

--- a/python/xorq/common/utils/tests/test_lineage_utils.py
+++ b/python/xorq/common/utils/tests/test_lineage_utils.py
@@ -24,6 +24,7 @@ from xorq.common.utils.lineage_utils import (
     build_column_trees,
     build_tree,
     compact_lineage_rows,
+    compact_node_label,
     extract_lineage_dag,
     format_compact_lineage,
     schema_diff,
@@ -1246,6 +1247,42 @@ def test_compact_lineage_rows_carry_via_off_the_label(
         assert all(isinstance(t, str) for t in row.via)
         assert row.via_suffix.startswith("   via [")
         assert row.text == row.prefix + row.label + row.via_suffix
+
+
+def test_compact_lineage_rooted_at_a_node_is_the_subtree_feeding_it(
+    udxf_expression: Expr,
+) -> None:
+    """`root=` renders one node's upstream instead of the whole expression, and
+    reaches a node that lives only inside a Flight's nested scope."""
+    dag = extract_lineage_dag(udxf_expression)
+    [udxf] = dag.boundaries(kind="flight_udxf")
+
+    subtree = format_compact_lineage(dag, root=udxf["id"])
+
+    assert subtree.splitlines()[0].startswith("UDXF[add_c]")
+    assert "↳ " in subtree
+    # the outer graph above the UDXF is excluded
+    full = format_compact_lineage(dag)
+    assert subtree != full
+    assert len(subtree.splitlines()) < len(full.splitlines())
+
+    # a node that lives only in the nested scope roots its own subtree, rendered
+    # from that scope's view rather than the root graph's
+    nested_root = udxf["nested_root"]
+    nested = format_compact_lineage(dag, root=nested_root)
+    assert nested.splitlines()[0] == compact_node_label(dag.by_id[nested_root])
+    assert "InMemoryTable" in nested
+    assert all(line.lstrip("│└├─ ↳") in subtree for line in nested.splitlines())
+
+    assert compact_lineage_rows(dag, root=udxf["id"])[0].kind == "flight_udxf"
+
+
+def test_compact_lineage_rooted_at_an_unknown_node_is_empty(
+    udxf_expression: Expr,
+) -> None:
+    assert format_compact_lineage(
+        extract_lineage_dag(udxf_expression), root="@nope"
+    ) == ("(empty)")
 
 
 def test_compact_lineage_rows_of_an_empty_dag() -> None:

--- a/python/xorq/config.py
+++ b/python/xorq/config.py
@@ -226,7 +226,7 @@ class TUI(Config):
     left_ratio : int
         Width fraction of the left column (catalog tree side).
     right_ratio : int
-        Width fraction of the right column (SQL / Info / Schema side).
+        Width fraction of the right column (Lineage / SQL / Data / Schema side).
     revisions_open : bool
         Whether the Revisions panel is shown at startup.
     git_log_open : bool
@@ -236,7 +236,7 @@ class TUI(Config):
         syntax highlighting. Set to 0 to disable highlighting entirely.
     highlight_debounce : float
         Seconds to wait after a tree-selection change before rendering the
-        SQL / Info / Schema / Revisions panels. Coalesces rapid ``j``/``k``
+        Lineage / SQL / Schema / Revisions panels. Coalesces rapid ``j``/``k``
         traversal so only the settled selection is rendered. Set to 0 to
         render synchronously on every focus change.
     row_limit : int


### PR DESCRIPTION
> **Stacked on #2185** (`mesejo/xor-363-compact-semantically-meaningful-lineage-in-expr-metadata`), which is itself stacked on #2177. Review and merge those first; this diff is one command, renderer additions to `lineage_utils`, a TUI rework of the right panel, their tests, and the docs-nav entry.

## What

`xorq catalog lineage <entry> [--level compact|boundaries|raw] [--node HANDLE] [--format text|mermaid] [--expand HANDLE]`.

Four independent dials: `--level` how much detail, `--node` how much of the graph, `--format` the rendering, `--expand` one node opened up to its columns.

The TUI keeps pace: the right panel becomes a 3-way Lineage/SQL/Data switch, and the Lineage panel gains a row cursor with the same column expansion the CLI's `--expand` does.

## Why

XOR-363 gave the sidecar a boundary-annotated `LineageDAG` and the TUI a compact tree to render it, but left no way to read either outside the TUI. Inspecting a build meant hand-writing `jq` over `expr_metadata.json` or a `python -c` against `LineageDAG`. The ticket never asked for a CLI -- this is the follow-up.

## Levels

Every level is **read or derived from the stored sidecar**. None re-walks the expression or loads the build's expr, so the command is cheap and works on a build whose backends are unreachable.

```
$ xorq catalog lineage lineage-demo                        # compact (default)
Join(2 inputs) (6 cols) [xorq_datafusion]
|-- Cache[ParquetCache] (4 cols) [xorq_datafusion]   via [Field, JoinReference]
|   `-- -> xorq_datafusion (4 cols)
|       `-- UDXF[OrderEnricher] : 3->4 cols [xorq_datafusion]   (+order_score)
|           `-- xorq_datafusion:raw_orders (3 cols)
`-- RemoteTable[duckdb -> xorq_datafusion] (3 cols)   via [Field, JoinReference]
    `-- duckdb:raw_customers (3 cols)

$ xorq catalog lineage lineage-demo --level boundaries     # tab-separated
@join_chain_1       join             Join(2 inputs) (6 cols) [xorq_datafusion]
@remote_table_10    engine_crossing  RemoteTable[duckdb -> xorq_datafusion] (3 cols)
@database_table_13  table            duckdb:raw_customers (3 cols)
@cached_node_14     cache            Cache[ParquetCache] (4 cols) [xorq_datafusion]
@flight_u_d_x_f_17  flight_udxf      UDXF[OrderEnricher] : 3->4 cols [...]   (+order_score)
# nested  @flight_u_d_x_f_17   1 node   root=@database_table_18

$ xorq catalog lineage lineage-demo -l raw | jq '.nodes[0]'
```

- **compact** is exactly what the TUI's Lineage panel shows (same `format_compact_lineage`), minus the colour.
- **boundaries** is tab-separated with no tree glyphs, for `grep`/`cut`. A `flight_udxf`/`flight_expr` boundary also reports its nested scope on a `# nested` line, so a UDXF's input lineage is discoverable without switching levels.
- **raw** is `LineageDAG.to_dict()` as JSON: every node, not just the boundaries the compact view keeps, plus the `{from,to,scope}` edges.

## Narrowing to one node (`--node`, `0d7abe79`)

The plan's Q3 ("stable expand-by-hash") and Q9 (`resolve(handle)` over `hash | @label | tag | kind | predicate`) were only reachable from Python. `--node` surfaces them; `resolve` needed no change -- it already matches a hash, an id, a kind (qualified or base), then a bare tag value.

```
$ xorq catalog lineage demo --node 2997f938a27d      # content hash (durable)
$ xorq catalog lineage demo --node @cached_node_14   # doc-local label
$ xorq catalog lineage demo --node catalog-source    # tag value
$ xorq catalog lineage demo --node flight_udxf       # boundary kind

$ xorq catalog lineage demo --node flight_udxf
UDXF[OrderEnricher] : 3->4 cols [xorq_datafusion]   (+order_score)
`-- xorq_datafusion:raw_orders (3 cols)              <- nested input scope

$ xorq catalog lineage demo --node flight_udxf --level boundaries
@flight_u_d_x_f_17  flight_udxf  UDXF[OrderEnricher] : 3->4 cols [...]   (+order_score)
# capabilities  @flight_u_d_x_f_17  schema_in_required,schema_in_observed,schema_out,schema_diff,nested
# nested  @flight_u_d_x_f_17  1 node  root=@database_table_18
```

- **compact** renders the subtree *feeding* the node, including a Flight boundary's nested input lineage.
- **boundaries** adds `# capabilities` (the code registry for that kind) and `# nested` scope lines. Capability lines are suppressed on the full listing, where they would double the output with what the kind column already implies.
- **raw** prints a JSON array of the matched node dicts instead of the whole document.
- A handle matching **several** nodes (a kind, a tag) prints every match, blank-line separated -- `--node table` listing all tables is useful. A handle matching **none** fails pointing at `--level boundaries`.

`format_compact_lineage`/`compact_lineage_rows` gain `root=`, with a `_view_containing` helper: a node reached only inside a Flight's nested lineage is absent from the root view, so rooting a subtree at it means resolving its scope first.

## Mermaid output (`--format`, `d4beaff2`)

`--format` defaults to `text`, so nothing above changes. `--format mermaid` is a second renderer over the same compact views:

```
$ xorq catalog lineage demo -f mermaid
flowchart TD
  n__join_chain_1["Join(2 inputs) (6 cols) [xorq_datafusion]"]
  n__flight_u_d_x_f_17["UDXF[OrderEnricher] : 3->4 cols [...]   (+order_score)"]
  subgraph n__flight_u_d_x_f_17_scope["input of UDXF[OrderEnricher]"]
    n__database_table_18["xorq_datafusion:raw_orders (3 cols)"]
  end
  n__database_table_18 --> n__flight_u_d_x_f_17
  n__cached_node_14 -->|via Field, JoinReference| n__join_chain_1
  n__remote_table_10 -->|via Field, JoinReference| n__join_chain_1
  classDef flight_udxf fill:#ffe0f0,stroke:#c2185b,color:#111
  class n__flight_u_d_x_f_17 flight_udxf
```

- **Edges are reversed.** The stored direction is depends-on; a diagram wants data flow, so `TD` puts sources at the top and the final expression at the bottom. A collapsed run becomes the edge label.
- **It keeps the graph**, where the text tree cannot: a node with two consumers is one mermaid node with two inbound edges instead of a repeat marked `↻`.
- **A Flight scope becomes a `subgraph`** -- which is what the stored `scope` tag already means.
- **Its own palette**, not the TUI's theme colours: a diagram gets pasted into docs and issues with their own background.
- Ids are sanitized (`@` is not legal in mermaid), labels are HTML-escaped so one cannot break out of its quoted node, and node order comes from a BFS rather than set iteration -- byte-identical under three `PYTHONHASHSEED`s, so a committed diagram does not churn.
- Composes with `--node`: `--node flight_udxf -f mermaid` diagrams just that node's upstream. A handle matching several nodes emits one `flowchart` block per match, to paste one at a time.

### The un-collapsed graph (`-l raw -f mermaid`, `9efffab6`)

`-l raw` is the stored graph -- every node, including the `Field`/`JoinReference`/`Literal` plumbing that `compact()` folds into `via`. Rendering *that* as mermaid is a third diagram, not a re-spelling of the compact one:

```
$ xorq catalog lineage demo -l raw -f mermaid
  n__join_reference_2["JoinReference (3 cols)"]
  n__field_4["Field:id"]
  n__equals_12["Equals"]
  n__field_4 --> n__equals_12
  classDef unknown fill:#fafafa,stroke:#bdbdbd,stroke-dasharray:3 3,color:#555
```

Non-boundary nodes get a dashed grey class so the boundaries still read as the structure.

`-l boundaries -f mermaid` stays a **UsageError**: keeping its edges would just re-spell `-l compact -f mermaid`, and dropping them draws an edgeless pile of nodes -- a worse listing than the text one. Erroring says the flag did nothing rather than silently picking one. (An earlier revision rejected `raw` on the same grounds; that was wrong, since `raw` really is a different graph.)

### Columns of one node (`--expand HANDLE`, `58b2b084`)

`--node` *narrows* -- it roots the view at the match and drops everything above it. `--expand` keeps the whole view and opens one node up to its columns:

```
$ xorq catalog lineage demo --expand @flight_u_d_x_f_17
...
|       `-- UDXF[OrderEnricher] : 3->4 cols [xorq_datafusion]   (+order_score)
|           |-- in id            int64
|           |-- in amount        float64
|           |-- out + order_score  float64      <- `+`/`~`/`-` from the stored schema_diff
|           `-- ...
```

Every relational node already stores its schema in the sidecar, so `expand_columns` lists those columns as child rows in the text tree, and inside the node's label (`<br/>`-joined) in mermaid, leaving the graph's shape alone. A Flight boundary is the one kind whose schema changes across it, so both sides are drawn (`in `/`out `) and the stored `schema_diff` marks what it added (`+`), retyped (`~`) or dropped (`-`).

Same handle forms as `--node`, and every match expands. `--expand` needs a rendered tree or diagram, so `--level boundaries|raw` with `--format text` is a UsageError (raw JSON already carries every stored schema).

> An earlier revision of this branch made `--expand` switch one *region* of the mermaid diagram to the stored op graph. That reading does not survive in a tree -- it repeats every shared op per consumer, so one expansion of a 681-node graph came to 1207 rows -- and `--level raw` already draws every op, so the mixed-detail dial and its `_stored_expansion` machinery were dropped in `58b2b084` (`format_mermaid_lineage`'s `expand`/`expand_from` args became `raw`/`expand_columns`).

## TUI (`21df8291`, `58b2b084`)

- **3-way right panel.** The Info panel was always on screen, capped at six rows, so a lineage tree deeper than that scrolled inside a sliver while SQL held the tall slot. It becomes the first of three swappable views -- `1` Lineage, `2` SQL, `3` Data -- one full-height slot above the always-visible Schema panel, with Lineage as the startup view. SQL and data previews cost a worker, so only the active view pays for them.
- **Row cursor and column folds.** While the Lineage panel holds focus, `j`/`k` move a row cursor (the panel scrolls to follow), `]` lists the cursor node's columns and `[` folds them back -- the same expansion as the CLI's `--expand`. A two-column gutter (`▸`/`▾`) marks expandable rows; fold state is kept per entry, so browsing to a neighbour and back leaves it as you left it. Rows are cached per fold state, so a keypress re-render does no tree walk.

## Behaviour

- Entry lookup goes through the existing `_get_catalog_entry`, so an **alias works** and a typo points at `xorq catalog list` / `list-aliases`.
- A sidecar with **no lineage** (written before XOR-363) fails with how to get one rather than printing an empty tree.
- The whole body runs inside `click_context_catalog`, as the sibling commands do, so a malformed sidecar reports instead of tracebacking.
- `--level` and `--format` are `click.Choice`s, so an unknown value is rejected by Click with the valid set.

## Verification

`test_cli_lineage.py` (new; 25 tests parameterized across the three catalog backends) + `test_lineage_utils.py` (77) + `test_tui.py` (386) + `test_compiler.py` + `test_graph_utils.py` + `docs/test_cli_contract.py` -- all green locally.

Covers: compact is the default and matches `--level compact`; alias resolves to the same output; `boundaries` rows are 3 tab-separated fields with `@`-prefixed ids, carry the expected kinds and no glyphs, and report the nested scope; `raw` round-trips against the entry's stored `LineageDAG`; unknown level, unknown entry, and a lineage-less sidecar all fail with a useful message. For `--node`: hash and `@label` agree, a tag resolves by value as well as by kind, a kind handle prints one subtree per match, `raw` narrows to the matched nodes, `boundaries` reports capabilities and nested scope (and does not on the full listing), and an unknown handle points at `--level boundaries`. For `--format`: text is the default and matches `--format text`, mermaid emits a `flowchart TD` with a subgraph, edges and classDefs and no tree glyphs, composes with `--node`, and is rejected on the boundaries level; `-l raw -f mermaid` draws strictly more nodes than compact and no `via` labels. For `--expand`: it lists a node's columns in the tree and in the diagram, shows both sides of a Flight boundary's transition with the diff marks, accepts hash/label/kind handles interchangeably, and errors on the listing levels and on an unknown handle. In `test_lineage_utils.py`: `root=` renders the subtree feeding a node, resolves a node that lives only in a nested scope, and degrades to `(empty)` for an unknown id; the mermaid renderer declares every node it classes, declares each node once, points its edges downstream, escapes labels, and is byte-stable across processes. TUI tests cover the view switch, the cursor, fold/unfold, per-entry fold state, and the no-op cases.

## Not changed

The **sidecar format** and `compiler.py`. Nothing new is stored and nothing is re-extracted: this only adds readers (and the TUI presentation of them).

`lineage_utils` does grow, in ways the CLI and TUI share:

- `format_mermaid_lineage` -- the second renderer, with `root=`, `raw=` and `expand_columns=`.
- `root=` and `expand_columns=` on `format_compact_lineage` / `compact_lineage_rows`, plus `node_columns`, `_view_containing`, and `node_id` on `LineageRow` so a renderer can address the node behind a row.
- `_compact_node_label` → public `compact_node_label` (rename only).

`LineageDAG` itself -- fields, serialization, `resolve`/`compact`/`scope` semantics -- is untouched.

## Docs

`docs/generate_cli_reference.py` fails when a visible command is in no nav group, so the new command is added to *Entries and aliases* with See-also links to `show`, `schema` and `tui` (and back-links from `show`/`schema`). The page body comes from the command docstring, so `--help` and the reference site cannot disagree. Docstring lists use the repo's `` - `name`—description `` bullet form (as in `xorq init -t`), which survives both Click's `\b` and markdown; the aligned two-column form collapsed in the generated page.

Refs XOR-363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xTFQFkPvzLa4cNEc689pg
