### PR TITLE
feat(identity): path-less Reads take identity from their registered normalize_method

### DIFF
--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -13,6 +13,7 @@ from xorq.common.constants import READ_IDENTITY_KEYS
 
 
 if TYPE_CHECKING:
+    from xorq.expr.relations import Read
     from xorq.vendor.ibis import Expr
 
 
@@ -31,9 +32,13 @@ def _lazy_default_key_prefix():
     return options.get("cache.key_prefix")
 
 
-def snapshot_normalize_read(read):
+def snapshot_normalize_read(read: Read) -> tuple:
     """Normalize Read for snapshot caching using path identity only, not file modification stats."""
     read_kwargs = dict(read.read_kwargs)
+    if "hash_path" not in read_kwargs:
+        # path-less Read (e.g. an API-backed source): the registered
+        # normalize_method already yields declarative (stat-free) identity
+        return ("snapshot_normalize_read", read.schema, read.normalize_method(read))
     # Materialized build-bundle reads carry a content-hash-named read_path that is
     # stable across environments. Their hash_path is an absolute tmpdir path that
     # changes every run, so prefer read_path when available.

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -38,7 +38,15 @@ def snapshot_normalize_read(read: Read) -> tuple:
     if "hash_path" not in read_kwargs:
         # path-less Read (e.g. an API-backed source): the registered
         # normalize_method already yields declarative (stat-free) identity
-        return ("snapshot_normalize_read", read.schema, read.normalize_method(read))
+        from xorq.common.utils.dasher._opaque import (  # noqa: PLC0415
+            require_normalize_method,
+        )
+
+        return (
+            "snapshot_normalize_read",
+            read.schema,
+            require_normalize_method(read)(read),
+        )
     # Materialized build-bundle reads carry a content-hash-named read_path that is
     # stable across environments. Their hash_path is an absolute tmpdir path that
     # changes every run, so prefer read_path when available.

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -12,6 +12,7 @@ import contextlib
 import contextvars
 import itertools
 import logging
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 import xxhash
@@ -115,6 +116,23 @@ def _rename_unbound_xorq(op: Node, prefix: str = "static") -> Node:
     return op.replace(rename)
 
 
+def _canonicalize_opaque_part(part: object) -> object:
+    """Map filesystem paths (and paths nested in sequences) to their string
+    form, elementwise; leave everything else alone.
+
+    ``PurePath.__str__`` is defined by the class, so it is address-free and
+    process-stable -- but dasher has no ``PurePath`` normalizer, and read
+    anchors reach ``_stable_opaque_name`` as a ``Path`` or a sequence of them.
+    Converting here keeps them hashable without registering a global rule that
+    would change how paths tokenize everywhere else.
+    """
+    if isinstance(part, PurePath):
+        return str(part)
+    if isinstance(part, (list, tuple)):
+        return tuple(_canonicalize_opaque_part(el) for el in part)
+    return part
+
+
 def _stable_opaque_name(prefix: str, *parts: str | Schema | FrozenOrderedDict) -> str:
     """Build a deterministic placeholder name from xxhash of structural parts.
 
@@ -122,8 +140,23 @@ def _stable_opaque_name(prefix: str, *parts: str | Schema | FrozenOrderedDict) -
     leaf names, which breaks across catalog reloads (different Python object
     identities for semantically-identical Reads). This helper keys on a
     content-stable hash of the supplied parts instead.
+
+    Each part is run through the project's canonical ``tokenize`` rather than
+    ``str``. ``str`` is only process-stable for types that define ``__str__``:
+    for a container (``tuple``, ``dict``, ...) it reprs its members, so a single
+    member whose class inherits the default ``object.__repr__`` embeds a memory
+    address and the placeholder name -- and therefore ``tokenize(expr)``, the
+    build hash, and the build directory name -- silently varies between
+    processes. Tokenizing per part makes any part type safe by construction: a
+    part dasher cannot normalize now raises instead of hashing an address.
     """
-    payload = "|".join(str(p) for p in parts).encode("utf-8")
+    # Lazy: HASHER is constructed in ``__init__`` *after* this module is
+    # imported, so a top-level import here would create a bootstrap cycle.
+    from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
+
+    payload = "|".join(tokenize(_canonicalize_opaque_part(p)) for p in parts).encode(
+        "utf-8"
+    )
     return f"{prefix}-{xxhash.xxh128(payload).hexdigest()[:16]}"
 
 

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -221,7 +221,15 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
         case Read():
             read_kwargs = dict(node.read_kwargs)
             rp = read_kwargs.get("read_path")
