### PR TITLE
chore(adr): drop the allowlist entries #2200 has landed

### DIFF
--- a/scripts/adr_check.py
+++ b/scripts/adr_check.py
@@ -55,9 +55,6 @@ PR_NUMBER_FLOOR = 1000
 # cited by slug until then.
 LEGACY_IN_FLIGHT = {
     18: "content-store-capability-and-binding",  # hosted-presigned-catalogs-fixes
-    20: "engine-behavior-as-immutable-identity-folded-spec",  # PR #2200
-    21: "engine-construction-is-two-level-identityspec-feeds-enginebuilder",  # PR #2200
-    23: "identity-spec-contributions-are-entry-points-composed-order-independently",  # PR #2200
 }
 
 # The slug must start with a letter, which is what keeps it lexically disjoint

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -359,9 +359,9 @@ def fake_allowlist(monkeypatch: pytest.MonkeyPatch) -> dict[int, str]:
     """A synthetic LEGACY_IN_FLIGHT, so these tests outlive the real one.
 
     Reading the live mapping made each of these need an entry to exist. That
-    is policy data on someone else's branch: it shrank from four to one when
-    #2200 landed and is documented as shrinking to nothing, at which point
-    every test that read it fails for a reason unrelated to the code.
+    is policy data about other people's branches: it is documented as only
+    ever shrinking, and once it reaches nothing every test that read it fails
+    for a reason unrelated to the code under test.
     """
     fake = {18: "one-legacy-adr", 19: "another-legacy-adr"}
     monkeypatch.setattr(adr_check, "LEGACY_IN_FLIGHT", fake)
