### PR TITLE
perf(ci): cache the quartodoc reference instead of rebuilding it every run

### DIFF
--- a/.github/workflows/ci-docs-lint.yml
+++ b/.github/workflows/ci-docs-lint.yml
@@ -22,6 +22,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # `quartodoc build` regenerates docs/reference/ (gitignored) by reflecting
+      # over the imported xorq.api: ~7 of this job's ~9 minutes, and a pure
+      # function of the code rather than of which doc changed. Hence the key —
+      # python/xorq/** (vendored ibis included), uv.lock for the deps whose
+      # docstrings get inherited and for the quartodoc pin, and the two files
+      # that configure the build. No restore-keys: a near-miss restore would
+      # keep pages for symbols the current code renamed away, and a stale
+      # reference that passes lint is the failure mode worth 7 minutes to avoid.
+      # Placed before the steps that drop __pycache__/ under python/xorq, which
+      # would otherwise perturb the key.
+      - name: Restore quartodoc API reference
+        id: quartodoc-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            docs/reference
+            docs/objects.json
+          key: quartodoc-${{ runner.os }}-py3.12-${{ hashFiles('python/xorq/**', '!python/xorq/**/__pycache__/**', 'uv.lock', 'docs/_quarto.yml', 'docs/_renderer.py') }}
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -70,6 +89,7 @@ jobs:
           CI: "true"
           SKIP_VALE: "1"
           SKIP_LYCHEE: "1"
+          SKIP_QUARTODOC: ${{ steps.quartodoc-cache.outputs.cache-hit == 'true' && '1' || '0' }}
 
       - name: Lychee (internal links)
         uses: lycheeverse/lychee-action@v2

--- a/docs/lint.sh
+++ b/docs/lint.sh
@@ -26,6 +26,8 @@
 #   python3     frontmatter parsing     pip install python-frontmatter
 #
 # CI: set CI=true; errors are emitted as GitHub Actions ::error annotations.
+#     SKIP_VALE=1 / SKIP_LYCHEE=1 skip checks a dedicated action already runs;
+#     SKIP_QUARTODOC=1 skips the rebuild when reference/ was restored from cache.
 
 set -uo pipefail
 
