### PR TITLE
feat(profiles): top up tier 2 from an imported backend's static _secret_keys

### DIFF
--- a/python/xorq/tests/test_profile.py
+++ b/python/xorq/tests/test_profile.py
@@ -1427,6 +1427,192 @@ def test_declared_sources_cannot_shrink_mirrored_keys(
         check_for_exposed_secrets("postgres", {"sslcert": "/path/to/cert"})
 
 
+class _StaticKeysBackend:
+    _secret_keys = ("secret",)
+
+
+def test_an_imported_backends_static_keys_top_up_the_mirror(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """Tier 2 is the mirror topped up from an already-imported backend's static
+    _secret_keys, exactly as tier 3 tops up the declared sources: an out-of-tree
+    backend cannot add a mirror entry, and a fixed kwarg name like "secret"
+    lives in no kwargs data for a source to point at, so without the top-up its
+    static declaration was dead documentation -- enforced as a convention by
+    test_declaring_backends_also_mirror_static_keys, read by nothing."""
+    con_name = _install_fake_backend(monkeypatch, _StaticKeysBackend)
+    assert profiles_mod.get_secret_keys(con_name) == ("password", "secret")
+    with pytest.raises(ValueError, match="'secret'"):
+        check_for_exposed_secrets(con_name, {"secret": "plaintext"})
+    # an env-var reference is accepted
+    check_for_exposed_secrets(con_name, {"secret": "${SECRET}"})
+    # and through Profile.save(): the save aborts and writes nothing
+    profile = Profile(con_name=con_name, kwargs_tuple=(("secret", "plaintext"),))
+    with pytest.raises(ValueError, match="'secret'"):
+        profile.save(profile_dir=tmp_path)
+    assert not tuple(tmp_path.iterdir())
+
+
+def test_unimported_backend_contributes_no_static_class_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The static-keys class read stays best-effort exactly as the sources read
+    is: an out-of-tree backend that isn't imported (and, being out-of-tree, has
+    no mirror entry) contributes nothing, and the unconditional default still
+    applies."""
+    con_name = _install_fake_backend(monkeypatch, _StaticKeysBackend, imported=False)
+    assert profiles_mod.get_secret_keys(con_name) == ("password",)
+    check_for_exposed_secrets(con_name, {"secret": "plaintext"})
+    with pytest.raises(ValueError, match="'password'"):
+        check_for_exposed_secrets(con_name, {"password": "plaintext"})
+
+
+def test_a_property_static_keys_declaration_contributes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_secret_keys declared as a property never executes: getattr_static reads
+    the class dict without firing descriptors and returns the descriptor object,
+    which fails the tuple check -- the same no-execution rule as the sources
+    read, on the same metaclass layout where a plain getattr would run it."""
+    executed = []
+
+    class Meta(type):
+        @property
+        def _secret_keys(cls) -> tuple:
+            executed.append(True)
+            return ("secret",)
+
+    class Backend(metaclass=Meta):
+        pass
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert profiles_mod.get_secret_keys(con_name) == ("password",)
+    assert not executed
+
+
+def test_a_non_tuple_static_keys_declaration_contributes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed class declaration -- a list here -- fails the tuple check
+    and contributes nothing: declaration shape is an authoring-time concern,
+    never a runtime guard, and tiers 1 and 3 keep enforcing."""
+
+    class Backend:
+        _secret_keys = ["secret"]
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert profiles_mod.get_secret_keys(con_name) == ("password",)
+
+
+def test_a_mixed_static_keys_declaration_keeps_the_str_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-str members are dropped while the well-formed names beside them are
+    kept and enforced -- the same rule as a resolved leaf's, because checking
+    the good names is strictly safer than dropping the declaration."""
+
+    class Backend:
+        _secret_keys = ("secret", 3, None)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert profiles_mod.get_secret_keys(con_name) == ("password", "secret")
+    with pytest.raises(ValueError, match="'secret'"):
+        check_for_exposed_secrets(con_name, {"secret": "plaintext"})
+
+
+def test_a_static_keys_tuple_subclass_has_its_true_names_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The class declaration is plugin-authored data, so it is read the way the
+    resolver reads a leaf: a tuple subclass forging __iter__ has the override
+    bypassed and its true names read and enforced."""
+
+    class Forging(tuple):
+        def __iter__(self) -> collections.abc.Iterator:
+            return iter(("forged",))
+
+    declared = Forging(("secret",))
+    assert tuple(declared) == ("forged",), "the forgery is live"
+
+    class Backend:
+        _secret_keys = declared
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert profiles_mod.get_secret_keys(con_name) == ("password", "secret")
+    with pytest.raises(ValueError, match="'secret'"):
+        check_for_exposed_secrets(con_name, {"secret": "plaintext"})
+
+
+def test_a_forged_str_static_key_cannot_escape_the_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """A static key comes back as an exact str copy, like a name out of a
+    resolved leaf: returned as-is, a str subclass would carry its own __eq__
+    into the membership test that matches it against a kwarg -- the key is
+    named in no error and the literal saves anyway."""
+
+    class Ghost(str):
+        def __eq__(self, other: object) -> bool:
+            return False
+
+        def __hash__(self) -> int:
+            return str.__hash__(self)
+
+    class Backend:
+        _secret_keys = (Ghost("secret"),)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    keys = profiles_mod.get_secret_keys(con_name)
+    assert keys == ("password", "secret")
+    assert all(type(key) is str for key in keys)
+    with pytest.raises(ValueError, match="'secret'"):
+        check_for_exposed_secrets(con_name, {"secret": "plaintext"})
+    profile = Profile(con_name=con_name, kwargs_tuple=(("secret", "plaintext"),))
+    with pytest.raises(ValueError, match="'secret'"):
+        profile.save(profile_dir=tmp_path)
+    assert not tuple(tmp_path.iterdir())
+
+
+def test_a_static_key_whose_hash_raises_cannot_escape_the_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nor can a static key reach the dedupe in get_secret_keys, which hashes
+    it outside any guard: an exact str copy has nothing left to raise."""
+
+    class HashBomb(str):
+        def __hash__(self) -> int:
+            raise RuntimeError("boom")
+
+    class Backend:
+        _secret_keys = (HashBomb("secret"),)
+
+    con_name = _install_fake_backend(monkeypatch, Backend)
+    assert profiles_mod.get_secret_keys(con_name) == ("password", "secret")
+    with pytest.raises(ValueError, match="'secret'"):
+        check_for_exposed_secrets(con_name, {"secret": "plaintext"})
+
+
+def test_static_class_keys_top_up_the_mirror_and_cannot_shrink_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirror and class keys are unioned, mirror first: a class declaration on
+    a mirrored backend can only widen the checked set, never narrow it."""
+
+    class Backend:
+        _secret_keys = ("extra_secret",)
+
+    _install_fake_backend(monkeypatch, Backend, con_name="postgres")
+    keys = profiles_mod.get_secret_keys("postgres")
+    mirror = con_name_to_secret_keys["postgres"]
+    assert set(mirror) <= set(keys)
+    assert "extra_secret" in keys
+    assert tuple(key for key in keys if key in mirror) == mirror
+    with pytest.raises(ValueError, match="'sslcert'"):
+        check_for_exposed_secrets("postgres", {"sslcert": "/path/to/cert"})
+    with pytest.raises(ValueError, match="'extra_secret'"):
+        check_for_exposed_secrets("postgres", {"extra_secret": "plaintext"})
+
+
 def test_validate_con_name_sees_a_backend_installed_mid_process(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -532,6 +532,28 @@ def _imported_backend(con_name: str) -> type | None:
     return backend if isinstance(backend, type) else None
 
 
+def _static_secret_keys_for(con_name: str) -> tuple[str, ...]:
+    """Every static secret key for ``con_name``: the mirror entry, topped up
+    from ``_secret_keys`` on an already-imported backend, exactly as
+    ``_secret_key_sources_for`` tops up the declared sources -- how an
+    out-of-tree backend, unable to add a mirror entry, keeps the tier. The
+    class is plugin-authored data, so it is read like the resolver reads a
+    leaf: unbound ``tuple.__iter__``, and the names come back as exact ``str``
+    copies, since a ``str`` subclass reaching the caller could forge the
+    ``__eq__`` that matches it against a kwarg or the ``__hash__`` that
+    dedupes it in ``get_secret_keys``."""
+    keys = tuple(con_name_to_secret_keys.get(con_name, ()))
+    if (backend := _imported_backend(con_name)) is not None:
+        declared = inspect.getattr_static(backend, "_secret_keys", ())
+        if isinstance(declared, tuple):
+            keys += tuple(
+                str.__str__(name)
+                for name in tuple.__iter__(declared)
+                if isinstance(name, str)
+            )
+    return keys
+
+
 def _secret_key_sources_for(con_name: str) -> tuple[tuple[str, ...], ...]:
     """Every declared source for ``con_name``: the mirror entry, topped up from
     ``_secret_key_sources`` on an already-imported backend, which is how an
@@ -582,7 +604,8 @@ def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...
     """Return every secret key to check for ``con_name``: the *union* of
 
     1. the unconditional ``default_secret_keys`` (``("password",)``),
-    2. the static ``con_name_to_secret_keys`` mirror entry, if any,
+    2. the static keys: the ``con_name_to_secret_keys`` mirror entry, topped up
+       from ``_secret_keys`` on an already-imported backend,
     3. the backend's declared ``_secret_key_sources``, resolved against kwargs.
 
     Unioning is what keeps this monotone: an empty, narrower, or unresolved tier 3
@@ -593,7 +616,7 @@ def get_secret_keys(con_name: str, kwargs: dict | None = None) -> tuple[str, ...
         dict.fromkeys(
             (
                 *default_secret_keys,
-                *con_name_to_secret_keys.get(con_name, ()),
+                *_static_secret_keys_for(con_name),
                 *get_declared_secret_keys(con_name, kwargs),
             )
         )


### PR DESCRIPTION
## Summary

Follow-up to #2184, closing the one asymmetry between its two class reads. `get_secret_keys` tier 2 read only the `con_name_to_secret_keys` mirror — deliberately, so validation never imports a backend. But an **out-of-tree** backend cannot add a mirror entry (the mirror is a `MappingProxyType` in vendored source), and a fixed kwarg name like `secret` is stored in no kwargs data for a `_secret_key_sources` source to point at. So a plugin's static `_secret_keys` was dead documentation: `test_declaring_backends_also_mirror_static_keys` *requires* declaring it, and nothing read it.

Tier 2 is now the mirror **topped up** from an already-imported backend's `_secret_keys`, symmetric with how `_secret_key_sources_for` tops up tier 3:

- `inspect.getattr_static`, so a `property` declaration contributes nothing instead of executing, and a tuple check, so a malformed (list-shaped) declaration contributes nothing instead of breaking the check;
- because a plugin class is plugin-authored data, it is read the way `_resolve_source` reads a leaf: the names come off the tuple through the unbound `tuple.__iter__` (a subclass's forged `__iter__` is bypassed and the true names are read), non-`str` members are dropped while the names beside them are kept, and each name is materialized as an exact `str` copy via `str.__str__` — a `str` subclass handed onward would carry its own `__eq__` into the membership test that matches it against a kwarg, and its own `__hash__` into the dedupe in `get_secret_keys`, which runs outside the fail-closed guard.
- Same import-gated best-effort semantics as the tier-3 class read: an unimported backend contributes nothing and tiers 1 and 3 keep enforcing. The union is unchanged in shape, so no key checked before this PR can be dropped, and ordering stays deterministic (default, mirror, class top-up, declared).

This unblocks the `land/4a` restack: the fixture backend's (and the xorq-mixpanel plugin's) static `secret` becomes enforceable by declaring `_secret_keys` alone, which is what the artifact-leak tests' enforcement path needs after the `_get_secret_keys` hook's deletion.

## Testing

`python -m pytest python/xorq/tests/test_profile.py python/xorq/tests/test_loader.py` — 106 passed; the 3 failures in test_profile.py are pre-existing and need a live postgres on localhost:5432 (they reproduce on `main`).

New tests, mirroring the tier-3 top-up suite:

- `test_an_imported_backends_static_keys_top_up_the_mirror` — the headline: a backend with a static `secret` and no mirror entry has it enforced through `check_for_exposed_secrets` and `Profile.save()` (the save aborts and writes nothing; an env-var reference is accepted).
- `test_unimported_backend_contributes_no_static_class_keys` — best-effort, exactly as tier 3: not imported means nothing contributed, and the default still applies.
- `test_a_property_static_keys_declaration_contributes_nothing` — the property lives on a metaclass, where a plain `getattr` would run it and get back a well-formed tuple; only the `getattr_static` read keeps it out.
- `test_a_non_tuple_static_keys_declaration_contributes_nothing` — a list-shaped declaration fails the tuple check.
- `test_a_mixed_static_keys_declaration_keeps_the_str_names` — `("secret", 3, None)` keeps `secret`, enforced.
- `test_a_static_keys_tuple_subclass_has_its_true_names_read` — a tuple subclass forging `__iter__` has the true names read and enforced.
- `test_a_forged_str_static_key_cannot_escape_the_match` — a `str` subclass whose `__eq__` never matches is materialized, the key is enforced, and the save writes nothing.
- `test_a_static_key_whose_hash_raises_cannot_escape_the_guard` — nor does a name reach the dedupe with a `__hash__` left to raise outside the guard.
- `test_static_class_keys_top_up_the_mirror_and_cannot_shrink_it` — monotonicity: mirror first, class keys can only widen.

Each was verified to go **red** against a deliberately weakened implementation (mirror-only tier 2 — the state on main before this PR; plain `getattr`; bound/uncopied/unfiltered name access), so none passes vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDir9n9kvdPCuLdwQ8FYDc