### PR TITLE
fix(caching): exclude FlightExpr/FlightUDXF names from the snapshot hash

### DIFF
--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -192,11 +192,28 @@ class SnapshotStrategy(CacheStrategy):
             normalize_remote_table,
         )
 
-        from xorq.expr.relations import CachedNode, Read, RemoteTable  # noqa: PLC0415
+        from xorq.common.utils.dasher._relations import (  # noqa: PLC0415
+            normalize_flight_expr,
+            normalize_flight_udxf,
+        )
+        from xorq.expr.relations import (  # noqa: PLC0415
+            CachedNode,
+            DatabaseTableView,
+            FlightExpr,
+            FlightUDXF,
+            Read,
+            RemoteTable,
+        )
 
-        # DatabaseTable subclasses (Read, CachedNode, RemoteTable) need
-        # concrete-type dispatch here — dasher's MRO lookup would otherwise
-        # pick this broader DatabaseTable rule over them.
+        # Every DatabaseTableView subclass needs concrete-type dispatch here —
+        # dasher's MRO lookup would otherwise pick this broader DatabaseTable
+        # rule over them. The `case _` fallback below folds `name` in, which is
+        # right for a real backend table (there `name` *is* the identity) and
+        # wrong for these views, whose `name` defaults to a per-process
+        # `gen_name()` uuid4. Missing FlightExpr/FlightUDXF here is what made
+        # `xorq build` non-reproducible and every SnapshotStrategy cache key
+        # churn per process (gh-2229); the DatabaseTableView guard makes the
+        # next such omission fail loudly instead of silently leaking a uuid4.
         memo = _snapshot_dt_normalize_memo.get()
         if memo is not None and dt in memo:
             return memo[dt]
@@ -207,6 +224,16 @@ class SnapshotStrategy(CacheStrategy):
                 result = normalize_cached_node(dt)
             case RemoteTable():
                 result = normalize_remote_table(dt)
+            case FlightExpr():
+                result = normalize_flight_expr(dt)
+            case FlightUDXF():
+                result = normalize_flight_udxf(dt)
+            case DatabaseTableView():
+                raise NotImplementedError(
+                    f"{type(dt).__name__} is a DatabaseTableView with no "
+                    "snapshot normalizer; add one rather than letting the "
+                    "fallback fold its generated name into the key"
+                )
             case _:
                 keys = ("name", "schema", "source", "namespace")
                 result = tuple((k, getattr(dt, k)) for k in keys)

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -181,9 +181,8 @@ class SnapshotStrategy(CacheStrategy):
 
         # In-memory backends identified by name alone; remote backends
         # delegate to HASHER.normalize which raises if unregistered. The name
-        # set is canonical (constants.NAME_ONLY_BACKEND_NAMES) rather than
-        # respelled here — this tuple is where gh-1842 kept the project's
-        # previous backend name `"let"` two renames after the fact.
+        # set is canonical (constants.NAME_ONLY_BACKEND_NAMES), never respelled
+        # here — see test_backend_names.py (gh-1842).
         name = con.name
         if name in NAME_ONLY_BACKEND_NAMES:
             return (name, None)
@@ -191,17 +190,12 @@ class SnapshotStrategy(CacheStrategy):
 
     @staticmethod
     def normalize_databasetable(dt: ops.DatabaseTable) -> tuple:
-        # Every DatabaseTable subclass needs concrete-type dispatch here —
-        # dasher's MRO lookup would otherwise pick this broader DatabaseTable
-        # rule over them — so the op->normalizer mapping is shared with the
-        # global dispatcher through ``view_rules`` rather than mirrored by hand.
-        # Mirroring is what drifted: this table used to omit
-        # FlightExpr/FlightUDXF, and the fallback below folded their per-process
-        # `gen_name()` uuid4 into the key, making `xorq build` non-reproducible
-        # and every SnapshotStrategy cache miss per run (gh-2229). The fallback
-        # deliberately keeps folding `name` in — for a genuine backend table
-        # `name` *is* the identity — and ``lookup_view_normalizer`` raises rather
-        # than let a DatabaseTableView reach it.
+        # Concrete-type dispatch is shared with the global dispatcher through
+        # ``view_rules`` — see its docstring for why the two tables must not be
+        # hand-mirrored (gh-2229). The fallback deliberately keeps folding
+        # `name` in — for a genuine backend table `name` *is* the identity —
+        # and ``lookup_view_normalizer`` raises rather than let a
+        # DatabaseTableView reach it.
         from xorq.common.utils.dasher._relations import (  # noqa: PLC0415
             lookup_view_normalizer,
         )

--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from attr import field, frozen
 from attr.validators import instance_of
 
-from xorq.common.constants import READ_IDENTITY_KEYS
+from xorq.common.constants import NAME_ONLY_BACKEND_NAMES, READ_IDENTITY_KEYS
 
 
 if TYPE_CHECKING:
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from xorq.expr.relations import Read
     from xorq.vendor.ibis import Expr
+    from xorq.vendor.ibis.expr import operations as ops
 
 
 # Per-outer-call memo for ``SnapshotStrategy.normalize_databasetable``.
@@ -179,64 +180,41 @@ class SnapshotStrategy(CacheStrategy):
         from xorq.common.utils.dasher import HASHER  # noqa: PLC0415
 
         # In-memory backends identified by name alone; remote backends
-        # delegate to HASHER.normalize which raises if unregistered.
+        # delegate to HASHER.normalize which raises if unregistered. The name
+        # set is canonical (constants.NAME_ONLY_BACKEND_NAMES) rather than
+        # respelled here — this tuple is where gh-1842 kept the project's
+        # previous backend name `"let"` two renames after the fact.
         name = con.name
-        if name in ("pandas", "duckdb", "datafusion", "xorq_datafusion"):
+        if name in NAME_ONLY_BACKEND_NAMES:
             return (name, None)
         return HASHER.normalize(con)
 
     @staticmethod
-    def normalize_databasetable(dt):
-        from xorq_dasher.rules.expr import (  # noqa: PLC0415
-            normalize_cached_node,
-            normalize_remote_table,
-        )
-
-        from xorq.common.utils.dasher._relations import (  # noqa: PLC0415
-            normalize_flight_expr,
-            normalize_flight_udxf,
-        )
-        from xorq.expr.relations import (  # noqa: PLC0415
-            CachedNode,
-            DatabaseTableView,
-            FlightExpr,
-            FlightUDXF,
-            Read,
-            RemoteTable,
-        )
-
-        # Every DatabaseTableView subclass needs concrete-type dispatch here —
+    def normalize_databasetable(dt: ops.DatabaseTable) -> tuple:
+        # Every DatabaseTable subclass needs concrete-type dispatch here —
         # dasher's MRO lookup would otherwise pick this broader DatabaseTable
-        # rule over them. The `case _` fallback below folds `name` in, which is
-        # right for a real backend table (there `name` *is* the identity) and
-        # wrong for these views, whose `name` defaults to a per-process
-        # `gen_name()` uuid4. Missing FlightExpr/FlightUDXF here is what made
-        # `xorq build` non-reproducible and every SnapshotStrategy cache key
-        # churn per process (gh-2229); the DatabaseTableView guard makes the
-        # next such omission fail loudly instead of silently leaking a uuid4.
+        # rule over them — so the op->normalizer mapping is shared with the
+        # global dispatcher through ``view_rules`` rather than mirrored by hand.
+        # Mirroring is what drifted: this table used to omit
+        # FlightExpr/FlightUDXF, and the fallback below folded their per-process
+        # `gen_name()` uuid4 into the key, making `xorq build` non-reproducible
+        # and every SnapshotStrategy cache miss per run (gh-2229). The fallback
+        # deliberately keeps folding `name` in — for a genuine backend table
+        # `name` *is* the identity — and ``lookup_view_normalizer`` raises rather
+        # than let a DatabaseTableView reach it.
+        from xorq.common.utils.dasher._relations import (  # noqa: PLC0415
+            lookup_view_normalizer,
+        )
+
         memo = _snapshot_dt_normalize_memo.get()
         if memo is not None and dt in memo:
             return memo[dt]
-        match dt:
-            case Read():
-                result = snapshot_normalize_read(dt)
-            case CachedNode():
-                result = normalize_cached_node(dt)
-            case RemoteTable():
-                result = normalize_remote_table(dt)
-            case FlightExpr():
-                result = normalize_flight_expr(dt)
-            case FlightUDXF():
-                result = normalize_flight_udxf(dt)
-            case DatabaseTableView():
-                raise NotImplementedError(
-                    f"{type(dt).__name__} is a DatabaseTableView with no "
-                    "snapshot normalizer; add one rather than letting the "
-                    "fallback fold its generated name into the key"
-                )
-            case _:
-                keys = ("name", "schema", "source", "namespace")
-                result = tuple((k, getattr(dt, k)) for k in keys)
+        normalizer = lookup_view_normalizer(dt, snapshot=True)
+        if normalizer is not None:
+            result = normalizer(dt)
+        else:
+            keys = ("name", "schema", "source", "namespace")
+            result = tuple((k, getattr(dt, k)) for k in keys)
         if memo is not None:
             memo[dt] = result
         return result

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -12,12 +12,9 @@ READ_EXCLUDE_KEYS = frozenset({"hash_path", "read_path", "relocatable"})
 
 # Backend names that identity/normalization dispatch keys on, kept here as the
 # single source so a backend rename cannot leave a stale string behind in one
-# dispatch table while the others move.  That has already happened: gh-1842
-# shipped ``SnapshotStrategy.normalize_backend`` still holding the project's
-# previous name ``"let"`` two renames after the fact, and the flight-name leak
-# of gh-2229 is the same defect one axis over.  ``test_backend_names.py``
-# asserts every name below is a live entry point in the ``xorq.backends``
-# group, so the next rename fails in CI instead of silently under-keying.
+# dispatch table while the others move (gh-1842 did exactly that).
+# ``test_backend_names.py`` anchors every name below to the live
+# ``xorq.backends`` entry-point group and holds the full story.
 DATAFUSION_BACKEND_NAMES = ("datafusion", "xorq_datafusion")
 PANDAS_BACKEND_NAME = "pandas"
 DUCKDB_BACKEND_NAME = "duckdb"

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -8,3 +8,37 @@ REMOTE_SCHEMES = HTTP_SCHEMES + CLOUD_SCHEMES
 READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
 
 READ_EXCLUDE_KEYS = frozenset({"hash_path", "read_path", "relocatable"})
+
+
+# Backend names that identity/normalization dispatch keys on, kept here as the
+# single source so a backend rename cannot leave a stale string behind in one
+# dispatch table while the others move.  That has already happened: gh-1842
+# shipped ``SnapshotStrategy.normalize_backend`` still holding the project's
+# previous name ``"let"`` two renames after the fact, and the flight-name leak
+# of gh-2229 is the same defect one axis over.  ``test_backend_names.py``
+# asserts every name below is a live entry point in the ``xorq.backends``
+# group, so the next rename fails in CI instead of silently under-keying.
+DATAFUSION_BACKEND_NAMES = ("datafusion", "xorq_datafusion")
+PANDAS_BACKEND_NAME = "pandas"
+DUCKDB_BACKEND_NAME = "duckdb"
+SQLITE_BACKEND_NAME = "sqlite"
+BIGQUERY_BACKEND_NAME = "bigquery"
+
+# Backends whose connection identity is fully determined by the backend name:
+# no connection parameter distinguishes two instances for hashing purposes.
+# Consumed by ``SnapshotStrategy.normalize_backend``.
+NAME_ONLY_BACKEND_NAMES = (
+    PANDAS_BACKEND_NAME,
+    DUCKDB_BACKEND_NAME,
+) + DATAFUSION_BACKEND_NAMES
+
+# Every backend name the DatabaseTable dispatch chain in
+# ``dasher/_relations.py`` special-cases before falling through to
+# ``xorq_dasher``.  Derived, never re-spelled -- see REMOTE_SCHEMES above for
+# the same subset-derivation pattern.
+DISPATCHED_BACKEND_NAMES = DATAFUSION_BACKEND_NAMES + (
+    PANDAS_BACKEND_NAME,
+    DUCKDB_BACKEND_NAME,
+    SQLITE_BACKEND_NAME,
+    BIGQUERY_BACKEND_NAME,
+)

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from xorq.common.enums import BackendName
+
 
 HTTP_SCHEMES = ("http://", "https://")
 CLOUD_SCHEMES = ("s3://", "gs://", "gcs://")
@@ -10,32 +12,24 @@ READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
 READ_EXCLUDE_KEYS = frozenset({"hash_path", "read_path", "relocatable"})
 
 