@@ -71,7 +73,7 @@ require_tool() {
 [[ "${SKIP_VALE:-}"   == "1" ]] || require_tool vale   "snap install vale --classic  (Linux)  |  brew install vale  (macOS)"
 [[ "${SKIP_LYCHEE:-}" == "1" ]] || require_tool lychee "https://github.com/lycheeverse/lychee/releases"
 require_tool quarto     "https://quarto.org/docs/get-started/"
-require_tool quartodoc  "pip install quartodoc"
+[[ "${SKIP_QUARTODOC:-}" == "1" ]] || require_tool quartodoc  "pip install quartodoc"
 require_tool pymarkdown "pip install pymarkdownlnt"
 python3 -c "import frontmatter" 2>/dev/null || {
     printf 'ERROR: python-frontmatter not installed.\n  Install: pip install python-frontmatter\n'
@@ -114,8 +116,19 @@ fi
 # the `quartodoc:` block of _quarto.yml). Rebuild before rendering so the API
 # reference reflects the current code and stale pages from renamed/removed
 # symbols don't linger.
+#
+# SKIP_QUARTODOC=1 means reference/ came from a cache whose key already answered
+# "is it still valid" (.github/workflows/ci-docs-lint.yml). The emptiness check
+# is the guard: a restore that produced nothing fails here, loudly.
 section "Quartodoc build — API reference"
-if quartodoc build 2>&1; then
+if [[ "${SKIP_QUARTODOC:-}" == "1" ]]; then
+    if [[ -d "reference" && -n "$(ls -A reference 2>/dev/null)" ]]; then
+        pass "quartodoc build: skipped (reference/ restored from cache)"
+    else
+        fail "quartodoc build: SKIP_QUARTODOC=1 but reference/ is missing or empty"
+        in_ci && printf '::error file=_quarto.yml,line=1::SKIP_QUARTODOC=1 with no reference/ to skip for\n'
+    fi
+elif quartodoc build 2>&1; then
     pass "quartodoc build"
 else
     fail "quartodoc build: failed"


### PR DESCRIPTION
Closes #2219.

Caches the quartodoc-generated API reference, keyed on what the build actually reads. A docs-only PR hits and skips ~7 minutes; a PR that touches the package or its dependencies misses and regenerates.

## The open question in the issue, settled: the output is deterministic

Three local `quartodoc build` runs against an unchanged tree — the third from a deleted `reference/`, which is the cold shape CI always builds in:

| Run | Wall | Result |
|---|---|---|
| 1 | 5m35s | baseline |
| 2 | 5m52s | byte-identical to 1 |
| 3 (cold, `rm -rf reference objects.json` first) | 5m59s | byte-identical to 1 |

`diff -r` clean across 56 pages + `reference/_sidebar.yml` + `objects.json`; sha256 over the sorted file list is `d257b68fcd2d6e78b8086f96adc8734595a485743011343ecf4d4f84cded67c5` for all three. No timestamps, no ordering instability. A hit is therefore worth trusting, which is what makes the skip sound rather than merely fast.

(Incidental finding: quartodoc leaves a page's mtime alone when the content it computes matches what's on disk. That is why run 3 mattered — runs 1 and 2 alone would have proven only that quartodoc declined to rewrite, not that it recomputed the same bytes.)

## The key

```
python/xorq/**      the reflected source, vendored ibis included
uv.lock             third-party packages whose docstrings get inherited into
                    the reference, plus the pinned quartodoc/griffe doing the work
docs/_quarto.yml    the `quartodoc:` block — package, sections, options
docs/_renderer.py   the custom renderer that formats every page
```

The issue's point 1 is why `uv.lock` is in there: a key over first-party source alone would serve a stale reference on a dependency bump and pass, and a lint job that passes against the wrong artifact is worse than a slow one.

`docs/_quarto.yml` and `docs/_renderer.py` are the same argument pointed at `docs/**` — both are inputs to the build and both are reachable by a "docs-only" change. Hashing all of `_quarto.yml` means a nav-only edit also busts the key; that costs one needless rebuild, which is the direction to err in.

No `restore-keys`. A near-miss restore would seed `reference/` with pages for symbols the current code has renamed or removed, and then the rebuild-on-miss wouldn't clear them.

The step sits immediately after `checkout` so `hashFiles` sees a clean tree — `uv sync` and the pytest step both drop `__pycache__/` under `python/xorq`, which would otherwise perturb the key on every run. The `!python/xorq/**/__pycache__/**` pattern guards that if the steps are ever reordered.

## On a hit

The workflow sets `SKIP_QUARTODOC=1`, following the existing `SKIP_VALE`/`SKIP_LYCHEE` convention in `docs/lint.sh`. The skip branch asserts `reference/` is non-empty before taking credit for it: a restore that silently produced nothing fails the job instead of rendering a site with no reference in it. Exercised locally in all four states — hit with `reference/` present (skips, passes), hit with it missing, hit with it empty (both fail, with the `::error` annotation), and the miss value `0` (runs the build). Also `bash -n`, and `actionlint` on the workflow via the repo's pre-commit hook.

## How this PR gets exercised, and what it showed

Worth checking before assuming there'd be no evidence here: the issue quotes `paths: ['docs/**']`, and on that basis a YAML-only change to this workflow would report no status at all. That is true of the `push` trigger, whose filter is `docs/**` alone — but not of this PR. The `pull_request` trigger already lists `.github/workflows/ci-docs-lint.yml` in its paths, so the workflow runs on changes to itself; and this PR also touches `docs/lint.sh`, which matches `docs/**`. Both triggers fire.

So both paths did get a real run, on this PR:

| | Run | Cache | `quartodoc build` | Job |
|---|---|---|---|---|
| Miss | [31434407429](https://github.com/xorq-labs/xorq/actions/runs/31434407429), first attempt | `Cache not found for input keys: quartodoc-Linux-py3.12-3eb8192…` | ran, 6m01s | **8m11s**, saved 86,849 B |
| Hit | same run, re-run against the cache the first attempt wrote | `Cache restored from key: …-3eb8192…` | `✓ quartodoc build: skipped (reference/ restored from cache)` | **1m37s** |
| Hit, cross-run | [31490561751](https://github.com/xorq-labs/xorq/actions/runs/31490561751) — separate run, next day, comment-only push | `Cache restored from key: …-3eb8192…` | same skip line | **2m22s** |

The third row is the one that counts: a distinct run reading a cache an earlier run wrote, which is the shape production has. Its key hashed to `3eb8192…` again despite the intervening push — the comment-only change is correctly not a key input, and the after-`checkout` placement keeps `__pycache__` out of the hash.

None of the hits are merely green. `quarto render --no-execute` passed on all of them with 58 `reference/*.qmd` in its render list, so the restored reference really was present and really was rendered.

**That is ~6 minutes off the job, but it is still not the acceptance test.** Every cache above is scoped to `refs/pull/2220/merge`, which `main` cannot read. Acceptance is two consecutive `ci-docs-lint` runs after merge:

1. **A miss that regenerates.** `main` starts cold whatever happened on this branch, so the merge commit's own run should take the usual ~9 minutes and populate the cache on `main`.
2. **A hit that skips.** The next docs change whose key inputs are unchanged should log the skip line, come in near 2 minutes, and still produce a correct reference — worth spot-checking `_site/reference/` on that run rather than only the green check.

`actions/cache` skips its save when the job fails, so a failing run can't poison the key.

## Not done

No path filter gating the generation, per the issue's reasoning: a content-keyed cache already encodes "regenerate when the package changed", and a second independent opinion about staleness can only disagree with the first. The remaining `quarto render --no-execute` (~1m37s) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEjMgAU9PnavZKknAN3G6k
