### PR TITLE
docs: adopt process conventions from the #2177/#2196 review retrospective

### DIFF
--- a/.claude/skills/blast-radius/SKILL.md
+++ b/.claude/skills/blast-radius/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: blast-radius
+description: Before removing or renaming behavior, compute the repo-wide blast radius — grep for removed symbols, error strings, and config keys across code, tests, and docs; report every hit that must be updated. Use when deleting code paths (even dead ones), renaming public names, or changing error messages.
+---
+
+# Blast radius of a removal or rename
+
+Given the working diff (or a described removal/rename):
+
+1. Extract from the removed or renamed lines:
+   - function/class/variable names (public AND private — tests import private names),
+   - string literals: error messages, log strings, config keys,
+   - CLI flags, dotted module paths, entry-point names.
+2. For each token, `grep -rn` the whole repo — including `**/tests/**`, `docs/`,
+   and `.github/` — for the exact token AND for distinctive substrings of string
+   literals (error messages are often asserted via `pytest.raises(match=...)`
+   with only a fragment of the message).
+3. Also search for the *module name itself* in other modules' test files:
+   a test that does `monkeypatch.setattr(other_module, ...)` is in the blast
+   radius even when no removed symbol matches textually.
+4. Classify every hit:
+   - (a) already updated by this diff,
+   - (b) must be updated — **blocker**, fix before proceeding,
+   - (c) safe to leave (changelog, historical notes).
+5. Report the classification before making the removal. If there are zero hits,
+   say exactly what was searched so the absence is verifiable.
+
+Rules of thumb:
+
+- Dead code can still have live tests. "Unreachable by construction" does not
+  mean "unreferenced".
+- When retiring a test that guarded a now-impossible drift, replace it with a
+  structural invariant test co-located with the owning module, and leave a
+  pointer comment at the old site.
+- After the removal, re-run the test modules of every file that appeared in
+  category (b), not just the module you edited.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# xorq — working conventions
+
+Sources of truth: `CONTRIBUTING.md` § "Removing or changing behavior" (process
+conventions) and `docs/adr/` (design decisions). Summaries below; when in
+doubt, read those.
+
+## Removing behavior requires a blast-radius grep
+
+Before deleting any code path — including provably dead ones — grep the whole
+repo (tests, docs, `.github/`) for the removed symbols AND their error-message
+strings. Dead code can still have live tests. Use the `/blast-radius` skill.
+
+## Invariants need an enforcement tier
+
+Every "must / cannot / never" in a docstring needs one of: impossible by
+construction, validated at import time, or pinned by a co-located test. A
+prose-only invariant is a review finding, not documentation.
+
+## Contract tests live with the contract owner
+
+A test pinning module A's behavior belongs in A's test module. Monkeypatching
+another module's globals in a test is a smell.
+
+## Graph traversal / opaque ops (`common/utils/graph_utils.py`)
+
+An op holding sub-expressions that `__children__` does not surface
+(`Expr`-typed fields, `__config__` payloads) MUST be registered in
+`OPAQUE_SPECS`; a deliberately-not-descended `Expr` field goes in
+`NON_EDGE_EXPR_FIELDS` with the reason. Runtime tripwires and a completeness
+test enforce this, except for `__config__` payloads (invisible to both —
+review-enforced). Full rationale: ADR-0016.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,30 @@ scope. Ruff enforces this split via `PLC0415` (import-outside-top-level): every
 deliberate lazy import must carry a `# noqa: PLC0415` comment, which makes each
 one an explicit, reviewable decision rather than an accident.
 
+## Removing or changing behavior
+
+Three conventions, distilled from a review retrospective (ADR-0016 records the
+case study):
+
+- **Blast-radius grep before removals.** Before deleting any code path —
+  including provably dead ones — grep the whole repo (tests, docs, `.github/`
+  included) for the removed *symbols* and their *error-message strings*. Dead
+  code can still have live tests: guards get monkeypatched into firing, and
+  error messages get asserted with `pytest.raises(match=...)` from other
+  modules' test files. `.claude/skills/blast-radius/SKILL.md` spells out the
+  steps as a manual checklist (agents run it as the `/blast-radius` skill).
+- **Invariants need an enforcement tier.** Every "must / cannot / never"
+  sentence in a docstring or comment should be (1) impossible by construction
+  (derive it, type it), (2) validated at import time (validators,
+  `__attrs_post_init__`), or (3) pinned by a test co-located with the module
+  that owns it. A prose-only invariant is a review finding, not documentation.
+- **Contract tests live with the contract owner.** A test that pins module A's
+  behavior belongs in A's test module, not in whichever test file first
+  observed the behavior. Monkeypatching another module's globals in a test is
+  a smell: it couples the test to internals invisible to that module's
+  editors, and it can silently stop testing anything when those internals are
+  restructured.
+
 ## Writing the commit
 
 xorq follows the [Conventional Commits](https://www.conventionalcommits.org/) structure.


### PR DESCRIPTION
## What

Team process conventions distilled from the #2177/#2196 review retrospectives, split out of #2196 so they get discussed and consented to on their own merits rather than riding a feature PR.

## Contents

- **`CONTRIBUTING.md` § "Removing or changing behavior"** — three rules:
  - *Blast-radius grep before removals*: grep the repo (tests, docs, `.github/`) for removed symbols AND their error-message strings before deleting any code path, even provably dead ones. Origin: removing an unreachable-by-construction guard in #2177 broke a `test_dasher.py` test that monkeypatched it into firing — dead code had a live test.
  - *Invariants need an enforcement tier*: every "must / cannot / never" in a docstring is either impossible by construction, validated at import time, or pinned by a co-located test. Origin: ~11 of the 28 findings across both PRs' review rounds were prose-only invariants.
  - *Contract tests live with the contract owner*: no cross-module monkeypatch tests.
- **`.claude/skills/blast-radius/SKILL.md`** — the grep procedure as a Claude Code skill; plain-markdown steps usable as a manual checklist by anyone.
- **`AGENTS.md`** — agent-facing summaries pointing at CONTRIBUTING and the ADRs as sources of truth (this repo gitignores `CLAUDE.md`, so `AGENTS.md` is the tracked home).

## Notes for reviewers

- These are norms, not code — the ask is team buy-in, and edits/pushback here are the point of the separate PR.
- References ADR-0016, which lands with #2196; the pointer is forward until that merges. Suggested merge order: #2196 first, this second (either order works).
- A companion PR adds a `/review-retro` skill (the retrospective practice itself), also priced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
