### PR TITLE
docs(adr): accept ADR-2210, and say what enforces it now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,8 @@ pull request exists. Cite an ADR that has no number yet by its slug
 (`ADR-my-decision`); both forms keep resolving.
 
 See [docs/adr/README.md](docs/adr/README.md) for the full convention. The
-`ci-adr` check reports on it.
+`ci-adr` workflow enforces it: its `adr` and `adr-tests` jobs are required
+status checks on `main`.
 
 ## Working with the documentation
 

--- a/docs/adr/2210-adr-numbers-from-pull-request-numbers.md
+++ b/docs/adr/2210-adr-numbers-from-pull-request-numbers.md
@@ -1,6 +1,6 @@
 # ADR-2210: Derive ADR numbers from pull request numbers
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-08
 - **Deciders:** dlovell
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,7 +44,9 @@ CI treats the two asymmetrically. A numbered reference that doesn't resolve is a
 4. `python3 scripts/adr_rename.py` reads the pull request number, renames the file, updates the heading, and rewrites any named references to it. Pass a slug — `python3 scripts/adr_rename.py my-decision` — if more than one ADR is in flight.
 5. Push.
 
-The `ci-adr` check fails while a filename still contains `XXXX`. It blocks the merge once the `adr` job is a required check in branch protection — repository configuration this convention asks for but cannot set.
+The `ci-adr` check fails while a filename still contains `XXXX`, so an unnumbered ADR can't merge: its `adr` and `adr-tests` jobs are both required status checks on `main`. They are required by job name — `ci-adr` is the workflow, and requiring that would match nothing and silently never block.
+
+A pull request opened before those checks existed reports neither, and shows "Expected — waiting for status to be reported" until any push to its branch triggers a run. It does not need to be up to date with `main`.
 
 Write one ADR per pull request. The number comes from the pull request, so a second ADR in the same pull request has no number to take. Open another pull request — an ADR reviews fine on its own, and splitting a set of related decisions costs nothing, because each is citable as `ADR-<slug>` from the moment it is written. Cite the others by slug; don't wait for their numbers, and don't reserve any.
 


### PR DESCRIPTION
Facts that stopped being true today, in the three places that state them.

**ADR-2210 was still `Proposed`** while being enforced by required status checks, with #2211 and #2212 landed against it. Status lives in each ADR's own header precisely so it can't go stale, and this one had. `scripts/adr_index.py` now renders it as Accepted.

**`docs/adr/README.md` said the enforcement didn't exist yet:**

> It blocks the merge once the `adr` job is a required check in branch protection — repository configuration this convention asks for but cannot set.

It is set. `adr` and `adr-tests` are both required status checks on `main` as of today.

**`CONTRIBUTING.md` said "The `ci-adr` check reports on it"** — loose on both axes. There is no check named `ci-adr`; that is the workflow, and requiring it by that name would match nothing and silently never block. And the checks no longer merely report.

The README also now says the thing a reader can't guess and will otherwise hit cold: a pull request opened *before* those checks existed reports neither, and sits at "Expected — waiting for status to be reported" until any push to its branch triggers a run. It does **not** need to be up to date with `main` (`strict` is off).

That last point is not hypothetical. **50 of the 57 currently open pull requests are in exactly that state** — only 7 postdate the workflow. Each unblocks on its next push; no rebase is required.

## What this deliberately does not do

The ADR's Consequences bullet — "The guard reports but does not block until the **`adr` job** is a required status check on `main`…" — is left exactly as written.

It records what the decision was foreseen to require, which is what a decision record is for; a future reader judging whether the decision was well-reasoned needs the cost as it was understood at the time. That the requirement has since been met is *current state*, and current state belongs in the README. Amending the ADR to say "and then we did it" would put the same fact in two places — the failure this ADR's own "why there is no index file" section argues against.

`docs/adr/README.md` reserves amendments for "the decision still holds but the implementation details changed", which this isn't: a required check being switched on is the decision's precondition being met. The bullet also self-dates, sitting under `Date: 2026-08-08`, and the `Accepted` status at the top of the same file is itself the signal that enforcement is live.

## Note

First pull request through the newly required checks, so it doubles as a live test that `adr` and `adr-tests` report and gate correctly on an ordinary change.
