### PR TITLE
feat(skills): add /review-retro for post-review structural retrospectives

### DIFF
--- a/.claude/skills/blast-radius/SKILL.md
+++ b/.claude/skills/blast-radius/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: blast-radius
+description: Before removing or renaming behavior, compute the repo-wide blast radius — grep for removed symbols, error strings, and config keys across code, tests, and docs; report every hit that must be updated. Use when deleting code paths (even dead ones), renaming public names, or changing error messages.
+---
+
+# Blast radius of a removal or rename
+
+Given the working diff (or a described removal/rename):
+
+1. Extract from the removed or renamed lines:
+   - function/class/variable names (public AND private — tests import private names),
+   - string literals: error messages, log strings, config keys,
+   - CLI flags, dotted module paths, entry-point names.
+2. For each token, `grep -rn` the whole repo — including `**/tests/**`, `docs/`,
+   and `.github/` — for the exact token AND for distinctive substrings of string
+   literals (error messages are often asserted via `pytest.raises(match=...)`
+   with only a fragment of the message).
+3. Also search for the *module name itself* in other modules' test files:
+   a test that does `monkeypatch.setattr(other_module, ...)` is in the blast
+   radius even when no removed symbol matches textually.
+4. Classify every hit:
+   - (a) already updated by this diff,
+   - (b) must be updated — **blocker**, fix before proceeding,
+   - (c) safe to leave (changelog, historical notes).
+5. Report the classification before making the removal. If there are zero hits,
+   say exactly what was searched so the absence is verifiable.
+
+Rules of thumb:
+
+- Dead code can still have live tests. "Unreachable by construction" does not
+  mean "unreferenced".
+- When retiring a test that guarded a now-impossible drift, replace it with a
+  structural invariant test co-located with the owning module, and leave a
+  pointer comment at the old site.
+- After the removal, re-run the test modules of every file that appeared in
+  category (b), not just the module you edited.

--- a/.claude/skills/review-retro/SKILL.md
+++ b/.claude/skills/review-retro/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: review-retro
-description: After sequential independent review rounds on a change, run a retrospective that groups ALL findings by generating cause and converts causes into structural fixes. Use when two or more review rounds have completed, before merge — or whenever review findings feel like whack-a-mole.
+description: The retrospective step of xorq's sequential-review policy for shared-infrastructure changes (CONTRIBUTING § "Review policy") — group ALL findings from the review rounds by generating cause and convert causes into structural fixes. Use when two or more review rounds have completed, before merge — or whenever review findings feel like whack-a-mole.
 ---
 
 # Review retrospective: from findings to generators
 
 Individual review findings are symptoms. This skill finds the process that
 *generated* them, so the fix kills the class, not the instance.
+
+## When this runs (repo policy)
+
+Per CONTRIBUTING § "Review policy: shared-infrastructure changes", changes to
+shared traversal/hashing/serialization infrastructure get two or more
+sequential independent cold reviews; when the rounds produce findings, this
+retrospective runs before merge. The convergence curve (step 4) is the stop
+criterion for the review loop itself. ADR-0016 records the #2177/#2196 case
+study this practice was distilled from.
 
 ## Method
 
@@ -27,9 +36,11 @@ Individual review findings are symptoms. This skill finds the process that
    10 → 5 (one high) → 5 (zero blocking) → suggestions-only means converged;
    flat or rising means the generators are still live.
 5. **Route outputs to their durable homes.** Mechanisms → code + tests;
-   design decisions → an ADR; process rules → CONTRIBUTING (with team
-   consent — norms are not riders on feature PRs); environment facts →
-   memory; unresolved causes → named follow-ups with owners.
+   design decisions → `docs/adr/` (see `template.md` there); process rules →
+   CONTRIBUTING § "Removing or changing behavior" (with team consent — norms
+   are not riders on feature PRs); agent-facing summaries → AGENTS.md;
+   environment facts → memory; unresolved causes → named follow-ups with
+   owners (ours: declaration-site spec registration → XOR-363).
 6. **Apply cause #1 below to the new mechanisms themselves.** Every checker
    added gets a planted-violation test (prove it catches a real violation)
    and a stated blind spot (what it does NOT catch). Enforcement layers
@@ -37,8 +48,11 @@ Individual review findings are symptoms. This skill finds the process that
 
 ## Known cause taxonomy (prior, not fence)
 
-Start from these — they have recurred — but explicitly hunt for causes that
-do not fit; a taxonomy that only confirms itself is another enumeration.
+Distilled from the #2177/#2196 review rounds (28 findings, four rounds; see
+ADR-0016 for the code-side outcome). Start from these — they have recurred —
+but explicitly hunt for causes that do not fit; a taxonomy that only confirms
+itself is another enumeration. Amend this list when a retro finds a new
+cause.
 
 1. **Claims without enforcement** — invariants living in prose (docstrings,
    comments, PR bodies) with no tier that makes them fail when violated.

