### PR TITLE
release: 0.3.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Details
 
+## [0.3.39] - 2026-08-11
+### Details
+#### Changed
+- Number ADRs by the pull request that adds them by @dlovell in [#2210](https://github.com/xorq-labs/xorq/pull/2210)
+- **Breaking:** Fold the rule-set fingerprint into the build hash (every build-directory name moves; cache keys are unaffected) by @dlovell in [#2200](https://github.com/xorq-labs/xorq/pull/2200)
+- Drop the allowlist entries #2200 has landed by @dlovell in [#2212](https://github.com/xorq-labs/xorq/pull/2212)
+- Accept ADR-2210, and say what enforces it now by @dlovell in [#2218](https://github.com/xorq-labs/xorq/pull/2218)
+- Update readme to consistently use the language around catalog by @hussainsultan in [#2209](https://github.com/xorq-labs/xorq/pull/2209)
+- Cache the quartodoc reference instead of rebuilding it every run by @dlovell in [#2220](https://github.com/xorq-labs/xorq/pull/2220)
+
+#### Fixed
+- Report an allowlist entry that has done its job by @dlovell in [#2211](https://github.com/xorq-labs/xorq/pull/2211)
+
 ## [0.3.38] - 2026-08-06
 ### Details
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ only-include = ["python"]
 
 [project]
 name = "xorq"
-version = "0.3.38"
+version = "0.3.39"
 dependencies = [
     "attrs>=24.1.0; python_version >= '3.10' and python_version < '4.0'",
     "pyarrow>=18.0.0,<22; python_version >= '3.10' and python_version < '4.0'",

--- a/uv.lock
+++ b/uv.lock
@@ -6151,7 +6151,7 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.3.38"
+version = "0.3.39"
 source = { editable = "." }
 dependencies = [
     { name = "atpublic" },


### PR DESCRIPTION
Release 0.3.39.

Includes one breaking change: #2200 folds the rule-set fingerprint into the build hash, so every build-directory name moves (cache keys are unaffected). Precedent for shipping breaking changes in a patch bump: 0.3.22, 0.3.24, 0.3.25.

Changes: pyproject.toml version bump, CHANGELOG via git cliff, uv.lock (xorq version line only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)