### PR TITLE
test(rbr_utils): pin copy_rbr_batches as arrow-rs#6471 alignment guard

### DIFF
--- a/python/xorq/common/utils/tests/test_rbr_utils.py
+++ b/python/xorq/common/utils/tests/test_rbr_utils.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import decimal
+import threading
+from contextlib import closing
+
+import pyarrow as pa
+import pyarrow.flight as flight
+
+import xorq.api as xo
+from xorq.common.utils.rbr_utils import (
+    copy_rbr_batches,
+    make_filtered_reader,
+)
+
+
+class _BatchServer(flight.FlightServerBase):
+    """Minimal vanilla PyArrow Flight server that streams pre-built batches."""
+
+    def __init__(self, location: str, batches: list[pa.RecordBatch]) -> None:
+        super().__init__(location)
+        self._batches = batches
+        self._schema = batches[0].schema
+
+    def do_get(
+        self,
+        context: flight.ServerCallContext,
+        ticket: flight.Ticket,
+    ) -> flight.GeneratorStream:
+        return flight.GeneratorStream(self._schema, iter(self._batches))
+
+
+def _decimal_batches(n_batches: int = 16, rows: int = 7) -> list[pa.RecordBatch]:
+    """Ordinary ``decimal128`` batches.
+
+    ``decimal128`` requires 16-byte buffer alignment, but the PyArrow (C++)
+    Flight client only hands back 8-byte-aligned buffers, so every decimal
+    data buffer arrives misaligned -- no buffer surgery required.
+    """
+    return [
+        pa.record_batch(
+            {
+                # a tiny bool column shifts the following buffer's offset
+                "pad": pa.array([True] * rows),
+                "amount": pa.array(
+                    [decimal.Decimal(f"{k}.0{i}") for i in range(rows)],
+                    pa.decimal128(18, 2),
+                ),
+            }
+        )
+        for k in range(n_batches)
+    ]
+
+
+def _fetch_raw_flight_batches(
+    batches: list[pa.RecordBatch],
+) -> list[pa.RecordBatch]:
+    """Round-trip ``batches`` through a real Flight server/client and return the
+    RAW received chunks (the buffers as the C++ Flight client laid them out).
+
+    We iterate ``reader`` chunk-by-chunk rather than calling ``read_all()`` on
+    purpose: ``read_all()`` re-consolidates into freshly aligned buffers and
+    would hide the misalignment. Iterating ``chunk.data`` is exactly what
+    ``make_filtered_reader`` does in the live ingest path.
+    """
+    server = _BatchServer("grpc://127.0.0.1:0", batches)
+    try:
+        threading.Thread(target=server.serve, daemon=True).start()
+        with closing(flight.FlightClient(f"grpc://127.0.0.1:{server.port}")) as client:
+            reader = client.do_get(flight.Ticket(b"all"))
+            return [chunk.data for chunk in reader if chunk.data is not None]
+    finally:
+        server.shutdown()
+
+
+def test_copy_rbr_batches_realigns_misaligned_flight_decimals() -> None:
+    """``copy_rbr_batches`` is the workaround for apache/arrow-rs#6471 and is
+    still load-bearing on the versions we pin.
+
+    Reproduces the real, non-synthetic trigger: ordinary ``decimal128`` data
+    fetched over Arrow Flight. The PyArrow/C++ Flight client returns buffers
+    aligned to only 8 bytes, but ``decimal128`` needs 16-byte alignment, so the
+    received buffers are misaligned. Feeding them straight into datafusion's
+    ``read_record_batches`` (a ``RecordBatchReader`` C-stream FFI import) makes
+    the Rust side reject them -- the batches are silently dropped and the table
+    comes back empty.
+
+    The upstream fix (arrow-rs#6472) only realigns the single-batch
+    ``RecordBatch.from_pyarrow_bound`` path; the maintainers deliberately kept
+    the general ``ffi::from_ffi`` import (which the reader path uses) strict, so
+    this cannot be relied on and ``copy_rbr_batches`` -- which reallocates every
+    batch through ``batch.copy_to(default_cpu_memory_manager())`` -- is still
+    required. Turn it into a passthrough and this test fails with 0 rows.
+    """
+    batches = _decimal_batches()
+    raw = _fetch_raw_flight_batches(batches)
+    expected_rows = sum(b.num_rows for b in batches)
+
+    # precondition: the Flight client really did hand back misaligned decimal
+    # buffers, otherwise this would pass vacuously even if the copy were a no-op.
+    assert any(b.column("amount").buffers()[1].address % 16 != 0 for b in raw), (
+        "expected misaligned decimal128 buffers from the Flight client"
+    )
+
+    con = xo.connect()
+    reader = copy_rbr_batches(pa.RecordBatchReader.from_batches(batches[0].schema, raw))
+    con.read_record_batches(reader, table_name="t")
+    out = con.table("t").execute()
+    assert len(out) == expected_rows
+
+
+def test_copy_rbr_batches_preserves_values_and_schema() -> None:
+    """The copy is a pure realignment: same schema, same data, same batching."""
+    batches = [
+        pa.record_batch({"a": pa.array([1, 2, 3]), "b": pa.array(["x", "y", "z"])}),
+        pa.record_batch({"a": pa.array([4, 5]), "b": pa.array(["p", "q"])}),
+    ]
+    reader = pa.RecordBatchReader.from_batches(batches[0].schema, batches)
+    out = copy_rbr_batches(reader).read_all()
+    assert out.schema.equals(batches[0].schema)
+    assert out.equals(pa.Table.from_batches(batches))
+
+
+def test_make_filtered_reader_unwraps_flight_chunks_and_drops_empty() -> None:
+    """``make_filtered_reader`` adapts a Flight stream (which yields
+    ``FlightStreamChunk`` wrappers, each carrying ``.data`` -- a RecordBatch or
+    ``None`` for metadata-only messages) into a plain ``RecordBatchReader``,
+    unwrapping ``.data`` and dropping chunks with no data.
+    """
+    flight_schema = pa.schema([("a", pa.int64())])
+    real = pa.record_batch({"a": pa.array([1, 2, 3])})
+
+    class _Chunk:
+        def __init__(self, data: pa.RecordBatch | None) -> None:
+            self.data = data
+
+    class _FlightLikeReader:
+        schema = flight_schema
+
+        def __iter__(self):  # noqa: ANN204
+            yield _Chunk(None)  # metadata-only chunk -> dropped
+            yield _Chunk(real)  # real batch -> unwrapped and kept
+
+    out = make_filtered_reader(_FlightLikeReader()).read_all()
+    assert out.equals(pa.Table.from_batches([real]))
+
+
+def test_make_filtered_reader_schema_survives_all_empty() -> None:
+    """A stream of only metadata-only chunks still yields a schema-correct,
+    zero-row table rather than raising."""
+    flight_schema = pa.schema([("a", pa.int64())])
+
+    class _Chunk:
+        def __init__(self, data: pa.RecordBatch | None) -> None:
+            self.data = data
+
+    class _FlightLikeReader:
+        schema = flight_schema
+
+        def __iter__(self):  # noqa: ANN204
+            yield _Chunk(None)
+
+    out = make_filtered_reader(_FlightLikeReader()).read_all()
+    assert out.schema.equals(flight_schema)
+    assert out.num_rows == 0