--- a/.claude/skills/review-retro/SKILL.md
+++ b/.claude/skills/review-retro/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: review-retro
+description: After sequential independent review rounds on a change, run a retrospective that groups ALL findings by generating cause and converts causes into structural fixes. Use when two or more review rounds have completed, before merge — or whenever review findings feel like whack-a-mole.
+---
+
+# Review retrospective: from findings to generators
+
+Individual review findings are symptoms. This skill finds the process that
+*generated* them, so the fix kills the class, not the instance.
+
+## Method
+
+1. **Collect the full corpus.** Findings from ALL review rounds — including
+   declined ones (they calibrate cost/benefit norms) and operational hiccups
+   (auth failures, hook surprises, wrong paths, CI misattribution). Code
+   findings alone miss half the causes.
+2. **Group by generating cause, not chronology or severity.** For each
+   finding ask: "what process would have produced this?" Many findings
+   collapsing into few causes is the signal you are looking for.
+3. **For each cause, seek a class-killer, not a finding-fixer.** Is there a
+   mechanism — impossible-by-construction, import-time validation, or a
+   co-located test — that makes the whole class impossible or loud?
+   Enumeration-to-derivation is the most common answer: wherever coverage is
+   defined by a hand-written list, look for a rule to close over instead.
+4. **Read the convergence curve.** Findings-per-round and their severity
+   trend tells you when another review round stops paying. A curve like
+   10 → 5 (one high) → 5 (zero blocking) → suggestions-only means converged;
+   flat or rising means the generators are still live.
+5. **Route outputs to their durable homes.** Mechanisms → code + tests;
+   design decisions → an ADR; process rules → CONTRIBUTING (with team
+   consent — norms are not riders on feature PRs); environment facts →
+   memory; unresolved causes → named follow-ups with owners.
+6. **Apply cause #1 below to the new mechanisms themselves.** Every checker
+   added gets a planted-violation test (prove it catches a real violation)
+   and a stated blind spot (what it does NOT catch). Enforcement layers
+   reliably exhibit the disease they treat.
+
+## Known cause taxonomy (prior, not fence)
+
+Start from these — they have recurred — but explicitly hunt for causes that
+do not fit; a taxonomy that only confirms itself is another enumeration.
+
+1. **Claims without enforcement** — invariants living in prose (docstrings,
+   comments, PR bodies) with no tier that makes them fail when violated.
+   Includes checkers overclaiming their own coverage.
+2. **Coverage by enumeration instead of closure** — a mechanism covers the
+   cases its author listed; each review round finds the complement.
+3. **Knowledge far from its point of use** — contract tests in another
+   module's test file, conventions discoverable only by collision, docs that
+   drift because they restate facts instead of citing their source.
+4. **Environment assumptions untested until they fail** — credentials,
+   hooks, CI quirks, branch policies. Cheapest fix is usually memory, not
+   machinery.
+5. **Single-perspective review saturation** — each independent cold review
+   finds a different character of issue; sequential rounds converge
+   measurably (see step 4).
+
+## Scope discipline
+
+This is a thinking scaffold, not an orchestration: it needs no fan-out and
+no verification machinery. Its outputs are promotions up the ladder
+(memory → skill prior → CONTRIBUTING/ADR), never a new document trail of
+its own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,13 @@ prose-only invariant is a review finding, not documentation.
 A test pinning module A's behavior belongs in A's test module. Monkeypatching
 another module's globals in a test is a smell.
 
+## Sequential reviews + retrospective (trial policy)
+
+Shared-infrastructure changes (traversal, hashing, serialization) get two or
+more independent cold reviews; when rounds produce findings, run
+`/review-retro` before merge. See CONTRIBUTING § "Review policy:
+shared-infrastructure changes".
+
 ## Graph traversal / opaque ops (`common/utils/graph_utils.py`)
 
 An op holding sub-expressions that `__children__` does not surface

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# xorq — working conventions
+
+Sources of truth: `CONTRIBUTING.md` § "Removing or changing behavior" (process
+conventions) and `docs/adr/` (design decisions). Summaries below; when in
+doubt, read those.
+
+## Removing behavior requires a blast-radius grep
+
+Before deleting any code path — including provably dead ones — grep the whole
+repo (tests, docs, `.github/`) for the removed symbols AND their error-message
+strings. Dead code can still have live tests. Use the `/blast-radius` skill.
+
+## Invariants need an enforcement tier
+
+Every "must / cannot / never" in a docstring needs one of: impossible by
+construction, validated at import time, or pinned by a co-located test. A
+prose-only invariant is a review finding, not documentation.
+
+## Contract tests live with the contract owner
+
+A test pinning module A's behavior belongs in A's test module. Monkeypatching
+another module's globals in a test is a smell.
+
+## Graph traversal / opaque ops (`common/utils/graph_utils.py`)
+
+An op holding sub-expressions that `__children__` does not surface
+(`Expr`-typed fields, `__config__` payloads) MUST be registered in
+`OPAQUE_SPECS`; a deliberately-not-descended `Expr` field goes in
+`NON_EDGE_EXPR_FIELDS` with the reason. Runtime tripwires and a completeness
+test enforce this, except for `__config__` payloads (invisible to both —
+review-enforced). Full rationale: ADR-0016.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,30 @@ scope. Ruff enforces this split via `PLC0415` (import-outside-top-level): every
 deliberate lazy import must carry a `# noqa: PLC0415` comment, which makes each
 one an explicit, reviewable decision rather than an accident.
 
