### PR TITLE
fix(adr): report an allowlist entry that has done its job

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,7 @@ Start from [template.md](template.md).
 
 A new ADR takes the number of the pull request that adds it. GitHub allocates pull request numbers, so two branches can't claim the same ADR number and you never have to check which number is free.
 
-ADR-0002 through ADR-0017 predate this rule and keep their sequential numbers permanently. Around fifty comments across `python/xorq` cite them by number, so renumbering would either break those citations or require a risky sweep of them. Pull request numbers are already far above 1000, so the two ranges can't collide. A small allowlist in `scripts/adr_check.py` covers the legacy-numbered ADRs that were still in flight when this rule landed; it only shrinks.
+ADR-0002 through ADR-0017 predate this rule and keep their sequential numbers permanently. Around fifty comments across `python/xorq` cite them by number, so renumbering would either break those citations or require a risky sweep of them. Pull request numbers are already far above 1000, so the two ranges can't collide. A small allowlist in `scripts/adr_check.py` covers the legacy-numbered ADRs that were still in flight when this rule landed; it only shrinks. An entry can't be removed by the pull request that lands its ADR — CI reads the merged code, so the entry has to still be there for the file to be allowed — so the cleanup is a follow-up, and the guard warns on every run until it happens.
 
 Numbers are sparse and non-consecutive under this rule. That's the trade: the number tells you which pull request introduced the decision rather than how many decisions came before it. For chronology, use `git log docs/adr/`.
 

--- a/scripts/adr_check.py
+++ b/scripts/adr_check.py
@@ -40,15 +40,20 @@ PR_NUMBER_FLOOR = 1000
 # Legacy-numbered ADRs still in flight on branches that were opened before the
 # PR-number scheme landed, as {number: slug}. Each entry exempts exactly one
 # file -- the number alone is not enough, or the entry becomes a general licence