@@ -436,8 +436,7 @@ def test_a_spent_entry_is_reported_on_an_unrelated_pull_request(
     """The shape every pull request sees after the ADR lands.
 
     The push-to-main run reports it once; this is the nag that keeps arriving
-    until someone acts, and it arrives through the `--base` path rather than
-    the directory-only one.
+    until someone acts, with an `added` set that does not contain the file.
     """
     tree.write("0018-one-legacy-adr.md", "# ADR-0018: Legacy\n\nBody.\n")
     monkeypatch.chdir(tree.root)
@@ -471,41 +470,64 @@ def test_a_spent_entry_readmits_its_filename_once_the_adr_is_gone(
     assert problems.count == 0
 
 
-@pytest.mark.skipif(
-    not adr_check.LEGACY_IN_FLIGHT,
-    reason="nothing left to exempt, so the wiring cannot be exercised end to end",
-)
-def test_the_allowlist_check_is_wired_into_the_command(tree: ADRTree) -> None:
-    """The one test that reads the live mapping, and only to prove the wiring.
+def run_main(monkeypatch: pytest.MonkeyPatch, tree: ADRTree, *args: str) -> int:
+    """`adr_check.main` in process, so a synthetic allowlist applies to it.
 
-    Everything above calls `check_allowlist` directly, which would not notice
-    the call being dropped from `main` or moved inside `if args.base`. This
-    runs the command as CI does. It skips once the allowlist is empty, because
-    at that point there is no entry to make it speak.
+    `ADRTree.check` runs the guard as a subprocess, which no monkeypatch can
+    reach -- it would read the real LEGACY_IN_FLIGHT. Calling `main` keeps the
+    argument parsing and the order of the checks under test while letting the
+    allowlist be fixture data.
     """
-    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
-    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
-    result = tree.check()
-    assert "has done its job" in result.stderr
-    assert result.returncode == 0, result.stderr
+    monkeypatch.chdir(tree.root)
+    monkeypatch.setattr(sys, "argv", ["adr_check.py", *args])
+    return adr_check.main()
+
+
+def test_the_command_reports_a_spent_entry(
+    tree: ADRTree,
+    fake_allowlist: dict[int, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """That `check_allowlist` is called at all, on the push-to-main path.
+
+    The tests above call it directly and so would not notice it being dropped
+    from `main`, or moved inside `if args.base` where the push run never
+    reaches it.
+    """
+    tree.write("0018-one-legacy-adr.md", "# ADR-0018: Legacy\n\nBody.\n")
+    assert run_main(monkeypatch, tree) == 0
+    assert "has done its job" in capsys.readouterr().err
+
+
+def test_the_command_does_not_nag_the_pull_request_landing_the_adr(
+    tree: ADRTree,
+    fake_allowlist: dict[int, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """That `main` hands the added set on, which is a separate mistake.
+
+    `check_allowlist` knows to skip an entry this run is adding, but only if
+    it is told what this run added. Calling it directly with a hand-built list
+    cannot catch `main` passing None instead -- and the cost of that is the
+    landing pull request being nagged to delete the entry keeping it green.
+    """
+    tree.init_repo()
+    tree.write("0018-one-legacy-adr.md", "# ADR-0018: Legacy\n\nBody.\n")
+    tree.commit_all()
+    assert run_main(monkeypatch, tree, "--base", "HEAD~1", "--pr", "2211") == 0
+    assert "has done its job" not in capsys.readouterr().err
 
 
 def test_batch_of_unrelated_adrs_on_allowlisted_numbers_is_rejected(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    fake_allowlist: dict[int, str], capsys: pytest.CaptureFixture[str]
 ) -> None:
     """The batch exemption must not become a general two-ADR bypass.
 
-    The allowlist is synthetic here, and deliberately: this is a fact about
-    `check_added`, not about whichever entries happen to be in flight today.
-    Reading the live mapping made the test need two entries to exist, so
-    shrinking the list to one broke it -- and the list is documented as
-    shrinking to nothing.
+    Reading the live mapping made this test need two entries to exist, which
+    is what broke it when the list shrank to one.
     """
-    monkeypatch.setattr(
-        adr_check,
-        "LEGACY_IN_FLIGHT",
-        {18: "one-legacy-adr", 19: "another-legacy-adr"},
-    )
     problems = adr_check.Problems()
     adr_check.check_added(
         problems,

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -354,19 +354,41 @@ def test_two_new_adrs_in_one_pull_request_is_rejected(tree: ADRTree) -> None:
     assert "ADR-<slug>" in result.stderr
 
 
-def test_allowlisted_legacy_adr_passes(tree: ADRTree) -> None:
-    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
-    tree.init_repo()
-    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
-    tree.commit_all()
-    result = tree.check("--base", "HEAD~1", "--pr", "2211")
-    assert result.returncode == 0, result.stderr
-    # The entry is in use, not spent: this run is the one adding the file.
-    assert "has done its job" not in result.stderr
+@pytest.fixture
+def fake_allowlist(monkeypatch: pytest.MonkeyPatch) -> dict[int, str]:
+    """A synthetic LEGACY_IN_FLIGHT, so these tests outlive the real one.
+
+    Reading the live mapping made each of these need an entry to exist. That
+    is policy data on someone else's branch: it shrank from four to one when
+    #2200 landed and is documented as shrinking to nothing, at which point
+    every test that read it fails for a reason unrelated to the code.
+    """
+    fake = {18: "one-legacy-adr", 19: "another-legacy-adr"}
+    monkeypatch.setattr(adr_check, "LEGACY_IN_FLIGHT", fake)
+    return fake
+
+
+def test_allowlisted_legacy_adr_passes(fake_allowlist: dict[int, str]) -> None:
+    problems = adr_check.Problems()
+    adr_check.check_added(problems, [Path("docs/adr/0018-one-legacy-adr.md")], 2211)
+    assert problems.count == 0
+
+
+def test_allowlisted_number_with_a_different_slug_is_rejected(
+    fake_allowlist: dict[int, str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The allowlist exempts one file, not a number anyone may claim."""
+    problems = adr_check.Problems()
+    adr_check.check_added(problems, [Path("docs/adr/0018-brand-new.md")], 2211)
+    assert problems.count == 1
+    assert "still in flight" in capsys.readouterr().err
 
 
 def test_an_allowlist_entry_is_reported_once_its_adr_has_landed(
     tree: ADRTree,
+    fake_allowlist: dict[int, str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The entry cannot be deleted by the pull request that lands the ADR.
 
@@ -376,44 +398,56 @@ def test_an_allowlist_entry_is_reported_once_its_adr_has_landed(
     reminding about is that the exemption outlives the file: see
     `test_a_spent_entry_readmits_its_filename_once_the_adr_is_gone`.
     """
-    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
-    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
-    result = tree.check()
-    assert "has done its job" in result.stderr
-    # A warning: the entry belongs to whoever landed the ADR, and someone
-    # else's pull request should not be blocked by it.
-    assert result.returncode == 0, result.stderr
+    tree.write("0018-one-legacy-adr.md", "# ADR-0018: Legacy\n\nBody.\n")
+    monkeypatch.chdir(tree.root)
+    problems = adr_check.Problems()
+    adr_check.check_allowlist(problems, None)
+    assert problems.warnings == 1
+    # A warning, not an error: the entry belongs to whoever landed the ADR,
+    # and someone else's pull request should not be blocked by it.
+    assert problems.count == 0
+    assert "has done its job" in capsys.readouterr().err
 
 
 def test_an_allowlist_entry_whose_adr_is_absent_is_not_reported(
-    tree: ADRTree,
+    tree: ADRTree, fake_allowlist: dict[int, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The ordinary state of an entry: its branch has not landed yet."""
-    assert "has done its job" not in tree.check().stderr
+    monkeypatch.chdir(tree.root)
+    problems = adr_check.Problems()
+    adr_check.check_allowlist(problems, None)
+    assert problems.warnings == 0
+
+
+def test_an_entry_this_run_is_using_is_not_reported(
+    tree: ADRTree, fake_allowlist: dict[int, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The landing pull request: in use, not spent."""
+    tree.write("0018-one-legacy-adr.md", "# ADR-0018: Legacy\n\nBody.\n")
+    monkeypatch.chdir(tree.root)
+    problems = adr_check.Problems()
+    adr_check.check_allowlist(problems, [Path("docs/adr/0018-one-legacy-adr.md")])
+    assert problems.warnings == 0
 
 
 def test_a_spent_entry_is_reported_on_an_unrelated_pull_request(
-    tree: ADRTree,
+    tree: ADRTree, fake_allowlist: dict[int, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The shape every pull request sees after the ADR lands.
 
     The push-to-main run reports it once; this is the nag that keeps arriving
-    until someone acts, and it runs through the `--base` path rather than the
-    directory-only one.
+    until someone acts, and it arrives through the `--base` path rather than
+    the directory-only one.
     """
-    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
-    tree.init_repo()
-    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
-    tree.commit_all()
-    tree.write("2222-unrelated.md", "# ADR-2222: Unrelated\n\nBody.\n")
-    tree.commit_all()
-    result = tree.check("--base", "HEAD~1", "--pr", "2222")
-    assert "has done its job" in result.stderr
-    assert result.returncode == 0, result.stderr
+    tree.write("0018-one-legacy-adr.md", "# ADR-0018: Legacy\n\nBody.\n")
+    monkeypatch.chdir(tree.root)
+    problems = adr_check.Problems()
+    adr_check.check_allowlist(problems, [Path("docs/adr/2222-unrelated.md")])
+    assert problems.warnings == 1
 
 
 def test_a_spent_entry_readmits_its_filename_once_the_adr_is_gone(
-    tree: ADRTree,
+    tree: ADRTree, fake_allowlist: dict[int, str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Why a spent entry is worth deleting, and why the warning cannot wait.
 
@@ -423,35 +457,37 @@ def test_a_spent_entry_readmits_its_filename_once_the_adr_is_gone(
     silent, because it keys on the file being present. The warning exists to
     be acted on while the entry is still harmless.
     """
-    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
-    tree.init_repo()
+    monkeypatch.chdir(tree.root)
+    readmitted = Path("docs/adr/0018-one-legacy-adr.md")
+
     # The ADR landed and was later removed, so nothing warns any more.
-    assert "has done its job" not in tree.check().stderr
+    silent = adr_check.Problems()
+    adr_check.check_allowlist(silent, None)
+    assert silent.warnings == 0
 
-    tree.write(
-        f"{number:04d}-{slug}.md",
-        f"# ADR-{number:04d}: Nothing to do with the original\n\nAnything.\n",
-    )
-    tree.commit_all()
-    result = tree.check("--base", "HEAD~1", "--pr", "2222")
+    # And the entry lets that exact filename back in, carrying anything.
+    problems = adr_check.Problems()
+    adr_check.check_added(problems, [readmitted], 2222)
+    assert problems.count == 0
+
+
+@pytest.mark.skipif(
+    not adr_check.LEGACY_IN_FLIGHT,
+    reason="nothing left to exempt, so the wiring cannot be exercised end to end",
+)
+def test_the_allowlist_check_is_wired_into_the_command(tree: ADRTree) -> None:
+    """The one test that reads the live mapping, and only to prove the wiring.
+
+    Everything above calls `check_allowlist` directly, which would not notice
+    the call being dropped from `main` or moved inside `if args.base`. This
+    runs the command as CI does. It skips once the allowlist is empty, because
+    at that point there is no entry to make it speak.
+    """
+    number, slug = next(iter(adr_check.LEGACY_IN_FLIGHT.items()))
+    tree.write(f"{number:04d}-{slug}.md", f"# ADR-{number:04d}: Legacy\n\nBody.\n")
+    result = tree.check()
+    assert "has done its job" in result.stderr
     assert result.returncode == 0, result.stderr
-    # Silent in the one state where the entry is doing harm: the file is being
-    # added, so there is nothing for check_allowlist to find.
-    assert "has done its job" not in result.stderr
-
-
-def test_allowlisted_number_with_a_different_slug_is_rejected(tree: ADRTree) -> None:
-    """The allowlist exempts one file, not a number anyone may claim."""
-    number = next(iter(adr_check.LEGACY_IN_FLIGHT))
-    tree.init_repo()
-    tree.write(
-        f"{number:04d}-brand-new-unrelated.md",
-        f"# ADR-{number:04d}: Unrelated\n\nBody.\n",
-    )
-    tree.commit_all()
-    result = tree.check("--base", "HEAD~1", "--pr", "2211")
-    assert result.returncode == 1
-    assert "still in flight" in result.stderr
 
 
 def test_batch_of_unrelated_adrs_on_allowlisted_numbers_is_rejected(

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -455,20 +455,29 @@ def test_allowlisted_number_with_a_different_slug_is_rejected(tree: ADRTree) -> 
 
 
 def test_batch_of_unrelated_adrs_on_allowlisted_numbers_is_rejected(
-    tree: ADRTree,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The batch exemption must not become a general two-ADR bypass."""
-    numbers = list(adr_check.LEGACY_IN_FLIGHT)[:2]
-    tree.init_repo()
-    for number in numbers:
-        tree.write(
-            f"{number:04d}-brand-new-{number}.md",
-            f"# ADR-{number:04d}: Unrelated\n\nBody.\n",
-        )
-    tree.commit_all()
-    result = tree.check("--base", "HEAD~1", "--pr", "2211")
-    assert result.returncode == 1
-    assert "only one ADR can be added" in result.stderr
+    """The batch exemption must not become a general two-ADR bypass.
+
+    The allowlist is synthetic here, and deliberately: this is a fact about
+    `check_added`, not about whichever entries happen to be in flight today.
+    Reading the live mapping made the test need two entries to exist, so
+    shrinking the list to one broke it -- and the list is documented as
+    shrinking to nothing.
+    """
+    monkeypatch.setattr(
+        adr_check,
+        "LEGACY_IN_FLIGHT",
+        {18: "one-legacy-adr", 19: "another-legacy-adr"},
+    )
+    problems = adr_check.Problems()
+    adr_check.check_added(
+        problems,
+        [Path("docs/adr/0018-brand-new.md"), Path("docs/adr/0019-brand-new.md")],
+        2211,
+    )
+    assert problems.count == 1
+    assert "only one ADR can be added" in capsys.readouterr().err
 
 
 def test_unresolvable_base_is_a_clean_usage_error(tree: ADRTree) -> None:


### PR DESCRIPTION
The follow-up #2211's warnings asked for. ADRs 0020, 0021 and 0023 are on `main` as of f883e4c6, so their `LEGACY_IN_FLIGHT` entries have done their job.

The guard asked for this directly — the `ci-adr` run on that merge:

```
docs/adr/0020-engine-behavior-as-immutable-identity-folded-spec.md: warning:
has landed, so the LEGACY_IN_FLIGHT entry for 0020 in scripts/adr_check.py has
done its job and should be deleted…
9 warning(s), which do not fail the run.
```

Three of those nine. The run stayed green, which is what a warning is for. After this it reports 6 — five forward references to REST ADRs that land later in the stack, and one to `ADR-out-of-core-patches-…`. All correct, and they go quiet by themselves.

`18: content-store-capability-and-binding` stays; `hosted-presigned-catalogs-fixes` has not landed.

## The deletion broke a test, which was worth catching

`test_batch_of_unrelated_adrs_on_allowlisted_numbers_is_rejected` read `list(LEGACY_IN_FLIGHT)[:2]`, so it needed **two** live entries to construct the batch it rejects. Shrinking to one broke it.

Pulling that thread: six tests built their fixtures from `LEGACY_IN_FLIGHT` itself. That is policy data about other people's branches, and the mapping is documented as only ever shrinking. Emptied, **five of them fail** — for reasons unrelated to the code under test, landing on whoever deletes the last entry.

They assert facts about `check_added` and `check_allowlist`, so they now use a synthetic allowlist and call those functions directly.

## What an independent review then found

Converting CLI tests to direct calls can weaken coverage while the count goes up, so this was reviewed for exactly that. It found real ground lost, by mutation testing:

> replacing `check_allowlist(problems, added)` with `check_allowlist(problems, None)` in `main()` passed the whole suite, while failing two tests before the rewrite.

Reproduced and fixed in `8faa7d2b`. The consequence was not theoretical: without the added set, the pull request *landing* an allowlisted ADR gets told its entry "has done its job and should be deleted" — the one entry keeping that pull request green.

Two tests now run `main()` in process, which keeps argument parsing and the order of the checks under test while leaving the allowlist as fixture data. Mutation results:

| Change to `main()` | Before the fix | After |
|---|---|---|
| `check_allowlist(problems, None)` | 92 passed | **1 failed** |
| delete the call | 92 passed | **1 failed** |
| move it inside `if args.base:` | 92 passed | **1 failed** |

That also retired the `skipif` this PR originally carried: it existed because the end-to-end test read the live allowlist and had nothing to say once it emptied. Running `main()` with a synthetic one has no such limit.

| Allowlist | Result |
|---|---|
| Real (1 entry) | 92 passed |
| Emptied | 92 passed |

## Review note

Commits 2 and 3 are larger than commit 1 and can be dropped if you'd rather keep this PR to the three-line deletion — commit 1 is independently green, since it carries its own test fix. Dropping them leaves the empty-allowlist failure for whoever removes entry 18.