-            anchor = rp if rp is not None else read_kwargs["hash_path"]
+            if rp is not None:
+                anchor = rp
+            elif "hash_path" in read_kwargs:
+                anchor = read_kwargs["hash_path"]
+            else:
+                # path-less Read (e.g. an API-backed source): anchor on the
+                # registered normalize_method's identity, mirroring the
+                # path-less branch of _normalize_read_xorq
+                anchor = node.normalize_method(node)
             name = _stable_opaque_name("read", node.schema, anchor)
         case RemoteTable():
             name = _stable_opaque_name(

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -21,7 +21,7 @@ from xorq.common.utils.dasher._canonical import normalize_inmemorytable_canonica
 
 
 if TYPE_CHECKING:
-    from typing import Literal, TypedDict
+    from typing import Callable, Literal, TypedDict
 
     from xorq.vendor.ibis.common.collections import FrozenOrderedDict
     from xorq.vendor.ibis.expr.operations.core import Node
@@ -133,6 +133,25 @@ def _canonicalize_opaque_part(part: object) -> object:
     return part
 
 
+def require_normalize_method(read: Read) -> Callable:
+    """Return ``read.normalize_method``, raising a diagnosable error if unset.
+
+    Shared by every path-less-``Read`` identity site (the xorq Read rule, the
+    snapshot Read normalizer, and the opaque-placeholder rewrite) so they all
+    fail the same explicable way instead of one raising ``ValueError`` and the
+    others a bare ``TypeError`` from calling ``None``. Unreachable through the
+    public constructors -- defense in depth for hand-built ops.
+    """
+    normalize_method = read.normalize_method
+    if normalize_method is None:
+        raise ValueError(
+            f"Read op {getattr(read, 'name', read)!r} has neither a "
+            "hash_path nor a normalize_method; path-less reads must set a "
+            "registered normalize_method"
+        )
+    return normalize_method
+
+
 def _stable_opaque_name(prefix: str, *parts: str | Schema | FrozenOrderedDict) -> str:
     """Build a deterministic placeholder name from xxhash of structural parts.
 
@@ -147,8 +166,7 @@ def _stable_opaque_name(prefix: str, *parts: str | Schema | FrozenOrderedDict) -
     member whose class inherits the default ``object.__repr__`` embeds a memory
     address and the placeholder name -- and therefore ``tokenize(expr)``, the
     build hash, and the build directory name -- silently varies between
-    processes. Tokenizing per part makes any part type safe by construction: a
-    part dasher cannot normalize now raises instead of hashing an address.
+    processes. Tokenizing per part makes any part type safe by construction.
     """
     # Lazy: HASHER is constructed in ``__init__`` *after* this module is
     # imported, so a top-level import here would create a bootstrap cycle.
@@ -262,7 +280,7 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
                 # path-less Read (e.g. an API-backed source): anchor on the
                 # registered normalize_method's identity, mirroring the
                 # path-less branch of _normalize_read_xorq
-                anchor = node.normalize_method(node)
+                anchor = require_normalize_method(node)(node)
             name = _stable_opaque_name("read", node.schema, anchor)
         case RemoteTable():
             name = _stable_opaque_name(

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -271,16 +271,24 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
             )
         case Read():
             read_kwargs = dict(node.read_kwargs)
-            rp = read_kwargs.get("read_path")
-            if rp is not None:
-                anchor = rp
-            elif "hash_path" in read_kwargs:
-                anchor = read_kwargs["hash_path"]
-            else:
+            if "hash_path" not in read_kwargs:
                 # path-less Read (e.g. an API-backed source): anchor on the
                 # registered normalize_method's identity, mirroring the
-                # path-less branch of _normalize_read_xorq
+                # path-less branch of _normalize_read_xorq.
+                #
+                # Tested first, and before read_path, so that all three
+                # path-less identity sites agree on the same predicate. The
+                # other two (_normalize_read_xorq, snapshot_normalize_read)
+                # branch on hash_path absence alone; checking read_path first
+                # here would make a read_path-without-hash_path op anchor
+                # structurally on the path while its data identity came from
+                # the normalize_method. No in-tree producer emits that shape,
+                # so this changes no reachable behavior -- it removes the
+                # divergence before a producer can rely on either reading.
                 anchor = require_normalize_method(node)(node)
+            else:
+                rp = read_kwargs.get("read_path")
+                anchor = rp if rp is not None else read_kwargs["hash_path"]
             name = _stable_opaque_name("read", node.schema, anchor)
         case RemoteTable():
             name = _stable_opaque_name(
@@ -572,9 +580,17 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
     structural_hash = hasher.tokenize(*hash_args)
 
     def _read_name(r: Read) -> str:
+        # A human-facing label for the expr_metadata slot, not identity: it is
+        # computed after structural_hash and feeds only `slots`. A path-less
+        # Read has neither path, so it falls back to method_name -- otherwise
+        # every path-less slot labels as "" and they become indistinguishable
+        # to anyone reading the metadata. method_name is declarative and
+        # stable, unlike the gen_name'd `name`.
         read_kwargs = dict(r.read_kwargs)
         rp = read_kwargs.get("read_path")
-        name = rp if rp is not None else read_kwargs.get("hash_path", "")
+        name = rp if rp is not None else read_kwargs.get("hash_path")
+        if name is None:
+            return str(getattr(r, "method_name", "") or "")
         if isinstance(name, (list, tuple)):
             name = ", ".join(str(p) for p in name) if name else ""
         return str(name)

--- a/python/xorq/common/utils/dasher/_opaque.py
+++ b/python/xorq/common/utils/dasher/_opaque.py
@@ -274,17 +274,8 @@ def _xorq_opaque_to_placeholder(node, _kwargs=None, **_kw):
             if "hash_path" not in read_kwargs:
                 # path-less Read (e.g. an API-backed source): anchor on the
                 # registered normalize_method's identity, mirroring the
-                # path-less branch of _normalize_read_xorq.
-                #
-                # Tested first, and before read_path, so that all three
-                # path-less identity sites agree on the same predicate. The
-                # other two (_normalize_read_xorq, snapshot_normalize_read)
-                # branch on hash_path absence alone; checking read_path first
-                # here would make a read_path-without-hash_path op anchor
-                # structurally on the path while its data identity came from
-                # the normalize_method. No in-tree producer emits that shape,
-                # so this changes no reachable behavior -- it removes the
-                # divergence before a producer can rely on either reading.
+                # path-less branch of _normalize_read_xorq. Checked before
+                # read_path so all three path-less sites share one predicate.
                 anchor = require_normalize_method(node)(node)
             else:
                 rp = read_kwargs.get("read_path")
@@ -580,16 +571,13 @@ def _hash_expr_components(expr: Expr, op: Node) -> tuple[str, list[SlotDict]]:
     structural_hash = hasher.tokenize(*hash_args)
 
     def _read_name(r: Read) -> str:
-        # A human-facing label for the expr_metadata slot, not identity: it is
-        # computed after structural_hash and feeds only `slots`. A path-less
-        # Read has neither path, so it falls back to method_name -- otherwise
-        # every path-less slot labels as "" and they become indistinguishable
-        # to anyone reading the metadata. method_name is declarative and
-        # stable, unlike the gen_name'd `name`.
+        # a label for the expr_metadata slot, not identity: computed after
+        # structural_hash and feeds only `slots`
         read_kwargs = dict(r.read_kwargs)
         rp = read_kwargs.get("read_path")
         name = rp if rp is not None else read_kwargs.get("hash_path")
         if name is None:
+            # path-less Read: no path to label it by
             return str(getattr(r, "method_name", "") or "")
         if isinstance(name, (list, tuple)):
             name = ", ".join(str(p) for p in name) if name else ""

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -62,6 +62,16 @@ def _normalize_read_xorq(read):
     """
 
     read_kwargs = dict(read.read_kwargs)
+    if "hash_path" not in read_kwargs:
+        # path-less Read (e.g. an API-backed source): identity comes entirely
+        # from the registered normalize_method, which receives the op itself
+        if read.normalize_method is None:
+            raise ValueError(
+                f"Read op {getattr(read, 'name', read)!r} has neither a "
+                "hash_path nor a normalize_method; path-less reads must set a "
+                "registered normalize_method"
+            )
+        return ("xorq.Read", read.schema, read.normalize_method(read))
     path = read_kwargs["hash_path"]
     if path is None:
         raise ValueError(

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -25,7 +25,11 @@ from xorq.common.utils.dasher._canonical import (
     normalize_memory_databasetable_canonical,
 )
 from xorq.common.utils.dasher._gap_rules import normalize_ibis_schema
-from xorq.common.utils.dasher._opaque import _MISSING, _rename_unbound_xorq
+from xorq.common.utils.dasher._opaque import (
+    _MISSING,
+    _rename_unbound_xorq,
+    require_normalize_method,
+)
 from xorq.common.utils.dasher._paths import (
     _extract_datafusion_plan_paths,
     _extract_duckdb_file_paths,
@@ -65,13 +69,7 @@ def _normalize_read_xorq(read):
     if "hash_path" not in read_kwargs:
         # path-less Read (e.g. an API-backed source): identity comes entirely
         # from the registered normalize_method, which receives the op itself
-        if read.normalize_method is None:
-            raise ValueError(
-                f"Read op {getattr(read, 'name', read)!r} has neither a "
-                "hash_path nor a normalize_method; path-less reads must set a "
-                "registered normalize_method"
-            )
-        return ("xorq.Read", read.schema, read.normalize_method(read))
+        return ("xorq.Read", read.schema, require_normalize_method(read)(read))
     path = read_kwargs["hash_path"]
     if path is None:
         raise ValueError(

--- a/python/xorq/common/utils/file_utils.py
+++ b/python/xorq/common/utils/file_utils.py
@@ -106,6 +106,15 @@ def normalize_read_source_identity(read: Read) -> tuple[tuple[str, object], ...]
     profile's content hash plus the read's declarative kwargs. `table_name`
     is excluded (gen_name'd, unstable across constructions) and the profile
     idx suffix is excluded (session-global, unstable across sessions).
+
+    The two contributions are returned *framed* --
+    ``(("parts", ...), ("kwargs", ...))`` -- rather than flat-concatenated.
+    Flat concatenation is not injective: a source contributing
+    ``(("resource", "things"),)`` via ``read_identity_parts`` with no kwargs
+    tokenizes identically to a read contributing no parts but carrying a
+    ``resource="things"`` kwarg -- two semantically different reads, one
+    identity. Framing keeps the encoding injective. This tuple shape is an
+    append-only identity contract.
     """
     import toolz  # noqa: PLC0415
 
@@ -130,6 +139,9 @@ def normalize_read_source_identity(read: Read) -> tuple[tuple[str, object], ...]
     if read_identity_parts is not None:
         parts += tuple(read_identity_parts(read))
     return (
-        *parts,
-        *sorted((k, v) for k, v in read.read_kwargs if k != "table_name"),
+        ("parts", parts),
+        (
+            "kwargs",
+            tuple(sorted((k, v) for k, v in read.read_kwargs if k != "table_name")),
+        ),
     )

--- a/python/xorq/common/utils/file_utils.py
+++ b/python/xorq/common/utils/file_utils.py
@@ -5,8 +5,12 @@ import hashlib
 import itertools
 from contextlib import closing
 from pathlib import Path
-from typing import IO, Callable
+from typing import IO, TYPE_CHECKING, Callable
 from zipfile import ZipExtFile
+
+
+if TYPE_CHECKING:
+    from xorq.expr.relations import Read
 
 
 def _manual_file_digest(
@@ -91,4 +95,41 @@ def normalize_read_path_stat(path: Path) -> tuple[tuple[str, object], ...]:
             "st_size",
             "st_ino",
         )
+    )
+
+
+def normalize_read_source_identity(read: Read) -> tuple[tuple[str, object], ...]:
+    """Identity for path-less Read ops (e.g. API-backed sources).
+
+    Unlike the path normalizers (which receive a path and hash file
+    content/stat), this receives the Read op itself: identity is the source
+    profile's content hash plus the read's declarative kwargs. `table_name`
+    is excluded (gen_name'd, unstable across constructions) and the profile
+    idx suffix is excluded (session-global, unstable across sessions).
+    """
+    import toolz  # noqa: PLC0415
+
+    from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
+
+    profile = getattr(read.source, "_profile", None)
+    if profile is None:
+        raise ValueError(
+            f"Read op {getattr(read, 'name', read)!r} has a source without a "
+            "profile; normalize_read_source_identity requires one"
+        )
+    profile_content_hash = tokenize(toolz.dissoc(profile.as_dict(), "idx"))
+    parts = (
+        ("profile", profile_content_hash),
+        ("method_name", read.method_name),
+    )
+    # a source may contribute identity of its own (RestBackend folds the
+    # per-resource config content hash so editing a resource's declarative
+    # config changes identity, ADR-0015, without invalidating siblings);
+    # delegation keeps backend-specific knowledge out of this normalizer
+    read_identity_parts = getattr(read.source, "read_identity_parts", None)
+    if read_identity_parts is not None:
+        parts += tuple(read_identity_parts(read))
+    return (
+        *parts,
+        *sorted((k, v) for k, v in read.read_kwargs if k != "table_name"),
     )

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -371,9 +371,16 @@ def _sanitize_generated_names(expr, normalize_method):
                 )
         else:
             if prefix := get_uid_prefix(node.name):