+## Removing or changing behavior
+
+Three conventions, distilled from a review retrospective (ADR-0016 records the
+case study):
+
+- **Blast-radius grep before removals.** Before deleting any code path —
+  including provably dead ones — grep the whole repo (tests, docs, `.github/`
+  included) for the removed *symbols* and their *error-message strings*. Dead
+  code can still have live tests: guards get monkeypatched into firing, and
+  error messages get asserted with `pytest.raises(match=...)` from other
+  modules' test files. `.claude/skills/blast-radius/SKILL.md` spells out the
+  steps as a manual checklist (agents run it as the `/blast-radius` skill).
+- **Invariants need an enforcement tier.** Every "must / cannot / never"
+  sentence in a docstring or comment should be (1) impossible by construction
+  (derive it, type it), (2) validated at import time (validators,
+  `__attrs_post_init__`), or (3) pinned by a test co-located with the module
+  that owns it. A prose-only invariant is a review finding, not documentation.
+- **Contract tests live with the contract owner.** A test that pins module A's
+  behavior belongs in A's test module, not in whichever test file first
+  observed the behavior. Monkeypatching another module's globals in a test is
+  a smell: it couples the test to internals invisible to that module's
+  editors, and it can silently stop testing anything when those internals are
+  restructured.
+
 ## Writing the commit
 
 xorq follows the [Conventional Commits](https://www.conventionalcommits.org/) structure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,24 @@ case study):
   editors, and it can silently stop testing anything when those internals are
   restructured.
 
+## Review policy: shared-infrastructure changes (trial)
+
+Changes to shared traversal, hashing, or serialization infrastructure (e.g.
+`common/utils/graph_utils.py`, `common/utils/dasher/`, `ibis_yaml/`) get at
+least two sequential *independent* reviews — each a cold read with no context
+from the previous round. Sequential rounds find different classes of issue;
+stop when the findings-per-round curve converges (declining count and
+severity).
+
+When review rounds produce findings, run a structural retrospective before
+merge: group all findings (including declined ones and operational hiccups)
+by generating cause, and convert causes into mechanisms, not just fixes.
+Agents run this as the `/review-retro` skill;
+`.claude/skills/review-retro/SKILL.md` doubles as the manual checklist.
+
+This is a trial norm adopted from the #2177/#2196 retrospectives (ADR-0016
+records the case study); revisit after a few uses.
+
 ## Writing the commit
 
 xorq follows the [Conventional Commits](https://www.conventionalcommits.org/) structure.


### PR DESCRIPTION
## What

The `/review-retro` skill plus the trial review policy that gives it repo residency: CONTRIBUTING gains a "Review policy: shared-infrastructure changes" section (≥2 sequential independent cold reviews; structural retrospective before merge when rounds produce findings; findings-per-round convergence curve as the stop rule), and the skill is its executable half. AGENTS.md carries the agent-facing summary.

## Why residency is by coupling, not location

Community practice scopes project skills to workflows the repo *depends on*, not workflows that merely originated here. A generic retro skill alone didn't meet that bar — the policy paragraph is what creates the dependency (same structure as #2198's blast-radius skill, which the removal convention cites). Skill and policy land together as one priced, revertable unit.

The skill's method is generic; its taxonomy prior is grounded in this repo's history (28 findings across the #2177/#2196 review rounds; ADR-0016 records the code-side outcome) and its routing step names this repo's homes (`docs/adr/`, the CONTRIBUTING sections, AGENTS.md, memory).

## Relationship to #2198

Base is `main`, but the branch is built on `dlovell/process-norms`: the policy paragraph belongs textually adjacent to the process-conventions section that PR introduces, so this PR's diff **includes #2198's commit** until #2198 merges (after which a rebase drops the duplicate and only the review-policy delta remains). Merge #2198 first. Basing on `main` keeps this PR safe from the branch auto-delete that fires when #2198 merges.

## Notes for reviewers

- The policy is deliberately **trial-framed and scoped** (shared traversal/hashing/serialization infrastructure, not all PRs) — it is adopted from n=2 uses; the ask is consent to trial it, with a revisit after a few uses.
- `SKILL.md` doubles as a manual checklist for contributors not using agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