-# Backend names that identity/normalization dispatch keys on, kept here as the
-# single source so a backend rename cannot leave a stale string behind in one
-# dispatch table while the others move (gh-1842 did exactly that).
-# ``test_backend_names.py`` anchors every name below to the live
-# ``xorq.backends`` entry-point group and holds the full story.
-DATAFUSION_BACKEND_NAMES = ("datafusion", "xorq_datafusion")
-PANDAS_BACKEND_NAME = "pandas"
-DUCKDB_BACKEND_NAME = "duckdb"
-SQLITE_BACKEND_NAME = "sqlite"
-BIGQUERY_BACKEND_NAME = "bigquery"
+# Dispatch sets derived from the ``BackendName`` enum — composed from members,
+# never re-spelled as literals (gh-1842; see the enum's docstring).
+
+# The two datafusion-flavored backends share every dispatch special case.
+DATAFUSION_BACKEND_NAMES = (BackendName.DATAFUSION, BackendName.XORQ_DATAFUSION)
 
 # Backends whose connection identity is fully determined by the backend name:
 # no connection parameter distinguishes two instances for hashing purposes.
 # Consumed by ``SnapshotStrategy.normalize_backend``.
-NAME_ONLY_BACKEND_NAMES = (
-    PANDAS_BACKEND_NAME,
-    DUCKDB_BACKEND_NAME,
-) + DATAFUSION_BACKEND_NAMES
+NAME_ONLY_BACKEND_NAMES = frozenset(
+    {
+        BackendName.PANDAS,
+        BackendName.DUCKDB,
+        *DATAFUSION_BACKEND_NAMES,
+    }
+)
 
 # Every backend name the DatabaseTable dispatch chain in
 # ``dasher/_relations.py`` special-cases before falling through to
-# ``xorq_dasher``.  Derived, never re-spelled -- see REMOTE_SCHEMES above for
-# the same subset-derivation pattern.
-DISPATCHED_BACKEND_NAMES = DATAFUSION_BACKEND_NAMES + (
-    PANDAS_BACKEND_NAME,
-    DUCKDB_BACKEND_NAME,
-    SQLITE_BACKEND_NAME,
-    BIGQUERY_BACKEND_NAME,
-)
+# ``xorq_dasher``.  Currently every member.
+DISPATCHED_BACKEND_NAMES = frozenset(BackendName)

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -12,9 +12,6 @@ READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
 READ_EXCLUDE_KEYS = frozenset({"hash_path", "read_path", "relocatable"})
 
 
-# Dispatch sets derived from the ``BackendName`` enum — composed from members,
-# never re-spelled as literals (gh-1842; see the enum's docstring).
-
 # The two datafusion-flavored backends share every dispatch special case.
 DATAFUSION_BACKEND_NAMES = (BackendName.DATAFUSION, BackendName.XORQ_DATAFUSION)
 

--- a/python/xorq/common/enums.py
+++ b/python/xorq/common/enums.py
@@ -7,13 +7,11 @@ XORQ_METADATA_PREFIX = "xorq:"
 
 
 class BackendName(StrEnum):
-    """Backend names that identity/normalization dispatch keys on.
+    """Canonical spellings of the backend names normalization dispatch keys on.
 
