### PR TITLE
fix(cli): exit quietly when a downstream consumer closes stdout

### DIFF
--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import collections.abc
 import contextlib
 import datetime
+import errno
 import os
 import pdb
+import signal
 import sys
 import traceback
 from functools import partial, wraps
@@ -32,6 +34,23 @@ from xorq.init_templates import InitTemplates
 
 if TYPE_CHECKING:
     from xorq.api import Expr
+
+
+# what a process killed by SIGPIPE reports, so `xorq run ... | head` behaves
+# like any other unix producer in a pipeline
+EPIPE_EXIT_CODE = 128 + getattr(signal, "SIGPIPE", 13)
+
+
+def _silence_stdout() -> None:
+    """Redirect fd 1 to devnull, discarding whatever is still buffered."""
+    try:
+        fd = sys.stdout.fileno()
+    except (AttributeError, OSError, ValueError):
+        return
+    with contextlib.suppress(OSError):
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, fd)
+        os.close(devnull)
 
 
 @contextlib.contextmanager
@@ -798,6 +817,12 @@ class PdbGroup(click.Group):
         except (click.ClickException, click.exceptions.Exit, SystemExit):
             raise
         except Exception as e:
+            if isinstance(e, OSError) and e.errno == errno.EPIPE:
+                # a downstream consumer (`| head`, `| less`, ...) closed the
+                # pipe: not our failure, and there is nowhere left to print a
+                # traceback to, so exit the way SIGPIPE-killed producers do
+                _silence_stdout()
+                sys.exit(EPIPE_EXIT_CODE)
             if ctx.params.get("use_pdb"):
                 traceback.print_exception(e)
                 pdb.post_mortem(e.__traceback__)

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -24,6 +24,7 @@ import xorq.api as xo
 from xorq.caching.strategy import SnapshotStrategy
 from xorq.catalog.cli import cli as catalog_cli
 from xorq.cli import (
+    EPIPE_EXIT_CODE,
     arbitrate_output_format,
     build_command,
     cli,
@@ -554,6 +555,58 @@ def test_run_command_stdout(tmp_path, fixture_dir, output_format):
         assert stdout
     else:
         raise AssertionError("No expression hash")
+
+
+@pytest.mark.slow(level=1)
+@pytest.mark.skipif(sys.platform == "win32", reason="no SIGPIPE/head on windows")
+@pytest.mark.parametrize(
+    "output_format",
+    [
+        pytest.param("csv", id="csv"),
+        pytest.param("json", id="json"),
+        pytest.param("parquet", id="parquet"),
+    ],
+)
+def test_run_command_stdout_broken_pipe(tmp_path: Path, output_format: str) -> None:
+    """`xorq run -o- | head` must exit quietly instead of dumping a traceback."""
+    # write far more than a pipe buffer holds, so the producer is still writing
+    # when head exits and actually takes EPIPE
+    parquet_path = tmp_path / "rows.parquet"
+    pd.DataFrame({"i": range(50_000), "s": ["x" * 64] * 50_000}).to_parquet(
+        parquet_path
+    )
+    expr = xo.deferred_read_parquet(
+        path=parquet_path, con=xo.connect(), table_name="rows"
+    )
+    expr_path = build_expr(
+        expr, builds_dir=tmp_path / "builds", cache_dir=tmp_path / "cache"
+    )
+
+    producer = _subprocess.Popen(
+        (
+            "xorq",
+            "run",
+            str(expr_path),
+            "--output-path",
+            "-",
+            "--format",
+            output_format,
+        ),
+        stdout=_subprocess.PIPE,
+        stderr=_subprocess.PIPE,
+    )
+    # head -c works the same for the binary formats as it does for csv/json
+    consumer = _subprocess.Popen(
+        ("head", "-c", "128"), stdin=producer.stdout, stdout=_subprocess.PIPE
+    )
+    producer.stdout.close()  # only head holds the read end of the pipe
+    (head_stdout, _) = consumer.communicate()
+    stderr = producer.stderr.read()
+    producer.stderr.close()
+
+    assert len(head_stdout) == 128
+    assert producer.wait() == EPIPE_EXIT_CODE
+    assert not stderr, stderr.decode()
 
 
 def test_run_command_logging(tmp_path):


### PR DESCRIPTION
## Symptom

```
$ xorq run ./builds/01430627d319 -o- -fjson | head -n 2
{"npi":"1508391186",...}
{"npi":"1508391186",...}
Traceback (most recent call last):
  ...
  File "python/xorq/expr/api.py", line 775, in to_json
    f.write(batch_json)
BrokenPipeError: [Errno 32] Broken pipe
```

Piping `xorq run -o-` into `head` (or `less`, or any consumer that stops early) reported a crash. Exit code 1, full traceback on stderr.

## Root cause

Click already handles EPIPE in `BaseCommand.main` — it swaps in a `PacifyFlushWrapper` and exits 1. But `PdbGroup.invoke` sits below that and catches every `Exception` first, printing a traceback and calling `sys.exit(1)`. A consumer closing the pipe was being reported as a xorq failure.

## Fix

Special-case EPIPE in `PdbGroup.invoke`, before the generic traceback path:

- point fd 1 at devnull first, so the interpreter's shutdown flush of still-buffered stdout cannot raise EPIPE again;
- exit `128 + SIGPIPE` (141), what a SIGPIPE-killed unix producer reports, so a pipeline can tell "the consumer went away" apart from a real failure.

Matching on `isinstance(e, OSError) and e.errno == errno.EPIPE` rather than `BrokenPipeError` mirrors click's own check and also covers EPIPE surfacing through pyarrow's writers (parquet/arrow output to stdout).

Non-EPIPE errors are untouched: a bad build path still prints its traceback and exits 1, and `--pdb` still drops into post-mortem for everything else.

## Verification

Same build, same command, with and without the patch:

| code under test | exit | stderr |
| --- | --- | --- |
| `main` | 1 | `BrokenPipeError: [Errno 32] Broken pipe` + traceback |
| this branch | 141 | empty |

`test_run_command_stdout_broken_pipe` covers csv/json/parquet: it builds an expr over a 50k-row parquet (output well past the 64K pipe buffer, so the producer is guaranteed to still be writing when the consumer exits), pipes `xorq run -o- -f<fmt>` into `head -c 128`, and asserts 128 bytes out, exit 141, empty stderr. It fails against the unpatched CLI. Marked `slow(level=1)`, so `ci-test-slow` runs it.

## Notes for review

- **Exit code is a judgement call.** 141 vs click's default 1 — both non-zero, so `pipefail` users see a failure either way (as they do with `yes | head`). 141 carries the extra information that the pipe closed rather than the query failing. Easy to change to 1 by deleting the branch and letting click handle it.
- **Not addressed here:** `run_command`'s `except Exception` still records `status="error"` in the run log for an interrupted run. Arguably it should be a distinct status like `"interrupted"`. Left out to keep this diff to the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WKxggU4E1N4KKKC3MGTPp