### PR TITLE
feat(adr): check cited repo paths and reject bare short SHAs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,18 @@ scope. Ruff enforces this split via `PLC0415` (import-outside-top-level): every
 deliberate lazy import must carry a `# noqa: PLC0415` comment, which makes each
 one an explicit, reviewable decision rather than an accident.
 
+## Commenting
+
+**Justify a rule with a ratio, not a count.** A comment that explains a threshold
+by what was measured is worth more than one that just states it — without the
+evidence the next reader takes the rule for a preference and relaxes it. But
+exact numbers rot, and duplicated exact numbers rot faster: `adr_check.py`
+shipped with "24 of the 119" in a test docstring beside "25 of the 106" in the
+module it tested. State the ratio at the rule it justifies, once. Never in a test
+docstring, where the assertion is already the specification and a count is a
+claim nothing checks. If a number has to be exact, compute it rather than write
+it down.
+
 ## Writing the commit
 
 xorq follows the [Conventional Commits](https://www.conventionalcommits.org/) structure.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,7 +53,7 @@ Cite a commit by the pull request that carried it, or as a Markdown link. A bare
 
 This is why the check needs no "historical block" marker: the pull request diff already knows which prose is new, so nothing has to be marked and nothing can be waved through. Renumbering a landed ADR doesn't count as adding it. The gap is an amendment to a landed ADR, whose new citations only warn.
 
-Every warning that exists today is in the second row: five across four ADRs, four paths and one SHA, out of 106 path citations in the directory. Leave them.
+Every warning that exists today is in the second row: five across four ADRs, four paths and one SHA. Leave them.
 
 ## Writing one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,25 @@ The sweep leaves code spans and fences alone in prose — `.md` and `.qmd` — o
 
 CI treats the two asymmetrically. A numbered reference that doesn't resolve is an **error** — the forge allocated that number, so a missing one is a mistake. A named reference that doesn't resolve is a **warning**, because the ADR it names may still be on a branch that hasn't landed.
 
+## Citing code and commits
+
+An ADR cites code by path, usually with a line number: `python/xorq/expr/api.py:84`. CI checks that the path resolves and ignores the line number, which drifts on every edit above it.
+
+A path resolves if it is a path git tracks, or the tail of one — `expr/api.py` is accepted for `python/xorq/expr/api.py`, so an abbreviated citation is fine. Two rules make the check quiet enough to keep: the last segment needs a file extension, and a citation with no slash in it isn't checked at all. So a cited *directory* is never checked (`build/cache` and `python/xorq/writes/` are the same shape, and only one is a path), and neither is a bare `core.py` (it would match anything of that name). A fenced block is not scanned, which is how you show a path that isn't meant to resolve — a module a proposal ADR would create, say.
+
+Cite a commit by the pull request that carried it, or as a Markdown link. A bare short SHA is reported: it resolves for whoever wrote it and for nobody else once the branch it was on is squash-merged or deleted. ADR-0007 cites `ce8004bc` as being "on `main`", and it is unreachable in a full clone today.
+
+**A path that has since moved is not a defect, and you must not fix it by editing the ADR.** An ADR records what was true when the decision was made. So the check is asymmetric, the same way the two citation forms are:
+
+| Where the citation is | Unresolved path, or a bare SHA |
+|-----------------------|--------------------------------|
+| An ADR this pull request adds | **Error** — nothing has had time to move, so it's wrong |
+| An ADR already in the tree | **Warning** — probably the record doing its job |
+
+This is why the check needs no "historical block" marker: the pull request diff already knows which prose is new, so nothing has to be marked and nothing can be waved through. Renumbering a landed ADR doesn't count as adding it. The gap is an amendment to a landed ADR, whose new citations only warn.
+
+Every warning that exists today is in the second row: five across four ADRs, four paths and one SHA, out of 106 path citations in the directory. Leave them.
+
 ## Writing one
 
 1. `python3 scripts/adr_new.py my-decision` copies the template to `docs/adr/XXXX-my-decision.md`.
@@ -60,6 +79,7 @@ The allowlist in `scripts/adr_check.py` is the one exception: a branch that pred
 - the `# ADR-NNNN:` heading agrees with the filename
 - every `ADR-NNNN` mention and every same-directory Markdown link resolves to a real ADR
 - every `ADR-<slug>` mention resolves, or is reported as a warning if it doesn't
+- every cited repo path is one git tracks, and no commit is cited by a bare short SHA — an error in an ADR the pull request adds, a warning in one already landed
 
 Unnumbered ADRs are checked too — a file still carrying `XXXX` has its heading and its references validated like any other.
 

--- a/scripts/adr_check.py
+++ b/scripts/adr_check.py
@@ -100,6 +100,52 @@ CODE_FENCE_RE = re.compile(
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 URL_RE = re.compile(r"<?https?://[^\s>)]+>?")
 
+# `[ce8004bc](https://github.com/xorq-labs/xorq/commit/ce8004bc)` is the form
+# the commit check asks for, so the whole link -- text as well as target --
+# comes out before it scans. Stripping only the URL would leave the SHA behind
+# as link text and make the recommended form the one thing that always fails.
+MD_LINK_ANY_RE = re.compile(r"\[[^\]]*\]\([^)]*\)")
+
+# A cited repo path: slash-joined segments whose last one carries a file
+# extension. The extension is what separates a path from prose. Without it,
+# `read-path/hash-path`, `try/except`, `I/O`, `NaN/NaT` and `build/cache` all
+# read as paths -- 75 of the 127 distinct slash-joined tokens in docs/adr are
+# not paths at all, mostly that kind of alternation, and a lint that fires on
+# English gets disabled. The cost is that a cited *directory* is not checked at
+# all: `python/xorq/writes/` and `commit/publish` are the same shape and only
+# one of them is a path.
+#
+# Placeholders fall out of the character class rather than needing a rule:
+# `metadata/<name>.zip.metadata.yaml`, `inmemory/<uuid>.parquet` and
+# `{name}/{remote_uuid}/` all contain characters no path of ours does.
+#
+# The `:NNN` suffix is matched so it is consumed rather than read as part of the
+# filename, and then ignored. Line numbers drift on every edit above the line
+# they name, so enforcing them would make every ADR churn for no gain.
+#
+# The lookbehind stops the scan from starting part-way along a longer path,
+# which is what keeps `s3://bucket/foo.parquet` from being read as a citation of
+# `bucket/foo.parquet`.
+PATH_CITATION_RE = re.compile(
+    r"(?<![\w./-])(?P<path>[\w.-]+(?:/[\w.-]+)*/[\w.-]+\.[A-Za-z]\w*)(?::\d+)?"
+)
+
+# A bare short commit: seven to twelve hex characters, neither linked nor
+# fenced. Both a digit and an a-f letter are required, which is what keeps
+# dates and counts (`20260427`) and hex-lettered words (`defaced`, `effaced`)
+# out of it. That costs the ~4% of short SHAs that happen to be all digits or
+# all letters: a check that fires on prose gets disabled, one that misses a
+# commit in twenty does not.
+#
+# Twelve is the ceiling because this repository's own content hashes are sixteen
+# hex characters and its ADRs are largely about hashing -- `38317617c8a70d3a` is
+# a build hash, not a commit. A full forty-character SHA is left alone for a
+# different reason: it is unambiguous and greppable, and abbreviation is the
+# part that rots.
+BARE_SHA_RE = re.compile(
+    r"(?<![\w/-])(?=[0-9a-f]*\d)(?=[0-9a-f]*[a-f])(?P<sha>[0-9a-f]{7,12})(?![\w-])"
+)
+
 
 class Problems:
     """Collects annotated failures so one run reports every problem."""
@@ -166,8 +212,92 @@ def strip_shown_code(text: str) -> str:
     return text
 
 
-def check_directory(problems: Problems) -> None:
-    """Validate every ADR on disk."""
+def strip_transcripts(text: str) -> str:
+    """Drop fenced blocks and URLs, keeping inline code spans.
+
+    This is where the path and commit checks part company with
+    `strip_shown_code`, and the asymmetry is deliberate. For an ADR reference a
+    backtick means "displayed, not cited" -- `` `ADR-9999` `` in a document
+    about numbering names no ADR. For a path or a commit a backtick is simply
+    how you write one, and the measurement is unambiguous: strip inline spans
+    and *nothing* is left to check, because all 106 path citations in docs/adr
+    are inside backticks, and so is its one bare SHA.
+
+    Fences and URLs still come out. A fence is a transcript -- a shell session,
+    a tree diagram, CI output -- and it is the escape hatch for showing a path
+    that is not meant to resolve. A URL's own path components belong to another
+    site, not to this repository.
+    """
+    for pattern in (CODE_FENCE_RE, URL_RE):
+        text = pattern.sub(" ", text)
+    return text
+
+
+class TrackedPaths:
+    """Every path git tracks, indexed by suffix, built once and only if needed.
+
+    Resolution is by suffix because ADRs cite paths abbreviated for
+    readability: `dasher/_opaque.py` for
+    `python/xorq/common/utils/dasher/_opaque.py`. Twenty-five of the 106 path
+    citations in docs/adr are that form, so a check wanting full paths would
+    either ignore a quarter of them or demand a sweep of landed ADRs to
+    lengthen them.
+
+    An ambiguous suffix counts as resolved: `expr/api.py` names both the real
+    module and the vendored ibis one. The citation names something real, and
+    picking between two real files is guesswork this check has no business
+    doing.
+
+    The index is what git tracks rather than what is on disk, because "a repo
+    path" is the question being asked. `.git/annex/objects` in ADR-0003 is a
+    runtime location that was never a file here, `docs/_site` is build output,
+    and a one-off script sitting untracked in one person's working tree should
+    not make their run pass where CI's fails.
+
+    Built on first use, so a directory that cites no paths never shells out to
+    git and the guard keeps working outside a repository.
+    """
+
+    def __init__(self) -> None:
+        self._suffixes: frozenset[str] | None = None
+        # Read by `check_directory` to report once, rather than once per ADR.
+        self.unavailable = False
+
+    def load(self) -> bool:
+        """Read the index, or report False having recorded why."""
+        if self._suffixes is not None:
+            return True
+        if self.unavailable:
+            return False
+        result = subprocess.run(
+            ["git", "ls-files", "-z"], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            self.unavailable = True
+            return False
+        suffixes: set[str] = set()
+        for tracked in result.stdout.split("\0"):
+            parts = tracked.split("/")
+            # Only suffixes that keep a slash. A citation has to contain one --
+            # a bare `core.py` would match anything of that name, which makes it
+            # both unresolvable and indistinguishable from an illustrative one.
+            for start in range(len(parts) - 1):
+                suffixes.add("/".join(parts[start:]))
+        self._suffixes = frozenset(suffixes)
+        return True
+
+    def contains(self, citation: str) -> bool:
+        return citation in (self._suffixes or frozenset())
+
+
+def check_directory(problems: Problems, added: list[Path] | None = None) -> None:
+    """Validate every ADR on disk.
+
+    `added` names the ADRs this pull request adds, when a base ref was given. It
+    is what the path and commit citation checks read to tell a citation that was
+    wrong when it was written from one that has merely aged; without it every
+    such citation is a warning, which is what a plain local run sees.
+    """
     by_number: dict[int, Path] = {}
     by_slug: dict[str, Path] = {}
     checkable: list[tuple[Path, int | None, str]] = []
@@ -228,10 +358,25 @@ def check_directory(problems: Problems) -> None:
         checkable.append((path, number, raw))
 
     # Second pass: both indexes must be complete before references resolve.
+    new_names = {path.name for path in added or ()}
+    tracked = TrackedPaths()
     for path, number, raw in checkable:
         text = path.read_text(encoding="utf-8")
+        is_new = path.name in new_names
         check_heading(problems, path, number, raw, text)
         check_references(problems, path, text, by_number, by_slug)
+        check_paths(problems, path, text, tracked, is_new)
+        check_shas(problems, path, text, is_new)
+
+    # Once, rather than once per ADR, and a warning rather than an error: an
+    # unreadable index means the path check could not run, not that anything is
+    # wrong with the ADRs.
+    if tracked.unavailable:
+        problems.warn(
+            ADR_DIR,
+            "cited repo paths were not checked: `git ls-files` failed, so there "
+            "is nothing to resolve them against. Run from inside a checkout",
+        )
 
 
 def check_heading(
@@ -303,7 +448,111 @@ def check_references(
             problems.add(path, f"links to {target}, which does not exist")
 
 
-def added_adrs(base: str) -> list[Path] | None:
+# Appended to every path and commit report on an ADR that is already in the
+# tree, and the only place this guard tells anyone *not* to fix something. Kept
+# to two sentences because it is repeated per finding and `--format github`
+# shows it as an inline annotation, where the full argument does not fit; the
+# reasoning lives in docs/adr/README.md and in `check_paths`.
+AGED_CITATION = (
+    "If that was accurate when this ADR landed, leave the ADR alone: it records "
+    "what was true when the decision was made, and editing a landed ADR to "
+    "match today's tree destroys that record. Fix it only if it was never right"
+)
+
+
+def check_paths(
+    problems: Problems,
+    path: Path,
+    text: str,
+    tracked: TrackedPaths,
+    is_new: bool,
+) -> None:
+    """Resolve every repo path an ADR cites.
+
+    An unresolved path is an error in an ADR this pull request adds and a
+    warning in one that has already landed. The asymmetry is the whole design,
+    because the two cases are opposites rather than degrees of the same thing.
+
+    In a new ADR the path is simply wrong: nothing has had time to move, and a
+    reader cannot open what the author just cited. In a landed ADR an
+    unresolved path is usually the document doing its job -- ADR-0006 and
+    ADR-0007 cite `dask_normalize_expr.py`, which was accurate until #1951
+    replaced dask tokenization, and the ADRs are a record of a decision taken
+    when that file existed. Failing on it would pressure people to edit landed
+    ADRs, which is exactly what docs/adr/README.md tells them not to do.
+
+    This is also the answer to the "marked historical block" that #2203 asked
+    for. A marker would put the burden on authors to remember it and would let a
+    genuinely wrong path be waved through; the pull request diff already knows
+    which citations are new, so git supplies the distinction for free and there
+    is no new syntax for anyone to learn. The cost is
+    that a path added to a landed ADR by an amendment only warns -- scoping to
+    the added *lines* rather than the added *files* would close that, at the
+    price of parsing diff hunks.
+
+    Nothing is reported for a path this run cannot resolve, only for one it can
+    prove absent, which is why `load` failing is silent here.
+    """
+    citations = {
+        match.group("path")
+        for match in PATH_CITATION_RE.finditer(strip_transcripts(text))
+        # Relative to the document rather than the repository root, and this
+        # check anchors at the root. Same-directory ADR links are already
+        # covered by `check_references`.
+        if ".." not in match.group("path")
+    }
+    if not citations or not tracked.load():
+        return
+
+    for citation in sorted(citations):
+        if tracked.contains(citation):
+            continue
+        message = (
+            f"cites `{citation}`, which is not a path git tracks in this repository. "
+        )
+        if is_new:
+            problems.add(
+                path,
+                message + "An ADR's citations have to resolve when it lands: "
+                "check the spelling, or put the path in a fenced block if it "
+                "names something this pull request does not create",
+            )
+        else:
+            problems.warn(path, message + AGED_CITATION)
+
+
+def check_shas(problems: Problems, path: Path, text: str, is_new: bool) -> None:
+    """Report commits cited as a bare short SHA.
+
+    A short SHA reads as authoritative and resolves for whoever wrote it, then
+    resolves for nobody once the branch it was on is squash-merged or deleted --
+    ADR-0007 cites `ce8004bc` as being "on `main`", and it is unreachable in a
+    full clone today. Abbreviations also grow ambiguous as a repository does, so
+    one that resolves now is not durable either.
+
+    Same error-versus-warning split as `check_paths`, for the same reason: in a
+    new ADR the citation is unusable on arrival, and in a landed one it is
+    history that must not be edited to suit today's object store.
+    """
+    prose = MD_LINK_ANY_RE.sub(" ", strip_transcripts(text))
+    for sha in sorted({match.group("sha") for match in BARE_SHA_RE.finditer(prose)}):
+        message = (
+            f"cites the bare short commit `{sha}`. A short SHA is unreachable "
+            "once the branch it was on is gone, and abbreviations grow "
+            "ambiguous as the repository grows. "
+        )
+        if is_new:
+            problems.add(
+                path,
+                message + "Cite the pull request that carried the change, or "
+                "link the commit -- a linked SHA is not bare, and a fenced "
+                "block is not scanned",
+            )
+        else:
+            problems.warn(path, message + AGED_CITATION)
+
+
+def added_adrs(base: str, pair_renames: bool = False) -> list[Path] | None:
     """ADR files this branch adds relative to the merge base with `base`.
 
     None means the base ref could not be resolved -- an unfetched sha, a
@@ -318,13 +567,20 @@ def added_adrs(base: str) -> list[Path] | None:
     landed, where git sees one file move and `--diff-filter=A` would report no
     new ADR at all. Without this flag the branch resolving a collision is the
     one branch the number check never runs on.
+
+    `pair_renames` asks for the opposite, and exactly one caller wants it: the
+    path and commit citation checks, which report an error only for an ADR whose
+    text is new. A renumbered ADR's citations are as historical after the
+    renumber as before it, so reading the move as an addition would fail the
+    branch on prose nobody touched -- and the only way to make it pass would be
+    to edit a landed ADR, which is what that asymmetry exists to prevent.
     """
     result = subprocess.run(
         [
             "git",
             "diff",
             "--name-only",
-            "--no-renames",
+            *(() if pair_renames else ("--no-renames",)),
             "--diff-filter=A",
             f"{base}...HEAD",
             "--",
@@ -497,12 +753,23 @@ def main() -> int:
         return 2
 
     problems = Problems(github=args.format == "github")
-    check_directory(problems)
+    # The diff comes first because the directory pass reads it: a path or commit
+    # citation is an error in an ADR this pull request adds and a warning in one
+    # that has landed, and only the diff can tell those apart. Two diffs, not
+    # one, because the numbering checks and the citation checks want opposite
+    # answers about a renumbered ADR -- see `added_adrs`.
     added = None
+    written = None
     if args.base:
+        # Sequenced, not batched, so an unresolvable base is reported once.
         added = added_adrs(args.base)
         if added is None:
             return 2
+        written = added_adrs(args.base, pair_renames=True)
+        if written is None:
+            return 2
+    check_directory(problems, written)
+    if added is not None:
         check_added(problems, added, args.pr)
     # Last, and with `added` in hand: an allowlist entry is only spent if this
     # run is not the one using it.
@@ -512,7 +779,8 @@ def main() -> int:
         sys.stderr.write(
             f"\n{problems.warnings} warning(s), which do not fail the run. A "
             "named reference resolves once its ADR lands; a spent allowlist "
-            "entry needs deleting.\n"
+            "entry needs deleting; a path or commit cited by a landed ADR may "
+            "have aged, and an ADR that has aged is not one to rewrite.\n"
         )
     if problems.count:
         sys.stderr.write(

--- a/scripts/adr_check.py
+++ b/scripts/adr_check.py
@@ -100,47 +100,40 @@ CODE_FENCE_RE = re.compile(
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 URL_RE = re.compile(r"<?https?://[^\s>)]+>?")
 
-# `[ce8004bc](https://github.com/xorq-labs/xorq/commit/ce8004bc)` is the form
-# the commit check asks for, so the whole link -- text as well as target --
-# comes out before it scans. Stripping only the URL would leave the SHA behind
-# as link text and make the recommended form the one thing that always fails.
-MD_LINK_ANY_RE = re.compile(r"\[[^\]]*\]\([^)]*\)")
+# Any Markdown link, target captured, because the two checks want different
+# halves of it. The commit check drops the whole thing: stripping only the URL
+# would leave the SHA behind as link text, so the linked form it recommends
+# would be the one thing that always failed it. The path check keeps the target
+# and drops the text, because that is which half is a citation -- a relative
+# target names a file in this repository, while the text is prose and may well
+# be an upstream path that is not ours to resolve.
+MD_LINK_ANY_RE = re.compile(r"\[[^\]]*\]\((?P<target>[^)]*)\)")
 
 # A cited repo path: slash-joined segments whose last one carries a file
-# extension. The extension is what separates a path from prose. Without it,
-# `read-path/hash-path`, `try/except`, `I/O`, `NaN/NaT` and `build/cache` all
-# read as paths -- 75 of the 127 distinct slash-joined tokens in docs/adr are
-# not paths at all, mostly that kind of alternation, and a lint that fires on
-# English gets disabled. The cost is that a cited *directory* is not checked at
-# all: `python/xorq/writes/` and `commit/publish` are the same shape and only
-# one of them is a path.
+# extension. The extension is what separates a path from prose -- without it
+# `try/except`, `I/O`, `NaN/NaT` and `build/cache` all read as paths, and most
+# slash-joined tokens in docs/adr are that kind of alternation rather than a
+# path. The cost is that a cited *directory* is never checked, because
+# `python/xorq/writes/` and `commit/publish` are the same shape.
 #
-# Placeholders fall out of the character class rather than needing a rule:
-# `metadata/<name>.zip.metadata.yaml`, `inmemory/<uuid>.parquet` and
-# `{name}/{remote_uuid}/` all contain characters no path of ours does.
+# The `:NNN` suffix is consumed so it is not read as part of the filename, then
+# ignored: line numbers drift on every edit above the line they name.
 #
-# The `:NNN` suffix is matched so it is consumed rather than read as part of the
-# filename, and then ignored. Line numbers drift on every edit above the line
-# they name, so enforcing them would make every ADR churn for no gain.
-#
-# The lookbehind stops the scan from starting part-way along a longer path,
-# which is what keeps `s3://bucket/foo.parquet` from being read as a citation of
-# `bucket/foo.parquet`.
+# The lookbehind stops a scan starting part-way along a longer path, which is
+# what keeps `s3://bucket/foo.parquet` from reading as `bucket/foo.parquet`.
 PATH_CITATION_RE = re.compile(
     r"(?<![\w./-])(?P<path>[\w.-]+(?:/[\w.-]+)*/[\w.-]+\.[A-Za-z]\w*)(?::\d+)?"
 )
 
 # A bare short commit: seven to twelve hex characters, neither linked nor
-# fenced. Both a digit and an a-f letter are required, which is what keeps
-# dates and counts (`20260427`) and hex-lettered words (`defaced`, `effaced`)
-# out of it. That costs the ~4% of short SHAs that happen to be all digits or
-# all letters: a check that fires on prose gets disabled, one that misses a
-# commit in twenty does not.
+# fenced. Both a digit and an a-f letter are required, which keeps dates
+# (`20260427`) and hex-lettered words (`defaced`) out, at the price of the few
+# short SHAs that are all digits or all letters.
 #
 # Twelve is the ceiling because this repository's own content hashes are sixteen
-# hex characters and its ADRs are largely about hashing -- `38317617c8a70d3a` is
-# a build hash, not a commit. A full forty-character SHA is left alone for a
-# different reason: it is unambiguous and greppable, and abbreviation is the
+# hex characters and its ADRs are largely about hashing: `38317617c8a70d3a` is a
+# build hash, not a commit. A full forty-character SHA is left alone for a
+# different reason -- it is unambiguous and greppable, and abbreviation is the
 # part that rots.
 BARE_SHA_RE = re.compile(
     r"(?<![\w/-])(?=[0-9a-f]*\d)(?=[0-9a-f]*[a-f])(?P<sha>[0-9a-f]{7,12})(?![\w-])"
@@ -215,18 +208,14 @@ def strip_shown_code(text: str) -> str:
 def strip_transcripts(text: str) -> str:
     """Drop fenced blocks and URLs, keeping inline code spans.
 
-    This is where the path and commit checks part company with
-    `strip_shown_code`, and the asymmetry is deliberate. For an ADR reference a
-    backtick means "displayed, not cited" -- `` `ADR-9999` `` in a document
-    about numbering names no ADR. For a path or a commit a backtick is simply
-    how you write one, and the measurement is unambiguous: strip inline spans
-    and *nothing* is left to check, because all 106 path citations in docs/adr
-    are inside backticks, and so is its one bare SHA.
+    Where the path and commit checks part company with `strip_shown_code`. For
+    an ADR reference a backtick means "displayed, not cited" -- `` `ADR-9999` ``
+    in a document about numbering names no ADR. For a path or a commit it is
+    simply how you write one: strip inline spans and there is *nothing* left to
+    check, because every path citation in docs/adr is inside backticks.
 
-    Fences and URLs still come out. A fence is a transcript -- a shell session,
-    a tree diagram, CI output -- and it is the escape hatch for showing a path
-    that is not meant to resolve. A URL's own path components belong to another
-    site, not to this repository.
+    A fence still comes out, and is the escape hatch for showing a path that is
+    not meant to resolve. A URL's path components belong to another site.
     """
     for pattern in (CODE_FENCE_RE, URL_RE):
         text = pattern.sub(" ", text)
@@ -237,22 +226,18 @@ class TrackedPaths:
     """Every path git tracks, indexed by suffix, built once and only if needed.
 
     Resolution is by suffix because ADRs cite paths abbreviated for
-    readability: `dasher/_opaque.py` for
-    `python/xorq/common/utils/dasher/_opaque.py`. Twenty-five of the 106 path
+    readability -- `dasher/_opaque.py` for
+    `python/xorq/common/utils/dasher/_opaque.py` -- and about a quarter of the
     citations in docs/adr are that form, so a check wanting full paths would
-    either ignore a quarter of them or demand a sweep of landed ADRs to
-    lengthen them.
-
-    An ambiguous suffix counts as resolved: `expr/api.py` names both the real
-    module and the vendored ibis one. The citation names something real, and
-    picking between two real files is guesswork this check has no business
-    doing.
+    either ignore them or demand a sweep of landed ADRs to lengthen them. An
+    ambiguous suffix counts as resolved: `expr/api.py` names both the real
+    module and the vendored ibis one, and picking between two real files is
+    guesswork this check has no business doing.
 
     The index is what git tracks rather than what is on disk, because "a repo
-    path" is the question being asked. `.git/annex/objects` in ADR-0003 is a
-    runtime location that was never a file here, `docs/_site` is build output,
-    and a one-off script sitting untracked in one person's working tree should
-    not make their run pass where CI's fails.
+    path" is the question being asked: `.git/annex/objects` in ADR-0003 was
+    never a file here, `docs/_site` is build output, and an untracked local
+    script should not make one person's run pass where CI's fails.
 
     Built on first use, so a directory that cites no paths never shells out to
     git and the guard keeps working outside a repository.
@@ -287,7 +272,7 @@ class TrackedPaths:
         return True
 
     def contains(self, citation: str) -> bool:
-        return citation in (self._suffixes or frozenset())
+        return self._suffixes is not None and citation in self._suffixes
 
 
 def check_directory(problems: Problems, added: list[Path] | None = None) -> None:
@@ -448,11 +433,10 @@ def check_references(
             problems.add(path, f"links to {target}, which does not exist")
 
 
-# Appended to every path and commit report on an ADR that is already in the
-# tree, and the only place this guard tells anyone *not* to fix something. Kept
-# to two sentences because it is repeated per finding and `--format github`
-# shows it as an inline annotation, where the full argument does not fit; the
-# reasoning lives in docs/adr/README.md and in `check_paths`.
+# Appended to every path and commit report on an ADR already in the tree, and
+# the only place this guard tells anyone *not* to fix something. Kept to two
+# sentences because `--format github` shows it as an inline annotation; the
+# reasoning lives in `check_paths` and docs/adr/README.md.
 AGED_CITATION = (
     "If that was accurate when this ADR landed, leave the ADR alone: it records "
     "what was true when the decision was made, and editing a landed ADR to "
@@ -471,35 +455,34 @@ def check_paths(
 
     An unresolved path is an error in an ADR this pull request adds and a
     warning in one that has already landed. The asymmetry is the whole design,
-    because the two cases are opposites rather than degrees of the same thing.
-
-    In a new ADR the path is simply wrong: nothing has had time to move, and a
-    reader cannot open what the author just cited. In a landed ADR an
-    unresolved path is usually the document doing its job -- ADR-0006 and
-    ADR-0007 cite `dask_normalize_expr.py`, which was accurate until #1951
-    replaced dask tokenization, and the ADRs are a record of a decision taken
-    when that file existed. Failing on it would pressure people to edit landed
-    ADRs, which is exactly what docs/adr/README.md tells them not to do.
+    because the two cases are opposites rather than degrees of the same thing:
+    in a new ADR the path is simply wrong, nothing having had time to move,
+    while in a landed one it is usually the document doing its job. ADR-0006 and
+    ADR-0007 cite `dask_normalize_expr.py`, accurate until #1951 replaced dask
+    tokenization; failing on that would pressure people to edit landed ADRs,
+    which docs/adr/README.md tells them not to do.
 
     This is also the answer to the "marked historical block" that #2203 asked
     for. A marker would put the burden on authors to remember it and would let a
     genuinely wrong path be waved through; the pull request diff already knows
-    which citations are new, so git supplies the distinction for free and there
-    is no new syntax for anyone to learn. The cost is
-    that a path added to a landed ADR by an amendment only warns -- scoping to
-    the added *lines* rather than the added *files* would close that, at the
-    price of parsing diff hunks.
+    which citations are new. The cost is that a path added to a landed ADR by an
+    amendment only warns -- scoping to the added *lines* rather than the added
+    *files* would close that, at the price of parsing diff hunks.
 
     Nothing is reported for a path this run cannot resolve, only for one it can
     prove absent, which is why `load` failing is silent here.
     """
+    prose = MD_LINK_ANY_RE.sub(r" \g<target> ", strip_transcripts(text))
     citations = {
         match.group("path")
-        for match in PATH_CITATION_RE.finditer(strip_transcripts(text))
-        # Relative to the document rather than the repository root, and this
-        # check anchors at the root. Same-directory ADR links are already
-        # covered by `check_references`.
-        if ".." not in match.group("path")
+        for match in PATH_CITATION_RE.finditer(prose)
+        # A `..` *segment* is relative to the document rather than the repository
+        # root, and this check anchors at the root; same-directory ADR links are
+        # already covered by `check_references`. Tested for by segment rather
+        # than as a substring so that a citation merely containing dots is
+        # reported instead of silently skipped: `...path/to/x.py` is a missing
+        # space, and a report quoting the dots is what shows the author that.
+        if ".." not in match.group("path").split("/")
     }
     if not citations or not tracked.load():
         return
@@ -530,9 +513,7 @@ def check_shas(problems: Problems, path: Path, text: str, is_new: bool) -> None:
     full clone today. Abbreviations also grow ambiguous as a repository does, so
     one that resolves now is not durable either.
 
-    Same error-versus-warning split as `check_paths`, for the same reason: in a
-    new ADR the citation is unusable on arrival, and in a landed one it is
-    history that must not be edited to suit today's object store.
+    Same error-versus-warning split as `check_paths`, for the same reason.
     """
     prose = MD_LINK_ANY_RE.sub(" ", strip_transcripts(text))
     for sha in sorted({match.group("sha") for match in BARE_SHA_RE.finditer(prose)}):
@@ -569,11 +550,10 @@ def added_adrs(base: str, pair_renames: bool = False) -> list[Path] | None:
     one branch the number check never runs on.
 
     `pair_renames` asks for the opposite, and exactly one caller wants it: the
-    path and commit citation checks, which report an error only for an ADR whose
-    text is new. A renumbered ADR's citations are as historical after the
-    renumber as before it, so reading the move as an addition would fail the
-    branch on prose nobody touched -- and the only way to make it pass would be
-    to edit a landed ADR, which is what that asymmetry exists to prevent.
+    citation checks in `check_paths` and `check_shas`, which error only on an ADR
+    whose text is new. A renumbered ADR's citations are as historical after the
+    renumber as before, so reading the move as an addition would fail the branch
+    on prose nobody touched.
     """
     result = subprocess.run(
         [
@@ -753,11 +733,10 @@ def main() -> int:
         return 2
 
     problems = Problems(github=args.format == "github")
-    # The diff comes first because the directory pass reads it: a path or commit
-    # citation is an error in an ADR this pull request adds and a warning in one
-    # that has landed, and only the diff can tell those apart. Two diffs, not
-    # one, because the numbering checks and the citation checks want opposite
-    # answers about a renumbered ADR -- see `added_adrs`.
+    # The diff comes first because the directory pass reads it: only the diff can
+    # tell a citation that was wrong when written from one that has aged. Two
+    # diffs, not one, because the numbering checks and the citation checks want
+    # opposite answers about a renumbered ADR -- see `added_adrs`.
     added = None
     written = None
     if args.base:

--- a/scripts/adr_check.py
+++ b/scripts/adr_check.py
@@ -94,8 +94,18 @@ MD_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*(?P<target>[^)#\s]+\.md)[^)]*\)")
 # the numbering scheme necessarily prints numbers that do not resolve, and CI
 # output pasted into an ADR would otherwise fail the very check that produced
 # it. Stripped before references and links are collected.
+#
+# The run length is captured rather than fixed at three, and a leading indent is
+# allowed, because this fence is also the escape hatch `check_paths` and
+# `check_shas` point people at: their message tells an author to fence a path
+# that is not meant to resolve. A fence form Markdown accepts and this pattern
+# does not is then a blocking error on advice the guard itself gave, which is
+# worse than the check not existing. The two forms that reach here are a fence
+# nested in a list item, which is indented, and a fence *showing* a fenced block,
+# which opens with four backticks -- `(?P=fence)` is what stops the inner three
+# from closing it early.
 CODE_FENCE_RE = re.compile(
-    r"^(?P<fence>```|~~~).*?^(?P=fence)", re.MULTILINE | re.DOTALL
+    r"^[ \t]*(?P<fence>`{3,}|~{3,}).*?^[ \t]*(?P=fence)", re.MULTILINE | re.DOTALL
 )
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 URL_RE = re.compile(r"<?https?://[^\s>)]+>?")

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -218,8 +218,8 @@ def test_a_cited_path_that_resolves_passes(repo: ADRTree) -> None:
 
 
 def test_a_path_written_short_resolves(repo: ADRTree) -> None:
-    """ADRs abbreviate paths for readability -- 24 of the 119 citations in
-    docs/adr do -- so a suffix of a tracked path counts as resolved."""
+    """ADRs abbreviate paths for readability, so a suffix of a tracked path
+    counts as resolved."""
     repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `expr/api.py`.\n")
     result = repo.check()
     assert result.returncode == 0
@@ -348,6 +348,56 @@ def test_what_is_not_a_path_citation(repo: ADRTree, body: str) -> None:
     `python/xorq/writes/` are the same shape and only one is a path.
     """
     repo.write("0012-two.md", f"# ADR-0012: Two\n\n{body}")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
+
+
+def test_a_relative_link_target_is_checked(repo: ADRTree) -> None:
+    """A link target that names a file in this repository is a citation."""
+    repo.write(
+        "0012-two.md", "# ADR-0012: Two\n\nSee [the api](python/xorq/expr/gone.py).\n"
+    )
+    result = repo.check()
+    assert "python/xorq/expr/gone.py" in result.stderr
+
+
+def test_a_path_used_as_link_text_is_not_checked(repo: ADRTree) -> None:
+    """The other half of a link is prose, and may name an upstream file.
+
+    Citing a dependency's source the natural way -- path as the text, upstream
+    repository as the target -- must not be an error, not least because the
+    advice the error gives (put it in a fence) cannot apply to link text.
+    """
+    repo.write(
+        "0012-two.md",
+        "# ADR-0012: Two\n\nSee "
+        "[ibis/expr/types/core.py](https://github.com/ibis-project/ibis/blob/main/x).\n",
+    )
+    result = repo.check()
+    assert result.returncode == 0
+    assert "core.py" not in result.stderr
+
+
+def test_a_path_run_together_with_an_ellipsis_is_still_reported(repo: ADRTree) -> None:
+    """Dots are excluded by segment, not as a substring.
+
+    A missing space after an ellipsis used to make the whole citation vanish,
+    which is the failure mode a guard can least afford: the report quoting the
+    stray dots is what tells the author what to fix.
+    """
+    repo.write(
+        "0012-two.md", "# ADR-0012: Two\n\nand so on ...python/xorq/expr/gone.py\n"
+    )
+    result = repo.check()
+    assert "gone.py" in result.stderr
+
+
+def test_a_document_relative_citation_is_not_checked(repo: ADRTree) -> None:
+    """`../` is relative to the ADR; this check anchors at the repository root."""
+    repo.write(
+        "0012-two.md", "# ADR-0012: Two\n\nSee `../../python/xorq/expr/gone.py`.\n"
+    )
     result = repo.check()
     assert result.returncode == 0
     assert "warning" not in result.stderr

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -173,6 +173,12 @@ def test_short_form_citation_is_reported(tree: ADRTree) -> None:
         pytest.param("Write `ADR-9999` here.\n", id="inline-code"),
         pytest.param("<https://example.com/ADR-9999>\n", id="autolink"),
         pytest.param("```\n[x](0099-nope.md)\n```\n", id="dead-link-in-fence"),
+        pytest.param(
+            "- item:\n\n  ```\n  ADR-9999\n  ```\n", id="fence-indented-in-a-list"
+        ),
+        pytest.param(
+            "````\n```\nADR-9999\n```\n````\n", id="fence-shown-inside-a-longer-fence"
+        ),
     ],
 )
 def test_shown_reference_is_not_checked(tree: ADRTree, body: str) -> None:
@@ -304,6 +310,38 @@ def test_a_path_in_a_fence_is_not_checked(repo: ADRTree) -> None:
     """The escape hatch, and the only one: a new ADR naming a path it does not
     create yet shows it rather than citing it."""
     repo.write("2211-new.md", "# ADR-2211: New\n\n```\npython/xorq/expr/gone.py\n```\n")
+    repo.commit_all()
+    result = repo.check("--base", "HEAD~1", "--pr", "2211")
+    assert result.returncode == 0, result.stderr
+    assert "gone.py" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(
+            "- the module:\n\n  ```\n  python/xorq/expr/gone.py\n  ```\n",
+            id="fence-indented-in-a-list",
+        ),
+        pytest.param(
+            "````\n```\npython/xorq/expr/gone.py\n```\n````\n",
+            id="fence-shown-inside-a-longer-fence",
+        ),
+    ],
+)
+def test_every_fence_markdown_accepts_is_an_escape_hatch(
+    repo: ADRTree, body: str
+) -> None:
+    """The advice the error gives has to work on the fence the author writes.
+
+    `check_paths` tells an author to fence a path that is not meant to resolve.
+    A fence Markdown renders and this guard does not read is then a blocking
+    error on the guard's own instruction, with nothing left to try -- worse than
+    having no check. Both forms below are ones an ADR reaches for: a fence under
+    a list item is indented, and a fence *showing* a fenced block opens wider
+    than the one it contains.
+    """
+    repo.write("2211-new.md", f"# ADR-2211: New\n\n{body}")
     repo.commit_all()
     result = repo.check("--base", "HEAD~1", "--pr", "2211")
     assert result.returncode == 0, result.stderr

--- a/scripts/tests/test_adr_check.py
+++ b/scripts/tests/test_adr_check.py
@@ -58,6 +58,13 @@ class ADRTree:
         path.write_text(text, encoding="utf-8")
         return path
 
+    def write_source(self, relative: str, text: str = "pass\n") -> Path:
+        """A file outside docs/adr, for a path citation to resolve to."""
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
     def check(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [sys.executable, str(SCRIPTS / "adr_check.py"), *args],
@@ -182,6 +189,249 @@ def test_a_live_reference_outside_a_fence_still_fails(tree: ADRTree) -> None:
     assert result.returncode == 1
     assert "ADR-8888" in result.stderr
     assert "ADR-9999" not in result.stderr
+
+
+# --- cited repo paths --------------------------------------------------------
+#
+# Paths resolve against `git ls-files`, so every test here needs a repository
+# and a citation only resolves if its file is in the index.
+
+
+@pytest.fixture
+def repo(tree: ADRTree) -> ADRTree:
+    """A tree that is a git repository with one tracked source file.
+
+    The base ADR is committed too, so it counts as landed: an unresolved
+    citation in it warns, where the same citation in an ADR the run is told is
+    new is an error.
+    """
+    tree.write_source("python/xorq/expr/api.py")
+    tree.init_repo()
+    return tree
+
+
+def test_a_cited_path_that_resolves_passes(repo: ADRTree) -> None:
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `python/xorq/expr/api.py`.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
+
+
+def test_a_path_written_short_resolves(repo: ADRTree) -> None:
+    """ADRs abbreviate paths for readability -- 24 of the 119 citations in
+    docs/adr do -- so a suffix of a tracked path counts as resolved."""
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `expr/api.py`.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
+
+
+def test_an_ambiguous_short_path_resolves(repo: ADRTree) -> None:
+    """`expr/api.py` names both the real module and the vendored one.
+
+    The citation names something real, and picking between two real files is
+    guesswork the guard has no business doing.
+    """
+    repo.write_source("python/xorq/vendor/ibis/expr/api.py")
+    repo.commit_all()
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `expr/api.py`.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
+
+
+def test_a_line_number_is_consumed_and_ignored(repo: ADRTree) -> None:
+    """Line numbers drift on every edit above the line they name, so the guard
+    reads the `:NNN` only to keep it out of the filename."""
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `python/xorq/expr/api.py:84`.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
+
+
+def test_a_missing_path_in_a_landed_adr_warns_and_says_not_to_fix_it(
+    repo: ADRTree,
+) -> None:
+    """The design tension, and the case that must never fail the run.
+
+    ADR-0006 and ADR-0007 cite a file that #1951 deleted. Those citations were
+    accurate when the decisions were taken, so the ADRs are doing their job as a
+    record; erroring on them would pressure people to rewrite landed ADRs.
+    """
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `python/xorq/expr/gone.py`.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" in result.stderr
+    assert "python/xorq/expr/gone.py" in result.stderr
+    assert "leave the ADR alone" in result.stderr
+
+
+def test_a_missing_path_in_a_new_adr_is_an_error(repo: ADRTree) -> None:
+    """In an ADR being added there is no history to protect: the path is wrong."""
+    repo.write("2211-new.md", "# ADR-2211: New\n\nSee `python/xorq/expr/gone.py`.\n")
+    repo.commit_all()
+    result = repo.check("--base", "HEAD~1", "--pr", "2211")
+    assert result.returncode == 1
+    assert "python/xorq/expr/gone.py" in result.stderr
+    assert "leave the ADR alone" not in result.stderr
+
+
+def test_renumbering_a_landed_adr_does_not_make_its_citations_new(
+    repo: ADRTree,
+) -> None:
+    """Why the citation checks want rename detection and the number check does not.
+
+    A renumber moves the file and touches one heading line. Read as an addition,
+    every aged citation in the ADR becomes a blocking error, and the only way to
+    get the branch green is to edit a landed ADR -- exactly what the warning
+    tier exists to prevent.
+    """
+    repo.write(
+        "0016-old-thing.md", "# ADR-0016: Old\n\nSee `python/xorq/expr/gone.py`.\n"
+    )
+    repo.commit_all()
+    repo.git("mv", "docs/adr/0016-old-thing.md", "docs/adr/2211-old-thing.md")
+    repo.write(
+        "2211-old-thing.md", "# ADR-2211: Old\n\nSee `python/xorq/expr/gone.py`.\n"
+    )
+    repo.commit_all()
+    result = repo.check("--base", "HEAD~1", "--pr", "2211")
+    assert result.returncode == 0, result.stderr
+    assert "leave the ADR alone" in result.stderr
+
+
+def test_a_path_in_a_fence_is_not_checked(repo: ADRTree) -> None:
+    """The escape hatch, and the only one: a new ADR naming a path it does not
+    create yet shows it rather than citing it."""
+    repo.write("2211-new.md", "# ADR-2211: New\n\n```\npython/xorq/expr/gone.py\n```\n")
+    repo.commit_all()
+    result = repo.check("--base", "HEAD~1", "--pr", "2211")
+    assert result.returncode == 0, result.stderr
+    assert "gone.py" not in result.stderr
+
+
+def test_a_path_in_inline_code_is_still_checked(repo: ADRTree) -> None:
+    """Where the path check parts company with the reference check.
+
+    `` `ADR-9999` `` displays a reference; `` `python/xorq/expr/gone.py` `` is
+    just how a path is written. Stripping inline spans would leave the check
+    with almost nothing to look at.
+    """
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nIn `python/xorq/expr/gone.py`.\n")
+    result = repo.check()
+    assert "gone.py" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param("Wrap it in try/except here.\n", id="alternation"),
+        pytest.param("The read-path/hash-path split.\n", id="hyphenated-alternation"),
+        pytest.param("Per-token I/O is the cost.\n", id="initialism"),
+        pytest.param("Written to build/cache as needed.\n", id="directory-alternation"),
+        pytest.param("Under `python/xorq/nowhere/`.\n", id="cited-directory"),
+        pytest.param(
+            "At `metadata/<name>.zip.metadata.yaml`.\n", id="angle-placeholder"
+        ),
+        pytest.param(
+            "At `{name}/{remote_uuid}/nope.parquet`.\n", id="brace-placeholder"
+        ),
+        pytest.param("Reads `s3://bucket/nope.parquet` directly.\n", id="uri"),
+        pytest.param("See <https://example.com/nope/missing.py>.\n", id="url"),
+    ],
+)
+def test_what_is_not_a_path_citation(repo: ADRTree, body: str) -> None:
+    """False positives are the failure mode that gets a lint disabled.
+
+    Requiring an extension is what separates a path from prose, and it is why a
+    cited *directory* is not checked at all: `build/cache` and
+    `python/xorq/writes/` are the same shape and only one is a path.
+    """
+    repo.write("0012-two.md", f"# ADR-0012: Two\n\n{body}")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
+
+
+def test_a_file_on_disk_but_not_in_the_index_does_not_resolve(repo: ADRTree) -> None:
+    """ "A repo path" means tracked, not present.
+
+    Otherwise a one-off script in one person's working tree makes their run pass
+    where CI's fails -- and `.git/annex/objects` or `docs/_site` would count as
+    repository files.
+    """
+    repo.write_source("scripts/local-only.py")  # written, never added
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nSee `scripts/local-only.py`.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "scripts/local-only.py" in result.stderr
+
+
+def test_paths_are_not_checked_outside_a_repository(tree: ADRTree) -> None:
+    """No index means the check could not run, not that the ADR is wrong."""
+    tree.write("0012-two.md", "# ADR-0012: Two\n\nSee `python/xorq/expr/gone.py`.\n")
+    result = tree.check()
+    assert result.returncode == 0
+    assert "were not checked" in result.stderr
+    assert "gone.py" not in result.stderr
+
+
+# --- bare short commit SHAs --------------------------------------------------
+
+
+def test_a_bare_short_sha_in_a_landed_adr_warns(repo: ADRTree) -> None:
+    """ADR-0007's `ce8004bc` is the real instance: cited as being on `main`,
+    unreachable in a full clone today."""
+    repo.write("0012-two.md", "# ADR-0012: Two\n\nA prior attempt (`ce8004bc`).\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "ce8004bc" in result.stderr
+    assert "leave the ADR alone" in result.stderr
+
+
+def test_a_bare_short_sha_in_a_new_adr_is_an_error(repo: ADRTree) -> None:
+    repo.write("2211-new.md", "# ADR-2211: New\n\nA prior attempt (`ce8004bc`).\n")
+    repo.commit_all()
+    result = repo.check("--base", "HEAD~1", "--pr", "2211")
+    assert result.returncode == 1
+    assert "ce8004bc" in result.stderr
+
+
+def test_a_linked_sha_is_not_bare(repo: ADRTree) -> None:
+    """The recommended fix must not be the thing that always trips the check."""
+    repo.write(
+        "0012-two.md",
+        "# ADR-0012: Two\n\nSee [ce8004bc](https://github.com/x/y/commit/ce8004bc).\n",
+    )
+    result = repo.check()
+    assert result.returncode == 0
+    assert "ce8004bc" not in result.stderr
+
+
+def test_a_sha_in_a_fence_is_not_checked(repo: ADRTree) -> None:
+    repo.write("0012-two.md", "# ADR-0012: Two\n\n```\ncommit ce8004bc\n```\n")
+    assert "ce8004bc" not in repo.check().stderr
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        pytest.param("38317617c8a70d3a", id="sixteen-char-content-hash"),
+        pytest.param("a" * 40, id="full-sha"),
+        pytest.param("0" * 64, id="sha256"),
+        pytest.param("20260427", id="date-like"),
+        pytest.param("defaced", id="hex-lettered-word"),
+        pytest.param("effaced", id="another-hex-lettered-word"),
+    ],
+)
+def test_what_is_not_a_commit_citation(repo: ADRTree, token: str) -> None:
+    """This repository's ADRs are largely about hashing, so a check that fires
+    on a content hash gets disabled. Requiring both a digit and an a-f letter
+    inside seven to twelve characters is what draws the line."""
+    repo.write("0012-two.md", f"# ADR-0012: Two\n\nThe value `{token}` here.\n")
+    result = repo.check()
+    assert result.returncode == 0
+    assert "warning" not in result.stderr
 
 
 # --- collisions --------------------------------------------------------------


### PR DESCRIPTION
Delivers checks 3 and 4 of #2203. **Check 2 stays open**, so this does not close the issue — deliberately: it was declined by design, and is worth revisiting on its own merits rather than being treated as covered. Read [dlovell's comment](https://github.com/xorq-labs/xorq/issues/2203#issuecomment-5243710874) before the issue body — the body predates ADR-2210 and is partly stale: check 1 is done, check 2 was declined by design, and the "why it cannot land in the current stack" section is resolved.

## The measurement came first

`docs/adr` cites **106 paths** (52 distinct). Before any code, I extracted them and looked at what didn't resolve, because the issue's own design note names the failure mode — "false positives are the failure mode that gets a lint disabled" — and a naive extractor earns them by the dozen:

| Slash-joined tokens in docs/adr | 204 occurrences, 127 distinct |
|---|---|
| …that aren't paths at all | **75 distinct** — `try/except`, `I/O`, `NaN/NaT`, `read-path/hash-path`, `build/cache`, `yes/no` |
| Path citations after filtering | 106 occurrences, 52 distinct |
| Resolve exactly | 76 |
| Resolve only as a suffix of a tracked path | 25 — `expr/api.py`, `dasher/_opaque.py` |
| **Unresolved** | **5** |

The five, in three kinds, only one of which is a defect:

- **Never a repo file.** `scripts/2026-04-27-pierre-sync.py` (no git history at all — someone's local one-off).
- **Never a repo file, runtime path.** `.git/annex/objects` in ADR-0003. Excluded by construction, not by a special case — it has no file extension, so it is not extracted.
- **Genuinely moved.** `python/xorq/common/utils/dask_normalize/dask_normalize_expr.py` in ADR-0006 and ADR-0007, deleted by #1951; `dev/init-catalog-submodule.sh`.

`vendor/ibis/expr/types/core.py`, which looks like a dependency path, turned out to be a suffix of the vendored `python/xorq/vendor/ibis/expr/types/core.py` — so it resolves, and "paths in dependencies" isn't a category here after all.

## The design tension, and what I did about it

**The third kind is not a bug — it is the opposite of one.** An ADR records what was true when the decision was made. A check that errors on a path that has since moved pressures people to edit landed ADRs, which `docs/adr/README.md` tells them not to do. The issue's phrase "or is inside a marked historical block" gestures at this, but nobody has marked any blocks, so a literal reading of check 3 fails on day one with no vocabulary for which failures are legitimate.

So the check is asymmetric, the same way the two ADR citation forms already are:

| Where the citation is | Unresolved path, or a bare short SHA |
|---|---|
| An ADR this pull request **adds** | **Error** — nothing has had time to move, so it's wrong |
| An ADR **already in the tree** | **Warning** — probably the record doing its job |

**This replaces the "marked historical block" rather than implementing it.** The pull request diff already knows which prose is new, so git supplies the distinction for free: nothing for authors to remember, and no marker that can wave a genuinely wrong path through. The warning text is the only place this guard tells anyone *not* to fix something.

Two consequences worth reviewing:

- `added_adrs` grew a `pair_renames` flag, and `main` now runs two diffs. The numbering check must be rename-*blind* (that's what makes a renumber count as a new ADR), and the citation check must be rename-*aware* — otherwise renumbering ADR-0006 turns its aged citation into a blocking error, and the only way to get green is the edit this whole design exists to prevent. Pinned by `test_renumbering_a_landed_adr_does_not_make_its_citations_new`.
- **Known gap:** an amendment that adds a bad path to a landed ADR only warns. Closing it means scoping to added *lines* rather than added *files*, i.e. parsing diff hunks. I left it, and said so in `check_paths`.

## Extraction choices, each one measured

- **A file extension is required.** It's what separates a path from prose; it's why 75 distinct tokens are rejected. Cost, stated in the code: a cited *directory* is never checked, because `build/cache` and `python/xorq/writes/` are the same shape.
- **Suffix resolution.** A quarter of citations are abbreviated. An ambiguous suffix counts as resolved — `expr/api.py` names two real files, and choosing between them is guesswork.
- **`git ls-files`, not the filesystem.** "A repo path" means tracked. Otherwise `.git/`, `docs/_site`, and untracked local scripts count as repo files, and a run passes for whoever has the file and fails in CI. Loaded lazily, so a directory citing no paths never shells out and the guard still runs outside a checkout (where it warns once that paths went unchecked, rather than reporting every path as missing).
- **Inline code spans are kept, not stripped** — the one place these checks diverge from `strip_shown_code`. For a reference a backtick means "displayed, not cited"; for a path it's just how you write one. The measurement is unambiguous: strip inline spans and there is *nothing* left to check, because all 106 path citations are inside backticks, and so is the one bare SHA. Fences and URLs still come out, and a fence is the escape hatch for showing a path that isn't meant to resolve.
- **Line numbers are matched and ignored**, per the issue's design note.

For check 4, the whole directory contains exactly one bare short SHA: ADR-0007's `ce8004bc`, cited as being "on `main`" — and `git cat-file` can't find it in a full clone today. Exactly the rot the issue described. The window is 7–12 hex chars requiring both a digit and an `a-f` letter: this repo's own content hashes are 16 hex chars and its ADRs are largely about hashing, so `38317617c8a70d3a` must not read as a commit, and `20260427` and `defaced` must not either. Markdown links are stripped whole, so the recommended fix isn't the one thing that always trips the check.

## Verification

Local and complete — no "can't verify this" caveat applies.

```
$ python3 scripts/adr_check.py
```

| | Before | After |
|---|---|---|
| Errors | 0 | **0** |
| Warnings | 6 (unresolved slugs) | **11** — the same 6, plus 4 paths and 1 SHA |
| Exit code | 0 | **0** |

```
$ uv run --isolated --no-project --with pytest -- pytest scripts/tests -q
122 passed
```

92 → 122 tests, +30. I mutation-tested the two parametrized false-positive guards (relaxing the extension requirement and the 12-char SHA ceiling) and confirmed 6 of them fail, so they aren't passing vacuously.

**No ADR was edited to make this pass.** The five warnings are meant to stay.