-    One canonical spelling per name, so a backend rename cannot leave a stale
-    string behind in one dispatch table while the others move (gh-1842 did
-    exactly that).  ``test_backend_names.py`` anchors every member to the live
-    ``xorq.backends`` entry-point group and holds the full story.  Derived
-    dispatch sets live in ``xorq.common.constants``.
+    ``test_backend_names.py`` anchors every member to the live ``xorq.backends``
+    entry-point group (gh-1842) and holds the full story; the derived dispatch
+    sets live in ``xorq.common.constants``.
     """
 
     PANDAS = "pandas"

--- a/python/xorq/common/enums.py
+++ b/python/xorq/common/enums.py
@@ -1,7 +1,27 @@
+from __future__ import annotations
+
 from xorq.common.compat import StrEnum
 
 
 XORQ_METADATA_PREFIX = "xorq:"
+
+
+class BackendName(StrEnum):
+    """Backend names that identity/normalization dispatch keys on.
+
+    One canonical spelling per name, so a backend rename cannot leave a stale
+    string behind in one dispatch table while the others move (gh-1842 did
+    exactly that).  ``test_backend_names.py`` anchors every member to the live
+    ``xorq.backends`` entry-point group and holds the full story.  Derived
+    dispatch sets live in ``xorq.common.constants``.
+    """
+
+    PANDAS = "pandas"
+    DUCKDB = "duckdb"
+    DATAFUSION = "datafusion"
+    XORQ_DATAFUSION = "xorq_datafusion"
+    SQLITE = "sqlite"
+    BIGQUERY = "bigquery"
 
 
 class RunLogFile(StrEnum):

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -23,14 +23,11 @@ from xorq_dasher.rules.expr import (
 )
 
 from xorq.common.constants import (
-    BIGQUERY_BACKEND_NAME,
     DATAFUSION_BACKEND_NAMES,
-    DUCKDB_BACKEND_NAME,
-    PANDAS_BACKEND_NAME,
     READ_IDENTITY_KEYS,
     REMOTE_SCHEMES,
-    SQLITE_BACKEND_NAME,
 )
+from xorq.common.enums import BackendName
 from xorq.common.utils.dasher._canonical import (
     normalize_memory_databasetable_canonical,
 )
@@ -469,19 +466,19 @@ def _dispatch_databasetable(dt: ops.DatabaseTable) -> tuple:
     # databasetable_xorq stats the underlying files to restore mtime sensitivity.
     if dt.source.name in DATAFUSION_BACKEND_NAMES:
         return _normalize_datafusion_databasetable_xorq(dt)
-    if dt.source.name == DUCKDB_BACKEND_NAME:
+    if dt.source.name == BackendName.DUCKDB:
         return _normalize_duckdb_databasetable_xorq(dt)
     # xorq_dasher 0.1.0's bigquery normalizer unpacks its result frame by
     # column label and crashes on every table; use the fixed xorq version.
-    if dt.source.name == BIGQUERY_BACKEND_NAME:
+    if dt.source.name == BackendName.BIGQUERY:
         return _normalize_bigquery_databasetable_xorq(dt)
     # pandas-backend tables and in-memory sqlite are memory-resident:
     # xorq_dasher's dispatch hashes the IPC bytes of their
     # ``to_pyarrow_batches()`` stream, which is pyarrow-version-coupled
     # (issue #2191) — route them to the canonical form instead.
-    if dt.source.name == PANDAS_BACKEND_NAME:
+    if dt.source.name == BackendName.PANDAS:
         return normalize_memory_databasetable_canonical(dt)
-    if dt.source.name == SQLITE_BACKEND_NAME and dt.source.is_in_memory():
+    if dt.source.name == BackendName.SQLITE and dt.source.is_in_memory():
         return normalize_memory_databasetable_canonical(dt)
     # All remaining backends fall through to ``xorq_dasher``
     # ``normalize_databasetable`` (bigquery is handled above and never reaches

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -372,7 +372,8 @@ def view_rules() -> tuple[ViewRule, ...]:
     non-reproducible and every ``SnapshotStrategy`` cache miss per process
     (gh-2229).  The identical bug had already been fixed once in the dask era
     (gh-610) and returned with the dasher rewrite, so the table is the fix:
-    adding a row serves both regimes at once.
+    adding a row serves both regimes at once (the ADR-0016 pattern —
+    table-driven dispatch with registration tripwires).
 
     Two columns because the regimes legitimately differ for exactly one op:
     ``Read`` takes stat-based identity globally and path-only identity under

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -320,9 +320,8 @@ def normalize_flight_expr(dt: ops.DatabaseTable) -> tuple:
     ``Field``).
 
     ``dt.name`` is omitted because it defaults to ``gen_name()`` — a fresh uuid4
-    per process — so folding it in makes the token non-reproducible. Shared with
-    ``SnapshotStrategy.normalize_databasetable`` so the two dispatch tables
-    cannot drift on this invariant again (see gh-2229).
+    per process — so folding it in makes the token non-reproducible (gh-2229;
+    see :func:`view_rules`).
     """
     return (
         "xorq.FlightExpr",
@@ -335,22 +334,12 @@ def normalize_flight_expr(dt: ops.DatabaseTable) -> tuple:
 def normalize_flight_udxf(dt: ops.DatabaseTable) -> tuple:
     """Identity of a ``FlightUDXF``, deliberately excluding ``dt.name``.
 
-    ``dt.udxf.__qualname__`` distinguishes UDXF classes even when ``exchange_f``
-    is absent or shared — bare ``getattr(..., None)`` would otherwise collapse
-    two distinct UDXFs (both missing ``exchange_f``) onto the same token.
-
-    Note ``dt.udxf`` is the exchanger *class*, not an instance: ``make_udxf``
-    returns ``type(name, (AbstractExchanger,), ...)``.  So this must be
-    ``dt.udxf.__qualname__`` and not ``type(dt.udxf).__qualname__`` — the latter
-    reads the metaclass and evaluates to the constant ``"ABCMeta"`` for every
-    UDXF that has ever existed, which is exactly the discrimination this element
-    is here to provide.  Two hand-written ``AbstractExchanger`` subclasses that
-    inherit rather than override ``exchange_f`` tokenized identically under that
-    spelling; ``test_flight_udxf_qualname_is_the_class_not_the_metaclass`` pins
-    it.
-
-    The qualname is a deterministic ``name or process_df.__name__`` (never a
-    ``gen_name()``), so folding it in does not reintroduce the gh-2229 leak.
+    The qualname is what distinguishes two exchangers that inherit rather than
+    override ``exchange_f``, and it is deterministic (``name or
+    process_df.__name__``, never a ``gen_name()``). ``dt.udxf`` is already the
+    exchanger *class* — do not write ``type(dt.udxf).__qualname__``, which reads
+    the metaclass and yields ``"ABCMeta"`` for every UDXF
+    (``test_flight_udxf_qualname_is_the_class_not_the_metaclass`` pins this).
 
     See :func:`normalize_flight_expr` for why ``dt.name`` is excluded.
     """
@@ -420,17 +409,15 @@ def view_rules() -> tuple[ViewRule, ...]:
 def lookup_view_normalizer(dt: ops.DatabaseTable, *, snapshot: bool) -> Callable | None:
     """Return the normalizer for ``dt``, or ``None`` to use the caller's fallback.
 
-    Raises ``NotImplementedError`` for an unhandled ``DatabaseTableView``.  Both
-    dispatch tables route through here so the guard covers both: a fallback that
-    folds ``name`` in is right for a genuine backend table (there ``name`` *is*
-    the identity) and wrong for a view, whose ``name`` defaults to a per-process
-    ``gen_name()`` uuid4.
+    Raises ``NotImplementedError`` for an unhandled ``DatabaseTableView``: a
+    name-folding fallback is right for a genuine backend table (there ``name``
+    *is* the identity) and wrong for a view, whose ``name`` defaults to a
+    per-process ``gen_name()`` uuid4 (gh-2229; see :func:`view_rules`).  Both
+    dispatch tables route through here so the guard covers both.
 
-    This runtime guard is not made redundant by
-    ``test_view_rules.py``'s static exhaustiveness check.  That check reads
-    ``DatabaseTableView.__subclasses__()``, which only sees imported modules, and
-    xorq imports backends lazily — a view op defined in a lazily-imported backend
-    module would slip past it vacuously.
+    Not made redundant by ``test_view_rules.py``'s static exhaustiveness check:
+    that check reads ``DatabaseTableView.__subclasses__()``, which only sees
+    imported modules, and xorq imports backends lazily.
     """
     for rule in view_rules():
         if isinstance(dt, rule.op_type):

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -299,6 +299,48 @@ def _databasetable_dispatcher(dt: ops.DatabaseTable) -> tuple:
     return result
 
 
+def normalize_flight_expr(dt):
+    """Identity of a ``FlightExpr``, deliberately excluding ``dt.name``.
+
+    FlightExpr/FlightUDXF carry input_expr / make_connection that the plain
+    datafusion path would silently flatten away. Inlines the dasher 0.1.0 logic
+    but uses ``_rename_unbound_xorq`` (whose op.replace callback signs
+    ``(node, _kwargs)`` correctly — dasher 0.1.0's ``_rename_unbound`` uses
+    ``**kwargs`` and crashes recreating ops with required positional fields like
+    ``Field``).
+
+    ``dt.name`` is omitted because it defaults to ``gen_name()`` — a fresh uuid4
+    per process — so folding it in makes the token non-reproducible. Shared with
+    ``SnapshotStrategy.normalize_databasetable`` so the two dispatch tables
+    cannot drift on this invariant again (see gh-2229).
+    """
+    return (
+        "xorq.FlightExpr",
+        dt.input_expr,
+        _rename_unbound_xorq(dt.unbound_expr.op()).to_expr(),
+        dt.make_connection,
+    )
+
+
+def normalize_flight_udxf(dt):
+    """Identity of a ``FlightUDXF``, deliberately excluding ``dt.name``.
+
+    ``type(dt.udxf).__qualname__`` distinguishes UDXF classes even when
+    ``exchange_f`` is absent or shared — bare ``getattr(..., None)`` would
+    otherwise collapse two distinct UDXFs (both missing ``exchange_f``) onto the
+    same token.
+
+    See :func:`normalize_flight_expr` for why ``dt.name`` is excluded.
+    """
+    return (
+        "xorq.FlightUDXF",
+        dt.input_expr,
+        type(dt.udxf).__qualname__,
+        getattr(dt.udxf, "exchange_f", _MISSING),
+        dt.make_connection,
+    )
+
+
 def _dispatch_databasetable(dt):
     from xorq.expr.relations import (  # noqa: PLC0415
         CachedNode,
@@ -316,30 +358,9 @@ def _dispatch_databasetable(dt):
         case RemoteTable():
             return normalize_remote_table(dt)
         case FlightExpr():
-            # FlightExpr/FlightUDXF carry input_expr / make_connection that the
-            # plain datafusion path would silently flatten away. Inline the
-            # dasher 0.1.0 logic but use ``_rename_unbound_xorq`` (whose
-            # op.replace callback signs ``(node, _kwargs)`` correctly — dasher
-            # 0.1.0's ``_rename_unbound`` uses ``**kwargs`` and crashes
-            # recreating ops with required positional fields like ``Field``).
-            return (
-                "xorq.FlightExpr",
-                dt.input_expr,
-                _rename_unbound_xorq(dt.unbound_expr.op()).to_expr(),
-                dt.make_connection,
-            )
+            return normalize_flight_expr(dt)
         case FlightUDXF():
-            # ``type(dt.udxf).__qualname__`` distinguishes UDXF classes even
-            # when ``exchange_f`` is absent or shared — bare
-            # ``getattr(..., None)`` would otherwise collapse two distinct
-            # UDXFs (both missing ``exchange_f``) onto the same token.
-            return (
-                "xorq.FlightUDXF",
-                dt.input_expr,
-                type(dt.udxf).__qualname__,
-                getattr(dt.udxf, "exchange_f", _MISSING),
-                dt.make_connection,
-            )
+            return normalize_flight_udxf(dt)
     # For datafusion-backed file tables, dasher's normalize_datafusion_
     # databasetable stops at ep_str — which captures the path but no stat —
     # so file edits don't invalidate the cache key. _normalize_datafusion_

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -10,9 +10,11 @@ ep_str-only DT rule loses.
 from __future__ import annotations
 
 import contextvars
+import functools
 import pathlib
 import re
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple
 
 from xorq_dasher.rules.expr import (
     normalize_cached_node,
@@ -20,7 +22,15 @@ from xorq_dasher.rules.expr import (
     normalize_remote_table,
 )
 
-from xorq.common.constants import READ_IDENTITY_KEYS, REMOTE_SCHEMES
+from xorq.common.constants import (
+    BIGQUERY_BACKEND_NAME,
+    DATAFUSION_BACKEND_NAMES,
+    DUCKDB_BACKEND_NAME,
+    PANDAS_BACKEND_NAME,
+    READ_IDENTITY_KEYS,
+    REMOTE_SCHEMES,
+    SQLITE_BACKEND_NAME,
+)
 from xorq.common.utils.dasher._canonical import (
     normalize_memory_databasetable_canonical,
 )
@@ -299,10 +309,10 @@ def _databasetable_dispatcher(dt: ops.DatabaseTable) -> tuple:
     return result
 
 
-def normalize_flight_expr(dt):
+def normalize_flight_expr(dt: ops.DatabaseTable) -> tuple:
     """Identity of a ``FlightExpr``, deliberately excluding ``dt.name``.
 
-    FlightExpr/FlightUDXF carry input_expr / make_connection that the plain
+    A ``FlightExpr`` carries input_expr / make_connection that the plain
     datafusion path would silently flatten away. Inlines the dasher 0.1.0 logic
     but uses ``_rename_unbound_xorq`` (whose op.replace callback signs
     ``(node, _kwargs)`` correctly — dasher 0.1.0's ``_rename_unbound`` uses
@@ -322,26 +332,74 @@ def normalize_flight_expr(dt):
     )
 
 
-def normalize_flight_udxf(dt):
+def normalize_flight_udxf(dt: ops.DatabaseTable) -> tuple:
     """Identity of a ``FlightUDXF``, deliberately excluding ``dt.name``.
 
-    ``type(dt.udxf).__qualname__`` distinguishes UDXF classes even when
-    ``exchange_f`` is absent or shared — bare ``getattr(..., None)`` would
-    otherwise collapse two distinct UDXFs (both missing ``exchange_f``) onto the
-    same token.
+    ``dt.udxf.__qualname__`` distinguishes UDXF classes even when ``exchange_f``
+    is absent or shared — bare ``getattr(..., None)`` would otherwise collapse
+    two distinct UDXFs (both missing ``exchange_f``) onto the same token.
+
+    Note ``dt.udxf`` is the exchanger *class*, not an instance: ``make_udxf``
+    returns ``type(name, (AbstractExchanger,), ...)``.  So this must be
+    ``dt.udxf.__qualname__`` and not ``type(dt.udxf).__qualname__`` — the latter
+    reads the metaclass and evaluates to the constant ``"ABCMeta"`` for every
+    UDXF that has ever existed, which is exactly the discrimination this element
+    is here to provide.  Two hand-written ``AbstractExchanger`` subclasses that
+    inherit rather than override ``exchange_f`` tokenized identically under that
+    spelling; ``test_flight_udxf_qualname_is_the_class_not_the_metaclass`` pins
+    it.
+
+    The qualname is a deterministic ``name or process_df.__name__`` (never a
+    ``gen_name()``), so folding it in does not reintroduce the gh-2229 leak.
 
     See :func:`normalize_flight_expr` for why ``dt.name`` is excluded.
     """
     return (
         "xorq.FlightUDXF",
         dt.input_expr,
-        type(dt.udxf).__qualname__,
+        dt.udxf.__qualname__,
         getattr(dt.udxf, "exchange_f", _MISSING),
         dt.make_connection,
     )
 
 
-def _dispatch_databasetable(dt):
+class ViewRule(NamedTuple):
+    """One row of :func:`view_rules`: an op type and its normalizer per regime."""
+
+    op_type: type
+    normalizer: Callable
+    snapshot_normalizer: Callable
+
+
+@functools.cache
+def view_rules() -> tuple[ViewRule, ...]:
+    """The single source of truth for ``DatabaseTable``-subclass normalization.
+
+    Two dispatch tables normalize these ops — the global one
+    (:func:`_dispatch_databasetable`) and the snapshot one
+    (``SnapshotStrategy.normalize_databasetable``) — because dasher's
+    MRO-with-earliest-match-wins lookup would otherwise pick the broader
+    ``DatabaseTable`` rule over the more specific subclasses.  They used to be
+    hand-mirrored ``match`` statements, and they drifted: the snapshot copy
+    omitted ``FlightExpr``/``FlightUDXF`` and its ``case _`` fallback folded
+    their ``gen_name()`` uuid4 into the key, making ``xorq build``
+    non-reproducible and every ``SnapshotStrategy`` cache miss per process
+    (gh-2229).  The identical bug had already been fixed once in the dask era
+    (gh-610) and returned with the dasher rewrite, so the table is the fix:
+    adding a row serves both regimes at once.
+
+    Two columns because the regimes legitimately differ for exactly one op:
+    ``Read`` takes stat-based identity globally and path-only identity under
+    snapshot.  Every other row is deliberately the same callable in both
+    columns, which is the invariant that drift used to break silently.
+
+    Order is significant — :func:`lookup_view_normalizer` takes the first
+    ``isinstance`` match, so a subtype must precede its supertype.
+
+    Resolved lazily (and cached) because the snapshot column lives in
+    ``xorq.caching.strategy``, which imports this module.
+    """
+    from xorq.caching.strategy import snapshot_normalize_read  # noqa: PLC0415
     from xorq.expr.relations import (  # noqa: PLC0415
         CachedNode,
         FlightExpr,
@@ -350,36 +408,93 @@ def _dispatch_databasetable(dt):
         RemoteTable,
     )
 
-    match dt:
-        case Read():
-            return _normalize_read_xorq(dt)
-        case CachedNode():
-            return normalize_cached_node(dt)
-        case RemoteTable():
-            return normalize_remote_table(dt)
-        case FlightExpr():
-            return normalize_flight_expr(dt)
-        case FlightUDXF():
-            return normalize_flight_udxf(dt)
+    return (
+        ViewRule(Read, _normalize_read_xorq, snapshot_normalize_read),
+        ViewRule(CachedNode, normalize_cached_node, normalize_cached_node),
+        ViewRule(RemoteTable, normalize_remote_table, normalize_remote_table),
+        ViewRule(FlightExpr, normalize_flight_expr, normalize_flight_expr),
+        ViewRule(FlightUDXF, normalize_flight_udxf, normalize_flight_udxf),
+    )
+
+
+def lookup_view_normalizer(dt: ops.DatabaseTable, *, snapshot: bool) -> Callable | None:
+    """Return the normalizer for ``dt``, or ``None`` to use the caller's fallback.
+
+    Raises ``NotImplementedError`` for an unhandled ``DatabaseTableView``.  Both
+    dispatch tables route through here so the guard covers both: a fallback that
+    folds ``name`` in is right for a genuine backend table (there ``name`` *is*
+    the identity) and wrong for a view, whose ``name`` defaults to a per-process
+    ``gen_name()`` uuid4.
+
+    This runtime guard is not made redundant by
+    ``test_view_rules.py``'s static exhaustiveness check.  That check reads
+    ``DatabaseTableView.__subclasses__()``, which only sees imported modules, and
+    xorq imports backends lazily — a view op defined in a lazily-imported backend
+    module would slip past it vacuously.
+    """
+    for rule in view_rules():
+        if isinstance(dt, rule.op_type):
+            return rule.snapshot_normalizer if snapshot else rule.normalizer
+    from xorq.expr.relations import DatabaseTableView  # noqa: PLC0415
+
+    if isinstance(dt, DatabaseTableView):
+        raise NotImplementedError(
+            f"{type(dt).__name__} is a DatabaseTableView with no normalizer; "
+            "add a row to xorq.common.utils.dasher._relations.view_rules "
+            "rather than letting a fallback fold its generated name into the key"
+        )
+    return None
+
+
+def unhandled_view_op_types() -> tuple[type, ...]:
+    """``DatabaseTableView`` subclasses (recursively) with no :func:`view_rules` row.
+
+    Only sees subclasses whose defining module has been imported; see the
+    caveat on :func:`lookup_view_normalizer`.
+    """
+    from xorq.expr.relations import DatabaseTableView  # noqa: PLC0415
+
+    handled = tuple(rule.op_type for rule in view_rules())
+
+    def descendants(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from descendants(sub)
+
+    return tuple(
+        cls
+        for cls in dict.fromkeys(descendants(DatabaseTableView))
+        if not issubclass(cls, handled)
+    )
+
+
+def _dispatch_databasetable(dt: ops.DatabaseTable) -> tuple:
+    # DatabaseTable-subclass dispatch is shared with
+    # ``SnapshotStrategy.normalize_databasetable`` via ``view_rules`` so the two
+    # regimes cannot drift on which ops they cover (gh-2229); returning None
+    # here means "not a view, fall through to the per-backend chain below".
+    normalizer = lookup_view_normalizer(dt, snapshot=False)
+    if normalizer is not None:
+        return normalizer(dt)
     # For datafusion-backed file tables, dasher's normalize_datafusion_
     # databasetable stops at ep_str — which captures the path but no stat —
     # so file edits don't invalidate the cache key. _normalize_datafusion_
     # databasetable_xorq stats the underlying files to restore mtime sensitivity.
-    if dt.source.name in ("datafusion", "xorq_datafusion"):
+    if dt.source.name in DATAFUSION_BACKEND_NAMES:
         return _normalize_datafusion_databasetable_xorq(dt)
-    if dt.source.name == "duckdb":
+    if dt.source.name == DUCKDB_BACKEND_NAME:
         return _normalize_duckdb_databasetable_xorq(dt)
     # xorq_dasher 0.1.0's bigquery normalizer unpacks its result frame by
     # column label and crashes on every table; use the fixed xorq version.
-    if dt.source.name == "bigquery":
+    if dt.source.name == BIGQUERY_BACKEND_NAME:
         return _normalize_bigquery_databasetable_xorq(dt)
     # pandas-backend tables and in-memory sqlite are memory-resident:
     # xorq_dasher's dispatch hashes the IPC bytes of their
     # ``to_pyarrow_batches()`` stream, which is pyarrow-version-coupled
     # (issue #2191) — route them to the canonical form instead.
-    if dt.source.name == "pandas":
+    if dt.source.name == PANDAS_BACKEND_NAME:
         return normalize_memory_databasetable_canonical(dt)
-    if dt.source.name == "sqlite" and dt.source.is_in_memory():
+    if dt.source.name == SQLITE_BACKEND_NAME and dt.source.is_in_memory():
         return normalize_memory_databasetable_canonical(dt)
     # All remaining backends fall through to ``xorq_dasher``
     # ``normalize_databasetable`` (bigquery is handled above and never reaches
@@ -404,9 +519,15 @@ def _dispatch_databasetable(dt):
 
 
 __all__ = [
+    "ViewRule",
     "_databasetable_dispatcher",
     "_normalize_bigquery_databasetable_xorq",
     "_normalize_datafusion_databasetable_xorq",
     "_normalize_duckdb_databasetable_xorq",
     "_normalize_read_xorq",
+    "lookup_view_normalizer",
+    "normalize_flight_expr",
+    "normalize_flight_udxf",
+    "unhandled_view_op_types",
+    "view_rules",
 ]

--- a/python/xorq/common/utils/tests/test_backend_names.py
+++ b/python/xorq/common/utils/tests/test_backend_names.py
@@ -85,13 +85,14 @@ def test_xorq_own_backend_is_classified_by_name() -> None:
     assert xo.connect().name in NAME_ONLY_BACKEND_NAMES
 
 
-def test_no_dispatched_name_is_stale_relative_to_upstream_dasher() -> None:
-    """The upstream per-backend dict is keyed on the same names.
+def test_retired_backend_name_stays_retired() -> None:
+    """No registered backend is named ``"xorq"`` again.
 
     ``_dispatch_databasetable`` falls through to
     ``xorq_dasher.rules.expr.normalize_databasetable`` for the backends it does
-    not intercept.  Upstream still carries a ``"xorq"`` key that no longer
-    matches any registered backend -- assert that dead key stays dead rather
-    than silently becoming live again under a future rename.
+    not intercept, and upstream's per-backend dict still carries a ``"xorq"``
+    key from before the ``xorq_datafusion`` rename.  If a backend named
+    ``"xorq"`` ever registers again, that stale upstream normalizer silently
+    becomes live for it -- fail here first.
     """
     assert "xorq" not in _get_backend_names()

--- a/python/xorq/common/utils/tests/test_backend_names.py
+++ b/python/xorq/common/utils/tests/test_backend_names.py
@@ -1,0 +1,97 @@
+"""The backend-name dispatch axis, guarded against renames.
+
+Normalization dispatches on two axes: op type (see ``test_view_rules.py``) and
+backend *name string*.  The name axis cannot be covered by a subclass sweep —
+it is an open set of strings — and it has already failed exactly the way the
+op-type axis failed in gh-2229: gh-1842 shipped
+``SnapshotStrategy.normalize_backend`` still holding the project's previous
+backend name ``"let"``, two renames after the fact, silently classifying
+xorq's own backend as remote.
+
+So the names live in ``xorq.common.constants`` as one canonical set, and these
+tests anchor that set to the live ``xorq.backends`` entry-point group: a rename
+that lands without updating the constants fails here instead of quietly
+under-keying a cache.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import xorq.api as xo
+from xorq.backends import _get_backend_names
+from xorq.common.constants import (
+    BIGQUERY_BACKEND_NAME,
+    DATAFUSION_BACKEND_NAMES,
+    DISPATCHED_BACKEND_NAMES,
+    DUCKDB_BACKEND_NAME,
+    NAME_ONLY_BACKEND_NAMES,
+    PANDAS_BACKEND_NAME,
+    SQLITE_BACKEND_NAME,
+)
+
+
+@pytest.mark.parametrize("name", sorted(set(DISPATCHED_BACKEND_NAMES)))
+def test_dispatched_backend_name_is_registered(name: str) -> None:
+    """Every name the DT dispatch chain keys on is a live backend.
+
+    This is the gh-1842 tripwire: a renamed backend leaves a string here that
+    matches nothing, and the branch it guards becomes dead code that fails open.
+    """
+    assert name in _get_backend_names()
+
+
+@pytest.mark.parametrize("name", sorted(set(NAME_ONLY_BACKEND_NAMES)))
+def test_name_only_backend_name_is_registered(name: str) -> None:
+    assert name in _get_backend_names()
+
+
+def test_name_only_names_are_a_subset_of_dispatched() -> None:
+    """A backend identified by name alone must also be intercepted by the chain.
+
+    Both sets are derived from the same constants; this pins the containment so
+    a future edit to one cannot silently desynchronize them.
+    """
+    assert set(NAME_ONLY_BACKEND_NAMES) <= set(DISPATCHED_BACKEND_NAMES)
+
+
+def test_constants_are_derived_not_respelled() -> None:
+    """The subsets compose from the same atoms (the REMOTE_SCHEMES pattern).
+
+    Guards against someone re-typing a literal into one tuple only.
+    """
+    assert set(DATAFUSION_BACKEND_NAMES) <= set(DISPATCHED_BACKEND_NAMES)
+    assert set(NAME_ONLY_BACKEND_NAMES) == {
+        PANDAS_BACKEND_NAME,
+        DUCKDB_BACKEND_NAME,
+        *DATAFUSION_BACKEND_NAMES,
+    }
+    assert set(DISPATCHED_BACKEND_NAMES) == {
+        *DATAFUSION_BACKEND_NAMES,
+        PANDAS_BACKEND_NAME,
+        DUCKDB_BACKEND_NAME,
+        SQLITE_BACKEND_NAME,
+        BIGQUERY_BACKEND_NAME,
+    }
+
+
+def test_xorq_own_backend_is_classified_by_name() -> None:
+    """xorq's default connection must land in the name-only set.
+
+    The concrete regression from gh-1842: after the ``let`` -> ``xorq`` ->
+    ``xorq_datafusion`` renames, ``xo.connect()`` fell through to the remote
+    branch of ``normalize_backend``.
+    """
+    assert xo.connect().name in NAME_ONLY_BACKEND_NAMES
+
+
+def test_no_dispatched_name_is_stale_relative_to_upstream_dasher() -> None:
+    """The upstream per-backend dict is keyed on the same names.
+
+    ``_dispatch_databasetable`` falls through to
+    ``xorq_dasher.rules.expr.normalize_databasetable`` for the backends it does
+    not intercept.  Upstream still carries a ``"xorq"`` key that no longer
+    matches any registered backend -- assert that dead key stays dead rather
+    than silently becoming live again under a future rename.
+    """
+    assert "xorq" not in _get_backend_names()

--- a/python/xorq/common/utils/tests/test_backend_names.py
+++ b/python/xorq/common/utils/tests/test_backend_names.py
@@ -8,10 +8,11 @@ op-type axis failed in gh-2229: gh-1842 shipped
 backend name ``"let"``, two renames after the fact, silently classifying
 xorq's own backend as remote.
 
-So the names live in ``xorq.common.constants`` as one canonical set, and these
-tests anchor that set to the live ``xorq.backends`` entry-point group: a rename
-that lands without updating the constants fails here instead of quietly
-under-keying a cache.
+So the names live in the ``BackendName`` enum (``xorq.common.enums``) with the
+dispatch sets in ``xorq.common.constants`` derived from its members, and these
+tests anchor the enum to the live ``xorq.backends`` entry-point group: a rename
+that lands without updating the enum fails here instead of quietly under-keying
+a cache.
 """
 
 from __future__ import annotations
@@ -21,58 +22,52 @@ import pytest
 import xorq.api as xo
 from xorq.backends import _get_backend_names
 from xorq.common.constants import (
-    BIGQUERY_BACKEND_NAME,
     DATAFUSION_BACKEND_NAMES,
     DISPATCHED_BACKEND_NAMES,
-    DUCKDB_BACKEND_NAME,
     NAME_ONLY_BACKEND_NAMES,
-    PANDAS_BACKEND_NAME,
-    SQLITE_BACKEND_NAME,
 )
+from xorq.common.enums import BackendName
 
 
-@pytest.mark.parametrize("name", sorted(set(DISPATCHED_BACKEND_NAMES)))
-def test_dispatched_backend_name_is_registered(name: str) -> None:
-    """Every name the DT dispatch chain keys on is a live backend.
+@pytest.mark.parametrize("name", sorted(BackendName))
+def test_backend_name_is_registered(name: BackendName) -> None:
+    """Every ``BackendName`` member is a live backend.
 
-    This is the gh-1842 tripwire: a renamed backend leaves a string here that
-    matches nothing, and the branch it guards becomes dead code that fails open.
+    This is the gh-1842 tripwire: a renamed backend leaves a member here that
+    matches nothing, and every branch it guards becomes dead code that fails
+    open.  Sweeping the enum itself means a newly added member is covered
+    automatically, with no aggregate tuple to forget to update.
     """
     assert name in _get_backend_names()
 
 
-@pytest.mark.parametrize("name", sorted(set(NAME_ONLY_BACKEND_NAMES)))
-def test_name_only_backend_name_is_registered(name: str) -> None:
-    assert name in _get_backend_names()
+def test_dispatch_sets_are_derived_from_the_enum() -> None:
+    """The dispatch sets compose from ``BackendName`` members, never literals.
 
-
-def test_name_only_names_are_a_subset_of_dispatched() -> None:
-    """A backend identified by name alone must also be intercepted by the chain.
-
-    Both sets are derived from the same constants; this pins the containment so
-    a future edit to one cannot silently desynchronize them.
+    Guards against someone re-typing a raw string into one set only — the
+    respelling that let gh-1842's stale name survive two renames.
     """
-    assert set(NAME_ONLY_BACKEND_NAMES) <= set(DISPATCHED_BACKEND_NAMES)
-
-
-def test_constants_are_derived_not_respelled() -> None:
-    """The subsets compose from the same atoms (the REMOTE_SCHEMES pattern).
-
-    Guards against someone re-typing a literal into one tuple only.
-    """
-    assert set(DATAFUSION_BACKEND_NAMES) <= set(DISPATCHED_BACKEND_NAMES)
-    assert set(NAME_ONLY_BACKEND_NAMES) == {
-        PANDAS_BACKEND_NAME,
-        DUCKDB_BACKEND_NAME,
+    assert DISPATCHED_BACKEND_NAMES == frozenset(BackendName)
+    assert NAME_ONLY_BACKEND_NAMES <= DISPATCHED_BACKEND_NAMES
+    assert set(DATAFUSION_BACKEND_NAMES) <= NAME_ONLY_BACKEND_NAMES
+    assert NAME_ONLY_BACKEND_NAMES == {
+        BackendName.PANDAS,
+        BackendName.DUCKDB,
         *DATAFUSION_BACKEND_NAMES,
     }
-    assert set(DISPATCHED_BACKEND_NAMES) == {
-        *DATAFUSION_BACKEND_NAMES,
-        PANDAS_BACKEND_NAME,
-        DUCKDB_BACKEND_NAME,
-        SQLITE_BACKEND_NAME,
-        BIGQUERY_BACKEND_NAME,
-    }
+
+
+def test_backend_names_are_plain_strings() -> None:
+    """Members must be drop-in for the ``str`` names backends report.
+
+    ``dt.source.name`` comparisons and ``NAME_ONLY_BACKEND_NAMES`` membership
+    tests run against plain strings, and anything folded into a hash token must
+    stay a plain string — pin the value semantics ``StrEnum`` provides.
+    """
+    for member in BackendName:
+        assert isinstance(member, str)
+        assert str(member) == member.value
+        assert hash(member) == hash(member.value)
 
 
 def test_xorq_own_backend_is_classified_by_name() -> None:

--- a/python/xorq/common/utils/tests/test_backend_names.py
+++ b/python/xorq/common/utils/tests/test_backend_names.py
@@ -37,20 +37,14 @@ from xorq.common.enums import BackendName
 def test_backend_name_is_registered(name: BackendName) -> None:
     """Every ``BackendName`` member is a live backend.
 
-    This is the gh-1842 tripwire: a renamed backend leaves a member here that
-    matches nothing, and every branch it guards becomes dead code that fails
-    open.  Sweeping the enum itself means a newly added member is covered
-    automatically, with no aggregate tuple to forget to update.
+    The gh-1842 tripwire: a renamed backend leaves a member that matches
+    nothing, and every branch it guards becomes dead code that fails open.
     """
     assert name in _get_backend_names()
 
 
 def test_dispatch_sets_are_derived_from_the_enum() -> None:
-    """The dispatch sets compose from ``BackendName`` members, never literals.
-
-    Guards against someone re-typing a raw string into one set only — the
-    respelling that let gh-1842's stale name survive two renames.
-    """
+    """The dispatch sets compose from ``BackendName`` members, never literals."""
     assert DISPATCHED_BACKEND_NAMES == frozenset(BackendName)
     assert NAME_ONLY_BACKEND_NAMES <= DISPATCHED_BACKEND_NAMES
     assert set(DATAFUSION_BACKEND_NAMES) <= NAME_ONLY_BACKEND_NAMES
@@ -77,18 +71,14 @@ def test_backend_names_are_plain_strings() -> None:
 def test_xorq_own_backend_is_classified_by_name() -> None:
     """xorq's default connection must land in the name-only set.
 
-    The concrete regression from gh-1842: after the ``let`` -> ``xorq`` ->
-    ``xorq_datafusion`` renames, ``xo.connect()`` fell through to the remote
-    branch of ``normalize_backend``.
+    The concrete gh-1842 regression: ``xo.connect()`` fell through to the
+    remote branch of ``normalize_backend``.
     """
     assert xo.connect().name in NAME_ONLY_BACKEND_NAMES
 
 
-# Modules whose dispatch keys on backend names.  A raw literal in one of these
-# is invisible to every other test here: the registration sweep only proves the
-# *enum's* members are live, so a branch keyed on a respelled string drifts
-# exactly like gh-1842 did.  Extend this tuple when a new module starts
-# dispatching on backend names.
+# Modules whose dispatch keys on backend names; extend when a new module
+# starts dispatching on them.
 BACKEND_NAME_DISPATCH_MODULES = (
     "xorq.caching.strategy",
     "xorq.common.utils.dasher._relations",
@@ -99,11 +89,10 @@ BACKEND_NAME_DISPATCH_MODULES = (
 def test_dispatch_modules_spell_no_backend_name_literals(module_name: str) -> None:
     """Backend names in dispatch modules must come from ``BackendName``.
 
-    The enum cannot enforce its own use — ``dt.source.name == "snowflake"``
-    compiles fine and bypasses every guard above.  So walk the module's AST and
-    reject any string constant exactly equal to a backend name, wherever it
-    appears; comments never reach the AST, and prose only trips on an
-    exact-equality match, so mentioning a backend is fine.
+    The enum cannot enforce its own use — a respelled ``dt.source.name ==
+    "duckdb"`` compiles, compares equal, and is invisible to the tests above.
+    Exact equality keeps prose safe: comments never reach the AST, and a
+    docstring only trips if it *is* a backend name.
     """
     module = importlib.import_module(module_name)
     tree = ast.parse(pathlib.Path(module.__file__).read_text())

--- a/python/xorq/common/utils/tests/test_backend_names.py
+++ b/python/xorq/common/utils/tests/test_backend_names.py
@@ -17,6 +17,10 @@ a cache.
 
 from __future__ import annotations
 
+import ast
+import importlib
+import pathlib
+
 import pytest
 
 import xorq.api as xo
@@ -78,6 +82,43 @@ def test_xorq_own_backend_is_classified_by_name() -> None:
     branch of ``normalize_backend``.
     """
     assert xo.connect().name in NAME_ONLY_BACKEND_NAMES
+
+
+# Modules whose dispatch keys on backend names.  A raw literal in one of these
+# is invisible to every other test here: the registration sweep only proves the
+# *enum's* members are live, so a branch keyed on a respelled string drifts
+# exactly like gh-1842 did.  Extend this tuple when a new module starts
+# dispatching on backend names.
+BACKEND_NAME_DISPATCH_MODULES = (
+    "xorq.caching.strategy",
+    "xorq.common.utils.dasher._relations",
+)
+
+
+@pytest.mark.parametrize("module_name", BACKEND_NAME_DISPATCH_MODULES)
+def test_dispatch_modules_spell_no_backend_name_literals(module_name: str) -> None:
+    """Backend names in dispatch modules must come from ``BackendName``.
+
+    The enum cannot enforce its own use — ``dt.source.name == "snowflake"``
+    compiles fine and bypasses every guard above.  So walk the module's AST and
+    reject any string constant exactly equal to a backend name, wherever it
+    appears; comments never reach the AST, and prose only trips on an
+    exact-equality match, so mentioning a backend is fine.
+    """
+    module = importlib.import_module(module_name)
+    tree = ast.parse(pathlib.Path(module.__file__).read_text())
+    literals = sorted(
+        (node.lineno, node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value in DISPATCHED_BACKEND_NAMES
+    )
+    assert not literals, (
+        f"{module_name} spells backend names as raw string literals "
+        f"(line, value): {literals}. Use the BackendName member instead, so a "
+        f"rename cannot leave a stale string behind (gh-1842)."
+    )
 
 
 def test_retired_backend_name_stays_retired() -> None:

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -35,6 +35,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import toolz
 import xorq_dasher
 from xorq_dasher.rules.expr import (
     normalize_memory_databasetable as dasher_normalize_memory_databasetable,
@@ -51,7 +52,16 @@ from xorq.common.utils.dasher._canonical import (
     normalize_inmemorytable_canonical,
     normalize_pyarrow_table_canonical,
 )
-from xorq.common.utils.dasher._relations import _dispatch_databasetable
+from xorq.common.utils.dasher._opaque import _MISSING
+from xorq.common.utils.dasher._relations import (
+    _dispatch_databasetable,
+    normalize_flight_expr,
+    normalize_flight_udxf,
+)
+from xorq.common.utils.func_utils import return_constant
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import FlightExpr, FlightUDXF
+from xorq.flight.exchanger import AbstractExchanger
 from xorq.vendor.ibis.expr.types.core import Expr
 
 
@@ -683,3 +693,146 @@ def test_refuses_extension_types() -> None:
     nested = pa.struct([("x", period_type)])
     with pytest.raises(NotImplementedError, match="extension"):
         canonical_column_digest(pa.array([], type=nested))
+
+
+# ---------------------------------------------------------------------------
+# Flight op identity
+#
+# gh-2229: FlightExpr/FlightUDXF fell through SnapshotStrategy's dispatch table
+# to a fallback that folded their per-process ``gen_name()`` uuid4 into the key,
+# so ``xorq build`` was not reproducible and every SnapshotStrategy cache missed
+# on every run. The op->normalizer wiring is now shared between both regimes
+# (``view_rules``) and covered by ``test_view_rules.py``. What that cannot catch
+# is a change to *what these normalizers fold in* -- ``rules_fingerprint``
+# digests rule *names* and is explicitly blind to a body edit under an unchanged
+# name, and since both regimes now share one callable, a single edit moves both
+# their hashes at once. These goldens are that tripwire.
+#
+# The goldens pin the normalizer's own contribution -- tag, arity, field order,
+# and the string-valued fields -- with the recursive ``Expr`` element and the
+# callables replaced by type placeholders. That is deliberate: per this module's
+# docstring, generated-SQL surfaces (sqlglot-coupled) and function bytecode
+# (cloudpickle/Python-version-coupled) are over-discrimination surfaces, not
+# per-environment contracts, so pinning them here would be flaky by
+# construction. Data identity for the input expression is covered by the
+# memtable/pyarrow goldens above.
+# ---------------------------------------------------------------------------
+
+GOLDEN_FLIGHT_TOKEN_SHAPES = {
+    "flight_expr": "fc01cbcb6c645d3d3d24587e68d32b88",
+    "flight_udxf": "1982bf850baa26017164227578e2f1ee",
+}
+
+
+def _flight_token_shape(token: tuple) -> tuple:
+    """Environment-independent projection of a flight token.
+
+    Strings (the tag and ``udxf.__qualname__``) survive verbatim; everything
+    else collapses to ``<TypeName>``. Adding, removing, reordering, or
+    retyping a folded field changes the result; a pyarrow or sqlglot upgrade
+    does not.
+    """
+    return tuple(
+        element if isinstance(element, str) else f"<{type(element).__name__}>"
+        for element in token
+    )
+
+
+def _echo_udxf() -> object:
+    return xo.expr.relations.flight_udxf(
+        process_df=toolz.identity,
+        maybe_schema_in=return_constant(True),
+        maybe_schema_out=toolz.identity,
+    )
+
+
+def _diamonds_table() -> Expr:
+    path = Path(xo.options.pins.get_path("diamonds"))
+    return xo.connect().read_parquet(path, "diamonds")
+
+
+def _flight_nodes() -> dict[str, object]:
+    t = _diamonds_table()
+    (udxf_node,) = walk_nodes(
+        FlightUDXF, t.pipe(_echo_udxf(), name="echo", inner_name="inner")
+    )
+    (expr_node,) = walk_nodes(
+        FlightExpr,
+        xo.expr.relations.flight_expr(
+            t, xo.table(t.schema(), name="unbound"), inner_name="inner"
+        ),
+    )
+    return {"flight_expr": expr_node, "flight_udxf": udxf_node}
+
+
+@pytest.mark.parametrize("name", sorted(GOLDEN_FLIGHT_TOKEN_SHAPES))
+def test_golden_flight_token_shape(name: str) -> None:
+    normalizer = {
+        "flight_expr": normalize_flight_expr,
+        "flight_udxf": normalize_flight_udxf,
+    }[name]
+    node = _flight_nodes()[name]
+    shape = _flight_token_shape(normalizer(node))
+    assert tokenize(shape) == GOLDEN_FLIGHT_TOKEN_SHAPES[name], _contract_message(
+        name, shape
+    )
+
+
+def test_flight_tokens_exclude_the_generated_name() -> None:
+    """The gh-2229 invariant, asserted on the token itself.
+
+    ``dt.name`` defaults to a fresh ``gen_name()`` uuid4 per process; if it ever
+    reappears in one of these tuples, every build directory and snapshot cache
+    key starts churning per run again.
+    """
+    for name, node in _flight_nodes().items():
+        normalizer = {
+            "flight_expr": normalize_flight_expr,
+            "flight_udxf": normalize_flight_udxf,
+        }[name]
+        token = normalizer(node)
+        assert node.name not in token, (
+            f"{name} token folds in the generated name {node.name!r} (gh-2229)"
+        )
+
+
+def test_flight_udxf_qualname_is_the_class_not_the_metaclass() -> None:
+    """``dt.udxf`` is the exchanger class, so ``type(dt.udxf)`` is its metaclass.
+
+    ``make_udxf`` returns ``type(name, (AbstractExchanger,), ...)``, so the
+    element must be ``dt.udxf.__qualname__``. Spelled
+    ``type(dt.udxf).__qualname__`` it evaluates to the constant ``"ABCMeta"``
+    for every UDXF in existence, contributing no discrimination at all.
+    """
+    node = _flight_nodes()["flight_udxf"]
+    (_, _, qualname, *_) = normalize_flight_udxf(node)
+    assert qualname == node.udxf.__qualname__
+    assert qualname != "ABCMeta"
+    assert type(node.udxf).__qualname__ == "ABCMeta"
+
+
+def test_flight_udxf_discriminates_exchangers_without_exchange_f() -> None:
+    """Two exchanger classes that inherit ``exchange_f`` must not collide.
+
+    This is the documented rationale for folding the qualname in at all, and it
+    is exactly what the metaclass spelling silently failed to deliver: both
+    classes yield ``"ABCMeta"`` and the same inherited ``exchange_f``, so their
+    tokens were identical.
+    """
+
+    class ExchangerA(AbstractExchanger):
+        pass
+
+    class ExchangerB(AbstractExchanger):
+        pass
+
+    def token_of(cls: type) -> str:
+        return tokenize(
+            (
+                "xorq.FlightUDXF",
+                cls.__qualname__,
+                getattr(cls, "exchange_f", _MISSING),
+            )
+        )
+
+    assert token_of(ExchangerA) != token_of(ExchangerB)

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -67,7 +67,9 @@ from xorq.vendor.ibis.expr.types.core import Expr
 
 def _env_versions() -> str:
     mods = (pa, pd, np, xorq_dasher, xorq)
-    return ", ".join(f"{m.__name__}=={m.__version__}" for m in mods)
+    return ", ".join(
+        f"{m.__name__}=={getattr(m, '__version__', 'unknown')}" for m in mods
+    )
 
 
 def _contract_message(name: str, obj: object) -> str:

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -700,22 +700,18 @@ def test_refuses_extension_types() -> None:
 # ---------------------------------------------------------------------------
 # Flight op identity
 #
-# gh-2229: FlightExpr/FlightUDXF fell through SnapshotStrategy's dispatch table
-# to a fallback that folded their per-process ``gen_name()`` uuid4 into the key,
-# so ``xorq build`` was not reproducible and every SnapshotStrategy cache missed
-# on every run. The op->normalizer wiring is now shared between both regimes
-# (``view_rules``) and covered by ``test_view_rules.py``. What that cannot catch
-# is a change to *what these normalizers fold in* -- ``rules_fingerprint``
-# digests rule *names* and is explicitly blind to a body edit under an unchanged
-# name, and since both regimes now share one callable, a single edit moves both
-# their hashes at once. These goldens are that tripwire.
+# The op->normalizer wiring is shared between both regimes (``view_rules``,
+# gh-2229 — see its docstring) and covered by ``test_view_rules.py``. What that
+# cannot catch is a change to *what these normalizers fold in* --
+# ``rules_fingerprint`` digests rule *names* and is blind to a body edit, and
+# since both regimes share one callable, a single edit moves both their hashes
+# at once. These goldens are that tripwire.
 #
 # The goldens pin the normalizer's own contribution -- tag, arity, field order,
 # and the string-valued fields -- with the recursive ``Expr`` element and the
-# callables replaced by type placeholders. That is deliberate: per this module's
-# docstring, generated-SQL surfaces (sqlglot-coupled) and function bytecode
-# (cloudpickle/Python-version-coupled) are over-discrimination surfaces, not
-# per-environment contracts, so pinning them here would be flaky by
+# callables replaced by type placeholders. Per this module's docstring,
+# generated-SQL and function-bytecode surfaces are over-discrimination
+# surfaces, not per-environment contracts, so pinning them would be flaky by
 # construction. Data identity for the input expression is covered by the
 # memtable/pyarrow goldens above.
 # ---------------------------------------------------------------------------
@@ -799,12 +795,10 @@ def test_flight_tokens_exclude_the_generated_name() -> None:
 
 
 def test_flight_udxf_qualname_is_the_class_not_the_metaclass() -> None:
-    """``dt.udxf`` is the exchanger class, so ``type(dt.udxf)`` is its metaclass.
+    """Pins the gotcha documented on :func:`normalize_flight_udxf`.
 
-    ``make_udxf`` returns ``type(name, (AbstractExchanger,), ...)``, so the
-    element must be ``dt.udxf.__qualname__``. Spelled
-    ``type(dt.udxf).__qualname__`` it evaluates to the constant ``"ABCMeta"``
-    for every UDXF in existence, contributing no discrimination at all.
+    ``make_udxf`` returns ``type(name, (AbstractExchanger,), ...)`` — the class
+    itself — so ``type(dt.udxf).__qualname__`` is the metaclass's ``"ABCMeta"``.
     """
     node = _flight_nodes()["flight_udxf"]
     (_, _, qualname, *_) = normalize_flight_udxf(node)
@@ -816,10 +810,8 @@ def test_flight_udxf_qualname_is_the_class_not_the_metaclass() -> None:
 def test_flight_udxf_discriminates_exchangers_without_exchange_f() -> None:
     """Two exchanger classes that inherit ``exchange_f`` must not collide.
 
-    This is the documented rationale for folding the qualname in at all, and it
-    is exactly what the metaclass spelling silently failed to deliver: both
-    classes yield ``"ABCMeta"`` and the same inherited ``exchange_f``, so their
-    tokens were identical.
+    This is why the qualname is folded in at all — and exactly what the
+    metaclass spelling silently failed to deliver.
     """
 
     class ExchangerA(AbstractExchanger):

--- a/python/xorq/common/utils/tests/test_hash_contract.py
+++ b/python/xorq/common/utils/tests/test_hash_contract.py
@@ -703,9 +703,9 @@ def test_refuses_extension_types() -> None:
 # The op->normalizer wiring is shared between both regimes (``view_rules``,
 # gh-2229 — see its docstring) and covered by ``test_view_rules.py``. What that
 # cannot catch is a change to *what these normalizers fold in* --
-# ``rules_fingerprint`` digests rule *names* and is blind to a body edit, and
-# since both regimes share one callable, a single edit moves both their hashes
-# at once. These goldens are that tripwire.
+# ``rules_fingerprint`` is body-blind by design (a known accepted trade,
+# gh-2204), and since both regimes share one callable, a single edit moves both
+# their hashes at once. These goldens are that tripwire.
 #
 # The goldens pin the normalizer's own contribution -- tag, arity, field order,
 # and the string-valued fields -- with the recursive ``Expr`` element and the

--- a/python/xorq/common/utils/tests/test_hash_determinism.py
+++ b/python/xorq/common/utils/tests/test_hash_determinism.py
@@ -1,0 +1,190 @@
+"""Cross-process determinism of build hashes and cache keys.
+
+Every test in this repo that guards hash stability runs inside one interpreter,
+so none of them can see a per-process value leaking into identity -- and that is
+the single most-repeated bug in this subsystem's history:
+
+* gh-610  -- FlightExpr/FlightUDXF names reached the cache key (dask era)
+* gh-1728 -- ``Profile.idx`` and UDF class-name counters reached build hashes
+* gh-1738 -- a process-global ScalarUDF counter reached the token via SQL
+* gh-2229 -- the same flight-name leak as gh-610, reintroduced by the dasher
+  rewrite, this time via ``SnapshotStrategy``'s copy of the dispatch table
+
+Each was found by hand, in production, by noticing that an unchanged script kept
+writing new ``builds/<hash>`` directories. This module automates that
+observation: build a corpus of expressions in two *fresh interpreters* with
+different ``PYTHONHASHSEED`` and assert the identities agree.
+
+It is deliberately not marked ``slow`` -- CI lanes that filter ``not slow``
+are exactly the lanes that need this guard. Cost is two interpreter starts
+total, because one child computes the whole corpus.
+
+Unlike the op-type sweep in ``test_view_rules.py``, this catches the leak class
+regardless of which op, which mechanism, or which dispatch table is at fault:
+the corpus below leaves every generated name *unset* so that ``gen_name()``
+uuid4s are live in the tree.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+
+# Built in the child, one entry per expression shape. Generated names are left
+# unset on purpose: passing ``inner_name``/``name`` would pin the very values
+# whose leakage this module exists to detect.
+CHILD_SCRIPT = """
+import json, pathlib, sys, traceback
+
+import toolz
+
+import xorq.api as xo
+from xorq.caching import ParquetSnapshotCache
+from xorq.caching.strategy import SnapshotStrategy
+from xorq.common.utils.func_utils import return_constant
+from xorq.common.utils.provenance_utils import get_expr_hash
+
+echo_udxf = xo.expr.relations.flight_udxf(
+    process_df=toolz.identity,
+    maybe_schema_in=return_constant(True),
+    maybe_schema_out=toolz.identity,
+)
+
+
+def diamonds_path():
+    return pathlib.Path(xo.options.pins.get_path("diamonds"))
+
+
+def build_flight_udxf():
+    # no inner_name -> FlightUDXF.name is a fresh gen_name() uuid4 (gh-2229)
+    con = xo.connect()
+    return con.read_parquet(diamonds_path(), "diamonds").pipe(echo_udxf)
+
+
+def build_flight_expr():
+    con = xo.connect()
+    t = con.read_parquet(diamonds_path(), "diamonds")
+    return xo.expr.relations.flight_expr(t, xo.table(t.schema(), name="unbound"))
+
+
+def build_remote_table():
+    con, other_con = xo.connect(), xo.connect()
+    return con.read_parquet(diamonds_path(), "diamonds").into_backend(other_con)
+
+
+def build_cached_node():
+    con = xo.connect()
+    return con.read_parquet(diamonds_path(), "diamonds").cache(
+        ParquetSnapshotCache.from_kwargs(source=con)
+    )
+
+
+def build_deferred_read():
+    return xo.deferred_read_parquet(diamonds_path(), xo.connect())
+
+
+def build_flight_udxf_cached():
+    con = xo.connect()
+    return (
+        con.read_parquet(diamonds_path(), "diamonds")
+        .pipe(echo_udxf)
+        .cache(ParquetSnapshotCache.from_kwargs(source=con))
+    )
+
+
+BUILDERS = {
+    "flight_udxf": build_flight_udxf,
+    "flight_expr": build_flight_expr,
+    "remote_table": build_remote_table,
+    "cached_node": build_cached_node,
+    "deferred_read": build_deferred_read,
+    "flight_udxf_cached": build_flight_udxf_cached,
+}
+
+out = {}
+for name, build in BUILDERS.items():
+    try:
+        expr = build()
+        out[name] = {
+            "build_hash": get_expr_hash(expr),
+            "snapshot_key": SnapshotStrategy().calc_key(expr),
+            "tokenized": expr.ls.tokenized,
+        }
+    except Exception:
+        out[name] = {"error": traceback.format_exc(limit=3)}
+
+json.dump(out, sys.stdout)
+"""
+
+CASES = (
+    "flight_udxf",
+    "flight_expr",
+    "remote_table",
+    "cached_node",
+    "deferred_read",
+    "flight_udxf_cached",
+)
+
+IDENTITIES = ("build_hash", "snapshot_key", "tokenized")
+
+
+def _run_child() -> dict:
+    """Run the corpus in a fresh interpreter, inheriting the current env."""
+    proc = subprocess.run(
+        [sys.executable, "-c", CHILD_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert proc.returncode == 0, (
+        f"child interpreter failed:\n{proc.stdout[-2000:]}\n{proc.stderr[-4000:]}"
+    )
+    return json.loads(proc.stdout)
+
+
+@pytest.fixture(scope="module")
+def child_identities() -> tuple[dict, dict]:
+    """Identities from two fresh interpreters with different hash seeds.
+
+    Module-scoped: two interpreter starts for the whole corpus, not per case.
+    Differing ``PYTHONHASHSEED`` also makes this sensitive to identity that
+    depends on str/bytes hash randomization or dict iteration order, not only
+    to uuid4s.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("PYTHONHASHSEED", "0")
+        first = _run_child()
+        mp.setenv("PYTHONHASHSEED", "123456")
+        second = _run_child()
+    return first, second
+
+
+@pytest.mark.parametrize("case", CASES)
+@pytest.mark.parametrize("identity", IDENTITIES)
+def test_identity_is_stable_across_processes(
+    case: str, identity: str, child_identities: tuple[dict, dict]
+) -> None:
+    first, second = child_identities
+    for run in (first, second):
+        assert "error" not in run[case], (
+            f"child failed to build {case!r}:\n{run[case]['error']}"
+        )
+    assert first[case][identity] == second[case][identity], (
+        f"{identity} for {case!r} differs between two fresh interpreters "
+        f"({first[case][identity]!r} vs {second[case][identity]!r}). Something "
+        f"per-process -- a gen_name() uuid4, a counter, an id(), a "
+        f"hash-randomized ordering -- is reaching identity. See gh-2229."
+    )
+
+
+def test_corpus_matches_child(child_identities: tuple[dict, dict]) -> None:
+    """The parametrized case list covers everything the child builds."""
+    first, _ = child_identities
+    assert set(first) == set(CASES), (
+        "CHILD_SCRIPT builders and CASES disagree; a case built in the child "
+        "but missing from CASES is silently unasserted"
+    )

--- a/python/xorq/common/utils/tests/test_hash_determinism.py
+++ b/python/xorq/common/utils/tests/test_hash_determinism.py
@@ -1,19 +1,14 @@
 """Cross-process determinism of build hashes and cache keys.
 
-Every test in this repo that guards hash stability runs inside one interpreter,
-so none of them can see a per-process value leaking into identity -- and that is
-the single most-repeated bug in this subsystem's history:
-
-* gh-610  -- FlightExpr/FlightUDXF names reached the cache key (dask era)
-* gh-1728 -- ``Profile.idx`` and UDF class-name counters reached build hashes
-* gh-1738 -- a process-global ScalarUDF counter reached the token via SQL
-* gh-2229 -- the same flight-name leak as gh-610, reintroduced by the dasher
-  rewrite, this time via ``SnapshotStrategy``'s copy of the dispatch table
-
-Each was found by hand, in production, by noticing that an unchanged script kept
-writing new ``builds/<hash>`` directories. This module automates that
-observation: build a corpus of expressions in two *fresh interpreters* with
-different ``PYTHONHASHSEED`` and assert the identities agree.
+Every other hash-stability test in this repo runs inside one interpreter, so
+none of them can see a per-process value leaking into identity -- the
+most-repeated bug in this subsystem's history (gh-610, gh-1728, gh-1738,
+gh-2229: generated names, counters, and process-global state reaching
+identity; see ``view_rules`` for the latest). Each was found by hand, in
+production, by noticing an unchanged script writing new ``builds/<hash>``
+directories. This module automates that observation: build a corpus of
+expressions in two *fresh interpreters* with different ``PYTHONHASHSEED`` and
+assert the identities agree.
 
 It is deliberately not marked ``slow`` -- CI lanes that filter ``not slow``
 are exactly the lanes that need this guard. Cost is two interpreter starts

--- a/python/xorq/common/utils/tests/test_view_rules.py
+++ b/python/xorq/common/utils/tests/test_view_rules.py
@@ -1,0 +1,334 @@
+"""Exhaustiveness and name-neutrality of the ``DatabaseTableView`` rule table.
+
+``view_rules`` is the single source of truth for how the two normalization
+regimes — the global hasher and ``SnapshotStrategy`` — identify
+``DatabaseTable`` subclasses.  It exists because those regimes used to be
+hand-mirrored ``match`` statements and drifted: the snapshot copy omitted
+``FlightExpr``/``FlightUDXF``, so their per-process ``gen_name()`` uuid4 reached
+the key and made ``xorq build`` non-reproducible while every
+``SnapshotStrategy`` cache missed on every run (gh-2229).  The same bug had
+already been fixed once in the dask era (gh-610) and came back with the dasher
+rewrite.
+
+Three layers here, deliberately overlapping:
+
+1. ``test_no_unhandled_view_op_types`` — static sweep of
+   ``DatabaseTableView.__subclasses__()``.  Cheap, but blind to view ops in
+   lazily-imported backend modules.
+2. ``test_guard_fires_in_both_regimes`` — the runtime guard that covers what the
+   sweep cannot see, in *both* tables.
+3. ``test_generated_names_do_not_reach_identity`` — the property that actually
+   matters, asserted per op type under both regimes plus the build hash.  This
+   is the test that would have caught gh-610 and gh-2229 mechanically.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+import toolz
+
+import xorq.api as xo
+from xorq.caching import (
+    ParquetSnapshotCache,
+)
+from xorq.caching.strategy import (
+    SnapshotStrategy,
+    snapshot_normalize_read,
+)
+from xorq.common.utils.dasher import (
+    HASHER,
+)
+from xorq.common.utils.dasher._relations import (
+    _dispatch_databasetable,
+    lookup_view_normalizer,
+    unhandled_view_op_types,
+    view_rules,
+)
+from xorq.common.utils.func_utils import (
+    return_constant,
+)
+from xorq.common.utils.graph_utils import (
+    walk_nodes,
+)
+from xorq.common.utils.provenance_utils import (
+    get_expr_hash,
+)
+from xorq.expr.relations import (
+    CachedNode,
+    DatabaseTableView,
+    FlightExpr,
+    FlightUDXF,
+    Read,
+    RemoteTable,
+    gen_name,
+)
+from xorq.vendor.ibis.expr import (
+    operations as ops,
+)
+
+
+if TYPE_CHECKING:
+    from xorq.vendor.ibis import Expr
+
+
+echo_udxf = xo.expr.relations.flight_udxf(
+    process_df=toolz.identity,
+    maybe_schema_in=return_constant(True),
+    maybe_schema_out=toolz.identity,
+)
+
+
+def _diamonds_path() -> pathlib.Path:
+    return pathlib.Path(xo.options.pins.get_path("diamonds"))
+
+
+def build_read(i: int) -> Expr:
+    """A deferred read; ``Read.name`` is caller-supplied and must not matter.
+
+    ``con.read_parquet`` registers eagerly and yields a plain ``DatabaseTable``;
+    only the deferred form produces a ``Read`` op.
+    """
+    return xo.deferred_read_parquet(_diamonds_path(), xo.connect(), f"diamonds_{i}")
+
+
+def build_cached_node(i: int) -> Expr:
+    """``CachedNode.name`` is a fresh ``gen_name()`` per construction."""
+    con = xo.connect()
+    return con.read_parquet(_diamonds_path(), "diamonds").cache(
+        ParquetSnapshotCache.from_kwargs(source=con)
+    )
+
+
+def build_remote_table(i: int) -> Expr:
+    """``RemoteTable.name`` is a fresh ``gen_name()`` per construction."""
+    con, other_con = xo.connect(), xo.connect()
+    return con.read_parquet(_diamonds_path(), "diamonds").into_backend(other_con)
+
+
+def build_flight_expr(i: int) -> Expr:
+    con = xo.connect()
+    t = con.read_parquet(_diamonds_path(), "diamonds")
+    return xo.expr.relations.flight_expr(
+        t,
+        xo.table(t.schema(), name="unbound"),
+        inner_name=f"inner_name-{i}",
+    )
+
+
+def build_flight_udxf(i: int) -> Expr:
+    con = xo.connect()
+    return con.read_parquet(_diamonds_path(), "diamonds").pipe(
+        echo_udxf, name="echo", inner_name=f"inner_name-{i}"
+    )
+
+
+class ViewOpSpec(NamedTuple):
+    """How to build one view op twice, and whether its own ``name`` varies.
+
+    ``name_varies`` records whether *this op's* ``name`` field differs between
+    two builds, which is what makes the neutrality assertion non-vacuous.  It is
+    False for ``CachedNode`` alone: that op carries the fixed sentinel
+    ``xorq_cached_node_name_placeholder`` rather than a ``gen_name()``, so its
+    per-process randomness lives in the ops beneath it.  Recorded explicitly so
+    a future op that *starts* generating names cannot quietly be tested
+    vacuously.
+    """
+
+    build: Callable[[int], Expr]
+    name_varies: bool
+
+
+# One spec per row of ``view_rules``.  A new row without a spec is a FAILURE,
+# never a skip -- a skipped case is how this class of bug survives (gh-2229's
+# three pre-existing name-neutrality tests all passed while the bug was live).
+VIEW_OP_BUILDERS = {
+    Read: ViewOpSpec(build_read, name_varies=True),
+    CachedNode: ViewOpSpec(build_cached_node, name_varies=False),
+    RemoteTable: ViewOpSpec(build_remote_table, name_varies=True),
+    FlightExpr: ViewOpSpec(build_flight_expr, name_varies=True),
+    FlightUDXF: ViewOpSpec(build_flight_udxf, name_varies=True),
+}
+
+
+def _in_library_module(cls: type) -> bool:
+    """Exclude view ops defined inside test modules.
+
+    Test-local subclasses (see ``test_guard_fires_in_both_regimes``) linger in
+    ``__subclasses__()`` until garbage collected, which would otherwise make the
+    static sweep order-dependent.
+    """
+    module = cls.__module__
+    return module.startswith("xorq.") and ".tests" not in module
+
+
+def test_no_unhandled_view_op_types() -> None:
+    """Every imported ``DatabaseTableView`` subclass has a ``view_rules`` row."""
+    unhandled = tuple(
+        cls for cls in unhandled_view_op_types() if _in_library_module(cls)
+    )
+    assert not unhandled, (
+        f"DatabaseTableView subclasses with no normalizer: "
+        f"{sorted(cls.__name__ for cls in unhandled)}. Add a row to "
+        f"xorq.common.utils.dasher._relations.view_rules and a builder to "
+        f"VIEW_OP_BUILDERS in this module."
+    )
+
+
+def test_every_view_rule_has_a_builder() -> None:
+    """The property test below must cover every row -- fail, never skip."""
+    missing = tuple(
+        rule.op_type for rule in view_rules() if rule.op_type not in VIEW_OP_BUILDERS
+    )
+    assert not missing, (
+        f"view_rules rows with no builder in VIEW_OP_BUILDERS: "
+        f"{sorted(cls.__name__ for cls in missing)}. Without one, "
+        f"test_generated_names_do_not_reach_identity silently stops covering it."
+    )
+
+
+def test_view_rules_covers_exactly_the_known_view_ops() -> None:
+    """Pins the row set, so adding an op type is a deliberate, reviewed edit."""
+    assert tuple(rule.op_type for rule in view_rules()) == (
+        Read,
+        CachedNode,
+        RemoteTable,
+        FlightExpr,
+        FlightUDXF,
+    )
+
+
+def test_only_read_diverges_between_regimes() -> None:
+    """The two columns agree everywhere except ``Read``.
+
+    ``Read`` legitimately differs: stat-based identity globally, path-only under
+    snapshot (gh-1861).  Every other row must be the *same callable* in both
+    columns -- that identity is the invariant whose absence let gh-2229 through,
+    so assert it rather than trusting the table to stay tidy.
+    """
+    diverging = {
+        rule.op_type
+        for rule in view_rules()
+        if rule.normalizer is not rule.snapshot_normalizer
+    }
+    assert diverging == {Read}
+    (read_rule,) = (rule for rule in view_rules() if rule.op_type is Read)
+    assert read_rule.snapshot_normalizer is snapshot_normalize_read
+
+
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        pytest.param(False, id="global"),
+        pytest.param(True, id="snapshot"),
+    ],
+)
+def test_guard_fires_in_both_regimes(snapshot: bool) -> None:
+    """An unhandled view raises in *both* dispatch tables.
+
+    The guard originally lived only in the snapshot table, so on the global side
+    an unhandled view either died with a misleading backend planning error or
+    -- on a fall-through backend -- silently folded its uuid4 ``name`` in, which
+    is the very defect gh-2229 was about.
+    """
+
+    class UnhandledView(DatabaseTableView):
+        pass
+
+    dt = UnhandledView(
+        name=gen_name(),
+        schema=xo.schema({"a": "int64"}),
+        source=xo.connect(),
+    )
+    with pytest.raises(NotImplementedError, match="UnhandledView"):
+        lookup_view_normalizer(dt, snapshot=snapshot)
+
+
+def test_guard_fires_through_the_public_dispatchers() -> None:
+    """Same guard, reached the way the hashers actually reach it."""
+
+    class UnhandledView(DatabaseTableView):
+        pass
+
+    dt = UnhandledView(
+        name=gen_name(),
+        schema=xo.schema({"a": "int64"}),
+        source=xo.connect(),
+    )
+    with pytest.raises(NotImplementedError, match="UnhandledView"):
+        _dispatch_databasetable(dt)
+    with pytest.raises(NotImplementedError, match="UnhandledView"):
+        SnapshotStrategy.normalize_databasetable(dt)
+
+
+def test_genuine_backend_table_still_folds_name_in() -> None:
+    """The fallback must keep ``name``: for a real table it *is* the identity.
+
+    The gh-2229 fix narrows the fallback's reach rather than dropping ``name``
+    from it -- blanket-dropping would under-key and risk wrong cache hits.
+    """
+    con = xo.connect()
+    t0 = con.read_parquet(_diamonds_path(), "diamonds_a")
+    t1 = con.read_parquet(_diamonds_path(), "diamonds_b")
+    dt0, dt1 = (
+        ops.DatabaseTable(
+            name=t.op().name,
+            schema=t.schema(),
+            source=con,
+        )
+        for t in (t0, t1)
+    )
+    assert lookup_view_normalizer(dt0, snapshot=True) is None
+    assert SnapshotStrategy.normalize_databasetable(
+        dt0
+    ) != SnapshotStrategy.normalize_databasetable(dt1)
+
+
+@pytest.mark.parametrize(
+    "op_type",
+    [
+        pytest.param(cls, id=cls.__name__)
+        for cls in sorted(VIEW_OP_BUILDERS, key=lambda cls: cls.__name__)
+    ],
+)
+def test_generated_names_do_not_reach_identity(op_type: type) -> None:
+    """Two structurally identical exprs hash equal under every regime.
+
+    Each builder is called twice, so every auto-generated name in the tree is
+    freshly drawn.  Asserted under the global hasher, ``SnapshotStrategy``, and
+    the build hash -- gh-2229 was invisible to the first and live in the other
+    two, which is precisely why it survived three passing tests.
+    """
+    spec = VIEW_OP_BUILDERS[op_type]
+    expr0, expr1 = spec.build(0), spec.build(1)
+
+    nodes0 = tuple(walk(op_type, expr0))
+    assert nodes0, f"builder for {op_type.__name__} produced no {op_type.__name__}"
+    names0 = tuple(n.name for n in nodes0)
+    names1 = tuple(n.name for n in walk(op_type, expr1))
+    if spec.name_varies:
+        assert names0 != names1, (
+            f"{op_type.__name__} names did not differ between builds "
+            f"({names0!r}); the name-neutrality assertions below would be vacuous."
+        )
+    else:
+        assert names0 == names1, (
+            f"{op_type.__name__} is recorded as not generating names, but its "
+            f"names varied ({names0!r} vs {names1!r}); flip name_varies to True."
+        )
+
+    assert HASHER.tokenize(expr0) == HASHER.tokenize(expr1)
+    assert SnapshotStrategy().calc_key(expr0) == SnapshotStrategy().calc_key(expr1)
+    assert get_expr_hash(expr0) == get_expr_hash(expr1)
+
+
+def walk(op_type: type, expr: Expr) -> tuple:
+    """All ``op_type`` nodes in ``expr``, descending into opaque sub-exprs.
+
+    ``op.find`` stops at ``Any``-typed fields, so a ``FlightUDXF`` nested under
+    a ``RemoteTable.remote_expr`` is invisible to it.
+    """
+    return walk_nodes(op_type, expr)

--- a/python/xorq/common/utils/tests/test_view_rules.py
+++ b/python/xorq/common/utils/tests/test_view_rules.py
@@ -2,13 +2,9 @@
 
 ``view_rules`` is the single source of truth for how the two normalization
 regimes — the global hasher and ``SnapshotStrategy`` — identify
-``DatabaseTable`` subclasses.  It exists because those regimes used to be
-hand-mirrored ``match`` statements and drifted: the snapshot copy omitted
-``FlightExpr``/``FlightUDXF``, so their per-process ``gen_name()`` uuid4 reached
-the key and made ``xorq build`` non-reproducible while every
-``SnapshotStrategy`` cache missed on every run (gh-2229).  The same bug had
-already been fixed once in the dask era (gh-610) and came back with the dasher
-rewrite.
+``DatabaseTable`` subclasses; its docstring records why the tables must not be
+hand-mirrored (gh-610, gh-2229: drift leaked per-process ``gen_name()`` uuid4s
+into keys).
 
 Three layers here, deliberately overlapping:
 

--- a/python/xorq/flight/tests/test_cache.py
+++ b/python/xorq/flight/tests/test_cache.py
@@ -83,13 +83,11 @@ def test_flight_udxf_inner_name_doesnt_matter():
     assert expr0.ls.get_key() == expr1.ls.get_key()
 
 
-# The three tests above assert name-neutrality through `ls.get_key()`, which for
-# ParquetCache means ModificationTimeStrategy -> the global hasher. That path was
-# always correct. The build hash and every SnapshotStrategy-backed cache go
-# through SnapshotStrategy's own DatabaseTable override instead, which used to
-# miss FlightExpr/FlightUDXF and fold their generated names in -- so `xorq build`
-# named a fresh directory per process and snapshot caches never hit (gh-2229).
-# These cover the two paths the tests above do not.
+# The three tests above assert name-neutrality through `ls.get_key()` on a
+# ParquetCache -- the global-hasher path, which was always correct. The build
+# hash and SnapshotStrategy-backed caches dispatch separately and used to fold
+# Flight ops' generated names in (gh-2229; see view_rules). These cover the two
+# paths the tests above do not.
 
 
 def test_flight_udxf_inner_name_doesnt_matter_build_hash():

--- a/python/xorq/flight/tests/test_cache.py
+++ b/python/xorq/flight/tests/test_cache.py
@@ -1,13 +1,25 @@
 import pathlib
 
+import pytest
 import toolz
 
 import xorq.api as xo
 from xorq.caching import (
     ParquetCache,
+    ParquetSnapshotCache,
+)
+from xorq.caching.strategy import (
+    SnapshotStrategy,
 )
 from xorq.common.utils.func_utils import (
     return_constant,
+)
+from xorq.common.utils.provenance_utils import (
+    get_expr_hash,
+)
+from xorq.expr.relations import (
+    DatabaseTableView,
+    gen_name,
 )
 
 
@@ -69,6 +81,75 @@ def test_flight_udxf_inner_name_doesnt_matter():
         )
     )
     assert expr0.ls.get_key() == expr1.ls.get_key()
+
+
+# The three tests above assert name-neutrality through `ls.get_key()`, which for
+# ParquetCache means ModificationTimeStrategy -> the global hasher. That path was
+# always correct. The build hash and every SnapshotStrategy-backed cache go
+# through SnapshotStrategy's own DatabaseTable override instead, which used to
+# miss FlightExpr/FlightUDXF and fold their generated names in -- so `xorq build`
+# named a fresh directory per process and snapshot caches never hit (gh-2229).
+# These cover the two paths the tests above do not.
+
+
+def test_flight_udxf_inner_name_doesnt_matter_build_hash():
+    name = "diamonds"
+    (con, other_con) = (xo.connect(), xo.connect())
+    path = pathlib.Path(xo.options.pins.get_path(name))
+    expr0, expr1 = (
+        c.read_parquet(path, name).pipe(echo_udxf, name="echo", inner_name=inner_name)
+        for (c, inner_name) in (
+            (con, "inner_name-a"),
+            (other_con, "inner_name-b"),
+        )
+    )
+    assert get_expr_hash(expr0) == get_expr_hash(expr1)
+
+
+def test_flight_udxf_inner_name_doesnt_matter_snapshot_key():
+    name = "diamonds"
+    (con, other_con) = (xo.connect(), xo.connect())
+    path = pathlib.Path(xo.options.pins.get_path(name))
+    expr0, expr1 = (
+        c.read_parquet(path, name)
+        .pipe(echo_udxf, name="echo", inner_name=inner_name)
+        .cache(ParquetSnapshotCache.from_kwargs(source=c))
+        for (c, inner_name) in (
+            (con, "inner_name-a"),
+            (other_con, "inner_name-b"),
+        )
+    )
+    assert expr0.ls.get_key() == expr1.ls.get_key()
+
+
+def test_flight_expr_inner_name_doesnt_matter_build_hash():
+    con = xo.connect()
+    name = "diamonds"
+    t = xo.examples.get_table_from_name(name, con)
+    expr0, expr1 = (
+        xo.expr.relations.flight_expr(
+            t,
+            xo.table(t.schema(), name="unbound"),
+            inner_name=inner_name,
+        )
+        for inner_name in ("inner_name-a", "inner_name-b")
+    )
+    assert get_expr_hash(expr0) == get_expr_hash(expr1)
+
+
+def test_snapshot_strategy_rejects_unnormalized_databasetableview():
+    """A new DatabaseTableView must fail loudly, not leak its generated name."""
+
+    class UnhandledView(DatabaseTableView):
+        pass
+
+    dt = UnhandledView(
+        name=gen_name(),
+        schema=xo.schema({"a": "int64"}),
+        source=xo.connect(),
+    )
+    with pytest.raises(NotImplementedError, match="UnhandledView"):
+        SnapshotStrategy.normalize_databasetable(dt)
 
 
 def test_flight_udxf_path_matters(tmp_path):


### PR DESCRIPTION
Fixes #2229.

## The bug

`SnapshotStrategy.normalize_databasetable` (`python/xorq/caching/strategy.py`) hand-mirrored dasher's concrete-type dispatch for `DatabaseTable` subclasses — necessary because dasher's MRO lookup would otherwise pick the broader `DatabaseTable` rule — and the mirror drifted: it handled `Read`, `CachedNode`, and `RemoteTable`, but let `FlightExpr`/`FlightUDXF` fall through to a fallback that folds `name` into the key. Those `name`s default to `gen_name()`, a fresh uuid4 per process. Consequences:

1. **`xorq build` was not reproducible** for any expression containing a `flight_udxf`/`flight_expr` with an unset inner name — a new `builds/<hash>` directory per invocation of an unchanged script.
2. **Every `SnapshotStrategy`-backed cache missed on every run** — `ParquetSnapshotCache`, `ParquetTTLSnapshotCache`, `ParquetDummySnapshotCache`, `SourceSnapshotCache`. Results written, never read back.

The global dispatcher (`_dispatch_databasetable`) had both Flight cases and deliberately omitted `name`, which is why `ModificationTimeStrategy`/`ParquetCache` were always correct — and why the three pre-existing name-neutrality tests (all asserting through that path) passed while the bug was live. The same leak had been fixed once before in the dask era (gh-610) and returned with the dasher rewrite.

## The fix

**One rule table for both regimes.** `view_rules()` in `dasher/_relations.py` is now the single op→normalizer declaration; both dispatch tables (`_dispatch_databasetable` and `SnapshotStrategy.normalize_databasetable`) resolve through `lookup_view_normalizer`. A view op handled in one regime cannot silently fall through the other. Exactly one op legitimately differs per regime — `Read` (stat-based globally, path-only under snapshot, gh-1861) — pinned by `test_only_read_diverges_between_regimes`.

**Fail loudly, not open.** The `case _` fallback deliberately keeps folding `name` in: for a genuine backend table, `name` *is* the identity, so blanket-dropping it would under-key and risk wrong cache hits. Instead, any `DatabaseTableView` with no `view_rules` row now raises `NotImplementedError` in both regimes — a newly added view op fails in CI instead of leaking a uuid4 into a cache key.

**Flight normalizers extracted and shared.** `normalize_flight_expr` / `normalize_flight_udxf` carry docstrings recording why `name` is excluded.

## Two adjacent defects fixed

- **`normalize_flight_udxf` folded the metaclass name, not the class name.** `dt.udxf` is already the exchanger *class* (`make_udxf` returns `type(name, (AbstractExchanger,), ...)`), so the previous `type(dt.udxf).__qualname__` evaluated to the constant `"ABCMeta"` for every UDXF ever constructed — two exchangers inheriting `exchange_f` collided. Now `dt.udxf.__qualname__`, which is deterministic (`name or process_df.__name__`, never a `gen_name()`).
- **`_env_versions` crashed on installs lacking `__version__`** (observed live: an `AttributeError` from `xorq_dasher` masked the golden-diff message that exists precisely to be read in a divergent environment). Now `getattr(m, "__version__", "unknown")`.

## The name axis: `BackendName`

Normalization dispatches on two axes: op type (fixed above) and backend *name string*. The name axis had already failed the same way — gh-1842 shipped `normalize_backend` still holding the project's previous backend name `"let"`, two renames after the fact. This PR is where canonical spellings first appear, so they land in their final shape:

- **`BackendName(StrEnum)`** in `common/enums.py` (compat `StrEnum` for the 3.10 floor); members are drop-in strings for `dt.source.name` comparisons.
- **Dispatch sets derive from members** in `common/constants.py`; `DISPATCHED_BACKEND_NAMES = frozenset(BackendName)`, so a new member joins the registration sweep automatically.
- **An AST guard** (`test_dispatch_modules_spell_no_backend_name_literals`) rejects any string constant equal to a backend name in the two dispatching modules — the enum cannot enforce its own use, and a respelled literal compiles and compares fine.

## Tests

| File | Guards |
|---|---|
| `test_view_rules.py` (new, 13) | Rule-table exhaustiveness (static subclass sweep + runtime guard in both regimes + per-op name-neutrality property under global hasher, `SnapshotStrategy`, and build hash). Builder/rule coupling is fail-never-skip: a new row without a builder is a failure. |
| `test_backend_names.py` (new, 12) | Every `BackendName` member is a registered backend (the gh-1842 tripwire); sets derive from the enum; `StrEnum` value semantics; the AST literal guard; the retired `"xorq"` name stays retired. |
| `test_hash_determinism.py` (new, 19) | Cross-process determinism: a corpus with every generated name left unset, built in two fresh interpreters under different `PYTHONHASHSEED`, comparing `build_hash`/`snapshot_key`/`tokenized` per case. Catches the whole leak class (uuid4s, counters, hash-randomized ordering) regardless of op or mechanism. Deliberately not marked `slow`: lanes filtering `not slow` are the ones that need it. |
| `test_hash_contract.py` (extended, +5) | Golden flight token shapes pin each normalizer's own contribution (tag, arity, field order, string fields; callables collapsed to type placeholders) — covers the `rules_fingerprint` blind spot (gh-2204): the fingerprint digests rule *names* and cannot see a body edit. Plus pins for the qualname fix. |
| `flight/tests/test_cache.py` (extended, +4) | The gh-2229 regression through the two paths the pre-existing tests missed: `get_expr_hash` and `ParquetSnapshotCache`, plus the unhandled-view guard. All four fail on pre-fix `main`. |

## Hash invalidation

This PR moves the hash of any expression containing a Flight op, twice over (the `name` exclusion and the qualname fix) — a one-time invalidation of build directories and `SnapshotStrategy` cache entries, inherent to the fix. #2231 (already on main) independently moved the same hashes by reshaping `exchange_f`; the golden caught that reshape during rebase exactly as predicted (`flight_udxf` golden `97220ca2…` → `1982bf85…`). Landing this in the same release as #2231 means users see **one** rebuild with one explanation.

The `BackendName` refactor is hash-neutral by construction — only plain strings from `con.name`/`dt.source.name` reach tokens — verified by the unchanged goldens and the determinism harness.

## Verification

- Two `FlightUDXF`s differing only in inner name: `get_expr_hash` / `SnapshotStrategy` keys now equal (both differed on `main`); `ModificationTimeStrategy` unchanged-correct as control.
- Three runs of one unchanged script in separate processes: one build hash (three distinct on `main`).
- The five test files above: **106 passed**.
- Full suites diffed against pristine `main` as control: `ibis_yaml/tests/`, `flight/tests/` + `caching/`, and the dasher/content-hash/ls-accessor tests — pre-existing failure sets identical on both sides; no new failures.

## Deliberately out of scope

- **Convert-once dispatch gate** (#2246; `BackendName(dt.source.name)` at the top of `_dispatch_databasetable`): would make an unlisted name structurally unreachable, but changes hot-path control flow and deserves its own before/after hash verification. The AST guard covers respelled *known* names meanwhile; a literal for a never-enumified backend remains the documented residual.
- **`_sanitize_generated_names` as a backstop**: cannot serve here for the two reasons documented in #2229 (its `(InMemoryTable, Read)` walk never visits Flight ops; `get_uid_prefix`'s 26-char pattern cannot match xorq's 14-char truncated uids). Left for that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

