### PR TITLE
docs(changelog): backfill #2221 and #2222 into the 0.3.39 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Details
 #### Changed
 - Number ADRs by the pull request that adds them by @dlovell in [#2210](https://github.com/xorq-labs/xorq/pull/2210)
+- Check cited repo paths and reject bare short SHAs by @dlovell in [#2221](https://github.com/xorq-labs/xorq/pull/2221)
+- Decide the citation tier per line, not per file by @dlovell in [#2222](https://github.com/xorq-labs/xorq/pull/2222)
 - **Breaking:** Fold the rule-set fingerprint into the build hash (every build-directory name moves; cache keys are unaffected) by @dlovell in [#2200](https://github.com/xorq-labs/xorq/pull/2200)
 - Drop the allowlist entries #2200 has landed by @dlovell in [#2212](https://github.com/xorq-labs/xorq/pull/2212)
 - Accept ADR-2210, and say what enforces it now by @dlovell in [#2218](https://github.com/xorq-labs/xorq/pull/2218)


### PR DESCRIPTION
PRs #2221 and #2222 merged to main after the release-0.3.39 branch was cut, so the git cliff run on the branch missed them. Both commits are in the v0.3.39 tag (and in the GitHub release notes), so this backfills the CHANGELOG section to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)