### PR DESCRIPTION
## What

Adds direct tests for `copy_rbr_batches` and `make_filtered_reader` in `python/xorq/common/utils/rbr_utils.py`, which previously had none.

## Why

Started as an investigation into whether `copy_rbr_batches` — a HAK for [apache/arrow-rs#6471](https://github.com/apache/arrow-rs/issues/6471) buffer misalignment — is still needed, since the upstream bug is marked fixed ([arrow-rs#6472](https://github.com/apache/arrow-rs/pull/6472), Oct 2024) and we now run `xorq-datafusion==0.2.10` / `datafusion>=47`.

**It is still load-bearing, and there's a real (non-synthetic) way to hit it.**

### The natural trigger: decimals over Flight

Ordinary `decimal128` data fetched over Arrow Flight reproduces the bug with no buffer surgery:

- The PyArrow/C++ Flight client hands back record-batch buffers aligned to only **8 bytes**.
- `decimal128` requires **16-byte** alignment (`decimal256` needs 32) — so every decimal data buffer arrives misaligned.
- Iterating the raw Flight chunks (exactly what `make_filtered_reader` does — not `read_all()`, which secretly re-consolidates into aligned buffers) and feeding them into datafusion's `read_record_batches` (a `RecordBatchReader` C-stream FFI import) makes the Rust side panic and **silently drop every batch → 0 rows**.
- `copy_rbr_batches` reallocates each batch through `batch.copy_to(default_cpu_memory_manager())`, producing aligned buffers → all rows ingest.

This is precisely the three live call sites (`relations.py`, `exchanger.py`, `server.py`): data crossing the PyArrow Flight boundary into a Rust consumer. Any `decimal`/`decimal256` column through a Flight exchange is a live landmine without the copy.

### Why the upstream fix doesn't cover us

I read [arrow-rs#6472](https://github.com/apache/arrow-rs/pull/6472) in full. It calls `align_buffers()` in **`RecordBatch::from_pyarrow_bound` only** — the single-batch Python binding path. Reviewer `@tustvold` argued to keep the strict "misalignment = error" contract at the general FFI boundary, and `@alamb` scoped the fix accordingly: *"this PR is very specific to pyarrow ... but not other arbitrary FFI boundaries."* The general `ffi::from_ffi` import — the C Stream Interface path that `RecordBatchReader`/`read_record_batches` uses — was **intentionally left strict**. That's the path xorq relies on, so the workaround is still required.

(PyArrow later added `IpcReadOptions.ensure_alignment` in [apache/arrow#44279](https://github.com/apache/arrow/issues/44279), but it defaults to no realignment and only covers IPC reads, not Flight.)

## Conclusion

The opposite of "safe to remove" — this PR locks the workaround in with a regression test that fails (0 rows) if `copy_rbr_batches` is ever turned into a passthrough.

## Tests (all pass locally)

- `test_copy_rbr_batches_realigns_misaligned_flight_decimals` — the natural guard: real Flight round-trip of `decimal128`, raw-chunk ingest into datafusion. Asserts a precondition that the buffers really are misaligned (so it can't pass vacuously); verified it fails with 0 rows when `copy_rbr_batches` is neutered to identity.
- `test_copy_rbr_batches_preserves_values_and_schema` — the copy is a pure realignment.
- `test_make_filtered_reader_unwraps_flight_chunks_and_drops_empty` — pins its role: unwrap `FlightStreamChunk.data`, drop metadata-only chunks.
- `test_make_filtered_reader_schema_survives_all_empty` — an all-metadata stream still yields a schema-correct, zero-row table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)