+                # relocatable reads keep their md5sum method; path-less reads
+                # (no hash_path, e.g. API-backed) keep their registered
+                # source-identity method -- the dumper-wide default is a
+                # path normalizer and cannot apply to them
                 read_nm = (
                     node.normalize_method
-                    if _is_relocatable_read(node)
+                    if (
+                        _is_relocatable_read(node)
+                        or "hash_path" not in dict(node.read_kwargs)
+                    )
                     else normalize_method
                 )
                 table_name = f"{prefix}{tokenize(recreate(node, name='name', normalize_method=read_nm).to_expr())}"

--- a/python/xorq/ibis_yaml/normalize_registry.py
+++ b/python/xorq/ibis_yaml/normalize_registry.py
@@ -28,6 +28,7 @@ from xorq.common.exceptions import NormalizeMethodError
 from xorq.common.utils.file_utils import (
     normalize_read_path_md5sum,
     normalize_read_path_stat,
+    normalize_read_source_identity,
 )
 
 
@@ -36,6 +37,7 @@ from xorq.common.utils.file_utils import (
 _NORMALIZE_RULES: tuple[tuple[str, object], ...] = (
     ("read_path_stat", normalize_read_path_stat),
     ("read_path_md5sum", normalize_read_path_md5sum),
+    ("read_source_identity", normalize_read_source_identity),
 )
 _KEY_TO_FN = dict(_NORMALIZE_RULES)
 _FN_TO_KEY = {fn: key for key, fn in _NORMALIZE_RULES}

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_and_relocatability/expected.json
@@ -1,6 +1,6 @@
 {
-  "build_dir_name": "00c36ffbdac0",
-  "expr.yaml": "0476a75f1b20c040c4625105c10f6f93",
-  "expr_metadata.json": "812287881c6d729034da6c6339590282",
+  "build_dir_name": "9bf634f73ecc",
+  "expr.yaml": "538d4b8471de430bd48f64e6b2096376",
+  "expr_metadata.json": "beed2ea4a797f85023134d0456b3d8fc",
   "profiles.yaml": "d88bdf2a30340b985c7002eead003f87"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_https/expected.json
@@ -4,8 +4,8 @@
   "8907ecd78b8c.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "1569fa2c7c9f512176a545e521dd79f6",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
-  "expr.yaml": "1f2feefe679834bdf31db4038900e4b8",
-  "expr_metadata.json": "3728e0d0543ee554b636dfea0b54d2e3",
+  "expr.yaml": "be336d299e967a1e106e345e1448d6fa",
+  "expr_metadata.json": "46fbf25d5878960a03c1627da14531e4",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_build_file_stability_local/expected.json
@@ -4,8 +4,8 @@
   "8907ecd78b8c.sql": "677d396e365f6dcbda3f20b588d6a064",
   "deferred_reads.yaml": "d2ba95a6587082eb55386c11f201e398",
   "e6d6f8dab204.sql": "0a5e02a1eb1b6acd8dac809e7105f589",
-  "expr.yaml": "5a037e3af6cacd794609a74ec29d9985",
-  "expr_metadata.json": "e366873b55dcfe2ae044f9026adba614",
+  "expr.yaml": "00a8f02682efb53e5e33c85c25d19581",
+  "expr_metadata.json": "d0d0bb71af65b4f94f58163f91a11588",
   "profiles.yaml": "17fc1971c64868c859c88207090cf5d3",
   "sql.yaml": "b086acedcd1eb44dff4c84f47aac3756"
 }

--- a/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_parquet/parquet-build-name.txt
+++ b/python/xorq/ibis_yaml/tests/snapshots/test_compiler/test_generated_name_sanitization_parquet/parquet-build-name.txt
@@ -1,1 +1,1 @@
-ibis_xorq-read_parquet_647ce9c0bb5be379014294e3f713ef4a
+ibis_xorq-read_parquet_9d2b1603eccedc91c71bf1b2a27dfae2

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -979,11 +979,14 @@ def test_uv_build_with_extra(tmpdir):
     assert build_path.exists()
 
 
+# Snapshot-strategy expr hashes of nodes in the pipeline_https fixture build.
+# These are hand-maintained literals, not pytest-snapshot files: --snapshot-update
+# does not reach them, so any change moving expr hashes has to update them here.
 serve_hashes = (
-    "c0480036de329f7d90bd9ebda3b58fc6",  # batting, rel.Read
-    "9f91abf3ff66d64d441724f71cab534e",  # awards_players, rel.Read
-    "3ce4de9ff26d12bbd0159061325af767",  # left, ops.Filter
-    "dd76e5abc15dc283090fa73338c1ecf3",  # right, ops.DropColumns
+    "74cb251c1f21ee5582635555511b89de",  # batting, rel.Read
+    "d906ac84789bfcc55348cc308123f7c6",  # awards_players, rel.Read
+    "87cf59fbf985ecbc80127ffdc47884b9",  # left, ops.Filter
+    "c0fb27e82cb99ea21d17642a7758674b",  # right, ops.DropColumns
 )
 
 
@@ -1052,8 +1055,8 @@ def hit_server(port, expr):
 @pytest.mark.parametrize("serve_hash", serve_hashes)
 def test_serve_unbound_hash(serve_hash, pipeline_https_build):
     lookup = {
-        "dd76e5abc15dc283090fa73338c1ecf3": "xorq.vendor.ibis.expr.operations.DropColumns",
-        "3ce4de9ff26d12bbd0159061325af767": "xorq.vendor.ibis.expr.operations.Filter",
+        "c0fb27e82cb99ea21d17642a7758674b": "xorq.vendor.ibis.expr.operations.DropColumns",
+        "87cf59fbf985ecbc80127ffdc47884b9": "xorq.vendor.ibis.expr.operations.Filter",
     }
     expr = load_expr(pipeline_https_build)
     typ = lookup.get(serve_hash)
@@ -1211,7 +1214,8 @@ def test_serve_penguins_template(tmpdir, tmp_path):
     assert returncode == 0, stderr
 
     if match := re.search(f"{target_dir}/([0-9a-f]+)", stdout.decode("ascii")):
-        serve_hash = "5ee5e0d98754937a205e8be7e0728bb7"  # CachedNode (test split)
+        # see serve_hashes above: a hand-maintained literal, not a snapshot
+        serve_hash = "f6bac73b04c52568518121e950435371"  # CachedNode (test split)
 
         serve_args = (
             "xorq",

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -979,9 +979,8 @@ def test_uv_build_with_extra(tmpdir):
     assert build_path.exists()
 
 
-# Snapshot-strategy expr hashes of nodes in the pipeline_https fixture build.
-# These are hand-maintained literals, not pytest-snapshot files: --snapshot-update
-# does not reach them, so any change moving expr hashes has to update them here.
+# hand-maintained expr hashes from the pipeline_https build -- not
+# pytest-snapshot files, so --snapshot-update does not reach them
 serve_hashes = (
     "74cb251c1f21ee5582635555511b89de",  # batting, rel.Read
     "d906ac84789bfcc55348cc308123f7c6",  # awards_players, rel.Read

--- a/python/xorq/tests/test_pathless_read_identity.py
+++ b/python/xorq/tests/test_pathless_read_identity.py
@@ -1,0 +1,83 @@
+"""Path-less Read ops (no ``hash_path``) take identity from a registered
+normalize_method instead of a file path.
+
+This is the core enabler for API-backed sources (backends whose resources
+are Read ops with no filesystem anchor): tokenize, snapshot caching, and
+build canonicalization must all accept a Read whose identity is
+``normalize_read_source_identity`` — the source profile's content hash,
+the source's optional ``read_identity_parts`` contribution, and the
+declarative read kwargs.
+"""
+
+from __future__ import annotations
+
+import xorq.api as xo
+from xorq.caching.strategy import snapshot_normalize_read
+from xorq.common.utils.dasher import tokenize
+from xorq.common.utils.file_utils import normalize_read_source_identity
+from xorq.expr.relations import Read
+from xorq.ibis_yaml.normalize_registry import (
+    serialize_normalize_method,
+    validate,
+)
+
+
+schema = xo.schema({"a": "int64"})
+
+
+def make_read(
+    con: object,
+    read_kwargs: tuple = (("resource", "things"),),
+    normalize_method: object = normalize_read_source_identity,
+    name: str = "t",
+) -> object:
+    kwargs = {} if normalize_method is None else {"normalize_method": normalize_method}
+    return Read(
+        method_name="fetch_resource",
+        name=name,
+        schema=schema,
+        source=con,
+        read_kwargs=read_kwargs,
+        **kwargs,
+    ).to_expr()
+
+
+def test_registered_by_name() -> None:
+    validate(normalize_read_source_identity)
+    assert serialize_normalize_method(normalize_read_source_identity) == {
+        "kind": "named",
+        "name": "read_source_identity",
+    }
+
+
+def test_tokenize_is_declarative() -> None:
+    (one, two) = (make_read(xo.connect()) for _ in range(2))
+    # same profile content, same kwargs -> same identity, across connections
+    assert tokenize(one) == tokenize(two)
+    # the gen_name'd op name is excluded from identity
+    assert tokenize(make_read(xo.connect(), name="other")) == tokenize(one)
+    # declarative kwargs are identity
+    changed = make_read(xo.connect(), read_kwargs=(("resource", "other"),))
+    assert tokenize(changed) != tokenize(one)
+
+
+def test_source_contributes_identity_parts() -> None:
+    (con_one, con_two) = (xo.connect() for _ in range(2))
+    con_one.read_identity_parts = lambda read: (("config", "hash-one"),)
+    con_two.read_identity_parts = lambda read: (("config", "hash-two"),)
+    assert tokenize(make_read(con_one)) != tokenize(make_read(con_two))
+    con_two.read_identity_parts = lambda read: (("config", "hash-one"),)
+    assert tokenize(make_read(con_one)) == tokenize(make_read(con_two))
+
+
+def test_snapshot_strategy_accepts_pathless_read() -> None:
+    expr = make_read(xo.connect())
+    normalized = snapshot_normalize_read(expr.op())
+    assert normalized[0] == "snapshot_normalize_read"
+    # stat-free: identical construction normalizes identically
+    assert normalized == snapshot_normalize_read(make_read(xo.connect()).op())
+
+
+# NB: the dasher loud-guard for a path-less Read with normalize_method=None
+# is defense-in-depth only: the Read op's Callable annotation rejects None at
+# construction, so the state is unreachable through the public constructor.

--- a/python/xorq/tests/test_pathless_read_identity.py
+++ b/python/xorq/tests/test_pathless_read_identity.py
@@ -126,6 +126,25 @@ def test_identity_is_stable_across_processes(
     assert run("0") == run("12345")
 
 
+def test_kwargs_and_parts_do_not_alias() -> None:
+    """The identity encoding must be injective across its two groups.
+
+    Flat ``(*parts, *sorted(kwargs))`` concatenation is not: a source
+    contributing ``(("resource", "things"),)`` via ``read_identity_parts`` with
+    no kwargs would tokenize identically to a read contributing no parts but
+    carrying ``resource="things"`` as a kwarg.
+    """
+    con_kwarg = xo.connect()
+    con_parts = xo.connect()
+    con_parts.read_identity_parts = lambda read: (("resource", "things"),)
+    from_kwarg = make_read(con_kwarg, read_kwargs=(("resource", "things"),))
+    from_parts = make_read(con_parts, read_kwargs=())
+    assert normalize_read_source_identity(
+        from_kwarg.op()
+    ) != normalize_read_source_identity(from_parts.op())
+    assert tokenize(from_kwarg) != tokenize(from_parts)
+
+
 def test_snapshot_strategy_accepts_pathless_read() -> None:
     expr = make_read(xo.connect())
     normalized = snapshot_normalize_read(expr.op())

--- a/python/xorq/tests/test_pathless_read_identity.py
+++ b/python/xorq/tests/test_pathless_read_identity.py
@@ -11,6 +11,11 @@ declarative read kwargs.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
+import pytest
+
 import xorq.api as xo
 from xorq.caching.strategy import snapshot_normalize_read
 from xorq.common.utils.dasher import tokenize
@@ -68,6 +73,57 @@ def test_source_contributes_identity_parts() -> None:
     assert tokenize(make_read(con_one)) != tokenize(make_read(con_two))
     con_two.read_identity_parts = lambda read: (("config", "hash-one"),)
     assert tokenize(make_read(con_one)) == tokenize(make_read(con_two))
+
+
+class Cursor:
+    """Tokenizable, but inherits the default ``object.__repr__``, so ``str()``
+    of any container holding one embeds a memory address."""
+
+    def __init__(self, page: int) -> None:
+        self.page = page
+
+    def __dasher_tokenize__(self) -> tuple:
+        return ("Cursor", self.page)
+
+
+_CROSS_PROCESS_SCRIPT = """
+import xorq.api as xo
+from xorq.common.utils.dasher import tokenize
+from xorq.common.utils.graph_utils import replace_nodes
+from xorq.common.utils.dasher._opaque import _xorq_opaque_to_placeholder
+from xorq.tests.test_pathless_read_identity import Cursor, make_read
+
+expr = make_read(xo.connect(), read_kwargs=(("cursor", Cursor(7)),))
+print(replace_nodes(_xorq_opaque_to_placeholder, expr.op()).name)
+print(tokenize(expr))
+"""
+
+
+def test_identity_is_stable_across_processes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opaque placeholder name and the expression token must not vary
+    between interpreters.
+
+    ``_stable_opaque_name`` used to ``str()`` each part; for the path-less
+    anchor (a nested tuple) that reprs its members, so a member with the
+    default ``__repr__`` leaked a memory address into the placeholder name and
+    the build hash -- silent permanent cache misses and unstable build
+    directory names, with no error raised. Two subprocesses with different
+    ``PYTHONHASHSEED`` values pin that down.
+    """
+
+    def run(seed: str) -> str:
+        monkeypatch.setenv("PYTHONHASHSEED", seed)
+        proc = subprocess.run(
+            [sys.executable, "-c", _CROSS_PROCESS_SCRIPT],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, proc.stderr
+        return proc.stdout
+
+    assert run("0") == run("12345")
 
 
 def test_snapshot_strategy_accepts_pathless_read() -> None:


### PR DESCRIPTION
Entry 1 of a 4-entry landing stack for the REST-backend workstream. This one is
the core identity enabler; the backend that consumes it lands two entries later.

## ⚠️ This moves every build hash

`_stable_opaque_name` now tokenizes each part instead of `str()`-ing it, which
changes every opaque placeholder name — and therefore `tokenize(expr)`, build
hashes, and build directory names — for **existing** reads, not just path-less
ones. Existing build caches are invalidated. **The next entry in the stack
(declarative identity registry) moves them again**, folding a rule-set
fingerprint into `get_expr_hash`; the double touch is deliberate, so that each
entry is green at its own head.

## What it does

A `Read` op with no filesystem anchor (`hash_path` absent from `read_kwargs`)
takes its identity from its registered `normalize_method` instead of from a
path. Four identity sites learn the path-less branch — the dasher Read rule,
the snapshot-cache Read normalizer, the opaque-placeholder rewrite, and the
build-name sanitizer — and `read_source_identity` joins the normalize registry.

Three fixes came out of getting that right, and two of them are live for reads
that exist today:

- **`_stable_opaque_name` built its payload with `str(p)`.** `str` is only
  process-stable for types that define `__str__`; for a container it reprs its
  members, so one member whose class inherits `object.__repr__` embeds a memory
  address. The placeholder name — and with it the build hash and the build
  directory name — varied between processes: permanent cache misses and unstable
  build dirs, **with no error raised at all**. Now each part goes through the
  project's canonical `tokenize`, which makes any part type safe by
  construction. (`PurePath` is canonicalized to `str` first, elementwise,
  because dasher has no `PurePath` rule and `PurePath.__str__` is class-defined
  and therefore address-free.)
- **`normalize_read_source_identity` returned a flat `(*parts, *sorted(kwargs))`.**
  Flat concatenation is not injective across the two groups: a source
  contributing `(("resource", "things"),)` via `read_identity_parts` with no
  kwargs tokenized identically to a read contributing no parts but carrying
  `resource="things"` as a kwarg — two semantically different reads, one
  identity. The groups are now framed as `(("parts", …), ("kwargs", …))`. This
  tuple shape is an append-only identity contract, so it had to be right before
  it is locked in.
- **One diagnosable guard** (`require_normalize_method`) shared by all
  path-less identity sites, so a `normalize_method`-less Read fails the same
  explicable way everywhere instead of raising `ValueError` at one site and a
  bare `TypeError` from calling `None` at the others. Defense in depth — the
  `Read` op's `Callable` annotation rejects `None` at construction, so the state
  is unreachable through the public constructor.

## The four regenerated goldens

All regenerated with `pytest --snapshot-update`, none by hand.

| golden | what moved |
|---|---|
| `test_build_file_stability_local` | `expr.yaml` `5a037e3a…` → `00a8f026…`; `expr_metadata.json` `e366873b…` → `d0d0bb71…` |
| `test_build_file_stability_https` | `expr.yaml` `1f2feefe…` → `be336d29…`; `expr_metadata.json` `3728e0d0…` → `46fbf25d…` |
| `test_build_file_stability_and_relocatability` | both files, **plus `build_dir_name` `00c36ffbdac0` → `9bf634f73ecc`** — this fixture's read carries no explicit `table_name`, so the generated placeholder reaches the expr hash and the directory name moves too |
| `test_generated_name_sanitization_parquet` | generated read name `ibis_xorq-read_parquet_647ce9c0…` → `…9d2b1603…` |

**What did NOT move, checked field by field:** every `<hash>.sql` filename
(`tokenize(sql)[:12]`) and its md5, `sql.yaml`, `deferred_reads.yaml` and
`profiles.yaml` are byte-identical. The https/local reads carry explicit
user-given `table_name`s, so the placeholder never reaches the emitted SQL;
read serialization and profile serialization are untouched. Inside `expr.yaml`
and `expr_metadata.json` only hash-derived identifiers changed — node keys,
`node_refs`, `snapshot_hash`, the `RemoteTable` table hash, and the snapshot
cache key. Structural fields (`method_name`, `read_kwargs`, `normalize_method`,
`schema_ref`, `profile`) are unchanged.

Two goldens that could plausibly have moved and correctly did not:
`test_generated_name_sanitization_memtable` names itself from a memtable content
hash rather than a read name, and `test_artifact_store_expr_hash`'s fixture is a
bare `ibis.table` with no `Read`, so `_stable_opaque_name` is called zero times
for it.

## Verification

Core suite (`-m core --ignore=python/xorq/catalog -k 'not script_execution and not slow'`)
at this head: **14 failed / 2706 passed / 39 skipped / 16 xfailed / 12 xpassed**.
The 14 are exactly the failure set present on `main` — 7× `expr/ml/tests/test_split_lib.py`,
2× `ibis_yaml/tests/test_sql.py`, 4× `tests/test_cli.py`, and
`test_profile.py::test_connection_with_env_vars_preserves_env_vars` (needs a
local postgres). Nothing beyond.

## Review note

The path-less branches added here have no in-tree producer until the REST
backend lands two entries later; `test_pathless_read_identity.py` exercises them
by constructing the op directly. The scaffolding is deliberately ahead of its
consumer so that the identity contract is reviewable on its own, separately from
~3,000 lines of backend. The `_stable_opaque_name` and injectivity fixes are the
half that is live on `main` immediately.

An earlier structural review covered an older shape of this branch, before the
streaming seam was removed; the current five commits are being reviewed
independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsWNHN92Jrq3AykZkNw2sx
