### PR TITLE
feat(dasher): pyarrow-version-stable canonical hashing of in-memory tables

### DIFF
--- a/docs/adr/0016-canonical-hash-forms-not-serializer-bytes.md
+++ b/docs/adr/0016-canonical-hash-forms-not-serializer-bytes.md
@@ -1,0 +1,118 @@
+# ADR-0016: Hash identity comes from xorq-owned canonical forms, never dependency-serializer bytes
+
+- **Status:** Proposed
+- **Date:** 2026-07-29
+- **Deciders:** Dan Lovell
+
+## Context
+
+Content-addressed identity (build hashes, cache keys, deterministic memtable
+names) was partly derived from the bytes that dependency serializers happen
+to produce: `xorq_dasher.normalize_inmemorytable` executed a memtable
+through a backend and xxhashed the IPC bytes of the resulting
+`to_pyarrow_batches()` stream, and `normalize_pyarrow_table` hashed
+serialized batch bytes directly.
+
+Arrow's format versioning guarantees *logical readability* across versions,
+not byte determinism — the columnar spec leaves padding bytes, null-slot
+contents, and validity-bitmap presence unspecified even within one version.
+When pyarrow changed its IPC dictionary-batch handling between 20 and 21,
+every memtable-bearing build silently got a new name: `ci-test-lowest-direct`
+broke when uv's resolver drifted pyarrow 21 → 20 (#2191), and the same
+pipeline built on adjacent pyarrow versions cache-missed against itself.
+
+The same failure family (hashing an incidental physical/environment artifact
+as if it were logical identity) recurs elsewhere: parquet bytes embed
+`created_by` version strings and change encoding defaults at 19→20 and
+21→22; cloudpickle output is Python-version-coupled; generated SQL text is
+sqlglot-coupled.
+
+## Decision drivers
+
+- **Correctness over efficiency (ADR-0015):** under-discrimination
+  (different data → same hash → wrong result) is never acceptable;
+  over-discrimination (same data → different hash → recompute) is a cost to
+  drive down.
+- Hash identity must change when *xorq decides*, not when a dependency
+  releases.
+- Reproducible builds: the same expression must produce the same artifact
+  name on any supported dependency matrix.
+- No fork of `xorq_dasher`: xorq already layers rule overrides via
+  `DEFAULT_HASHER.override(...)`.
+
+## Decision
+
+1. **Identity is a hash of a logical canonical form, defined and versioned
+   by xorq** (`python/xorq/common/utils/dasher/_canonical.py`). For
+   in-memory table data the canonical form is: stored proxy data (never a
+   backend re-execution), per column `combine_chunks` → recursively decode
+   dictionary encoding → metadata-free single-column RecordBatch → xxh128
+   of its IPC bytes; plus an explicit `(name, str(type))` schema tuple and
+   row count.
+
+2. **No normalizer may hash a dependency serializer's byte output** (Arrow
+   IPC streams, parquet bytes, pickle) as identity unless the exact byte
+   surface is covered by a cross-version stability check. The canonical
+   column digest is currently the one sanctioned use: it was verified
+   byte-identical across pyarrow 18.0.0–25.0.0 (probe on #2191), and its
+   body is isolated so a buffer-level logical fold can replace it without
+   another design change.
+
+3. **Every canonical tuple embeds `NORMALIZATION_VERSION`.** Changing any
+   canonical form requires bumping it — a deliberate, release-noted,
+   fleet-wide cache-invalidation event — and regenerating the golden tokens.
+
+4. **Golden-token contract tests**
+   (`python/xorq/common/utils/tests/test_hash_contract.py`) pin the token
+   output per surface. Any change to token output fails in the PR that
+   causes it, with a message carrying dependency versions and the
+   normalized tuple for diagnosis.
+
+5. **Canonicalization must be audited for omissions.** A serializer's
+   omissions are under-discrimination holes: `RecordBatch.serialize()`
+   carries no schema message (int8 vs uint8 with identical buffers collide
+   without an explicit type component) and no dictionary values (encoded
+   indices hash alone unless decoded). Where a dictionary layer cannot be
+   erased (union / list_view / run-end nesting), refuse loudly rather than
+   hash indices without values.
+
+## Alternatives considered
+
+- **Pin pyarrow to a proven-stable block (`>=21,<22`).** Rejected as the
+  fix: it narrows the supported range, must be re-litigated every pyarrow
+  release, and hides rather than removes the coupling. (It was also skipped
+  as a stopgap once the canonical digest was verified stable on 18–25.)
+- **Scrub version strings from serialized bytes.** Insufficient: the pa20↔21
+  divergence is a real dictionary-batch layout change, not a metadata
+  string; parquet 21→22 changes live inside SNAPPY-compressed bytes.
+- **Fully logical buffer-level hash (per-type folds over value bytes, null
+  masks, offsets).** Strictly more robust (immune to IPC framing/padding
+  choices) but more per-type code; deferred as the designated escalation:
+  swap the body of `canonical_column_digest` and bump
+  `NORMALIZATION_VERSION` if a future pyarrow breaks IPC byte stability
+  (see #2194's monitor and escalation policy).
+- **Upstream a canonical-bytes mode into Arrow.** Arrow explicitly declines
+  byte-stability guarantees; not a realistic dependency.
+
+## Consequences
+
+- One-time hash bump for memtable-bearing expressions (#2192); thereafter
+  artifact names are stable across the supported dependency matrix.
+- Deterministic memtable naming no longer executes data through a backend
+  (also removes a datafusion round-trip from tokenization).
+- New rules that hash serializer bytes must either canonicalize or join the
+  cross-version monitor (#2194 adds an allowlist guard test enforcing
+  this).
+- Known over-discrimination surfaces remain (UDF cloudpickle tokens,
+  generated SQL text) — acceptable per ADR-0015's asymmetry, tracked by the
+  monitor rather than golden tokens.
+
+## References
+
+- #2191 (investigation + cross-version probe script), #2192
+  (implementation), #2193 (content-hash read default), #2194
+  (version-matrix monitor + provenance guard)
+- ADR-0015 (build-hash/cache-hash split; correctness > efficiency)
+- Arrow format versioning and columnar spec:
+  https://arrow.apache.org/docs/format/Versioning.html,
+  https://arrow.apache.org/docs/format/Columnar.html

--- a/docs/adr/0017-canonical-hash-forms-not-serializer-bytes.md
+++ b/docs/adr/0017-canonical-hash-forms-not-serializer-bytes.md
@@ -45,18 +45,33 @@ sqlglot-coupled.
 1. **Identity is a hash of a logical canonical form, defined and versioned
    by xorq** (`python/xorq/common/utils/dasher/_canonical.py`). For
    in-memory table data the canonical form is: stored proxy data (never a
-   backend re-execution), per column `combine_chunks` → recursively decode
-   dictionary encoding → metadata-free single-column RecordBatch → xxh128
-   of its IPC bytes; plus an explicit `(name, str(type))` schema tuple and
-   row count.
+   backend re-execution), then per column — recursively decode dictionary
+   encoding, widen int32-offset var-length types to `large_*`, and rewrite
+   `string_view`/`binary_view` to `large_string`/`large_binary` (one
+   chunk-wise `cast`) → `combine_chunks`/`concat_arrays` → metadata-free
+   single-column RecordBatch → xxh128 of its IPC bytes; plus an explicit
+   `(name, str(canonical type))` schema tuple and row count.
 
-2. **No normalizer may hash a dependency serializer's byte output** (Arrow
-   IPC streams, parquet bytes, pickle) as identity unless the exact byte
-   surface is covered by a cross-version stability check. The canonical
-   column digest is currently the one sanctioned use: it was verified
-   byte-identical across pyarrow 18.0.0–25.0.0 (probe on #2191), and its
-   body is isolated so a buffer-level logical fold can replace it without
-   another design change.
+   The cast **precedes** compaction and the order is load-bearing: a
+   >2 GiB string column holds more value data than one contiguous
+   int32-offset array can address, so compacting before widening would
+   overflow.
+
+2. **No normalizer may hash or embed a dependency-owned representation**
+   (Arrow IPC streams, parquet bytes, pickle, type reprs) as identity
+   unless that exact surface is covered by a cross-version stability
+   check. Two surfaces are currently sanctioned, both verified across
+   pyarrow 18.0.0–25.0.0 by `scripts/canonical_digest_xver_probe.py`
+   (#2191) and both emitted by that probe so the check keeps running:
+
+   - the canonical column digest (IPC bytes), whose body is isolated so a
+     buffer-level logical fold can replace it without another design
+     change; and
+   - `str(canonical type)` in the schema component, i.e. pyarrow's
+     `DataType.__str__`. It carries real identity — `RecordBatch.serialize()`
+     emits no schema message, so int8 and uint8 with equal buffers are
+     otherwise indistinguishable — and is therefore as much a stability
+     dependency as the digest, not a free-form label.
 
 3. **Every canonical tuple embeds `NORMALIZATION_VERSION`.** Changing any
    canonical form requires bumping it — a deliberate, release-noted,
@@ -73,8 +88,16 @@ sqlglot-coupled.
    carries no schema message (int8 vs uint8 with identical buffers collide
    without an explicit type component) and no dictionary values (encoded
    indices hash alone unless decoded). Where a dictionary layer cannot be
-   erased (union / list_view / run-end nesting), refuse loudly rather than
-   hash indices without values.
+   erased, refuse loudly rather than hash indices without values — and the
+   walk that looks for such types must descend a dictionary's value type
+   explicitly, since `pa.DictionaryType.num_fields == 0`.
+
+   Separately and unconditionally, four families are refused outright
+   because no verified canonicalizing cast exists for them: extension types
+   (parameters live in `__arrow_ext_serialize__` bytes that `str(type)`
+   omits — an under-discrimination hole), and list-view, union and
+   run-end-encoded types (their serialized form is unboundedly
+   layout-coupled). This is independent of whether they nest a dictionary.
 
 ## Alternatives considered
 
@@ -87,10 +110,14 @@ sqlglot-coupled.
   string; parquet 21→22 changes live inside SNAPPY-compressed bytes.
 - **Fully logical buffer-level hash (per-type folds over value bytes, null
   masks, offsets).** Strictly more robust (immune to IPC framing/padding
-  choices) but more per-type code; deferred as the designated escalation:
-  swap the body of `canonical_column_digest` and bump
-  `NORMALIZATION_VERSION` if a future pyarrow breaks IPC byte stability
-  (see #2194's monitor and escalation policy).
+  choices, and the only thing that erases the null-slot-payload residual
+  below at every nesting level) but more per-type code; deferred as the
+  designated escalation: swap the body of `canonical_column_digest` and bump
+  `NORMALIZATION_VERSION` if a future pyarrow breaks IPC byte stability (see
+  #2194's monitor and escalation policy). Rejected as a partial measure:
+  zeroing null payloads for top-level primitives only would leave nested
+  children (struct/list of nullable primitives) untouched, reproducing the
+  non-uniform-exclusion defect that round 3 fixed for `keys_sorted`.
 - **Upstream a canonical-bytes mode into Arrow.** Arrow explicitly declines
   byte-stability guarantees; not a realistic dependency.
 
@@ -106,6 +133,23 @@ sqlglot-coupled.
 - Known over-discrimination surfaces remain (UDF cloudpickle tokens,
   generated SQL text) — acceptable per ADR-0015's asymmetry, tracked by the
   monitor rather than golden tokens.
+- Two over-discrimination residuals are accepted *inside* the canonical form
+  itself, priced as recomputation and pinned by tests in
+  `test_hash_contract.py` rather than left undocumented:
+  - **Null-slot payload.** The columnar spec leaves null-slot contents
+    unspecified and `RecordBatch.serialize()` writes the values buffer
+    verbatim, so producers disagree on `.equals()`-identical data:
+    `pa.Table.from_pandas` leaves NaN/NaT/mask-garbage under a null where a
+    literal `None` leaves zero (float64, nullable `Int64`, `datetime64`
+    confirmed). Not refused, unlike union/run-end-encoded — those have
+    unbounded, non-producer-stable layout variance and are rare, whereas
+    refusing null-slot variance would refuse nearly every nullable column.
+    Closing it is exactly the deferred buffer-level fold below.
+  - **Timezone spelling.** `str(type)` distinguishes `tz=UTC` from
+    `tz=+00:00` for the same instant; the value digests agree.
+
+  Neither re-opens #2191: both are deterministic given the producer, so
+  identity never moves because a dependency moved.
 
 ## References
 

--- a/docs/adr/0017-canonical-hash-forms-not-serializer-bytes.md
+++ b/docs/adr/0017-canonical-hash-forms-not-serializer-bytes.md
@@ -1,4 +1,4 @@
-# ADR-0016: Hash identity comes from xorq-owned canonical forms, never dependency-serializer bytes
+# ADR-0017: Hash identity comes from xorq-owned canonical forms, never dependency-serializer bytes
 
 - **Status:** Proposed
 - **Date:** 2026-07-29

--- a/python/xorq/common/utils/dasher/__init__.py
+++ b/python/xorq/common/utils/dasher/__init__.py
@@ -10,6 +10,9 @@ types, Python callables (FunctionType/MethodType/CodeType/CellType/classmethod
 This package adds the gap rules and xorq-specific normalizers split across
 submodules:
 
+* ``_canonical`` — pyarrow-version-stable logical hashing of in-memory
+                   table data (InMemoryTable, memory DatabaseTable,
+                   ``pa.Table``), versioned by ``NORMALIZATION_VERSION``
 * ``_gap_rules`` — stdlib/toolz/numpy/pandas/ibis-Schema normalizers
 * ``_paths``     — catalog path canonicalization, stat helpers, plan/DDL
                    extractors
@@ -52,6 +55,9 @@ _current_hasher: contextvars.ContextVar[Hasher | None] = contextvars.ContextVar(
 # have no in-package deps; ``_opaque`` lazily imports HASHER from this
 # module so it can be loaded before HASHER is built; ``_relations`` depends
 # on ``_paths`` + ``_opaque._rename_unbound_xorq``.
+from xorq.common.utils.dasher._canonical import (  # noqa: E402
+    normalize_pyarrow_table_canonical,
+)
 from xorq.common.utils.dasher._gap_rules import (  # noqa: E402
     normalize_attrs,
     normalize_builtin_callable,
@@ -118,6 +124,7 @@ _EXTRA_RULES: tuple[tuple[str, object], ...] = (
     ("xorq.vendor.ibis.expr.types.core.Expr", _normalize_expr_xorq),
     ("xorq.vendor.ibis.expr.schema.Schema", normalize_ibis_schema),
     ("xorq.vendor.ibis.expr.operations.udf.ScalarUDF", _normalize_scalar_udf_xorq),
+    ("pyarrow.lib.Table", normalize_pyarrow_table_canonical),
     ("numpy.dtype", normalize_numpy_dtype),
     ("pandas.core.series.Series", normalize_pandas_series),
     ("pandas.core.frame.DataFrame", normalize_pandas_dataframe),

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -12,21 +12,27 @@ The canonical form hashed here is a *logical* one:
 
 * never re-execute an ``InMemoryTable`` through a backend — hash the stored
   proxy data (``op.data.to_pyarrow(op.schema)``);
-* per column: ``combine_chunks`` (erases chunk layout), recursively decode
-  dictionary encoding (erases physical encoding; an un-decoded dictionary
-  batch message would serialize indices *without* the dictionary values —
-  an under-discrimination hazard), then xxh128 the IPC bytes of a
-  metadata-free single-column RecordBatch;
-* carry the schema as an explicit ``(name, str(type))`` tuple —
+* per column: recursively decode dictionary encoding and widen int32
+  offsets to ``large_*`` (both erase physical encoding; an un-decoded
+  dictionary batch message would serialize indices *without* the dictionary
+  values — an under-discrimination hazard), compact via
+  ``combine_chunks``/``concat_arrays`` (erases chunk layout and slicing),
+  then xxh128 the IPC bytes of a metadata-free single-column RecordBatch;
+* carry the schema as an explicit ``(name, str(canonical type))`` tuple —
   ``RecordBatch.serialize()`` emits no schema message, so type identity
-  must not be left to the value bytes alone.
+  must not be left to the value bytes alone;
+* refuse what cannot be canonicalized (extension types, dictionaries
+  nested where they cannot be decoded away) with ``NotImplementedError``
+  rather than hash them unstably or collidingly.
 
-The column digest was verified byte-identical across pyarrow 18.0.0–25.0.0
-for a corpus covering nulls, NaN/-0.0/inf, decimals, tz timestamps, nested
-list/struct/map, multi-chunk dictionary arrays, and sliced arrays (probe
-script on issue #2191). If a future pyarrow breaks IPC byte stability, swap
-the body of :func:`canonical_column_digest` for a buffer-level logical fold
-and bump ``NORMALIZATION_VERSION``.
+The column digest was verified byte-identical across pyarrow 18.0.0, 20.0.0,
+21.0.0 and 25.0.0 for a corpus covering nulls, NaN/-0.0/inf, decimals, tz
+timestamps, nested list/struct/map, multi-chunk dictionary arrays, and
+sliced/chunked var-length arrays — rerun
+``scripts/canonical_digest_xver_probe.py`` (a standalone replica of this
+logic) to re-verify. If a future pyarrow breaks IPC byte stability, swap the
+body of :func:`canonical_column_digest` for a buffer-level logical fold and
+bump ``NORMALIZATION_VERSION``.
 
 ``NORMALIZATION_VERSION`` is folded into every tuple produced here: hash
 identity is versioned by xorq, deliberately, not by dependency drift. Any
@@ -56,30 +62,70 @@ if TYPE_CHECKING:
 NORMALIZATION_VERSION = 1
 
 
-def _dictionary_free_type(typ: pa.DataType) -> pa.DataType:
-    """Return ``typ`` with every dictionary layer (at any nesting depth)
-    replaced by its logical value type."""
+def _assert_canonicalizable(typ: pa.DataType) -> None:
+    """Refuse types whose logical identity this module cannot provably
+    capture, walking child fields generically (so an extension type nested
+    in any family — list, struct, map, union, list_view, … — is found).
+
+    Extension types are refused outright: their parameters live in
+    ``__arrow_ext_serialize__()`` bytes — third-party serialization with no
+    cross-version stability contract (hashing them would re-introduce the
+    dependency-drift coupling of #2191) — while ``str(type)`` omits them
+    entirely, so passing the storage through would collide logically
+    different tables (e.g. pandas period columns of freq 'M' vs 'D' with
+    equal ordinals). Loud refusal is the only option that neither collides
+    nor version-couples; support requires a ``NORMALIZATION_VERSION`` bump.
+    """
+    import pyarrow as pa  # noqa: PLC0415
+
+    if isinstance(typ, pa.BaseExtensionType):
+        raise NotImplementedError(
+            f"cannot canonically hash extension type {typ!r}: its parameters "
+            f"(__arrow_ext_serialize__ bytes) have no cross-version stability "
+            f"contract and str(type) omits them, so logically different "
+            f"tables would collide"
+        )
+    for i in range(typ.num_fields):
+        _assert_canonicalizable(typ.field(i).type)
+
+
+def _canonical_type(typ: pa.DataType) -> pa.DataType:
+    """Return the canonical logical type for ``typ``: every dictionary layer
+    (at any nesting depth) replaced by its logical value type, and
+    int32-offset var-length types widened to their ``large_*`` (int64-offset)
+    variants.
+
+    Widening does double duty: offset width is a physical encoding, not a
+    logical property (ibis maps string and large_string to the same dtype),
+    and a single contiguous int32-offset array can address at most 2 GiB of
+    value data — a chunked column can hold more in memory just fine, so
+    canonicalizing to one contiguous array would overflow where the widened
+    type cannot. (``map`` has no large variant in Arrow; a >2^31-entry map
+    column fails loudly in ``combine_chunks`` rather than mis-hashing.)
+    """
     import pyarrow as pa  # noqa: PLC0415
 
     if pa.types.is_dictionary(typ):
-        return _dictionary_free_type(typ.value_type)
-    if pa.types.is_list(typ):
-        return pa.list_(_dictionary_free_type(typ.value_type))
-    if pa.types.is_large_list(typ):
-        return pa.large_list(_dictionary_free_type(typ.value_type))
+        return _canonical_type(typ.value_type)
+    if pa.types.is_string(typ):
+        return pa.large_string()
+    if pa.types.is_binary(typ):
+        return pa.large_binary()
+    if pa.types.is_list(typ) or pa.types.is_large_list(typ):
+        return pa.large_list(_canonical_type(typ.value_type))
     if pa.types.is_fixed_size_list(typ):
-        return pa.list_(_dictionary_free_type(typ.value_type), typ.list_size)
+        return pa.list_(_canonical_type(typ.value_type), typ.list_size)
     if pa.types.is_struct(typ):
         return pa.struct(
             [
-                (typ.field(i).name, _dictionary_free_type(typ.field(i).type))
+                (typ.field(i).name, _canonical_type(typ.field(i).type))
                 for i in range(typ.num_fields)
             ]
         )
     if pa.types.is_map(typ):
         return pa.map_(
-            _dictionary_free_type(typ.key_type),
-            _dictionary_free_type(typ.item_type),
+            _canonical_type(typ.key_type),
+            _canonical_type(typ.item_type),
             keys_sorted=typ.keys_sorted,
         )
     return typ
@@ -88,8 +134,8 @@ def _dictionary_free_type(typ: pa.DataType) -> pa.DataType:
 def _contains_dictionary(typ: pa.DataType) -> bool:
     """True if ``typ`` has a dictionary layer anywhere in its nesting,
     traversing child fields generically (so union / list_view / run-end
-    encoded families — which :func:`_dictionary_free_type` does not rewrite
-    — are still inspected)."""
+    encoded families — which :func:`_canonical_type` does not rewrite —
+    are still inspected)."""
     import pyarrow as pa  # noqa: PLC0415
 
     if pa.types.is_dictionary(typ):
@@ -100,9 +146,9 @@ def _contains_dictionary(typ: pa.DataType) -> bool:
 def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
     """xxh128 digest of one column's logical values, physical-layout-free.
 
-    Identical for chunked vs contiguous, sliced vs compact, and
-    dictionary-encoded vs plain representations of the same values
-    (invariants asserted in ``test_hash_contract.py``).
+    Identical for chunked vs contiguous, sliced vs compact,
+    dictionary-encoded vs plain, and int32- vs int64-offset representations
+    of the same values (invariants asserted in ``test_hash_contract.py``).
 
     The digest carries NO type identity: ``RecordBatch.serialize()`` emits
     no schema message, so e.g. int8 and uint8 arrays with identical buffers
@@ -112,10 +158,10 @@ def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
     """
     import pyarrow as pa  # noqa: PLC0415
 
-    arr = col.combine_chunks() if isinstance(col, pa.ChunkedArray) else col
-    canonical_type = _dictionary_free_type(arr.type)
+    _assert_canonicalizable(col.type)
+    canonical_type = _canonical_type(col.type)
     if _contains_dictionary(canonical_type):
-        # ``_dictionary_free_type`` does not rewrite this type family
+        # ``_canonical_type`` does not rewrite this type family
         # (union / list_view / run-end encoded …), so a dictionary layer
         # survived. Serializing it would emit indices *without* the
         # dictionary values — refuse loudly rather than under-discriminate.
@@ -123,8 +169,21 @@ def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
             f"cannot erase dictionary encoding nested in {canonical_type!r}; "
             f"hashing it would drop the dictionary values from the digest"
         )
-    if canonical_type != arr.type:
-        arr = arr.cast(canonical_type)
+    if canonical_type != col.type:
+        # ChunkedArray.cast casts chunk-wise, so offset widening happens
+        # BEFORE the chunks are combined — a >2 GiB string column would
+        # otherwise overflow its int32 offsets in combine_chunks.
+        col = col.cast(canonical_type)
+    # Both branches funnel through concat_arrays, which rebuilds buffers
+    # compactly: a slice of a var-length array carries un-rebased offsets
+    # that serialize differently from a fresh equivalent. The per-type
+    # slicing invariants in test_hash_contract.py pin this compaction
+    # behavior — if a future pyarrow adds a zero-copy fast path, they fail
+    # there, not in production.
+    if isinstance(col, pa.ChunkedArray):
+        arr = col.combine_chunks()
+    else:
+        arr = pa.concat_arrays([col])
     batch = pa.RecordBatch.from_arrays([arr], names=["c"])
     return xxhash.xxh128(batch.serialize().to_pybytes()).hexdigest()
 
@@ -134,15 +193,16 @@ def normalize_pyarrow_table_canonical(table: pa.Table) -> tuple:
     + per-column value digests. Schema/field metadata (where ``from_pandas``
     embeds pandas/pyarrow version strings) is deliberately excluded. The row
     count is carried explicitly because a zero-column table has no digests
-    to carry it implicitly."""
+    to carry it implicitly. The schema carries the *canonical* type string,
+    so representations that differ only in physical encoding (dictionary
+    vs plain, string vs large_string) normalize identically."""
+    for field in table.schema:
+        _assert_canonicalizable(field.type)
     return (
         "xorq.pa.Table",
         NORMALIZATION_VERSION,
         table.num_rows,
-        tuple(
-            (field.name, str(_dictionary_free_type(field.type)))
-            for field in table.schema
-        ),
+        tuple((field.name, str(_canonical_type(field.type))) for field in table.schema),
         tuple(canonical_column_digest(col) for col in table.columns),
     )
 

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -12,22 +12,26 @@ The canonical form hashed here is a *logical* one:
 
 * never re-execute an ``InMemoryTable`` through a backend — hash the stored
   proxy data (``op.data.to_pyarrow(op.schema)``);
-* per column: recursively decode dictionary encoding and widen int32
-  offsets to ``large_*`` (both erase physical encoding; an un-decoded
-  dictionary batch message would serialize indices *without* the dictionary
-  values — an under-discrimination hazard), compact via
-  ``combine_chunks``/``concat_arrays`` (erases chunk layout and slicing),
-  then xxh128 the IPC bytes of a metadata-free single-column RecordBatch;
+* per column: recursively decode dictionary encoding, widen int32
+  offsets to ``large_*``, and rewrite ``string_view``/``binary_view`` to
+  their ``large_*`` offset forms (all erase physical encoding; an
+  un-decoded dictionary batch message would serialize indices *without*
+  the dictionary values — an under-discrimination hazard — and a view
+  array serializes its physical buffer layout, which varies with how the
+  array was built), compact via ``combine_chunks``/``concat_arrays``
+  (erases chunk layout and slicing), then xxh128 the IPC bytes of a
+  metadata-free single-column RecordBatch;
 * carry the schema as an explicit ``(name, str(canonical type))`` tuple —
   ``RecordBatch.serialize()`` emits no schema message, so type identity
   must not be left to the value bytes alone;
-* refuse what cannot be canonicalized (extension types, dictionaries
-  nested where they cannot be decoded away) with ``NotImplementedError``
-  rather than hash them unstably or collidingly.
+* refuse what cannot be canonicalized (extension types, list-view types,
+  dictionaries nested where they cannot be decoded away) with
+  ``NotImplementedError`` rather than hash them unstably or collidingly.
 
 The column digest was verified byte-identical across pyarrow 18.0.0, 20.0.0,
 21.0.0 and 25.0.0 for a corpus covering nulls, NaN/-0.0/inf, decimals, tz
-timestamps, nested list/struct/map, multi-chunk dictionary arrays, and
+timestamps, nested list/struct/map, multi-chunk dictionary arrays,
+string_view/binary_view arrays (plain, sliced and chunked), and
 sliced/chunked var-length arrays — rerun
 ``scripts/canonical_digest_xver_probe.py`` (a standalone replica of this
 logic) to re-verify. If a future pyarrow breaks IPC byte stability, swap the
@@ -75,6 +79,14 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
     different tables (e.g. pandas period columns of freq 'M' vs 'D' with
     equal ordinals). Loud refusal is the only option that neither collides
     nor version-couples; support requires a ``NORMALIZATION_VERSION`` bump.
+
+    List-view types are refused because they cannot be canonicalized:
+    pyarrow's ``list_view`` → ``list`` cast emits invalid arrays (offsets
+    fail ``validate(full=True)``; verified on pyarrow 18 and 21), and
+    passing a view array through uncanonicalized would serialize its
+    physical buffer layout — equal data hashing unequally, breaking the
+    layout-invariance contract. (``string_view``/``binary_view`` cast
+    correctly and are canonicalized by :func:`_canonical_type` instead.)
     """
     import pyarrow as pa  # noqa: PLC0415
 
@@ -85,6 +97,13 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
             f"contract and str(type) omits them, so logically different "
             f"tables would collide"
         )
+    if pa.types.is_list_view(typ) or pa.types.is_large_list_view(typ):
+        raise NotImplementedError(
+            f"cannot canonically hash list-view type {typ!r}: pyarrow's "
+            f"list_view->list cast produces invalid arrays, and serializing "
+            f"the view uncanonicalized would hash its physical buffer layout "
+            f"instead of its logical values"
+        )
     for i in range(typ.num_fields):
         _assert_canonicalizable(typ.field(i).type)
 
@@ -92,24 +111,28 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
 def _canonical_type(typ: pa.DataType) -> pa.DataType:
     """Return the canonical logical type for ``typ``: every dictionary layer
     (at any nesting depth) replaced by its logical value type, and
-    int32-offset var-length types widened to their ``large_*`` (int64-offset)
-    variants.
+    int32-offset and view var-length types rewritten to their ``large_*``
+    (int64-offset) variants.
 
     Widening does double duty: offset width is a physical encoding, not a
     logical property (ibis maps string and large_string to the same dtype),
     and a single contiguous int32-offset array can address at most 2 GiB of
     value data — a chunked column can hold more in memory just fine, so
     canonicalizing to one contiguous array would overflow where the widened
-    type cannot. (``map`` has no large variant in Arrow; a >2^31-entry map
-    column fails loudly in ``combine_chunks`` rather than mis-hashing.)
+    type cannot. View types additionally MUST be rewritten because their
+    IPC form serializes the physical buffer layout — equal data built
+    differently serializes differently. (``map`` has no large variant in
+    Arrow; a >2^31-entry map column fails loudly in ``combine_chunks``
+    rather than mis-hashing. Likewise a ``dictionary`` of view values —
+    pyarrow cannot decode it, so the cast fails loudly.)
     """
     import pyarrow as pa  # noqa: PLC0415
 
     if pa.types.is_dictionary(typ):
         return _canonical_type(typ.value_type)
-    if pa.types.is_string(typ):
+    if pa.types.is_string(typ) or pa.types.is_string_view(typ):
         return pa.large_string()
-    if pa.types.is_binary(typ):
+    if pa.types.is_binary(typ) or pa.types.is_binary_view(typ):
         return pa.large_binary()
     if pa.types.is_list(typ) or pa.types.is_large_list(typ):
         return pa.large_list(_canonical_type(typ.value_type))
@@ -133,9 +156,10 @@ def _canonical_type(typ: pa.DataType) -> pa.DataType:
 
 def _contains_dictionary(typ: pa.DataType) -> bool:
     """True if ``typ`` has a dictionary layer anywhere in its nesting,
-    traversing child fields generically (so union / list_view / run-end
-    encoded families — which :func:`_canonical_type` does not rewrite —
-    are still inspected)."""
+    traversing child fields generically (so union / run-end encoded
+    families — which :func:`_canonical_type` does not rewrite — are still
+    inspected; list-view families are refused outright in
+    :func:`_assert_canonicalizable` before this runs)."""
     import pyarrow as pa  # noqa: PLC0415
 
     if pa.types.is_dictionary(typ):
@@ -162,7 +186,7 @@ def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
     canonical_type = _canonical_type(col.type)
     if _contains_dictionary(canonical_type):
         # ``_canonical_type`` does not rewrite this type family
-        # (union / list_view / run-end encoded …), so a dictionary layer
+        # (union / run-end encoded …), so a dictionary layer
         # survived. Serializing it would emit indices *without* the
         # dictionary values — refuse loudly rather than under-discriminate.
         raise NotImplementedError(
@@ -224,7 +248,11 @@ def normalize_memory_databasetable_canonical(dt: DatabaseTable) -> tuple:
     backend, so one execution is unavoidable — but hashing the canonical
     form of the materialized table (rather than the raw batch stream)
     erases the batch-size and IPC-dictionary variance that execution
-    introduces."""
+    introduces. Streaming ``to_pyarrow_batches()`` here would save no peak
+    memory: the canonical digest compacts each column across ALL chunks
+    (that compaction is what erases batch boundaries), so every batch must
+    be resident anyway — and an incremental per-batch fold would re-couple
+    the hash to batch boundaries, the exact defect being removed."""
     return (
         "xorq.MemoryDatabaseTable",
         NORMALIZATION_VERSION,

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -1,0 +1,152 @@
+"""Canonical, pyarrow-version-stable hashing of in-memory table data.
+
+Replaces xorq_dasher 0.1.0's ``normalize_inmemorytable`` /
+``normalize_memory_databasetable`` / ``normalize_pyarrow_table``, which hash
+the IPC bytes of a backend-executed ``to_pyarrow_batches()`` stream. That
+stream is an incidental physical artifact: its bytes depend on batch size
+and on pyarrow's IPC dictionary-batch handling, which changed between
+pyarrow 20 and 21 and silently renamed every memtable-bearing build
+(issue #2191).
+
+The canonical form hashed here is a *logical* one:
+
+* never re-execute an ``InMemoryTable`` through a backend — hash the stored
+  proxy data (``op.data.to_pyarrow(op.schema)``);
+* per column: ``combine_chunks`` (erases chunk layout), recursively decode
+  dictionary encoding (erases physical encoding; an un-decoded dictionary
+  batch message would serialize indices *without* the dictionary values —
+  an under-discrimination hazard), then xxh128 the IPC bytes of a
+  metadata-free single-column RecordBatch;
+* carry the schema as an explicit ``(name, str(type))`` tuple —
+  ``RecordBatch.serialize()`` emits no schema message, so type identity
+  must not be left to the value bytes alone.
+
+The column digest was verified byte-identical across pyarrow 18.0.0–25.0.0
+for a corpus covering nulls, NaN/-0.0/inf, decimals, tz timestamps, nested
+list/struct/map, multi-chunk dictionary arrays, and sliced arrays (probe
+script on issue #2191). If a future pyarrow breaks IPC byte stability, swap
+the body of :func:`canonical_column_digest` for a buffer-level logical fold
+and bump ``NORMALIZATION_VERSION``.
+
+``NORMALIZATION_VERSION`` is folded into every tuple produced here: hash
+identity is versioned by xorq, deliberately, not by dependency drift. Any
+change to the canonical form must bump it (one fleet-wide cache
+invalidation) and update the golden tokens in
+``python/xorq/common/utils/tests/test_hash_contract.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xxhash
+
+from xorq.common.utils.dasher._gap_rules import normalize_ibis_schema
+
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+    from xorq.vendor.ibis.expr.operations.relations import (
+        DatabaseTable,
+        InMemoryTable,
+    )
+
+
+NORMALIZATION_VERSION = 1
+
+
+def _dictionary_free_type(typ: pa.DataType) -> pa.DataType:
+    """Return ``typ`` with every dictionary layer (at any nesting depth)
+    replaced by its logical value type."""
+    import pyarrow as pa  # noqa: PLC0415
+
+    if pa.types.is_dictionary(typ):
+        return _dictionary_free_type(typ.value_type)
+    if pa.types.is_list(typ):
+        return pa.list_(_dictionary_free_type(typ.value_type))
+    if pa.types.is_large_list(typ):
+        return pa.large_list(_dictionary_free_type(typ.value_type))
+    if pa.types.is_fixed_size_list(typ):
+        return pa.list_(_dictionary_free_type(typ.value_type), typ.list_size)
+    if pa.types.is_struct(typ):
+        return pa.struct(
+            [
+                (typ.field(i).name, _dictionary_free_type(typ.field(i).type))
+                for i in range(typ.num_fields)
+            ]
+        )
+    if pa.types.is_map(typ):
+        return pa.map_(
+            _dictionary_free_type(typ.key_type),
+            _dictionary_free_type(typ.item_type),
+            keys_sorted=typ.keys_sorted,
+        )
+    return typ
+
+
+def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
+    """xxh128 digest of one column's logical values, physical-layout-free.
+
+    Identical for chunked vs contiguous, sliced vs compact, and
+    dictionary-encoded vs plain representations of the same values
+    (invariants asserted in ``test_hash_contract.py``).
+    """
+    import pyarrow as pa  # noqa: PLC0415
+
+    arr = col.combine_chunks() if isinstance(col, pa.ChunkedArray) else col
+    canonical_type = _dictionary_free_type(arr.type)
+    if canonical_type != arr.type:
+        arr = arr.cast(canonical_type)
+    batch = pa.RecordBatch.from_arrays([arr], names=["c"])
+    return xxhash.xxh128(batch.serialize().to_pybytes()).hexdigest()
+
+
+def normalize_pyarrow_table_canonical(table: pa.Table) -> tuple:
+    """Canonical normalization of a ``pa.Table``: logical schema + per-column
+    value digests. Schema/field metadata (where ``from_pandas`` embeds
+    pandas/pyarrow version strings) is deliberately excluded."""
+    return (
+        "xorq.pa.Table",
+        NORMALIZATION_VERSION,
+        tuple(
+            (field.name, str(_dictionary_free_type(field.type)))
+            for field in table.schema
+        ),
+        tuple(canonical_column_digest(col) for col in table.columns),
+    )
+
+
+def normalize_inmemorytable_canonical(op: InMemoryTable) -> tuple:
+    """InMemoryTable identity from its STORED proxy data — no backend
+    round-trip, so no dependence on execution batching or a backend's
+    choice of physical encoding."""
+    return (
+        "xorq.InMemoryTable",
+        NORMALIZATION_VERSION,
+        normalize_ibis_schema(op.schema),
+        normalize_pyarrow_table_canonical(op.data.to_pyarrow(op.schema)),
+    )
+
+
+def normalize_memory_databasetable_canonical(dt: DatabaseTable) -> tuple:
+    """Memory-backed DatabaseTable identity. The data lives inside the
+    backend, so one execution is unavoidable — but hashing the canonical
+    form of the materialized table (rather than the raw batch stream)
+    erases the batch-size and IPC-dictionary variance that execution
+    introduces."""
+    return (
+        "xorq.MemoryDatabaseTable",
+        NORMALIZATION_VERSION,
+        normalize_ibis_schema(dt.schema),
+        normalize_pyarrow_table_canonical(dt.to_expr().to_pyarrow()),
+    )
+
+
+__all__ = [
+    "NORMALIZATION_VERSION",
+    "canonical_column_digest",
+    "normalize_inmemorytable_canonical",
+    "normalize_memory_databasetable_canonical",
+    "normalize_pyarrow_table_canonical",
+]

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -131,6 +131,19 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
             f"data can hash unequally"
         )
     if pa.types.is_dictionary(typ):
+        if pa.types.is_string_view(typ.value_type) or pa.types.is_binary_view(
+            typ.value_type
+        ):
+            # pyarrow has no take kernel for view-typed dictionary values,
+            # so the decoding cast fails (verified on 18 and 21). The raw
+            # ArrowNotImplementedError already satisfies the refusal
+            # contract (it subclasses NotImplementedError); refusing here
+            # keeps the diagnostic framing uniform and the behavior
+            # version-independent should a future pyarrow grow the kernel.
+            raise NotImplementedError(
+                f"cannot canonically hash dictionary-of-view type {typ!r}: "
+                f"pyarrow cannot decode view-typed dictionary values"
+            )
         _assert_canonicalizable(typ.value_type)
     for i in range(typ.num_fields):
         _assert_canonicalizable(typ.field(i).type)
@@ -174,10 +187,11 @@ def _canonical_type(typ: pa.DataType) -> pa.DataType:
             ]
         )
     if pa.types.is_map(typ):
+        # keys_sorted is a constraint flag like nullability, not data —
+        # dropped so sorted/unsorted spellings of the same entries agree
         return pa.map_(
             _canonical_type(typ.key_type),
             _canonical_type(typ.item_type),
-            keys_sorted=typ.keys_sorted,
         )
     return typ
 
@@ -257,9 +271,10 @@ def normalize_pyarrow_table_canonical(table: pa.Table) -> tuple:
     Deliberately excluded from identity, at every nesting level: field
     nullability (a constraint on future writes, not data —
     ``_canonical_type``'s reconstruction drops nested ``not null`` and the
-    tuple below omits ``field.nullable``) and the dictionary ``ordered``
-    flag (meaningless once the encoding it qualifies is erased); both
-    exclusions are pinned in ``test_hash_contract.py``."""
+    tuple below omits ``field.nullable``), the dictionary ``ordered`` flag
+    (meaningless once the encoding it qualifies is erased), and the map
+    ``keys_sorted`` flag (a constraint assertion, same family as
+    nullability); all exclusions are pinned in ``test_hash_contract.py``."""
     for field in table.schema:
         _assert_canonicalizable(field.type)
     return (
@@ -292,7 +307,12 @@ def normalize_memory_databasetable_canonical(dt: DatabaseTable) -> tuple:
     memory: the canonical digest compacts each column across ALL chunks
     (that compaction is what erases batch boundaries), so every batch must
     be resident anyway — and an incremental per-batch fold would re-couple
-    the hash to batch boundaries, the exact defect being removed."""
+    the hash to batch boundaries, the exact defect being removed. This IS
+    a peak-memory regression relative to the old rule, which hashed each
+    batch's bytes and held only one at a time: full residency (plus a
+    transient ``combine_chunks`` copy of the largest column) is the price
+    of batch-boundary-free identity, paid only for memory-backed tables —
+    whose data is by definition already resident in the backend."""
     return (
         "xorq.MemoryDatabaseTable",
         NORMALIZATION_VERSION,

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -87,6 +87,20 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
     physical buffer layout — equal data hashing unequally, breaking the
     layout-invariance contract. (``string_view``/``binary_view`` cast
     correctly and are canonicalized by :func:`_canonical_type` instead.)
+
+    Union and run-end-encoded types are refused for the same
+    layout-invariance reason: a sparse union serializes its type-masked
+    child slots (logically invisible values enter the bytes) and a
+    run-end-encoded array serializes its run partitioning (``[3,5]/[7,9]``
+    vs ``[2,3,5]/[7,7,9]`` encode the same values), so equal data hashes
+    unequally, and neither has a verified canonicalizing cast. Support for
+    either requires a decode step plus a ``NORMALIZATION_VERSION`` bump.
+
+    The child walk cannot rely on ``num_fields`` alone:
+    ``pa.DictionaryType.num_fields == 0``, so a dictionary's value type
+    must be descended explicitly — an extension type smuggled in as a
+    dictionary's value type would otherwise slip past this refusal and
+    collide (found by the round-2 cold review).
     """
     import pyarrow as pa  # noqa: PLC0415
 
@@ -104,6 +118,20 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
             f"the view uncanonicalized would hash its physical buffer layout "
             f"instead of its logical values"
         )
+    if pa.types.is_union(typ):
+        raise NotImplementedError(
+            f"cannot canonically hash union type {typ!r}: a sparse union "
+            f"serializes its type-masked child slots, so equal data can "
+            f"hash unequally"
+        )
+    if pa.types.is_run_end_encoded(typ):
+        raise NotImplementedError(
+            f"cannot canonically hash run-end-encoded type {typ!r}: its "
+            f"serialized form depends on the run partitioning, so equal "
+            f"data can hash unequally"
+        )
+    if pa.types.is_dictionary(typ):
+        _assert_canonicalizable(typ.value_type)
     for i in range(typ.num_fields):
         _assert_canonicalizable(typ.field(i).type)
 
@@ -155,11 +183,15 @@ def _canonical_type(typ: pa.DataType) -> pa.DataType:
 
 
 def _contains_dictionary(typ: pa.DataType) -> bool:
-    """True if ``typ`` has a dictionary layer anywhere in its nesting,
-    traversing child fields generically (so union / run-end encoded
-    families — which :func:`_canonical_type` does not rewrite — are still
-    inspected; list-view families are refused outright in
-    :func:`_assert_canonicalizable` before this runs)."""
+    """True if ``typ`` has a dictionary layer anywhere in its nesting.
+
+    Backstop, believed unreachable for currently-supported families: every
+    field-bearing family :func:`_canonical_type` does not rewrite (union,
+    run-end encoded, list-view) is refused in
+    :func:`_assert_canonicalizable` before this runs. It stays because it
+    is cheap and a future pyarrow type family could reopen the path — an
+    un-erased dictionary hashing indices without values is the worst
+    silent failure this module can have."""
     import pyarrow as pa  # noqa: PLC0415
 
     if pa.types.is_dictionary(typ):
@@ -185,10 +217,11 @@ def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
     _assert_canonicalizable(col.type)
     canonical_type = _canonical_type(col.type)
     if _contains_dictionary(canonical_type):
-        # ``_canonical_type`` does not rewrite this type family
-        # (union / run-end encoded …), so a dictionary layer
-        # survived. Serializing it would emit indices *without* the
-        # dictionary values — refuse loudly rather than under-discriminate.
+        # A dictionary layer survived canonicalization — only possible for
+        # a type family this module does not know (the known un-rewritable
+        # families are refused in _assert_canonicalizable). Serializing it
+        # would emit indices *without* the dictionary values — refuse
+        # loudly rather than under-discriminate.
         raise NotImplementedError(
             f"cannot erase dictionary encoding nested in {canonical_type!r}; "
             f"hashing it would drop the dictionary values from the digest"
@@ -219,7 +252,14 @@ def normalize_pyarrow_table_canonical(table: pa.Table) -> tuple:
     count is carried explicitly because a zero-column table has no digests
     to carry it implicitly. The schema carries the *canonical* type string,
     so representations that differ only in physical encoding (dictionary
-    vs plain, string vs large_string) normalize identically."""
+    vs plain, string vs large_string) normalize identically.
+
+    Deliberately excluded from identity, at every nesting level: field
+    nullability (a constraint on future writes, not data —
+    ``_canonical_type``'s reconstruction drops nested ``not null`` and the
+    tuple below omits ``field.nullable``) and the dictionary ``ordered``
+    flag (meaningless once the encoding it qualifies is erased); both
+    exclusions are pinned in ``test_hash_contract.py``."""
     for field in table.schema:
         _assert_canonicalizable(field.type)
     return (

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -1,6 +1,6 @@
 """Canonical, pyarrow-version-stable hashing of in-memory table data.
 
-Replaces xorq_dasher 0.1.0's ``normalize_inmemorytable`` /
+Replaces xorq_dasher's ``normalize_inmemorytable`` /
 ``normalize_memory_databasetable`` / ``normalize_pyarrow_table``, which hash
 the IPC bytes of a backend-executed ``to_pyarrow_batches()`` stream. That
 stream is an incidental physical artifact: its bytes depend on batch size
@@ -85,17 +85,44 @@ def _dictionary_free_type(typ: pa.DataType) -> pa.DataType:
     return typ
 
 
+def _contains_dictionary(typ: pa.DataType) -> bool:
+    """True if ``typ`` has a dictionary layer anywhere in its nesting,
+    traversing child fields generically (so union / list_view / run-end
+    encoded families — which :func:`_dictionary_free_type` does not rewrite
+    — are still inspected)."""
+    import pyarrow as pa  # noqa: PLC0415
+
+    if pa.types.is_dictionary(typ):
+        return True
+    return any(_contains_dictionary(typ.field(i).type) for i in range(typ.num_fields))
+
+
 def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
     """xxh128 digest of one column's logical values, physical-layout-free.
 
     Identical for chunked vs contiguous, sliced vs compact, and
     dictionary-encoded vs plain representations of the same values
     (invariants asserted in ``test_hash_contract.py``).
+
+    The digest carries NO type identity: ``RecordBatch.serialize()`` emits
+    no schema message, so e.g. int8 and uint8 arrays with identical buffers
+    produce identical digests. Never use it as a standalone identity — it
+    must always be paired with the column's logical type, as
+    :func:`normalize_pyarrow_table_canonical` does via its schema component.
     """
     import pyarrow as pa  # noqa: PLC0415
 
     arr = col.combine_chunks() if isinstance(col, pa.ChunkedArray) else col
     canonical_type = _dictionary_free_type(arr.type)
+    if _contains_dictionary(canonical_type):
+        # ``_dictionary_free_type`` does not rewrite this type family
+        # (union / list_view / run-end encoded …), so a dictionary layer
+        # survived. Serializing it would emit indices *without* the
+        # dictionary values — refuse loudly rather than under-discriminate.
+        raise NotImplementedError(
+            f"cannot erase dictionary encoding nested in {canonical_type!r}; "
+            f"hashing it would drop the dictionary values from the digest"
+        )
     if canonical_type != arr.type:
         arr = arr.cast(canonical_type)
     batch = pa.RecordBatch.from_arrays([arr], names=["c"])
@@ -103,12 +130,15 @@ def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
 
 
 def normalize_pyarrow_table_canonical(table: pa.Table) -> tuple:
-    """Canonical normalization of a ``pa.Table``: logical schema + per-column
-    value digests. Schema/field metadata (where ``from_pandas`` embeds
-    pandas/pyarrow version strings) is deliberately excluded."""
+    """Canonical normalization of a ``pa.Table``: row count + logical schema
+    + per-column value digests. Schema/field metadata (where ``from_pandas``
+    embeds pandas/pyarrow version strings) is deliberately excluded. The row
+    count is carried explicitly because a zero-column table has no digests
+    to carry it implicitly."""
     return (
         "xorq.pa.Table",
         NORMALIZATION_VERSION,
+        table.num_rows,
         tuple(
             (field.name, str(_dictionary_free_type(field.type)))
             for field in table.schema

--- a/python/xorq/common/utils/dasher/_canonical.py
+++ b/python/xorq/common/utils/dasher/_canonical.py
@@ -28,6 +28,27 @@ The canonical form hashed here is a *logical* one:
   dictionaries nested where they cannot be decoded away) with
   ``NotImplementedError`` rather than hash them unstably or collidingly.
 
+Two over-discrimination residuals are accepted rather than refused or erased
+(recorded in ADR-0017):
+
+* **bytes under null slots enter the digest.** The Arrow spec leaves null-slot
+  contents unspecified and ``RecordBatch.serialize()`` writes the values
+  buffer verbatim, so logically-equal columns built by different producers
+  can hash unequally: ``pa.Table.from_pandas`` of a float column leaves the
+  NaN under a null where a literal ``[1.0, None, 3.0]`` leaves zero (same for
+  pandas nullable ``Int64`` and ``datetime64`` ``NaT``).
+* **``str(type)`` distinguishes timezone spellings.** ``tz=UTC`` and
+  ``tz=+00:00`` denote the same instant but produce different schema
+  components (their value digests do agree).
+
+Both cost recomputation, never a wrong answer, and — unlike #2191's defect —
+neither couples identity to a dependency version: each is deterministic given
+the producer. Erasing them requires the per-type buffer-level fold that
+ADR-0017 defers as the designated escalation, not a refusal (see
+:func:`_assert_canonicalizable` for why the refused families are judged
+differently). Pinned by ``test_null_slot_payload_is_accepted_residual`` and
+``test_timezone_spelling_is_accepted_residual``.
+
 The column digest was verified byte-identical across pyarrow 18.0.0, 20.0.0,
 21.0.0 and 25.0.0 for a corpus covering nulls, NaN/-0.0/inf, decimals, tz
 timestamps, nested list/struct/map, multi-chunk dictionary arrays,
@@ -95,6 +116,16 @@ def _assert_canonicalizable(typ: pa.DataType) -> None:
     vs ``[2,3,5]/[7,7,9]`` encode the same values), so equal data hashes
     unequally, and neither has a verified canonicalizing cast. Support for
     either requires a decode step plus a ``NORMALIZATION_VERSION`` bump.
+
+    "Equal data can hash unequally" is not by itself the refusal criterion —
+    the accepted null-slot-payload residual (module docstring) has the same
+    shape. What separates the families refused here is that their layout
+    variance is unbounded and not producer-stable (a concat can re-partition
+    an REE column's runs within a single process), neither family is covered
+    by the cross-version digest probe, and both are rare enough that loud
+    refusal costs almost nothing. Refusing null-slot variance would instead
+    refuse nearly every nullable column — the residual is priced as
+    recomputation, per ADR-0015's asymmetry.
 
     The child walk cannot rely on ``num_fields`` alone:
     ``pa.DictionaryType.num_fields == 0``, so a dictionary's value type
@@ -214,11 +245,15 @@ def _contains_dictionary(typ: pa.DataType) -> bool:
 
 
 def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
-    """xxh128 digest of one column's logical values, physical-layout-free.
+    """xxh128 digest of one column's values, with physical *encoding* erased.
 
     Identical for chunked vs contiguous, sliced vs compact,
     dictionary-encoded vs plain, and int32- vs int64-offset representations
     of the same values (invariants asserted in ``test_hash_contract.py``).
+
+    Not fully layout-free: the bytes occupying null slots survive into the
+    digest, so two producers of the same logical column can disagree — an
+    accepted over-discrimination residual, see the module docstring.
 
     The digest carries NO type identity: ``RecordBatch.serialize()`` emits
     no schema message, so e.g. int8 and uint8 arrays with identical buffers
@@ -274,7 +309,17 @@ def normalize_pyarrow_table_canonical(table: pa.Table) -> tuple:
     tuple below omits ``field.nullable``), the dictionary ``ordered`` flag
     (meaningless once the encoding it qualifies is erased), and the map
     ``keys_sorted`` flag (a constraint assertion, same family as
-    nullability); all exclusions are pinned in ``test_hash_contract.py``."""
+    nullability); all exclusions are pinned in ``test_hash_contract.py``.
+
+    Cost: each column is cast and compacted, so peak memory is the table plus
+    a copy of the largest column — see
+    :func:`normalize_memory_databasetable_canonical` for the full accounting.
+    This is the registered ``pa.Table`` rule, so pandas DataFrame/Series
+    normalization pays it too (the old rule streamed batches instead)."""
+    # Refuse before doing any of the per-column cast/compaction work below:
+    # a table whose last column is an extension type should not first pay a
+    # full compaction of the preceding columns. (canonical_column_digest
+    # re-checks its own column; this loop is for the fail-fast ordering.)
     for field in table.schema:
         _assert_canonicalizable(field.type)
     return (

--- a/python/xorq/common/utils/dasher/_gap_rules.py
+++ b/python/xorq/common/utils/dasher/_gap_rules.py
@@ -128,15 +128,15 @@ def normalize_numpy_dtype(dtype: np.dtype) -> tuple:
 
 def normalize_pandas_series(series: pd.Series) -> tuple:
     """Promotes to a single-column DataFrame and delegates so both paths
-    share the same ``pa.Table`` → ``normalize_pyarrow_table`` hashing.
+    share the same ``pa.Table`` canonical hashing.
     """
     return ("pandas.Series", series.name, normalize_pandas_dataframe(series.to_frame()))
 
 
 def normalize_pandas_dataframe(df: pd.DataFrame) -> tuple:
-    """Returns the raw ``pa.Table`` so dasher's registered ``pa.Table`` rule
-    (``xorq_dasher.rules.other.normalize_pyarrow_table``) does the hashing —
-    serializes each batch to bytes and xxhashes.
+    """Returns the raw ``pa.Table`` so the registered ``pa.Table`` rule
+    (``_canonical.normalize_pyarrow_table_canonical``) does the hashing —
+    per-column, layout- and pyarrow-version-independent.
     """
     import pyarrow as pa  # noqa: PLC0415
 

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -15,7 +15,8 @@ import logging
 from typing import TYPE_CHECKING
 
 import xxhash
-from xorq_dasher.rules.expr import normalize_inmemorytable
+
+from xorq.common.utils.dasher._canonical import normalize_inmemorytable_canonical
 
 
 if TYPE_CHECKING:
@@ -526,7 +527,7 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
             (
                 "InMemoryTable",
                 getattr(m, "name", ""),
-                hasher.tokenize(normalize_inmemorytable(m)),
+                hasher.tokenize(normalize_inmemorytable_canonical(m)),
             )
             for m in mems
         ),

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -344,12 +344,21 @@ def _dispatch_databasetable(dt):
     # column label and crashes on every table; use the fixed xorq version.
     if dt.source.name == "bigquery":
         return _normalize_bigquery_databasetable_xorq(dt)
+    # pandas-backend tables and in-memory sqlite are memory-resident:
+    # xorq_dasher's dispatch hashes the IPC bytes of their
+    # ``to_pyarrow_batches()`` stream, which is pyarrow-version-coupled
+    # (issue #2191) — route them to the canonical form instead.
+    if dt.source.name == "pandas":
+        return normalize_memory_databasetable_canonical(dt)
+    if dt.source.name == "sqlite" and dt.source.is_in_memory():
+        return normalize_memory_databasetable_canonical(dt)
     # All remaining backends fall through to ``xorq_dasher``
     # ``normalize_databasetable`` (bigquery is handled above and never reaches
     # here), which is itself a per-backend dispatch table postgres calls
     # ``get_postgres_n_reltuples``, snowflake calls
     # ``get_snowflake_last_modification_time``, pyiceberg calls
-    # ``get_iceberg_snapshots_ids``, sqlite calls ``get_sqlite_stats``,
+    # ``get_iceberg_snapshots_ids``, file-backed sqlite calls
+    # ``get_sqlite_stats`` (memory-backed is intercepted above),
     # trino/gizmosql fall back to ``normalize_remote_databasetable``.
     # Data-sensitivity is preserved upstream, not blindly flattened to
     # schema+name, see xorq_dasher/rules/expr.py::normalize_databasetable.

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -362,7 +362,16 @@ def _dispatch_databasetable(dt):
     # trino/gizmosql fall back to ``normalize_remote_databasetable``.
     # Data-sensitivity is preserved upstream, not blindly flattened to
     # schema+name, see xorq_dasher/rules/expr.py::normalize_databasetable.
-    return normalize_databasetable(dt)
+    result = normalize_databasetable(dt)
+    if isinstance(result, tuple) and result[:1] == ("ibis.MemoryDatabaseTable",):
+        # Safety net: dasher resolved this table to its memory rule, whose
+        # token hashes the to_pyarrow_batches() IPC stream — the
+        # pyarrow-version-coupled form (#2191). Known memory backends are
+        # intercepted above before dasher runs; this catches renamed or
+        # future ones (dasher still maps a backend *named* "xorq" to that
+        # rule) at the cost of one redundant materialization.
+        return normalize_memory_databasetable_canonical(dt)
+    return result
 
 
 __all__ = [

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -17,11 +17,13 @@ from typing import TYPE_CHECKING
 from xorq_dasher.rules.expr import (
     normalize_cached_node,
     normalize_databasetable,
-    normalize_memory_databasetable,
     normalize_remote_table,
 )
 
 from xorq.common.constants import READ_IDENTITY_KEYS, REMOTE_SCHEMES
+from xorq.common.utils.dasher._canonical import (
+    normalize_memory_databasetable_canonical,
+)
 from xorq.common.utils.dasher._gap_rules import normalize_ibis_schema
 from xorq.common.utils.dasher._opaque import _MISSING, _rename_unbound_xorq
 from xorq.common.utils.dasher._paths import (
@@ -130,7 +132,7 @@ def _normalize_duckdb_databasetable_xorq(dt):
         )
     scan_kind = scan_match.group(1)
     if scan_kind in ("ARROW_SCAN", "PANDAS_SCAN"):
-        return normalize_memory_databasetable(dt)
+        return normalize_memory_databasetable_canonical(dt)
     if scan_kind in ("READ_PARQUET", "READ_CSV", "SEQ_SCAN"):
         sql_name = sg.exp.convert(dt.name).sql(dialect=dt.source.name)
         (sql_ddl,) = dt.source.con.sql(
@@ -183,7 +185,7 @@ def _normalize_datafusion_databasetable_xorq(dt):
             f"no parquet/csv paths extractable from execution plan: {ep_str!r}"
         )
     if ep_str.startswith(("MemoryExec:", "DataSourceExec:")):
-        return normalize_memory_databasetable(dt)
+        return normalize_memory_databasetable_canonical(dt)
     if "PyRecordBatchProviderExec" in ep_str:
         return (
             "ibis.DatabaseTable.datafusion.recordbatch",

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -1088,6 +1088,7 @@ def test_extra_rules_fqn_strings() -> None:
         "xorq.vendor.ibis.expr.types.core.Expr": Expr,
         "xorq.vendor.ibis.expr.schema.Schema": Schema,
         "xorq.vendor.ibis.expr.operations.udf.ScalarUDF": ScalarUDF,
+        "pyarrow.lib.Table": pa.Table,
         "numpy.dtype": np.dtype,
         "pandas.core.series.Series": pd.Series,
         "pandas.core.frame.DataFrame": pd.DataFrame,

--- a/python/xorq/common/utils/tests/test_dasher.py
+++ b/python/xorq/common/utils/tests/test_dasher.py
@@ -788,8 +788,8 @@ def test_normalize_ibis_schema_decimal_precision_distinguishes():
 
 
 def test_normalize_pandas_dataframe_returns_pa_table():
-    """normalize_pandas_dataframe returns a raw pa.Table for dasher's
-    normalize_pyarrow_table rule to hash."""
+    """normalize_pandas_dataframe returns a raw pa.Table for the registered
+    pa.Table rule (``_canonical.normalize_pyarrow_table_canonical``) to hash."""
     df = pd.DataFrame({"a": [1, 2, 3]})
     result = normalize_pandas_dataframe(df)
     assert result[0] == "pandas.DataFrame"

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -27,12 +27,17 @@ from __future__ import annotations
 
 import datetime as dt
 import decimal
+import importlib.util
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
 import xorq_dasher
+from xorq_dasher.rules.expr import (
+    normalize_memory_databasetable as dasher_normalize_memory_databasetable,
+)
 
 import xorq
 import xorq.api as xo
@@ -106,6 +111,16 @@ def _fixture_columns() -> dict[str, pa.Array | pa.ChunkedArray]:
                 pa.array(["cherry", "banana", None]).dictionary_encode(),
             ]
         ),
+        # interior dictionary layer: erased by ``col.cast``'s nested decode,
+        # the most cast-machinery-dependent canonicalization branch
+        "nested_dict_in_list": pa.array(
+            [["a", "b"], None, ["a"]], type=pa.list_(pa.string())
+        ).cast(pa.list_(pa.dictionary(pa.int32(), pa.string()))),
+        # view type: canonicalized to large_string (long value forces an
+        # out-of-line buffer, the layout-dependent case)
+        "string_view": pa.array(
+            ["apple", None, "", "é中文", "x" * 100], type=pa.string_view()
+        ),
         "empty_string": pa.array([], type=pa.string()),
     }
 
@@ -121,6 +136,8 @@ GOLDEN_COLUMN_DIGESTS = {
     "struct": "d7c505e657beab1d3b433ee2633c9131",
     "map": "d4a434fe254471ca2176cd8b7ae9120e",
     "dictionary_multichunk": "b50c865c81720aa1354729bda834915d",
+    "nested_dict_in_list": "5ea7e62c328b1dc0af45bf7307b544c0",
+    "string_view": "a8d8f0321b2ca4aa7ca2b1768f9ee97e",
     "empty_string": "1ff18035104640f53e6bbf8ca6bb9aa1",
 }
 
@@ -178,6 +195,11 @@ SLICE_CASES = {
         [[i, None, i * 2] if i % 3 else None for i in range(30)],
         type=pa.list_(pa.int64()),
     ),
+    # view: serializes its physical buffer layout verbatim — only the cast
+    # to large_string erases it (concat_arrays does NOT compact views)
+    "string_view": pa.array(
+        [f"s{i}" * (i % 5 + 1) for i in range(30)], type=pa.string_view()
+    ),
 }
 
 
@@ -206,6 +228,39 @@ def test_digest_erases_offset_width() -> None:
     ) == normalize_pyarrow_table_canonical(
         pa.table({"c": pa.array(strings, type=pa.large_string())})
     )
+
+
+def test_digest_erases_view_encoding() -> None:
+    # string_view/binary_view serialize their physical buffer layout (views
+    # + variadic data buffers), which varies with how the array was built —
+    # the canonical form rewrites them to large_string/large_binary, so all
+    # three offset representations of the same values must agree, digests
+    # and full-table normalizations alike.
+    strings = ["apple", None, "", "é中文", "x" * 100]
+    want = canonical_column_digest(pa.array(strings, type=pa.large_string()))
+    assert canonical_column_digest(pa.array(strings, type=pa.string_view())) == want
+    bins = [b"\x00\x01" * 20, None, b""]
+    assert canonical_column_digest(pa.array(bins, type=pa.binary_view())) == (
+        canonical_column_digest(pa.array(bins, type=pa.large_binary()))
+    )
+    assert normalize_pyarrow_table_canonical(
+        pa.table({"c": pa.array(strings, type=pa.string_view())})
+    ) == normalize_pyarrow_table_canonical(
+        pa.table({"c": pa.array(strings, type=pa.large_string())})
+    )
+
+
+def test_digest_refuses_list_view_types() -> None:
+    # pyarrow's list_view -> list cast emits invalid arrays (offsets fail
+    # validate(full=True); seen on 18 and 21), so list-view columns cannot
+    # be canonicalized — and hashing them raw would serialize physical
+    # buffer layout. Refuse loudly, at any nesting depth.
+    lv = pa.array([[1, 2, None], None, []], type=pa.list_view(pa.int64()))
+    with pytest.raises(NotImplementedError, match="list-view"):
+        canonical_column_digest(lv)
+    nested = pa.array([], type=pa.struct([("x", pa.large_list_view(pa.int64()))]))
+    with pytest.raises(NotImplementedError, match="list-view"):
+        canonical_column_digest(nested)
 
 
 def test_digest_erases_dictionary_encoding() -> None:
@@ -259,7 +314,7 @@ def test_memtable_normalization_does_not_execute_backends(
 
 
 def test_digest_refuses_unerasable_nested_dictionary() -> None:
-    # ``_dictionary_free_type`` does not rewrite union types, so a
+    # ``_canonical_type`` does not rewrite union types, so a
     # dictionary nested inside one cannot be decoded away — and serializing
     # it would drop the dictionary values from the digest. Refusing loudly
     # beats silently under-discriminating.
@@ -301,6 +356,21 @@ def test_sqlite_memory_databasetable_routes_to_canonical() -> None:
     assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)
 
 
+def test_dasher_memory_rule_tag_still_matches_safety_net() -> None:
+    # The fall-through safety net in _dispatch_databasetable recognizes
+    # dasher's memory rule by its tuple tag ("ibis.MemoryDatabaseTable", ...).
+    # The fallthrough test below proves the net catches that tag, but only
+    # this test proves dasher still EMITS it — if a dasher release renames
+    # the tag, the net dies silently and #2191 revives; fail here instead.
+    con = PandasBackend().connect({"t": _fixture_df()})
+    result = dasher_normalize_memory_databasetable(con.table("t").op())
+    assert result[:1] == ("ibis.MemoryDatabaseTable",), (
+        "xorq_dasher renamed its memory-rule tag "
+        f"(got {result[:1]!r}; {_env_versions()}); update the safety net in "
+        "_relations._dispatch_databasetable to match"
+    )
+
+
 def test_dispatcher_fallthrough_net_reroutes_dasher_memory_rule(
     monkeypatch: pytest.MonkeyPatch, tmp_path: object
 ) -> None:
@@ -319,6 +389,29 @@ def test_dispatcher_fallthrough_net_reroutes_dasher_memory_rule(
     )
     normalized = _dispatch_databasetable(dt)
     assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)
+
+
+def test_probe_script_matches_module() -> None:
+    # scripts/canonical_digest_xver_probe.py is a hand-maintained standalone
+    # replica of the module's digest logic (it must import nothing from
+    # xorq so it runs in bare venvs across pyarrow versions). Any edit to
+    # one that misses the other silently invalidates the cross-version
+    # verification story — pin them to each other over the probe's corpus.
+    probe_path = (
+        Path(__file__).parents[5] / "scripts" / "canonical_digest_xver_probe.py"
+    )
+    if not probe_path.exists():
+        pytest.skip("probe script not present (installed-package test run)")
+    spec = importlib.util.spec_from_file_location(
+        "canonical_digest_xver_probe", probe_path
+    )
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+    for name, col in probe.corpus().items():
+        assert probe.canonical_column_digest(col) == canonical_column_digest(col), (
+            f"probe script and _canonical module disagree on corpus column {name!r}: "
+            f"their digest logic has drifted apart"
+        )
 
 
 def test_refuses_extension_types() -> None:

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import datetime as dt
 import decimal
 import importlib.util
+import types
 from pathlib import Path
 
 import numpy as np
@@ -396,6 +397,31 @@ def test_nullability_excluded_from_identity_at_every_level() -> None:
     assert normalize_pyarrow_table_canonical(nn) == normalize_pyarrow_table_canonical(n)
 
 
+def test_map_keys_sorted_excluded_from_identity() -> None:
+    # keys_sorted is a constraint assertion, same family as nullability:
+    # sorted/unsorted spellings of the same entries must normalize
+    # identically (round-3 review found the exclusion policy was applied
+    # non-uniformly here).
+    data = [[("a", 1), ("b", 2)], None]
+    plain = pa.array(data, type=pa.map_(pa.string(), pa.int64()))
+    sorted_arr = plain.cast(pa.map_(pa.string(), pa.int64(), keys_sorted=True))
+    assert normalize_pyarrow_table_canonical(
+        pa.table({"c": sorted_arr})
+    ) == normalize_pyarrow_table_canonical(pa.table({"c": plain}))
+
+
+def test_digest_refuses_dictionary_of_view_values() -> None:
+    # pyarrow has no take kernel for view-typed dictionary values, so the
+    # decode cast fails with a raw ArrowNotImplementedError; the module
+    # refuses with its own framing instead, uniformly across versions.
+    dict_of_sv = pa.DictionaryArray.from_arrays(
+        pa.array([0, 1], type=pa.int32()),
+        pa.array(["a", "b"], type=pa.string_view()),
+    )
+    with pytest.raises(NotImplementedError, match="dictionary-of-view"):
+        canonical_column_digest(dict_of_sv)
+
+
 def test_dictionary_ordered_flag_excluded_from_identity() -> None:
     # ordered qualifies the dictionary encoding; the canonical form erases
     # the encoding entirely, so ordered/unordered categoricals of equal
@@ -472,12 +498,7 @@ def test_dispatcher_fallthrough_net_reroutes_dasher_memory_rule(
     assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)
 
 
-def test_probe_script_matches_module() -> None:
-    # scripts/canonical_digest_xver_probe.py is a hand-maintained standalone
-    # replica of the module's digest logic (it must import nothing from
-    # xorq so it runs in bare venvs across pyarrow versions). Any edit to
-    # one that misses the other silently invalidates the cross-version
-    # verification story — pin them to each other over the probe's corpus.
+def _load_probe() -> types.ModuleType:
     probe_path = (
         Path(__file__).parents[5] / "scripts" / "canonical_digest_xver_probe.py"
     )
@@ -488,11 +509,86 @@ def test_probe_script_matches_module() -> None:
     )
     probe = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(probe)
+    return probe
+
+
+def test_probe_script_matches_module() -> None:
+    # scripts/canonical_digest_xver_probe.py is a hand-maintained standalone
+    # replica of the module's digest logic (it must import nothing from
+    # xorq so it runs in bare venvs across pyarrow versions). Any edit to
+    # one that misses the other silently invalidates the cross-version
+    # verification story — pin them to each other over the probe's corpus.
+    probe = _load_probe()
     for name, col in probe.corpus().items():
         assert probe.canonical_column_digest(col) == canonical_column_digest(col), (
             f"probe script and _canonical module disagree on corpus column {name!r}: "
             f"their digest logic has drifted apart"
         )
+
+
+# Fixed values for the ENTIRE probe corpus (canonical type string + digest).
+# The parity test above only proves probe == module; without these, a change
+# applied to both in the same PR would pass every test while silently
+# renaming artifacts (round-3 review finding). Regenerate deliberately with
+# a NORMALIZATION_VERSION bump:
+#   python scripts/canonical_digest_xver_probe.py
+PROBE_CORPUS_GOLDENS = {
+    "int64_nulls": ("int64", "f7e0cccc78c213f89bac19e52fb2f67d"),
+    "float64_edges": ("double", "8a2d78480547a06c5665712722a97e30"),
+    "bool_nulls": ("bool", "448934082adc04da19a2274aab5d3b69"),
+    "decimal128": ("decimal128(38, 9)", "27f431c699954a75aa6a9ff7a5be1881"),
+    "string": ("large_string", "8174a8d746db7b57a1d0721bf83487cd"),
+    "large_string": ("large_string", "408a226ea70d15e92319a8f109ac47db"),
+    "binary": ("large_binary", "263964d66d52e8bd6d28b60bfe01822d"),
+    "timestamp_tz": ("timestamp[us, tz=UTC]", "0a0e7066f0f567772d2185e5e7eff7d4"),
+    "date32": ("date32[day]", "91add32bd9842f85a28ea8d2d9202026"),
+    "duration": ("duration[us]", "f3d55be10391c507378e8825ba4740ff"),
+    "float32": ("float", "0a591e570f92340dc843c8e642d716fc"),
+    "list_int": ("large_list<item: int64>", "26e34968d249b6e878408d1c638b1066"),
+    "list_string": (
+        "large_list<item: large_string>",
+        "7c87d85d181f2e895904238463730e0a",
+    ),
+    "fixed_size_list": (
+        "fixed_size_list<item: int64>[2]",
+        "8c1a7f5dc7f6f03166c117e4810033f9",
+    ),
+    "fixed_size_list_string": (
+        "fixed_size_list<item: large_string>[2]",
+        "fa3d177e87ab1270155e121659545dc6",
+    ),
+    "struct": (
+        "struct<a: int64, b: large_string>",
+        "d7c505e657beab1d3b433ee2633c9131",
+    ),
+    "map": ("map<large_string, int64>", "d4a434fe254471ca2176cd8b7ae9120e"),
+    "dictionary_multichunk": ("large_string", "b50c865c81720aa1354729bda834915d"),
+    "nested_dict_in_list": (
+        "large_list<item: large_string>",
+        "5ea7e62c328b1dc0af45bf7307b544c0",
+    ),
+    "empty_string": ("large_string", "1ff18035104640f53e6bbf8ca6bb9aa1"),
+    "string_view": ("large_string", "a8d8f0321b2ca4aa7ca2b1768f9ee97e"),
+    "binary_view": ("large_binary", "1495aac6483cd881d05fa96d77c05d40"),
+    "string_sliced": ("large_string", "b8b4b84c3b1ef871ba2127f45ba7601d"),
+    "string_chunked": ("large_string", "5c01935870bed4cc22cbb756bac9293f"),
+    "bool_sliced_unaligned": ("bool", "ab5bd07b5acc07d6bfccbd795be26a37"),
+    "list_sliced": ("large_list<item: int64>", "acaa20fdc5da1b88e919b00dcdead6d8"),
+    "string_view_sliced": ("large_string", "679e4697d3fc93103a1bd8c802e9e50f"),
+    "string_view_chunked": ("large_string", "3aefd06ede44ea213065e15d09994a69"),
+}
+
+
+def test_probe_corpus_matches_goldens() -> None:
+    probe = _load_probe()
+    corpus = probe.corpus()
+    assert set(corpus) == set(PROBE_CORPUS_GOLDENS), (
+        "probe corpus and PROBE_CORPUS_GOLDENS list different columns — "
+        "add goldens for new corpus entries"
+    )
+    for name, col in corpus.items():
+        actual = (str(probe._canonical_type(col.type)), canonical_column_digest(col))
+        assert actual == PROBE_CORPUS_GOLDENS[name], _contract_message(name, col)
 
 
 def test_refuses_extension_types() -> None:

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -433,6 +433,82 @@ def test_dictionary_ordered_flag_excluded_from_identity() -> None:
     assert canonical_column_digest(ordered) == canonical_column_digest(unordered)
 
 
+@pytest.mark.parametrize(
+    ("name", "frame", "literal"),
+    [
+        pytest.param(
+            "float64_nan_null",
+            pd.DataFrame({"c": [1.0, np.nan, 3.0]}),
+            pa.array([1.0, None, 3.0], type=pa.float64()),
+            id="float64_nan_null",
+        ),
+        pytest.param(
+            "nullable_int64_masked",
+            pd.DataFrame({"c": pd.array([1, None, 3], dtype="Int64")}),
+            pa.array([1, None, 3], type=pa.int64()),
+            id="nullable_int64_masked",
+        ),
+        pytest.param(
+            "datetime_nat",
+            pd.DataFrame({"c": pd.to_datetime(["2020-01-01", None, "2020-01-03"])}),
+            pa.array(
+                [dt.datetime(2020, 1, 1), None, dt.datetime(2020, 1, 3)],
+                type=pa.timestamp("ns"),
+            ),
+            id="datetime_nat",
+        ),
+    ],
+)
+def test_null_slot_payload_is_accepted_residual(
+    name: str, frame: pd.DataFrame, literal: pa.Array
+) -> None:
+    # ACCEPTED RESIDUAL, not a bug to fix opportunistically: the Arrow spec
+    # leaves null-slot contents unspecified and RecordBatch.serialize() writes
+    # the values buffer verbatim, so the bytes under nulls reach the digest.
+    # ``from_pandas`` leaves NaN/NaT/mask-garbage there where a literal None
+    # leaves zero — two producers of ``.equals()``-identical data disagree.
+    #
+    # Pinned as an inequality rather than a golden digest on purpose: the
+    # inequality is the contract statement and holds on every pyarrow version,
+    # whereas a fixed digest over pandas-produced padding would add a
+    # cross-version liability the probe script cannot check.
+    #
+    # This costs recomputation, never a wrong answer, and is deterministic per
+    # producer — so it does NOT re-open #2191 (identity never moves because a
+    # dependency moved). Closing it needs the per-type buffer-level fold
+    # ADR-0017 defers; if that lands, this test flips to assert equality and
+    # NORMALIZATION_VERSION bumps. See _canonical's module docstring for why
+    # the refused families (union / run-end-encoded) are judged differently.
+    from_pandas = pa.Table.from_pandas(frame, preserve_index=False).column("c")
+    from_literal = pa.chunked_array([literal])
+    assert from_pandas.equals(from_literal), (
+        f"{name}: fixture no longer builds logically-equal columns, so it "
+        f"cannot demonstrate the residual"
+    )
+    assert canonical_column_digest(from_pandas) != canonical_column_digest(
+        from_literal
+    ), (
+        f"{name}: null-slot payload no longer reaches the digest. If this was "
+        f"deliberate (buffer-level fold landed), invert this assertion, bump "
+        f"NORMALIZATION_VERSION and regenerate the goldens; if it was "
+        f"incidental, a pyarrow change moved the canonical form under us "
+        f"({_env_versions()})"
+    )
+
+
+def test_timezone_spelling_is_accepted_residual() -> None:
+    # ACCEPTED RESIDUAL: type identity rides on pyarrow's DataType.__str__,
+    # which spells the same zero offset as "UTC" or "+00:00". The value
+    # digests agree; only the schema component diverges. Same pricing as the
+    # null-slot residual above (recomputation, producer-deterministic).
+    utc = pa.array([1, 2], type=pa.timestamp("us", tz="UTC"))
+    offset = pa.array([1, 2], type=pa.timestamp("us", tz="+00:00"))
+    assert canonical_column_digest(utc) == canonical_column_digest(offset)
+    assert normalize_pyarrow_table_canonical(
+        pa.table({"c": utc})
+    ) != normalize_pyarrow_table_canonical(pa.table({"c": offset}))
+
+
 def test_zero_column_table_discriminates_row_count() -> None:
     # With no columns there are no digests to carry the row count, so the
     # normalization carries ``num_rows`` explicitly.

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -38,7 +38,7 @@ import xorq
 import xorq.api as xo
 from xorq.backends.pandas import Backend as PandasBackend
 from xorq.backends.sqlite import Backend as SqliteBackend
-from xorq.common.utils.dasher import normalize, tokenize
+from xorq.common.utils.dasher import _relations, normalize, tokenize
 from xorq.common.utils.dasher._canonical import (
     NORMALIZATION_VERSION,
     canonical_column_digest,
@@ -115,19 +115,19 @@ GOLDEN_COLUMN_DIGESTS = {
     "float64_edges": "8a2d78480547a06c5665712722a97e30",
     "bool_nulls": "448934082adc04da19a2274aab5d3b69",
     "decimal128": "27f431c699954a75aa6a9ff7a5be1881",
-    "string": "e6e303236c8b24e8bb47ba4e568ddb8f",
+    "string": "8174a8d746db7b57a1d0721bf83487cd",
     "timestamp_tz": "0a0e7066f0f567772d2185e5e7eff7d4",
-    "list_int": "f8e26be3b81d390d0b214c95d8eab034",
-    "struct": "9ad3a5c7685e160e7892d9603985e3d0",
-    "map": "2f994665818074e02eb7d7d29b9a0c59",
-    "dictionary_multichunk": "7f6586a4862513f7cd033019b8af5815",
-    "empty_string": "95f33ef94af5d33af33b4f80eb67ad76",
+    "list_int": "26e34968d249b6e878408d1c638b1066",
+    "struct": "d7c505e657beab1d3b433ee2633c9131",
+    "map": "d4a434fe254471ca2176cd8b7ae9120e",
+    "dictionary_multichunk": "b50c865c81720aa1354729bda834915d",
+    "empty_string": "1ff18035104640f53e6bbf8ca6bb9aa1",
 }
 
 GOLDEN_TOKENS = {
-    "memtable": "4e63f45b8697b50ee81aef56b74486bc",
-    "pandas_dataframe": "b1f14a347336ad9e53509ec2edea9db6",
-    "pyarrow_table": "c25a6ba3568ef8f3494bd1a2d91d0457",
+    "memtable": "97a59f9c8d55dc45684174488aa34f1e",
+    "pandas_dataframe": "eef21642b55d3160e3f85e18cee39c99",
+    "pyarrow_table": "798314b6d6e801a854c99cfa5fb8ca70",
 }
 
 
@@ -166,10 +166,46 @@ def test_digest_erases_chunk_layout() -> None:
     assert canonical_column_digest(chunked) == canonical_column_digest(single)
 
 
-def test_digest_erases_slicing() -> None:
-    big = pa.array(list(range(100)), type=pa.int64())
-    direct = pa.array(list(range(3, 13)), type=pa.int64())
-    assert canonical_column_digest(big.slice(3, 10)) == canonical_column_digest(direct)
+SLICE_CASES = {
+    # fixed-width: IPC truncation alone happens to be exact
+    "int64": pa.array(list(range(100)), type=pa.int64()),
+    # bitmap-packed: slice offsets are not byte-aligned
+    "bool_nulls": pa.array([True, None, False] * 10),
+    # var-length: slice offsets are NOT rebased by the IPC writer — only
+    # explicit compaction (concat_arrays) makes sliced == fresh
+    "string": pa.array([f"s{i}" * (i % 3 + 1) for i in range(30)]),
+    "list_int": pa.array(
+        [[i, None, i * 2] if i % 3 else None for i in range(30)],
+        type=pa.list_(pa.int64()),
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(SLICE_CASES))
+def test_digest_erases_slicing(name: str) -> None:
+    big = SLICE_CASES[name]
+    sliced = big.slice(3, 10)
+    fresh = pa.array(sliced.to_pylist(), type=big.type)
+    assert canonical_column_digest(sliced) == canonical_column_digest(fresh)
+
+
+def test_digest_erases_offset_width() -> None:
+    # string vs large_string (and list vs large_list) differ only in offset
+    # width — a physical encoding. The canonical form widens to large_*, so
+    # both the digests and the full table normalizations must agree.
+    strings = ["apple", None, "", "é中文"]
+    assert canonical_column_digest(pa.array(strings, type=pa.string())) == (
+        canonical_column_digest(pa.array(strings, type=pa.large_string()))
+    )
+    lists = [[1, None], None, []]
+    assert canonical_column_digest(pa.array(lists, type=pa.list_(pa.int64()))) == (
+        canonical_column_digest(pa.array(lists, type=pa.large_list(pa.int64())))
+    )
+    assert normalize_pyarrow_table_canonical(
+        pa.table({"c": pa.array(strings, type=pa.string())})
+    ) == normalize_pyarrow_table_canonical(
+        pa.table({"c": pa.array(strings, type=pa.large_string())})
+    )
 
 
 def test_digest_erases_dictionary_encoding() -> None:
@@ -205,13 +241,19 @@ def test_memtable_normalization_does_not_execute_backends(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # The pa20↔21 regression came from hashing a backend-executed batch
-    # stream. Identity must come from the stored proxy data only.
+    # stream. Identity must come from the stored proxy data only
+    # (``op.data.to_pyarrow`` is a proxy format conversion, not execution).
+    # NOTE: this guard is enumerative, not exhaustive — it proves these
+    # specific Expr entry points are unused, not that no execution of any
+    # kind occurs. A regression that reached a backend directly (e.g. via
+    # ``dt.source``) would not trip it.
     def _forbidden(self: Expr, *args: object, **kwargs: object) -> None:
         raise AssertionError(
             "normalize_inmemorytable_canonical must not execute the expression"
         )
 
-    monkeypatch.setattr(Expr, "to_pyarrow_batches", _forbidden)
+    for entry_point in ("to_pyarrow_batches", "to_pyarrow", "execute"):
+        monkeypatch.setattr(Expr, entry_point, _forbidden)
     op = xo.memtable(_fixture_df(), name="name").op()
     tokenize(normalize_inmemorytable_canonical(op))
 
@@ -257,3 +299,41 @@ def test_sqlite_memory_databasetable_routes_to_canonical() -> None:
     con.create_table("t", pd.DataFrame({"a": [1, 2, 3]}))
     normalized = _dispatch_databasetable(con.table("t").op())
     assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)
+
+
+def test_dispatcher_fallthrough_net_reroutes_dasher_memory_rule(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    # If xorq_dasher's fall-through dispatch ever resolves a table to its
+    # batch-stream memory rule (e.g. a future/renamed backend — dasher still
+    # maps a backend *named* "xorq" to it), the dispatcher must re-route to
+    # the canonical form rather than let #2191 silently revive.
+    con = SqliteBackend().connect(f"{tmp_path}/t.db")
+    assert not con.is_in_memory()
+    con.create_table("t", pd.DataFrame({"a": [1, 2, 3]}))
+    dt = con.table("t").op()
+    monkeypatch.setattr(
+        _relations,
+        "normalize_databasetable",
+        lambda dt: ("ibis.MemoryDatabaseTable", "version-coupled-form"),
+    )
+    normalized = _dispatch_databasetable(dt)
+    assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)
+
+
+def test_refuses_extension_types() -> None:
+    # Extension type parameters live in __arrow_ext_serialize__ bytes
+    # (third-party, no cross-version stability contract) and str(type)
+    # omits them — pandas period columns of freq 'M' vs 'D' with equal
+    # ordinals produce IDENTICAL storage and str(type), so hashing the
+    # storage would collide logically different tables. Refuse loudly.
+    monthly = pa.Table.from_pandas(
+        pd.DataFrame({"p": pd.PeriodIndex.from_ordinals([0, 1], freq="M")})
+    )
+    with pytest.raises(NotImplementedError, match="extension"):
+        normalize_pyarrow_table_canonical(monthly)
+    # nested extensions must be found too
+    period_type = monthly.schema.field("p").type
+    nested = pa.struct([("x", period_type)])
+    with pytest.raises(NotImplementedError, match="extension"):
+        canonical_column_digest(pa.array([], type=nested))

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -1,0 +1,212 @@
+"""Golden-token contract tests for xorq's canonical hashing.
+
+These tokens are the *definition* of hash identity for in-memory table data
+(``NORMALIZATION_VERSION`` in ``xorq.common.utils.dasher._canonical``). Any
+code change that alters them silently renames every existing build artifact
+and invalidates every cache entry fleet-wide — so it must fail here, in the
+PR that causes it, not in production.
+
+If a test in this module fails:
+
+* You changed normalization on purpose → bump ``NORMALIZATION_VERSION``,
+  regenerate the goldens below, and call out the cache-invalidation event in
+  the release notes.
+* You didn't → a dependency broke a stability assumption. The failure
+  message prints the hash-relevant dependency versions and the normalized
+  tuple; compare against a passing environment to localize the divergent
+  component.
+
+Deliberately excluded from the goldens: UDF tokens (cloudpickle/bytecode are
+Python-version-coupled) and generated-SQL surfaces (sqlglot-coupled) — those
+are over-discrimination surfaces, not per-environment contracts. The
+canonical digests here were verified byte-identical across pyarrow
+18.0.0–25.0.0 (probe script on issue #2191).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import decimal
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+import xorq_dasher
+
+import xorq
+import xorq.api as xo
+from xorq.common.utils.dasher import normalize, tokenize
+from xorq.common.utils.dasher._canonical import (
+    NORMALIZATION_VERSION,
+    canonical_column_digest,
+    normalize_inmemorytable_canonical,
+)
+from xorq.vendor.ibis.expr.types.core import Expr
+
+
+def _env_versions() -> str:
+    mods = (pa, pd, np, xorq_dasher, xorq)
+    return ", ".join(f"{m.__name__}=={m.__version__}" for m in mods)
+
+
+def _contract_message(name: str, obj: object) -> str:
+    return (
+        f"hash contract broken for {name!r} "
+        f"(NORMALIZATION_VERSION={NORMALIZATION_VERSION}; {_env_versions()}).\n"
+        f"Either bump NORMALIZATION_VERSION and regenerate goldens "
+        f"(deliberate), or diff this normalized form against a passing "
+        f"environment to find the divergent component:\n{normalize(obj)!r}"
+    )
+
+
+def _fixture_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "i": [1, 2, None],
+            "f": [1.5, float("nan"), -0.0],
+            "s": ["a", None, "é中文"],
+            "t": pd.to_datetime(["2020-01-01", "2021-06-15", "NaT"]).tz_localize("UTC"),
+        }
+    )
+
+
+def _fixture_columns() -> dict[str, pa.Array | pa.ChunkedArray]:
+    D = decimal.Decimal
+    utc = dt.timezone.utc
+    return {
+        "int64_nulls": pa.array([1, None, 2**62], type=pa.int64()),
+        "float64_edges": pa.array(
+            [0.0, -0.0, float("nan"), float("inf"), None], type=pa.float64()
+        ),
+        "bool_nulls": pa.array([True, None, False]),
+        "decimal128": pa.array(
+            [D("1.230000000"), None, D("-99.999999999")], type=pa.decimal128(38, 9)
+        ),
+        "string": pa.array(["apple", "banana", "apple", None, "", "é中文"]),
+        "timestamp_tz": pa.array(
+            [dt.datetime(2020, 1, 1, tzinfo=utc), None],
+            type=pa.timestamp("us", tz="UTC"),
+        ),
+        "list_int": pa.array([[1, 2, None], None, []], type=pa.list_(pa.int64())),
+        "struct": pa.array(
+            [{"a": 1, "b": "x"}, None, {"a": None, "b": ""}],
+            type=pa.struct([("a", pa.int64()), ("b", pa.string())]),
+        ),
+        "map": pa.array(
+            [[("k1", 1), ("k2", 2)], None, []], type=pa.map_(pa.string(), pa.int64())
+        ),
+        "dictionary_multichunk": pa.chunked_array(
+            [
+                pa.array(["apple", "banana", "apple"]).dictionary_encode(),
+                pa.array(["cherry", "banana", None]).dictionary_encode(),
+            ]
+        ),
+        "empty_string": pa.array([], type=pa.string()),
+    }
+
+
+GOLDEN_COLUMN_DIGESTS = {
+    "int64_nulls": "f7e0cccc78c213f89bac19e52fb2f67d",
+    "float64_edges": "8a2d78480547a06c5665712722a97e30",
+    "bool_nulls": "448934082adc04da19a2274aab5d3b69",
+    "decimal128": "27f431c699954a75aa6a9ff7a5be1881",
+    "string": "e6e303236c8b24e8bb47ba4e568ddb8f",
+    "timestamp_tz": "0a0e7066f0f567772d2185e5e7eff7d4",
+    "list_int": "f8e26be3b81d390d0b214c95d8eab034",
+    "struct": "9ad3a5c7685e160e7892d9603985e3d0",
+    "map": "2f994665818074e02eb7d7d29b9a0c59",
+    "dictionary_multichunk": "7f6586a4862513f7cd033019b8af5815",
+    "empty_string": "95f33ef94af5d33af33b4f80eb67ad76",
+}
+
+GOLDEN_TOKENS = {
+    "memtable": "c3a49075e3d5f635d0eb5b999bad74ca",
+    "pandas_dataframe": "5a2b5b1d7e148d299ff2bd592a2e7714",
+    "pyarrow_table": "f38b0e88acf5958f4955e9c8ec917a2e",
+}
+
+
+@pytest.mark.parametrize("name", sorted(GOLDEN_COLUMN_DIGESTS))
+def test_golden_column_digest(name: str) -> None:
+    col = _fixture_columns()[name]
+    actual = canonical_column_digest(col)
+    assert actual == GOLDEN_COLUMN_DIGESTS[name], _contract_message(name, col)
+
+
+def test_golden_memtable_token() -> None:
+    op = xo.memtable(_fixture_df(), name="name").op()
+    actual = tokenize(normalize_inmemorytable_canonical(op))
+    assert actual == GOLDEN_TOKENS["memtable"], _contract_message("memtable", op)
+
+
+def test_golden_pandas_dataframe_token() -> None:
+    df = _fixture_df()
+    assert tokenize(df) == GOLDEN_TOKENS["pandas_dataframe"], _contract_message(
+        "pandas_dataframe", df
+    )
+
+
+def test_golden_pyarrow_table_token() -> None:
+    table = pa.Table.from_pandas(_fixture_df())
+    assert tokenize(table) == GOLDEN_TOKENS["pyarrow_table"], _contract_message(
+        "pyarrow_table", table
+    )
+
+
+def test_digest_erases_chunk_layout() -> None:
+    single = pa.array([1, 2, None, 4, 5], type=pa.int64())
+    chunked = pa.chunked_array(
+        [pa.array([1, 2, None], type=pa.int64()), pa.array([4, 5], type=pa.int64())]
+    )
+    assert canonical_column_digest(chunked) == canonical_column_digest(single)
+
+
+def test_digest_erases_slicing() -> None:
+    big = pa.array(list(range(100)), type=pa.int64())
+    direct = pa.array(list(range(3, 13)), type=pa.int64())
+    assert canonical_column_digest(big.slice(3, 10)) == canonical_column_digest(direct)
+
+
+def test_digest_erases_dictionary_encoding() -> None:
+    plain = pa.array(["apple", "banana", "apple", "cherry", None])
+    assert canonical_column_digest(plain.dictionary_encode()) == (
+        canonical_column_digest(plain)
+    )
+
+
+def test_digest_discriminates_dictionary_values() -> None:
+    # Two dictionary arrays with identical indices but different dictionary
+    # values MUST hash differently (an un-decoded batch message serializes
+    # indices only — the exact under-discrimination this module exists to
+    # prevent).
+    a = pa.array(["x", "y", "x"]).dictionary_encode()
+    b = pa.array(["p", "q", "p"]).dictionary_encode()
+    assert canonical_column_digest(a) != canonical_column_digest(b)
+
+
+def test_digest_discriminates_signedness() -> None:
+    # Same buffer bytes, different logical type: identity must come from the
+    # schema component, not the value bytes alone.
+    signed = pa.array([1, -128], type=pa.int8())
+    unsigned = signed.view(pa.uint8())  # bit-identical buffers, values [1, 128]
+    op_s = xo.memtable(pa.table({"c": signed})).op()
+    op_u = xo.memtable(pa.table({"c": unsigned})).op()
+    assert tokenize(normalize_inmemorytable_canonical(op_s)) != tokenize(
+        normalize_inmemorytable_canonical(op_u)
+    )
+
+
+def test_memtable_normalization_does_not_execute_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The pa20↔21 regression came from hashing a backend-executed batch
+    # stream. Identity must come from the stored proxy data only.
+    def _forbidden(self: Expr, *args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            "normalize_inmemorytable_canonical must not execute the expression"
+        )
+
+    monkeypatch.setattr(Expr, "to_pyarrow_batches", _forbidden)
+    op = xo.memtable(_fixture_df(), name="name").op()
+    tokenize(normalize_inmemorytable_canonical(op))

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -36,12 +36,16 @@ import xorq_dasher
 
 import xorq
 import xorq.api as xo
+from xorq.backends.pandas import Backend as PandasBackend
+from xorq.backends.sqlite import Backend as SqliteBackend
 from xorq.common.utils.dasher import normalize, tokenize
 from xorq.common.utils.dasher._canonical import (
     NORMALIZATION_VERSION,
     canonical_column_digest,
     normalize_inmemorytable_canonical,
+    normalize_pyarrow_table_canonical,
 )
+from xorq.common.utils.dasher._relations import _dispatch_databasetable
 from xorq.vendor.ibis.expr.types.core import Expr
 
 
@@ -121,9 +125,9 @@ GOLDEN_COLUMN_DIGESTS = {
 }
 
 GOLDEN_TOKENS = {
-    "memtable": "c3a49075e3d5f635d0eb5b999bad74ca",
-    "pandas_dataframe": "5a2b5b1d7e148d299ff2bd592a2e7714",
-    "pyarrow_table": "f38b0e88acf5958f4955e9c8ec917a2e",
+    "memtable": "4e63f45b8697b50ee81aef56b74486bc",
+    "pandas_dataframe": "b1f14a347336ad9e53509ec2edea9db6",
+    "pyarrow_table": "c25a6ba3568ef8f3494bd1a2d91d0457",
 }
 
 
@@ -210,3 +214,46 @@ def test_memtable_normalization_does_not_execute_backends(
     monkeypatch.setattr(Expr, "to_pyarrow_batches", _forbidden)
     op = xo.memtable(_fixture_df(), name="name").op()
     tokenize(normalize_inmemorytable_canonical(op))
+
+
+def test_digest_refuses_unerasable_nested_dictionary() -> None:
+    # ``_dictionary_free_type`` does not rewrite union types, so a
+    # dictionary nested inside one cannot be decoded away — and serializing
+    # it would drop the dictionary values from the digest. Refusing loudly
+    # beats silently under-discriminating.
+    dict_arr = pa.array(["x", "y"]).dictionary_encode()
+    int_arr = pa.array([1, 2], type=pa.int64())
+    type_ids = pa.array([0, 1], type=pa.int8())
+    union = pa.UnionArray.from_sparse(type_ids, [dict_arr, int_arr])
+    with pytest.raises(NotImplementedError, match="dictionary"):
+        canonical_column_digest(union)
+
+
+def test_zero_column_table_discriminates_row_count() -> None:
+    # With no columns there are no digests to carry the row count, so the
+    # normalization carries ``num_rows`` explicitly.
+    two = pa.table({"a": [1, 2]}).drop_columns(["a"])
+    three = pa.table({"a": [1, 2, 3]}).drop_columns(["a"])
+    assert two.num_columns == 0 and two.num_rows == 2
+    assert normalize_pyarrow_table_canonical(two) != (
+        normalize_pyarrow_table_canonical(three)
+    )
+
+
+def test_pandas_backend_databasetable_routes_to_canonical() -> None:
+    # xorq_dasher's DatabaseTable dispatch would hash a pandas-backend
+    # table's to_pyarrow_batches() IPC stream — the pyarrow-version-coupled
+    # form (#2191). The dispatcher must route it to the canonical rule.
+    con = PandasBackend().connect({"t": _fixture_df()})
+    normalized = _dispatch_databasetable(con.table("t").op())
+    assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)
+
+
+def test_sqlite_memory_databasetable_routes_to_canonical() -> None:
+    # Same as above for in-memory sqlite (xorq_dasher's sqlite rule falls
+    # back to the batch-stream form when is_in_memory()).
+    con = SqliteBackend().connect()
+    assert con.is_in_memory()
+    con.create_table("t", pd.DataFrame({"a": [1, 2, 3]}))
+    normalized = _dispatch_databasetable(con.table("t").op())
+    assert normalized[:2] == ("xorq.MemoryDatabaseTable", NORMALIZATION_VERSION)

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -98,6 +98,11 @@ def _fixture_columns() -> dict[str, pa.Array | pa.ChunkedArray]:
             type=pa.timestamp("us", tz="UTC"),
         ),
         "list_int": pa.array([[1, 2, None], None, []], type=pa.list_(pa.int64())),
+        # fixed_size_list with a var-length child: the only fixture whose
+        # fixed_size_list branch actually requires the child cast
+        "fixed_size_list_string": pa.array(
+            [["a", "bb"], None, ["c", None]], type=pa.list_(pa.string(), 2)
+        ),
         "struct": pa.array(
             [{"a": 1, "b": "x"}, None, {"a": None, "b": ""}],
             type=pa.struct([("a", pa.int64()), ("b", pa.string())]),
@@ -133,6 +138,7 @@ GOLDEN_COLUMN_DIGESTS = {
     "string": "8174a8d746db7b57a1d0721bf83487cd",
     "timestamp_tz": "0a0e7066f0f567772d2185e5e7eff7d4",
     "list_int": "26e34968d249b6e878408d1c638b1066",
+    "fixed_size_list_string": "fa3d177e87ab1270155e121659545dc6",
     "struct": "d7c505e657beab1d3b433ee2633c9131",
     "map": "d4a434fe254471ca2176cd8b7ae9120e",
     "dictionary_multichunk": "b50c865c81720aa1354729bda834915d",
@@ -313,17 +319,92 @@ def test_memtable_normalization_does_not_execute_backends(
     tokenize(normalize_inmemorytable_canonical(op))
 
 
-def test_digest_refuses_unerasable_nested_dictionary() -> None:
-    # ``_canonical_type`` does not rewrite union types, so a
-    # dictionary nested inside one cannot be decoded away — and serializing
-    # it would drop the dictionary values from the digest. Refusing loudly
-    # beats silently under-discriminating.
+def test_digest_refuses_union_types() -> None:
+    # A sparse union serializes its type-masked child slots: two unions
+    # with equal to_pylist() but different values in the masked slots
+    # digest differently (verified — round-2 cold review). No verified
+    # canonicalizing cast exists, so refuse loudly, dictionary children or
+    # not.
     dict_arr = pa.array(["x", "y"]).dictionary_encode()
     int_arr = pa.array([1, 2], type=pa.int64())
     type_ids = pa.array([0, 1], type=pa.int8())
     union = pa.UnionArray.from_sparse(type_ids, [dict_arr, int_arr])
-    with pytest.raises(NotImplementedError, match="dictionary"):
+    with pytest.raises(NotImplementedError, match="union"):
         canonical_column_digest(union)
+    plain_union = pa.UnionArray.from_sparse(type_ids, [int_arr, pa.array(["a", "b"])])
+    with pytest.raises(NotImplementedError, match="union"):
+        canonical_column_digest(plain_union)
+
+
+def test_digest_refuses_run_end_encoded_types() -> None:
+    # A run-end-encoded array serializes its run partitioning:
+    # [3,5]/[7,9] and [2,3,5]/[7,7,9] encode the same logical values but
+    # digest differently (verified — round-2 cold review). Refuse until a
+    # decode step is verified cross-version.
+    ree = pa.RunEndEncodedArray.from_arrays([3, 5], [7, 9])
+    with pytest.raises(NotImplementedError, match="run-end"):
+        canonical_column_digest(ree)
+
+
+def test_refuses_extension_type_hidden_as_dictionary_values() -> None:
+    # BLOCKER regression (round-2 cold review): pa.DictionaryType has
+    # num_fields == 0, so a field-only walk never visits the value type —
+    # an extension type smuggled in as a dictionary's value type slipped
+    # past the refusal, and _canonical_type then unwrapped the dictionary
+    # straight to the extension type, whose str() omits its parameters:
+    # logically different tables collided.
+    monthly = pa.Table.from_pandas(
+        pd.DataFrame({"p": pd.PeriodIndex.from_ordinals([0, 1], freq="M")})
+    )
+    period_type = monthly.schema.field("p").type
+    dict_of_ext = pa.dictionary(pa.int32(), period_type)
+    with pytest.raises(NotImplementedError, match="extension"):
+        canonical_column_digest(pa.array([], type=dict_of_ext))
+    # dictionary-of-list_view must hit the curated refusal too, not an
+    # uncurated ArrowNotImplementedError from deep inside cast
+    # (from_arrays because pa.array's converter can't build this type)
+    dict_of_lv = pa.DictionaryArray.from_arrays(
+        pa.array([], type=pa.int32()), pa.array([], type=pa.list_view(pa.int64()))
+    )
+    with pytest.raises(NotImplementedError, match="list-view"):
+        canonical_column_digest(dict_of_lv)
+
+
+def test_nullability_excluded_from_identity_at_every_level() -> None:
+    # Nullability is a constraint on future writes, not data: the schema
+    # tuple omits field.nullable and _canonical_type's reconstruction
+    # drops nested "not null", so the exclusion is uniform (round-2 review
+    # suspected an inconsistency; this pins the deliberate behavior).
+    nn = pa.table(
+        {
+            "c": pa.array(
+                [{"x": 1}], type=pa.struct([pa.field("x", pa.int64(), nullable=False)])
+            )
+        }
+    ).cast(
+        pa.schema(
+            [
+                pa.field(
+                    "c",
+                    pa.struct([pa.field("x", pa.int64(), nullable=False)]),
+                    nullable=False,
+                )
+            ]
+        )
+    )
+    n = pa.table({"c": pa.array([{"x": 1}], type=pa.struct([("x", pa.int64())]))})
+    assert normalize_pyarrow_table_canonical(nn) == normalize_pyarrow_table_canonical(n)
+
+
+def test_dictionary_ordered_flag_excluded_from_identity() -> None:
+    # ordered qualifies the dictionary encoding; the canonical form erases
+    # the encoding entirely, so ordered/unordered categoricals of equal
+    # values normalize identically (deliberate; also true of the old
+    # batch-stream rule).
+    values = pa.array(["a", "b", "a"])
+    unordered = values.dictionary_encode()
+    ordered = unordered.cast(pa.dictionary(pa.int32(), pa.string(), ordered=True))
+    assert canonical_column_digest(ordered) == canonical_column_digest(unordered)
 
 
 def test_zero_column_table_discriminates_row_count() -> None:

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
-  "build_dir_name": "87159956626f",
-  "expr.yaml": "611cffaddaca6e6188e00f580b1393cd",
-  "expr_metadata.json": "c870f146f4a3cc08dfb360c76a5e0f53",
+  "build_dir_name": "00c36ffbdac0",
+  "expr.yaml": "0476a75f1b20c040c4625105c10f6f93",
+  "expr_metadata.json": "646bd83bb82ee155b98353e18b973ff9",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
-  "build_dir_name": "222f26324a6e",
-  "expr.yaml": "18723faa585294793ceac0440fad042c",
-  "expr_metadata.json": "45e1691cc486ccebddd24c526143a21c",
+  "build_dir_name": "f137b26b0a49",
+  "expr.yaml": "7ab941c1eb614f86e8b63a44d98b7c19",
+  "expr_metadata.json": "806629bbcc13db566f7128c40bae6227",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
-  "build_dir_name": "f137b26b0a49",
-  "expr.yaml": "7ab941c1eb614f86e8b63a44d98b7c19",
-  "expr_metadata.json": "806629bbcc13db566f7128c40bae6227",
+  "build_dir_name": "87159956626f",
+  "expr.yaml": "611cffaddaca6e6188e00f580b1393cd",
+  "expr_metadata.json": "c870f146f4a3cc08dfb360c76a5e0f53",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_memtable/memory-build-name.txt
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_memtable/memory-build-name.txt
@@ -1,1 +1,1 @@
-ibis_pandas_memtable_987b9284af139577b53b61ce5e79684b
+ibis_pandas_memtable_b9886c50fdf704db24b5e1bdaf5ac0ae

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_memtable/memory-build-name.txt
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_memtable/memory-build-name.txt
@@ -1,1 +1,1 @@
-ibis_pandas_memtable_b9886c50fdf704db24b5e1bdaf5ac0ae
+ibis_pandas_memtable_516d67ba393b5f180427b8bbc14999a3

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_memtable/memory-build-name.txt
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_memtable/memory-build-name.txt
@@ -1,1 +1,1 @@
-ibis_pandas_memtable_516d67ba393b5f180427b8bbc14999a3
+ibis_pandas_memtable_40313e0d56936ba634a84910173d821c

--- a/scripts/canonical_digest_xver_probe.py
+++ b/scripts/canonical_digest_xver_probe.py
@@ -1,0 +1,130 @@
+"""Cross-pyarrow-version probe for the canonical column digest.
+
+Standalone replica of ``xorq.common.utils.dasher._canonical`` digest logic
+(no xorq import, so it runs in a bare venv with just pyarrow+xxhash+pandas).
+Writes one ``name<TAB>digest`` line per corpus column to stdout; run under
+multiple pyarrow versions and diff the outputs — they must be byte-identical.
+
+    for v in 18.0.0 20.0.0 21.0.0 25.0.0; do
+      uv venv /tmp/pa$v -q && uv pip install -p /tmp/pa$v -q pyarrow==$v xxhash pandas
+      /tmp/pa$v/bin/python scripts/canonical_digest_xver_probe.py > /tmp/pa$v.out
+    done
+    diff /tmp/pa18.0.0.out /tmp/pa21.0.0.out  # etc.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import decimal
+import sys
+
+import pyarrow as pa
+import xxhash
+
+
+def _canonical_type(typ: pa.DataType) -> pa.DataType:
+    if pa.types.is_dictionary(typ):
+        return _canonical_type(typ.value_type)
+    if pa.types.is_string(typ):
+        return pa.large_string()
+    if pa.types.is_binary(typ):
+        return pa.large_binary()
+    if pa.types.is_list(typ) or pa.types.is_large_list(typ):
+        return pa.large_list(_canonical_type(typ.value_type))
+    if pa.types.is_fixed_size_list(typ):
+        return pa.list_(_canonical_type(typ.value_type), typ.list_size)
+    if pa.types.is_struct(typ):
+        return pa.struct(
+            [
+                (typ.field(i).name, _canonical_type(typ.field(i).type))
+                for i in range(typ.num_fields)
+            ]
+        )
+    if pa.types.is_map(typ):
+        return pa.map_(
+            _canonical_type(typ.key_type),
+            _canonical_type(typ.item_type),
+            keys_sorted=typ.keys_sorted,
+        )
+    return typ
+
+
+def canonical_column_digest(col: pa.Array | pa.ChunkedArray) -> str:
+    canonical_type = _canonical_type(col.type)
+    if canonical_type != col.type:
+        col = col.cast(canonical_type)
+    if isinstance(col, pa.ChunkedArray):
+        arr = col.combine_chunks()
+    else:
+        arr = pa.concat_arrays([col])
+    batch = pa.RecordBatch.from_arrays([arr], names=["c"])
+    return xxhash.xxh128(batch.serialize().to_pybytes()).hexdigest()
+
+
+def corpus() -> dict[str, pa.Array | pa.ChunkedArray]:
+    D = decimal.Decimal
+    utc = dt.timezone.utc
+    cols = {
+        "int64_nulls": pa.array([1, None, 2**62], type=pa.int64()),
+        "float64_edges": pa.array(
+            [0.0, -0.0, float("nan"), float("inf"), None], type=pa.float64()
+        ),
+        "bool_nulls": pa.array([True, None, False]),
+        "decimal128": pa.array(
+            [D("1.230000000"), None, D("-99.999999999")], type=pa.decimal128(38, 9)
+        ),
+        "string": pa.array(["apple", "banana", "apple", None, "", "é中文"]),
+        "large_string": pa.array(["apple", None, ""], type=pa.large_string()),
+        "binary": pa.array([b"\x00\x01", None, b""], type=pa.binary()),
+        "timestamp_tz": pa.array(
+            [dt.datetime(2020, 1, 1, tzinfo=utc), None],
+            type=pa.timestamp("us", tz="UTC"),
+        ),
+        "date32": pa.array([dt.date(2020, 1, 1), None]),
+        "duration": pa.array([dt.timedelta(seconds=1), None]),
+        "float32": pa.array([1.5, None], type=pa.float32()),
+        "list_int": pa.array([[1, 2, None], None, []], type=pa.list_(pa.int64())),
+        "list_string": pa.array([["a", None], None, []], type=pa.list_(pa.string())),
+        "fixed_size_list": pa.array(
+            [[1, 2], None, [3, None]], type=pa.list_(pa.int64(), 2)
+        ),
+        "struct": pa.array(
+            [{"a": 1, "b": "x"}, None, {"a": None, "b": ""}],
+            type=pa.struct([("a", pa.int64()), ("b", pa.string())]),
+        ),
+        "map": pa.array(
+            [[("k1", 1), ("k2", 2)], None, []], type=pa.map_(pa.string(), pa.int64())
+        ),
+        "dictionary_multichunk": pa.chunked_array(
+            [
+                pa.array(["apple", "banana", "apple"]).dictionary_encode(),
+                pa.array(["cherry", "banana", None]).dictionary_encode(),
+            ]
+        ),
+        "nested_dict_in_list": pa.array(
+            [["a", "b"], None, ["a"]], type=pa.list_(pa.string())
+        ).cast(pa.list_(pa.dictionary(pa.int32(), pa.string()))),
+        "empty_string": pa.array([], type=pa.string()),
+    }
+    # physical-layout variants: sliced and chunked forms of var-length data
+    s = pa.array([f"s{i}" * (i % 3 + 1) for i in range(30)])
+    cols["string_sliced"] = s.slice(3, 10)
+    cols["string_chunked"] = pa.chunked_array([s.slice(0, 11), s.slice(11)])
+    b = pa.array([True, None, False] * 10)
+    cols["bool_sliced_unaligned"] = b.slice(3, 10)
+    li = pa.array(
+        [[i, None, i * 2] if i % 3 else None for i in range(30)],
+        type=pa.list_(pa.int64()),
+    )
+    cols["list_sliced"] = li.slice(3, 10)
+    return cols
+
+
+def main() -> None:
+    sys.stdout.write(f"# pyarrow=={pa.__version__}\n")
+    for name, col in corpus().items():
+        sys.stdout.write(f"{name}\t{canonical_column_digest(col)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/canonical_digest_xver_probe.py
+++ b/scripts/canonical_digest_xver_probe.py
@@ -2,8 +2,11 @@
 
 Standalone replica of ``xorq.common.utils.dasher._canonical`` digest logic
 (no xorq import, so it runs in a bare venv with just pyarrow+xxhash+pandas).
-Writes one ``name<TAB>digest`` line per corpus column to stdout; run under
-multiple pyarrow versions and diff the outputs — they must be byte-identical.
+Writes one ``name<TAB>canonical-type<TAB>digest`` line per corpus column to
+stdout; run under multiple pyarrow versions and diff the outputs — they must
+be byte-identical. The canonical-type column guards the ``str(type)`` schema
+surface of the normalized tuple: a pyarrow type-repr change across versions
+would drift tokens even with stable digests.
 
     for v in 18.0.0 20.0.0 21.0.0 25.0.0; do
       uv venv /tmp/pa$v -q && uv pip install -p /tmp/pa$v -q pyarrow==$v xxhash pandas
@@ -88,6 +91,9 @@ def corpus() -> dict[str, pa.Array | pa.ChunkedArray]:
         "fixed_size_list": pa.array(
             [[1, 2], None, [3, None]], type=pa.list_(pa.int64(), 2)
         ),
+        "fixed_size_list_string": pa.array(
+            [["a", "bb"], None, ["c", None]], type=pa.list_(pa.string(), 2)
+        ),
         "struct": pa.array(
             [{"a": 1, "b": "x"}, None, {"a": None, "b": ""}],
             type=pa.struct([("a", pa.int64()), ("b", pa.string())]),
@@ -132,7 +138,10 @@ def corpus() -> dict[str, pa.Array | pa.ChunkedArray]:
 def main() -> None:
     sys.stdout.write(f"# pyarrow=={pa.__version__}\n")
     for name, col in corpus().items():
-        sys.stdout.write(f"{name}\t{canonical_column_digest(col)}\n")
+        canonical_type = _canonical_type(col.type)
+        sys.stdout.write(
+            f"{name}\t{canonical_type!s}\t{canonical_column_digest(col)}\n"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/canonical_digest_xver_probe.py
+++ b/scripts/canonical_digest_xver_probe.py
@@ -25,9 +25,9 @@ import xxhash
 def _canonical_type(typ: pa.DataType) -> pa.DataType:
     if pa.types.is_dictionary(typ):
         return _canonical_type(typ.value_type)
-    if pa.types.is_string(typ):
+    if pa.types.is_string(typ) or pa.types.is_string_view(typ):
         return pa.large_string()
-    if pa.types.is_binary(typ):
+    if pa.types.is_binary(typ) or pa.types.is_binary_view(typ):
         return pa.large_binary()
     if pa.types.is_list(typ) or pa.types.is_large_list(typ):
         return pa.large_list(_canonical_type(typ.value_type))
@@ -105,6 +105,12 @@ def corpus() -> dict[str, pa.Array | pa.ChunkedArray]:
             [["a", "b"], None, ["a"]], type=pa.list_(pa.string())
         ).cast(pa.list_(pa.dictionary(pa.int32(), pa.string()))),
         "empty_string": pa.array([], type=pa.string()),
+        # view types: physical buffer layout is erased by canonicalizing to
+        # large_string/large_binary (long values force out-of-line buffers)
+        "string_view": pa.array(
+            ["apple", None, "", "é中文", "x" * 100], type=pa.string_view()
+        ),
+        "binary_view": pa.array([b"\x00\x01" * 20, None, b""], type=pa.binary_view()),
     }
     # physical-layout variants: sliced and chunked forms of var-length data
     s = pa.array([f"s{i}" * (i % 3 + 1) for i in range(30)])
@@ -117,6 +123,9 @@ def corpus() -> dict[str, pa.Array | pa.ChunkedArray]:
         type=pa.list_(pa.int64()),
     )
     cols["list_sliced"] = li.slice(3, 10)
+    sv = pa.array([f"s{i}" * (i % 5 + 1) for i in range(30)], type=pa.string_view())
+    cols["string_view_sliced"] = sv.slice(3, 10)
+    cols["string_view_chunked"] = pa.chunked_array([sv.slice(0, 11), sv.slice(11)])
     return cols
 
 

--- a/scripts/canonical_digest_xver_probe.py
+++ b/scripts/canonical_digest_xver_probe.py
@@ -47,7 +47,6 @@ def _canonical_type(typ: pa.DataType) -> pa.DataType:
         return pa.map_(
             _canonical_type(typ.key_type),
             _canonical_type(typ.item_type),
-            keys_sorted=typ.keys_sorted,
         )
     return typ
 


### PR DESCRIPTION
## Problem

Memtable identity was hashed from the IPC bytes of a backend-executed `to_pyarrow_batches()` stream (`xorq_dasher.normalize_inmemorytable`). pyarrow's IPC dictionary-batch layout changed between 20 and 21, so the same expression got a different build name per pyarrow version. That surfaced as the `ci-test-lowest-direct` snapshot failures in #2191 when uv's resolution drifted 21 to 20. Arrow guarantees logical readability across versions, not byte stability, so any hash over serializer output is implicitly version-coupled.

Closes #2191.

## What to read first

| File | Lines | Role |
| --- | --- | --- |
| `dasher/_canonical.py` | 375 | the new mechanism |
| `tests/test_hash_contract.py` | 685 | the contract: goldens, invariants, refusals, residuals |
| `scripts/canonical_digest_xver_probe.py` | 147 | standalone replica, run under several pyarrow versions |
| `docs/adr/0017-canonical-hash-forms-not-serializer-bytes.md` | 162 | why identity never comes from serializer bytes |

The other 7 files are call-site swaps (`_opaque.py`, `_relations.py`, `__init__.py`, `_gap_rules.py`) and two regenerated snapshots.

## Fix

New `xorq.common.utils.dasher._canonical` replaces the dasher IPC-stream rules at every call site. All in-repo; no dasher fork.

InMemoryTable identity is the **stored proxy data** (`op.data.to_pyarrow(op.schema)`), never re-executed through a backend.

The per-column canonical digest, in order:

1. Recursively decode dictionary encoding. An un-decoded dictionary batch message serializes indices *without* the dictionary values, an under-discrimination hazard.
2. Widen int32-offset var-length types to `large_*`, and rewrite `string_view`/`binary_view` to `large_string`/`large_binary`. View IPC serializes physical buffer layout, so sliced or chunked views of equal data would otherwise hash unequally.
3. Compact via `combine_chunks`/`concat_arrays`, erasing chunk layout and un-rebased slice offsets.
4. xxh128 the IPC bytes of a metadata-free single-column RecordBatch.

Steps 1 and 2 are a single chunk-wise `cast` and must precede step 3: a >2 GiB string column holds more value data than one contiguous int32-offset array can address, so compacting first would overflow.

Row count and schema are carried explicitly, as `num_rows` (a zero-column table has no digests to carry it) and `(name, str(canonical type))`. `RecordBatch.serialize()` emits no schema message, so type identity cannot ride on value bytes alone; int8 and uint8 with identical buffers must differ.

Excluded from identity at every nesting level, each pinned by a test: field nullability, the dictionary `ordered` flag, and the map `keys_sorted` flag. All three are constraint assertions, not data.

### Cost

Step 3 compacts each column across all chunks, so peak memory is the full table plus a transient copy of the largest column. Three consequences:

* Memory-backed `DatabaseTable`s are fully materialized. Streaming would save nothing, since the compaction is what erases batch boundaries, and an incremental per-batch fold would re-couple identity to batch size, the exact defect being removed. Paid only for tables whose data is already resident in the backend.
* The registered `pyarrow.lib.Table` rule means every pandas DataFrame/Series normalization pays the cast and compaction too. The old rule streamed batches and held one at a time.
* This is a real peak-memory regression against the old rule, accepted as the price of batch-boundary-free identity.

### Refused rather than hashed

`NotImplementedError`, detected at any nesting depth including as a dictionary's value type, which `num_fields`-based walks miss since `pa.DictionaryType.num_fields == 0`:

| Family | Why | Test |
| --- | --- | --- |
| extension | parameters live in `__arrow_ext_serialize__` bytes with no cross-version contract, and `str(type)` omits them, so hashing the storage collides logically different tables | `test_refuses_extension_types`, `test_refuses_extension_type_hidden_as_dictionary_values` |
| list-view | pyarrow's `list_view`→`list` cast emits arrays that fail `validate(full=True)` (upstream bug, reproduced on 18 and 21), and raw view bytes hash buffer layout | `test_digest_refuses_list_view_types` |
| union | sparse unions serialize their type-masked child slots, so equal data hashes unequally | `test_digest_refuses_union_types` |
| run-end-encoded | the serialized form depends on run partitioning; `[3,5]/[7,9]` and `[2,3,5]/[7,7,9]` encode the same values | `test_digest_refuses_run_end_encoded_types` |

"Equal data can hash unequally" is not on its own the criterion, since the accepted null-slot residual under Known limitations has the same shape. What separates these four is that their layout variance is unbounded and not producer-stable (a concat re-partitions an REE column's runs within one process), none is covered by the cross-version probe, and all are rare enough that loud refusal costs almost nothing.

### Changing the canonical form

`NORMALIZATION_VERSION`, currently `1`, lives at the top of `_canonical.py` and is folded into every tuple the module produces, so hash identity moves when xorq decides rather than when a dependency releases. Any edit that changes a digest, a canonical type string, or a tuple shape obliges a bump plus regenerated goldens in `test_hash_contract.py`. The golden tests fail with the dependency versions and the normalized tuple printed, to distinguish "I changed this on purpose" from "a dependency moved under me". Rationale in ADR-0017.

## Verification

* Canonical digests **and** canonical type strings are byte-identical across pyarrow 18.0.0, 20.0.0, 21.0.0 and 25.0.0 in isolated venvs. Supported range is `pyarrow>=18,<22`; 25 is checked as forward headroom, not as support. The corpus covers nulls, NaN/−0.0/inf, decimals, tz timestamps, nested list/struct/map, fixed-size lists with var-length children, multi-chunk dictionary arrays with per-chunk dictionaries, dictionary-in-list, sliced and chunked var-length arrays, and plain, sliced and chunked `string_view`/`binary_view`. `test_probe_script_matches_module` pins the probe replica to the module so the two cannot drift apart silently.
* The #2191 repro, `build_expr` of the awards/batting join, now yields the same build name under pyarrow 20 and 21 (`00c36ffbdac0`). On main it produces `222f26324a6e` and `9d8f46b5e7ac`.
* `test_hash_contract.py`, 49 tests: goldens over the full probe corpus, so a digest-changing edit applied to module and probe together still fails; invariants (chunked==single, sliced==direct per type family, dict-encoded==plain, view==offset forms, plus the three exclusions above); under-discrimination guards (dictionary values, signedness, no-backend-execution, zero-column row count, pandas and in-memory-sqlite dispatcher routing); and a pin on the dasher memory-rule tuple tag that the `_relations` safety net matches, so a dasher rename fails the pin instead of silently reviving #2191. Goldens pass under pyarrow 20 and 21.
* `test_dasher.py`: 106 passed, 1 xfailed. `ibis_yaml`: green except pre-existing postgres-service-dependent tests, env-only.

## Known limitations

Two over-discrimination residuals are accepted, documented in the module docstring and ADR-0017, and pinned by test. Both cost recomputation, never a wrong answer, and neither re-opens #2191, because each is deterministic given the producer.

**Null-slot payload reaches the digest.** The columnar spec leaves null-slot contents unspecified and `serialize()` writes the values buffer verbatim, so two producers of `.equals()`-identical data can disagree: `pa.Table.from_pandas` leaves NaN, NaT or mask garbage under a null where a literal `None` leaves zero. Confirmed for `float64`, pandas nullable `Int64` and `datetime64`.

If a hash changes with no data change, check this first. It means the column reached the memtable by a different route (`from_pandas`, literals, or a parquet round-trip), not that its values differ.

Erasing it requires the per-type recursive buffer fold that ADR-0017 defers as the designated escalation. A primitives-only partial fix was rejected: it would leave nested nullable children, such as a struct or list of nullable primitives, untouched, and a non-uniform exclusion is worse than a documented one. Refusing the types outright was also rejected, since that would refuse nearly every nullable column. Pinned by `test_null_slot_payload_is_accepted_residual`.

**Timezone spelling.** `str(type)` distinguishes `tz=UTC` from `tz=+00:00` for the same instant, so the schema component diverges while the value digests agree. Pinned by `test_timezone_spelling_is_accepted_residual`.

## Breaking, and what to do about it

### 1. Arrow extension types now raise instead of hashing

Tokenizing data that contains Arrow extension types raises `NotImplementedError`. In practice that means pandas **period and interval columns**, which is not an exotic case. It is a loud failure at tokenize time rather than silent corruption, and it replaces a real collision: before this PR, period columns of freq `M` and `D` with equal ordinals normalized identically.

Convert before tokenizing:

| Column | Use | Avoid |
| --- | --- | --- |
| period | `.dt.to_timestamp()` or `.astype(str)` | `.astype("int64")` |
| interval | split into separate `left`/`right` columns | |

`.astype("int64")` re-introduces exactly the collision the refusal exists to prevent: it keeps the ordinal and drops the freq, so `M` and `D` columns with equal ordinals hash identically (verified). `to_timestamp()` and `astype(str)` both preserve the distinction.

List-view, union and run-end-encoded types also raise. These are rare in pandas- and ibis-shaped data and have no in-place workaround; materialize to the equivalent plain type first.

### 2. One-time hash bump for expressions containing memtables or in-memory tables

Build names and cache keys change once. Previously they changed whenever pyarrow did.

A stale cache entry is a **silent recompute, not an error**: the new key misses, `set_default` writes a fresh entry, and the pre-upgrade entry stays on disk orphaned. Build directories behave the same way, with the old name simply no longer produced. Reclaim disk by dropping pre-upgrade cache and build directories; nothing reads them again. Two snapshots are regenerated here.

## Review

Four sequential independent cold reviews, per the trial policy proposed in #2197, which names dasher shared infrastructure. One blocker, in round 2: an extension type hidden as a dictionary's value type bypassed the refusal walk because `pa.DictionaryType.num_fields == 0`, producing a real collision. Every finding is fixed or pinned by a test named above; the two entries under Known limitations are the deliberate "pinned" cases.

Findings-per-round curve and what it implies for #2197's stopping rule: https://github.com/xorq-labs/xorq/pull/2197#issuecomment-5172474664

A #2198-style blast-radius grep caught a stale docstring and an ADR number collision with #2196, so this ADR is 0017 rather than 0016 (#2197 and #2198 reference #2196's by number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGsyV5Vi2pzw24SXghKcWJ