-# to add any ADR at that number. Delete an entry once its branch merges. This
-# mapping must only ever shrink.
+# to add any ADR at that number.
+#
+# This mapping must only ever shrink, and `check_allowlist` is what makes that
+# more than a wish: once an entry's ADR is in the tree, the entry has done its
+# job and is reported until someone deletes it. The deletion is always a
+# follow-up, never part of the pull request that lands the ADR -- CI reads the
+# merged code, so an entry removed there would reject the file it was
+# protecting.
 #
 # Numbers are NOT held here for ADRs that do not exist yet. Reserving a number
 # ahead of the file is the coordination this scheme exists to remove; an ADR
 # still being written takes the number of the pull request that adds it, and is
 # cited by slug until then.
 LEGACY_IN_FLIGHT = {
-    1: "git-annex-over-git-lfs",  # origin/perf/catalog/use-git-annex
     18: "content-store-capability-and-binding",  # hosted-presigned-catalogs-fixes
     20: "engine-behavior-as-immutable-identity-folded-spec",  # PR #2200
     21: "engine-construction-is-two-level-identityspec-feeds-enginebuilder",  # PR #2200
@@ -117,8 +122,9 @@ class Problems:
     def warn(self, path: Path | str, message: str) -> None:
         """Report without failing the run.
 
-        Used for named references that do not resolve, which are legitimate
-        while the ADR they name is still on an unlanded branch.
+        For things that are legitimate now and wrong later: a named reference
+        whose ADR is still on an unlanded branch, or an allowlist entry whose
+        ADR has landed and which someone else has to delete.
         """
         self.warnings += 1
         self._emit("warning", path, message)
@@ -368,6 +374,39 @@ def is_allowlisted(path: Path) -> bool:
     return number is not None and LEGACY_IN_FLIGHT.get(number) == slug
 
 
+def check_allowlist(problems: Problems, added: list[Path] | None) -> None:
+    """Report allowlist entries that have done their job.
+
+    An entry exists to let one legacy-numbered ADR land from a branch that
+    predates this scheme. Once that file is in the tree and this run is not the
+    one adding it, the exemption is spent -- and a spent entry is a standing
+    licence for anyone to claim that number, which is the thing the scheme
+    exists to prevent.
+
+    It cannot be deleted by the pull request that lands the ADR: CI reads the
+    merged code, so the entry has to still be there for `check_added` to allow
+    the file, and removing it in the same pull request rejects the very ADR it
+    was protecting. The cleanup is therefore always a follow-up -- and the
+    comment on LEGACY_IN_FLIGHT saying the list "must only ever shrink" names
+    no one and nothing enforced it. This is that enforcement.
+
+    A warning rather than an error, because the entry belongs to whoever landed
+    the ADR and an unrelated pull request should not be blocked by it. It
+    reappears on every run until someone deletes it.
+    """
+    being_added = {path.name for path in added or ()}
+    for number, slug in sorted(LEGACY_IN_FLIGHT.items()):
+        path = ADR_DIR / f"{number:04d}-{slug}.md"
+        if path.name in being_added or not path.exists():
+            continue
+        problems.warn(
+            path,
+            f"has landed, so the LEGACY_IN_FLIGHT entry for {number:04d} in "
+            "scripts/adr_check.py has done its job and should be deleted. "
+            "Until it is, anyone can add an ADR at that number",
+        )
+
+
 def check_added(problems: Problems, added: list[Path], pr: int | None) -> None:
     # A batch of allowlisted legacy ADRs is exempt from one-per-pull-request:
     # those branches predate the scheme and their files were already written
@@ -453,16 +492,21 @@ def main() -> int:
 
     problems = Problems(github=args.format == "github")
     check_directory(problems)
+    added = None
     if args.base:
         added = added_adrs(args.base)
         if added is None:
             return 2
         check_added(problems, added, args.pr)
+    # Last, and with `added` in hand: an allowlist entry is only spent if this
+    # run is not the one using it.
+    check_allowlist(problems, added)
 
     if problems.warnings:
         sys.stderr.write(
-            f"\n{problems.warnings} unresolved named reference(s). Not a "
-            "failure: an ADR named by slug may still be on an unlanded branch.\n"
+            f"\n{problems.warnings} warning(s), which do not fail the run. A "
+            "named reference resolves once its ADR lands; a spent allowlist "
+            "entry needs deleting.\n"
         )
     if problems.count:
         sys.stderr.write(

--- a/scripts/adr_check.py
+++ b/scripts/adr_check.py
@@ -379,9 +379,16 @@ def check_allowlist(problems: Problems, added: list[Path] | None) -> None:
 
     An entry exists to let one legacy-numbered ADR land from a branch that
     predates this scheme. Once that file is in the tree and this run is not the
-    one adding it, the exemption is spent -- and a spent entry is a standing
-    licence for anyone to claim that number, which is the thing the scheme
-    exists to prevent.
+    one adding it, the exemption is spent.
+
+    A spent entry is not a licence to claim that number: while the ADR is
+    present, anything else at that number fails on the duplicate check, and
+    `is_allowlisted` matches the slug too, so the exemption only ever covered
+    one filename. The risk is that it outlives the file. Delete or renumber
+    that ADR and the entry silently readmits its exact filename carrying any
+    content at all -- and this check cannot warn about that, because it keys
+    on the file being present. Which is the argument for clearing entries
+    while they are still merely redundant.
 
     It cannot be deleted by the pull request that lands the ADR: CI reads the
     merged code, so the entry has to still be there for `check_added` to allow
@@ -402,8 +409,10 @@ def check_allowlist(problems: Problems, added: list[Path] | None) -> None:
         problems.warn(
             path,
             f"has landed, so the LEGACY_IN_FLIGHT entry for {number:04d} in "
-            "scripts/adr_check.py has done its job and should be deleted. "
-            "Until it is, anyone can add an ADR at that number",
+            "scripts/adr_check.py has done its job and should be deleted. It "
+            "now exempts a file that is already here, and if this ADR is ever "
+            "deleted or renumbered it would let that exact filename back in "
+            "unchecked, carrying anything",
         )
 
 

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -361,6 +361,34 @@ def test_allowlisted_legacy_adr_passes(tree: ADRTree) -> None:
     tree.commit_all()
     result = tree.check("--base", "HEAD~1", "--pr", "2211")
     assert result.returncode == 0, result.stderr
+    # The entry is in use, not spent: this run is the one adding the file.
+    assert "has done its job" not in result.stderr
+
+
+def test_an_allowlist_entry_is_reported_once_its_adr_has_landed(
+    tree: ADRTree,
+) -> None:
+    """The entry cannot be deleted by the pull request that lands the ADR.
+
+    CI reads the merged code, so removing it there rejects the very file it
+    was protecting -- the cleanup is always a follow-up, and a follow-up
+    nobody is reminded of is one that does not happen. A spent entry is a
+    standing licence to claim that number.
+    """
+    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
+    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
+    result = tree.check()
+    assert "has done its job" in result.stderr
+    # A warning: the entry belongs to whoever landed the ADR, and someone
+    # else's pull request should not be blocked by it.
+    assert result.returncode == 0, result.stderr
+
+
+def test_an_allowlist_entry_whose_adr_is_absent_is_not_reported(
+    tree: ADRTree,
+) -> None:
+    """The ordinary state of an entry: its branch has not landed yet."""
+    assert "has done its job" not in tree.check().stderr
 
 
 def test_allowlisted_number_with_a_different_slug_is_rejected(tree: ADRTree) -> None:

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -372,8 +372,9 @@ def test_an_allowlist_entry_is_reported_once_its_adr_has_landed(
 
     CI reads the merged code, so removing it there rejects the very file it
     was protecting -- the cleanup is always a follow-up, and a follow-up
-    nobody is reminded of is one that does not happen. A spent entry is a
-    standing licence to claim that number.
+    nobody is reminded of is one that does not happen. What makes it worth
+    reminding about is that the exemption outlives the file: see
+    `test_a_spent_entry_readmits_its_filename_once_the_adr_is_gone`.
     """
     number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
     tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
@@ -389,6 +390,54 @@ def test_an_allowlist_entry_whose_adr_is_absent_is_not_reported(
 ) -> None:
     """The ordinary state of an entry: its branch has not landed yet."""
     assert "has done its job" not in tree.check().stderr
+
+
+def test_a_spent_entry_is_reported_on_an_unrelated_pull_request(
+    tree: ADRTree,
+) -> None:
+    """The shape every pull request sees after the ADR lands.
+
+    The push-to-main run reports it once; this is the nag that keeps arriving
+    until someone acts, and it runs through the `--base` path rather than the
+    directory-only one.
+    """
+    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
+    tree.init_repo()
+    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
+    tree.commit_all()
+    tree.write("2222-unrelated.md", "# ADR-2222: Unrelated\n\nBody.\n")
+    tree.commit_all()
+    result = tree.check("--base", "HEAD~1", "--pr", "2222")
+    assert "has done its job" in result.stderr
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_spent_entry_readmits_its_filename_once_the_adr_is_gone(
+    tree: ADRTree,
+) -> None:
+    """Why a spent entry is worth deleting, and why the warning cannot wait.
+
+    While the ADR is present the entry is merely redundant: anything else at
+    that number fails the duplicate check. Delete the ADR and the entry
+    readmits its exact filename carrying anything -- and by then this check is
+    silent, because it keys on the file being present. The warning exists to
+    be acted on while the entry is still harmless.
+    """
+    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
+    tree.init_repo()
+    # The ADR landed and was later removed, so nothing warns any more.
+    assert "has done its job" not in tree.check().stderr
+
+    tree.write(
+        f"{number:04d}-{slug}.md",
+        f"# ADR-{number:04d}: Nothing to do with the original\n\nAnything.\n",
+    )
+    tree.commit_all()
+    result = tree.check("--base", "HEAD~1", "--pr", "2222")
+    assert result.returncode == 0, result.stderr
+    # Silent in the one state where the entry is doing harm: the file is being
+    # added, so there is nothing for check_allowlist to find.
+    assert "has done its job" not in result.stderr
 
 
 def test_allowlisted_number_with_a_different_slug_is_rejected(tree: ADRTree) -> None:


### PR DESCRIPTION
`LEGACY_IN_FLIGHT` in `scripts/adr_check.py` says it "must only ever shrink". It names nobody, and nothing detected a violation.

**The cleanup can't be left to remembering**, because it can never be atomic with the merge that makes it necessary. CI reads the merged code, so a pull request that lands an allowlisted ADR *and* removes its entry fails on the ADR it was protecting:

```
docs/adr/0020-….md: new ADRs take the number of the pull request that adds
them, which is at least 1000. Numbers below that are frozen legacy ADRs.
rc=1
```

So the deletion is always a follow-up, and a follow-up nobody is reminded of does not happen.

## What this does

The guard reports an entry whose ADR is in the tree when this run is not the one adding it. On the landing pull request the file is in `added`, so nothing fires; on every run afterwards it does.

Verified against the current allowlist — simulating #2200's three ADRs landing produces exactly three warnings and leaves the run green:

```
docs/adr/0020-engine-behavior-as-immutable-identity-folded-spec.md: warning:
has landed, so the LEGACY_IN_FLIGHT entry for 0020 in scripts/adr_check.py has
done its job and should be deleted. It now exempts a file that is already here,
and if this ADR is ever deleted or renumbered it would let that exact filename
back in unchecked, carrying anything
rc=0
```

A **warning, not an error**: the entry belongs to whoever landed the ADR, and an unrelated contributor's pull request should not be blocked by it. It reappears on every run until someone deletes it.

## What a spent entry actually risks

Worth being precise, because the first version of this warning was not. A spent entry is **not** a licence for anyone to claim that number — while the ADR is present, a second file at that number fails on both the duplicate-number check and the slug mismatch, since `is_allowlisted` matches number *and* slug and never exempted more than one filename.

The risk is that the exemption outlives the file. Delete or renumber that ADR and the entry readmits its exact filename carrying any content at all — and by then this check is silent, because it keys on the file being present. Verified: 0 warnings, and the re-add passes `rc=0`. That is the argument for clearing an entry while it is still merely redundant.

## Also

Drops the entry for `0001-git-annex-over-git-lfs`. Its branch, `origin/perf/catalog/use-git-annex`, was last touched **2026-03-24**, and nothing anywhere cites `ADR-0001`. If that work resumes, its ADR takes its pull request number like any other.

## Ordering

Deliberately landing **before** #2200 rather than after. Nothing is spent today, so this is silent on merge; the warnings appear the moment #2200 lands, which is when the cleanup is owed. Landing it afterwards and bundling the deletions would mean shipping a reminder whose first real use was skipped.

Whoever lands #2200 does **not** need to touch `LEGACY_IN_FLIGHT` — entries 20, 21 and 23 must stay for that merge to pass. The follow-up deleting them is what these warnings will ask for.

89 tests pass; five are new.
