### PR TITLE
fix(flight): surface exchange failures instead of hanging or returning empty

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -67,8 +67,13 @@ def transform_predict(df):
 
 # For Flight server
 def sentiment_analysis(df: pd.DataFrame):
+    # one score per title, like `transform_predict` above. `predict` returns an
+    # array, and `float()` on an array is a TypeError on numpy >= 2 for *any*
+    # size, so the scalar form failed on every batch -- invisibly, until the
+    # exchange stopped swallowing. It also emitted a single row per batch no
+    # matter how many titles came in.
     scores = predict_sentiment(df["title"])
-    return pd.DataFrame({"sentiment_score": [float(scores)]})
+    return pd.DataFrame({"sentiment_score": pd.Series(scores, dtype="float64")})
 
 
 def test_flight_service(do_sentiment, schema_in):
@@ -78,6 +83,10 @@ def test_flight_service(do_sentiment, schema_in):
     (_, rbr) = do_sentiment(test_data)
     res = rbr.read_pandas()
     print("Flight service test result:\n", res)
+    # nothing here asserted anything, so a service returning zero rows -- which
+    # is what the swallowed TypeError produced -- still counted as a pass
+    assert len(res) == 1, f"expected one score per title, got {len(res)} rows"
+    assert res["sentiment_score"].notna().all()
 
 
 # connect to xorq's embedded engine

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -67,11 +67,9 @@ def transform_predict(df):
 
 # For Flight server
 def sentiment_analysis(df: pd.DataFrame):
-    # one score per title, like `transform_predict` above. `predict` returns an
-    # array, and `float()` on an array is a TypeError on numpy >= 2 for *any*
-    # size, so the scalar form failed on every batch -- invisibly, until the
-    # exchange stopped swallowing. It also emitted a single row per batch no
-    # matter how many titles came in.
+    # one score per title, like `transform_predict`. `float()` on `predict`'s
+    # array is a TypeError on numpy >= 2 for any size, so the scalar form failed
+    # on every batch -- and emitted one row however many titles came in.
     scores = predict_sentiment(df["title"])
     return pd.DataFrame({"sentiment_score": pd.Series(scores, dtype="float64")})
 
@@ -83,8 +81,8 @@ def test_flight_service(do_sentiment, schema_in):
     (_, rbr) = do_sentiment(test_data)
     res = rbr.read_pandas()
     print("Flight service test result:\n", res)
-    # nothing here asserted anything, so a service returning zero rows -- which
-    # is what the swallowed TypeError produced -- still counted as a pass
+    # this asserted nothing, so the zero rows the swallowed TypeError produced
+    # still counted as a pass
     assert len(res) == 1, f"expected one score per title, got {len(res)} rows"
     assert res["sentiment_score"].notna().all()
 

--- a/python/xorq/common/utils/func_utils.py
+++ b/python/xorq/common/utils/func_utils.py
@@ -33,7 +33,13 @@ def log_excepts(f, exception=Exception):
             logger.info(f"{f.__name__} :: exiting  :: {i}")
             return value
         except exception:
+            # log where it happened, then propagate. Swallowing here made debug
+            # mode *lose* errors that plain mode surfaces: `maybe_log_excepts`
+            # leaves `f` undecorated when debug is off, so returning None turned
+            # a failed Flight RPC into a clean, empty, cacheable stream under
+            # XORQ_DEBUG=1 alone. This decorator adds logging, not semantics.
             logger.exception("exception!")
+            raise
 
     return wrapper
 

--- a/python/xorq/common/utils/func_utils.py
+++ b/python/xorq/common/utils/func_utils.py
@@ -33,11 +33,9 @@ def log_excepts(f, exception=Exception):
             logger.info(f"{f.__name__} :: exiting  :: {i}")
             return value
         except exception:
-            # log where it happened, then propagate. Swallowing here made debug
-            # mode *lose* errors that plain mode surfaces: `maybe_log_excepts`
-            # leaves `f` undecorated when debug is off, so returning None turned
-            # a failed Flight RPC into a clean, empty, cacheable stream under
-            # XORQ_DEBUG=1 alone. This decorator adds logging, not semantics.
+            # adds logging, not semantics: `maybe_log_excepts` leaves `f`
+            # undecorated when debug is off, so swallowing here lost errors
+            # that plain mode surfaces
             logger.exception("exception!")
             raise
 

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -19,10 +19,7 @@ from xorq.common.utils.otel_utils import (
 def reraise(exc: BaseException) -> NoReturn:
     """``excepts_print_exc`` handler that propagates instead of swallowing.
 
-    The default handler returns ``None``, which turns a failure into a
-    successful-looking empty result. Pass this one wherever the caller has to
-    learn that the call failed -- e.g. a Flight exchange, where swallowing
-    leaves the client reading an empty stream and caching the nothing it got.
+    The default returns ``None``, turning a failure into an empty result.
     """
     raise exc
 

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import itertools
 import traceback
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from typing import NoReturn
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -15,8 +16,23 @@ from xorq.common.utils.otel_utils import (
 )
 
 
+def reraise(exc: BaseException) -> NoReturn:
+    """``excepts_print_exc`` handler that propagates instead of swallowing.
+
+    The default handler returns ``None``, which turns a failure into a
+    successful-looking empty result. Pass this one wherever the caller has to
+    learn that the call failed -- e.g. a Flight exchange, where swallowing
+    leaves the client reading an empty stream and caching the nothing it got.
+    """
+    raise exc
+
+
 @toolz.curry
-def excepts_print_exc(func, exc=Exception, handler=toolz.functoolz.return_none):
+def excepts_print_exc(
+    func: Callable,
+    exc: type[BaseException] = Exception,
+    handler: Callable = toolz.functoolz.return_none,
+) -> Callable:
     _handler = toolz.compose(handler, toolz.curried.do(traceback.print_exception))
     return toolz.excepts(exc, func, _handler)
 

--- a/python/xorq/common/utils/tests/test_func_utils.py
+++ b/python/xorq/common/utils/tests/test_func_utils.py
@@ -5,12 +5,9 @@ import pytest
 from xorq.common.utils.func_utils import log_excepts, maybe_log_excepts
 
 
-# `log_excepts` decorates the four Flight RPC handlers in flight/server.py, but
-# only when `options.debug` is set -- which CI never sets. So nothing else in
-# the suite covers it, and the swallow it used to do was invisible until it hit
-# someone: under XORQ_DEBUG=1 alone, a failed exchange was caught at the RPC
-# boundary and returned None, i.e. a clean, empty, cacheable stream, undoing
-# the propagation the exchangers had just been fixed to guarantee. These tests
+# `log_excepts` decorates the four Flight RPC handlers only when `options.debug`
+# is set, which CI never sets -- so nothing else covers it, and its swallow
+# silently undid the exchangers' propagation under XORQ_DEBUG=1 alone. These
 # pin the decorator to "adds logging, changes nothing else".
 
 
@@ -55,11 +52,10 @@ def test_log_excepts_does_not_catch_a_narrower_exception_arg() -> None:
 def test_maybe_log_excepts_propagates_whether_or_not_debug_is_on(
     debug: bool,
 ) -> None:
-    """The point of the whole thing: debug mode must not change semantics.
+    """Debug mode must not change semantics.
 
-    With debug off `maybe_log_excepts` hands back the undecorated function, so
-    these two paths agreeing is what keeps a failure from depending on an env
-    var to reach the caller.
+    With debug off the function comes back undecorated, so these two agreeing
+    is what keeps a failure from depending on an env var to reach the caller.
     """
     with pytest.raises(ValueError, match="boom"):
         maybe_log_excepts(boom, debug=debug)()

--- a/python/xorq/common/utils/tests/test_func_utils.py
+++ b/python/xorq/common/utils/tests/test_func_utils.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from xorq.common.utils.func_utils import log_excepts, maybe_log_excepts
+
+
+# `log_excepts` decorates the four Flight RPC handlers in flight/server.py, but
+# only when `options.debug` is set -- which CI never sets. So nothing else in
+# the suite covers it, and the swallow it used to do was invisible until it hit
+# someone: under XORQ_DEBUG=1 alone, a failed exchange was caught at the RPC
+# boundary and returned None, i.e. a clean, empty, cacheable stream, undoing
+# the propagation the exchangers had just been fixed to guarantee. These tests
+# pin the decorator to "adds logging, changes nothing else".
+
+
+def boom() -> None:
+    raise ValueError("boom")
+
+
+def test_log_excepts_propagates_the_exception() -> None:
+    with pytest.raises(ValueError, match="boom"):
+        log_excepts(boom)()
+
+
+def test_log_excepts_propagates_the_same_instance() -> None:
+    """Not a re-wrap: the caller sees the original error, traceback included."""
+    error = ValueError("boom")
+
+    def raise_error() -> None:
+        raise error
+
+    with pytest.raises(ValueError) as excinfo:
+        log_excepts(raise_error)()
+    assert excinfo.value is error
+
+
+def test_log_excepts_returns_the_value_when_nothing_raises() -> None:
+    assert log_excepts(lambda: 42)() == 42
+
+
+def test_log_excepts_does_not_catch_a_narrower_exception_arg() -> None:
+    """`exception` selects what is *logged*; nothing is swallowed either way."""
+    with pytest.raises(ValueError, match="boom"):
+        log_excepts(boom, exception=KeyError)()
+
+
+@pytest.mark.parametrize(
+    "debug",
+    (
+        pytest.param(True, id="debug-on"),
+        pytest.param(False, id="debug-off"),
+    ),
+)
+def test_maybe_log_excepts_propagates_whether_or_not_debug_is_on(
+    debug: bool,
+) -> None:
+    """The point of the whole thing: debug mode must not change semantics.
+
+    With debug off `maybe_log_excepts` hands back the undecorated function, so
+    these two paths agreeing is what keeps a failure from depending on an env
+    var to reach the caller.
+    """
+    with pytest.raises(ValueError, match="boom"):
+        maybe_log_excepts(boom, debug=debug)()

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -225,15 +225,10 @@ class FlightClient:
             return i
 
         def do_writes_reads(command, reader, queue):
-            # The consumer blocks on `queue` until it sees the sentinel, so every
-            # exit path from here must put one -- including a failure to open the
-            # exchange at all, which is why `do_exchange` is inside the `try`. A
-            # server-side failure arrives as an exception out of `do_reads` (or
-            # out of closing the writer), not as an end-of-stream: without the
-            # sentinel the reader would block in `queue.get()` forever -- and
-            # since the caller of `do_exchange_batches` consumes `rbr` and drops
-            # `fut`, the exception would go unseen. Hand it to the queue instead,
-            # for `queue_to_gen` to raise in the consumer's thread.
+            # The consumer blocks until it sees the sentinel, so every exit path
+            # must put one -- including a failure to open the exchange, which is
+            # why `do_exchange` is inside the `try`. Callers drop `fut`, so an
+            # exception left there goes unseen; it goes on the queue instead.
             try:
                 descriptor = pa.flight.FlightDescriptor.for_command(command)
                 writer, _reader = self._client.do_exchange(descriptor, self._options)
@@ -255,8 +250,7 @@ class FlightClient:
         def queue_to_rbr(schema, queue):
             def queue_to_gen(queue):
                 while (value := queue.get()) is not None:
-                    # the exchange failed: re-raise in the thread that is pulling
-                    # batches, where the caller can actually see it
+                    # re-raise where the caller can see it: the pulling thread
                     if isinstance(value, BaseException):
                         raise value
                     yield value

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -225,17 +225,18 @@ class FlightClient:
             return i
 
         def do_writes_reads(command, reader, queue):
-            descriptor = pa.flight.FlightDescriptor.for_command(command)
-            writer, _reader = self._client.do_exchange(descriptor, self._options)
             # The consumer blocks on `queue` until it sees the sentinel, so every
-            # exit path from here must put one. A server-side failure arrives as
-            # an exception out of `do_reads` (or out of closing the writer), not
-            # as an end-of-stream: without the sentinel the reader would block in
-            # `queue.get()` forever -- and since the caller of `do_exchange_batches`
-            # consumes `rbr` and drops `fut`, the exception would go unseen. Hand
-            # it to the queue instead, for `queue_to_gen` to raise in the
-            # consumer's thread.
+            # exit path from here must put one -- including a failure to open the
+            # exchange at all, which is why `do_exchange` is inside the `try`. A
+            # server-side failure arrives as an exception out of `do_reads` (or
+            # out of closing the writer), not as an end-of-stream: without the
+            # sentinel the reader would block in `queue.get()` forever -- and
+            # since the caller of `do_exchange_batches` consumes `rbr` and drops
+            # `fut`, the exception would go unseen. Hand it to the queue instead,
+            # for `queue_to_gen` to raise in the consumer's thread.
             try:
+                descriptor = pa.flight.FlightDescriptor.for_command(command)
+                writer, _reader = self._client.do_exchange(descriptor, self._options)
                 # `with writer` must happen inside a future
                 # # so its context remains alive during enclosed writes and reads
                 with writer:

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -222,23 +222,42 @@ class FlightClient:
             i = -1
             for i, batch in enumerate(_reader, 1):  # noqa: B007
                 queue.put(batch.data)
-            queue.put(None)
             return i
 
         def do_writes_reads(command, reader, queue):
             descriptor = pa.flight.FlightDescriptor.for_command(command)
             writer, _reader = self._client.do_exchange(descriptor, self._options)
-            # `with writer` must happen inside a future
-            # # so its context remains alive during enclosed writes and reads
-            with writer:
-                do_writes_fut = executor.submit(do_writes, writer, reader)
-                do_reads_fut = executor.submit(do_reads, _reader, queue)
-                (n_writes, n_reads) = (do_writes_fut.result(), do_reads_fut.result())
+            # The consumer blocks on `queue` until it sees the sentinel, so every
+            # exit path from here must put one. A server-side failure arrives as
+            # an exception out of `do_reads` (or out of closing the writer), not
+            # as an end-of-stream: without the sentinel the reader would block in
+            # `queue.get()` forever -- and since the caller of `do_exchange_batches`
+            # consumes `rbr` and drops `fut`, the exception would go unseen. Hand
+            # it to the queue instead, for `queue_to_gen` to raise in the
+            # consumer's thread.
+            try:
+                # `with writer` must happen inside a future
+                # # so its context remains alive during enclosed writes and reads
+                with writer:
+                    do_writes_fut = executor.submit(do_writes, writer, reader)
+                    do_reads_fut = executor.submit(do_reads, _reader, queue)
+                    (n_writes, n_reads) = (
+                        do_writes_fut.result(),
+                        do_reads_fut.result(),
+                    )
+            except BaseException as e:
+                queue.put(e)
+                raise
+            queue.put(None)
             return {"n_writes": n_writes, "n_reads": n_reads}
 
         def queue_to_rbr(schema, queue):
             def queue_to_gen(queue):
                 while (value := queue.get()) is not None:
+                    # the exchange failed: re-raise in the thread that is pulling
+                    # batches, where the caller can actually see it
+                    if isinstance(value, BaseException):
+                        raise value
                     yield value
 
             return pa.RecordBatchReader.from_batches(schema, queue_to_gen(queue))

--- a/python/xorq/flight/exchanger.py
+++ b/python/xorq/flight/exchanger.py
@@ -59,11 +59,10 @@ def replace_one_unbound(unbound_expr, table):
     return replace_unbound(unbound_expr, dt, target=unbound)
 
 
-# print the traceback where it happened -- on the server side, with the
-# fetcher's own frames -- and then let it out: the exchange must end in an error
-# status, not in a clean empty stream that the client would cache as the answer.
-# `BaseException`, because a `SystemExit` raised by the exchanged function is
-# exactly the case that used to escape and leave the client's reader hanging.
+# print the traceback server-side, with the fetcher's frames, then let it out:
+# the exchange must end in an error status, not a clean empty stream the client
+# would cache. `BaseException` because `SystemExit` is the case that used to
+# escape and hang the client's reader.
 @excepts_print_exc(exc=BaseException, handler=reraise)
 def streaming_exchange(
     f, context, reader, writer, options=None, out_schema=None, **kwargs
@@ -418,8 +417,8 @@ def make_udxf(
         )
 
     if do_wraps:
-        # no excepts wrapper here: `streaming_exchange` already prints and
-        # re-raises, and wrapping it again only doubles the traceback
+        # no wrapper: `streaming_exchange` already prints and re-raises, and
+        # wrapping twice only doubles the traceback
         exchange_f = functools.partial(
             streaming_exchange,
             functools.partial(process_batch, process_df),

--- a/python/xorq/flight/exchanger.py
+++ b/python/xorq/flight/exchanger.py
@@ -24,6 +24,7 @@ from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
     excepts_print_exc,
     make_filtered_reader,
+    reraise,
 )
 from xorq.vendor import ibis
 
@@ -58,7 +59,12 @@ def replace_one_unbound(unbound_expr, table):
     return replace_unbound(unbound_expr, dt, target=unbound)
 
 
-@excepts_print_exc
+# print the traceback where it happened -- on the server side, with the
+# fetcher's own frames -- and then let it out: the exchange must end in an error
+# status, not in a clean empty stream that the client would cache as the answer.
+# `BaseException`, because a `SystemExit` raised by the exchanged function is
+# exactly the case that used to escape and leave the client's reader hanging.
+@excepts_print_exc(exc=BaseException, handler=reraise)
 def streaming_exchange(
     f, context, reader, writer, options=None, out_schema=None, **kwargs
 ):
@@ -98,7 +104,7 @@ def find_unbound_next_con(unbound_expr):
             raise ValueError("unexpected match case in find_unbound_next_con")
 
 
-@excepts_print_exc
+@excepts_print_exc(exc=BaseException, handler=reraise)
 def streaming_expr_exchange(
     unbound_expr, make_connection, context, reader, writer, options=None, **kwargs
 ):
@@ -412,13 +418,12 @@ def make_udxf(
         )
 
     if do_wraps:
-        exchange_f = excepts_print_exc(
-            functools.partial(
-                streaming_exchange,
-                functools.partial(process_batch, process_df),
-                out_schema=out_schema.to_pyarrow() if out_schema else None,
-            ),
-            Exception,
+        # no excepts wrapper here: `streaming_exchange` already prints and
+        # re-raises, and wrapping it again only doubles the traceback
+        exchange_f = functools.partial(
+            streaming_exchange,
+            functools.partial(process_batch, process_df),
+            out_schema=out_schema.to_pyarrow() if out_schema else None,
         )
     else:
         exchange_f = process_df

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import operator
+import threading
 from pathlib import Path
 
 import cloudpickle
@@ -6,8 +9,10 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 import toolz
+from pytest import param
 
 import xorq.api as xo
+from xorq.caching import ParquetCache
 from xorq.expr.relations import (
     FlightExpr,
     FlightUDXF,
@@ -249,3 +254,85 @@ def test_bare_flight_udxf_binds_params_through_to_rbr() -> None:
 
     reader = xo.to_pyarrow_batches(fu, params={"cutoff": 1})
     assert reader.read_all().num_rows == 2
+
+
+def execute_with_deadline(expr: xo.Table, seconds: int = 90) -> pd.DataFrame:
+    """``xo.execute`` on a daemon thread, so a deadlock fails instead of hanging.
+
+    The bug these tests cover is a hang, and a hang inside pytest is a 300s
+    faulthandler dump rather than a failure. A daemon thread is abandonable: if
+    it is still running at the deadline the test fails immediately, and the
+    interpreter can still exit.
+    """
+    box = {}
+
+    def run() -> None:
+        try:
+            box["value"] = xo.execute(expr)
+        except BaseException as e:  # noqa: BLE001
+            box["error"] = e
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(seconds)
+    if thread.is_alive():
+        raise AssertionError(f"exchange did not finish within {seconds}s: deadlocked")
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
+def make_failing_udxf(exc_type: type[BaseException], message: str) -> xo.Table:
+    """A UDXF whose ``process_df`` raises ``exc_type(message)``.
+
+    The exception is built inside the fetcher rather than closed over: an
+    exception *instance* in the closure is not hashable by dasher, so the
+    expression would fail to build and never reach the exchange at all.
+    """
+    schema = xo.schema({"unit": "int64"})
+
+    def boom(df: pd.DataFrame) -> pd.DataFrame:
+        raise exc_type(message)
+
+    return xo.expr.relations.flight_udxf(
+        process_df=boom,
+        maybe_schema_in=schema,
+        maybe_schema_out=schema,
+        name="Boom",
+    )(xo.memtable([{"unit": 1}], name="unit_tbl"))
+
+
+@pytest.mark.parametrize(
+    ("exc_type", "message"),
+    (
+        param(ValueError, "plain exception", id="exception"),
+        # SystemExit is not an Exception: it used to escape the exchange's
+        # excepts wrapper entirely, leaving the client's reader in queue.get()
+        # forever with no error and no end-of-stream
+        param(SystemExit, "missing credential", id="systemexit"),
+    ),
+)
+def test_udxf_failure_raises_instead_of_hanging(
+    exc_type: type[BaseException], message: str
+) -> None:
+    """A failed exchange must surface as an error to whoever pulls the batches.
+
+    The failure reaches the client as an error status, i.e. as an exception out
+    of the reader -- never as an end-of-stream. Both halves matter: the client
+    has to forward that exception to the consumer (or it deadlocks), and the
+    server has to re-raise rather than swallow (or the consumer sees a clean,
+    empty, cacheable stream).
+    """
+    expr = make_failing_udxf(exc_type, message)
+    with pytest.raises(Exception, match=message):
+        execute_with_deadline(expr)
+
+
+def test_failed_udxf_writes_no_cache(tmp_path: Path) -> None:
+    """A swallowed failure used to be cached: zero rows, stored as the answer."""
+    expr = make_failing_udxf(ValueError, "plain exception").cache(
+        ParquetCache.from_kwargs(source=xo.connect(), relative_path=tmp_path)
+    )
+    with pytest.raises(Exception, match="plain exception"):
+        execute_with_deadline(expr)
+    assert not tuple(tmp_path.glob("*.parquet"))

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -259,10 +259,8 @@ def test_bare_flight_udxf_binds_params_through_to_rbr() -> None:
 def execute_with_deadline(expr: xo.Table, seconds: int = 90) -> pd.DataFrame:
     """``xo.execute`` on a daemon thread, so a deadlock fails instead of hanging.
 
-    The bug these tests cover is a hang, and a hang inside pytest is a 300s
-    faulthandler dump rather than a failure. A daemon thread is abandonable: if
-    it is still running at the deadline the test fails immediately, and the
-    interpreter can still exit.
+    A hang inside pytest is a 300s faulthandler dump rather than a failure, and
+    a daemon thread is abandonable, so the interpreter can still exit.
     """
     box = {}
 
@@ -285,9 +283,8 @@ def execute_with_deadline(expr: xo.Table, seconds: int = 90) -> pd.DataFrame:
 def make_failing_udxf(exc_type: type[BaseException], message: str) -> xo.Table:
     """A UDXF whose ``process_df`` raises ``exc_type(message)``.
 
-    The exception is built inside the fetcher rather than closed over: an
-    exception *instance* in the closure is not hashable by dasher, so the
-    expression would fail to build and never reach the exchange at all.
+    Built inside the fetcher, not closed over: an exception *instance* in the
+    closure is not hashable by dasher, so the expression would fail to build.
     """
     schema = xo.schema({"unit": "int64"})
 
@@ -306,9 +303,8 @@ def make_failing_udxf(exc_type: type[BaseException], message: str) -> xo.Table:
     ("exc_type", "message"),
     (
         param(ValueError, "plain exception", id="exception"),
-        # SystemExit is not an Exception: it used to escape the exchange's
-        # excepts wrapper entirely, leaving the client's reader in queue.get()
-        # forever with no error and no end-of-stream
+        # not an Exception, so it used to escape the excepts wrapper and leave
+        # the client's reader in queue.get() forever
         param(SystemExit, "missing credential", id="systemexit"),
     ),
 )
@@ -317,11 +313,9 @@ def test_udxf_failure_raises_instead_of_hanging(
 ) -> None:
     """A failed exchange must surface as an error to whoever pulls the batches.
 
-    The failure reaches the client as an error status, i.e. as an exception out
-    of the reader -- never as an end-of-stream. Both halves matter: the client
-    has to forward that exception to the consumer (or it deadlocks), and the
-    server has to re-raise rather than swallow (or the consumer sees a clean,
-    empty, cacheable stream).
+    Both halves matter: the client forwards the exception to the consumer (or
+    it deadlocks), and the server re-raises rather than swallows (or the
+    consumer sees a clean, empty, cacheable stream).
     """
     expr = make_failing_udxf(exc_type, message)
     with pytest.raises(Exception, match=message):


### PR DESCRIPTION
## Summary

A failure inside a Flight exchange did not reach the caller. Which of the two bad outcomes you got depended only on what the fetcher raised:

- an ordinary `Exception` was swallowed by `excepts_print_exc`'s default handler (`return_none`), so the exchange ended in a clean, empty stream — indistinguishable from a legitimately empty result, and cacheable as the answer;
- a `BaseException` — the `SystemExit` a credential check raises — escaped that wrapper instead and killed the handler. The client's `do_reads` then never queued its end-of-stream sentinel, so the consumer blocked in `queue.get()` forever, uninterruptibly.

Both halves are fixed, because either alone leaves a hole.

**Server side.** `streaming_exchange` and `streaming_expr_exchange` now wrap with `excepts_print_exc(exc=BaseException, handler=reraise)`: the traceback still prints where it happened, with the fetcher's own frames, and then propagates so the exchange ends in an error status rather than a clean EOS. `reraise` is a new `excepts_print_exc` handler in `rbr_utils` — the printing is what you want, the swallowing is not. The now-redundant wrapper in `make_udxf` is dropped, since double-wrapping only doubles the traceback.

**Client side.** `do_writes_reads` now owns stream termination: the sentinel moves out of `do_reads` and every exit path puts something on the queue — `None` on success, the exception itself on failure. `queue_to_gen` re-raises that exception in the thread pulling batches. This matters because the caller of `do_exchange_batches` consumes `rbr` and drops the future, so an exception left in the future is never seen by anyone.

## Testing

`python -m pytest python/xorq/flight/tests/test_flight_exchange.py` — 13 passed.

New tests:

- `test_udxf_failure_raises_instead_of_hanging[exception]` / `[systemexit]` — a failed UDXF surfaces as an error to whoever pulls the batches. The `SystemExit` case is the one that used to deadlock.
- `test_failed_udxf_writes_no_cache` — the swallowed-failure path used to write a zero-row parquet and store it as the answer; now it raises and writes nothing.

The tests run `xo.execute` on a daemon thread with a deadline (`execute_with_deadline`), because the bug under test is a hang: inside pytest that is a 300s faulthandler dump rather than a failure, and a daemon thread is abandonable so the deadline fails fast and the interpreter can still exit.

All three were verified red against `main` (source files reverted, new tests kept):

- `[exception]` — `Failed: DID NOT RAISE <class 'Exception'>`; the traceback prints server-side but the stream ends clean.
- `[systemexit]` — `AssertionError: exchange did not finish within 90s: deadlocked`.
- `test_failed_udxf_writes_no_cache` — same `DID NOT RAISE`; the zero-row result is written to the cache.


Two commits were added after review (`ff69955f`, `efd9f3a5`): `do_writes_reads` now builds the descriptor and opens the exchange *inside* its `try`, so a failure to open the exchange at all also queues a terminator; and `log_excepts` (`func_utils.py`) re-raises after logging, because it decorates the four Flight RPC handlers under `options.debug` and its swallow re-hid exchange failures under `XORQ_DEBUG=1` alone. `test_func_utils.py` pins that, since no CI job sets the flag.

Flight suite: 84 passed with and without `XORQ_DEBUG=1`; 90 passed including the new `test_func_utils.py`.

## Relation to #2227

Partially addresses #2227 — deliberately not a closing reference, since that issue catalogues more than this PR fixes.

Fixed here, of #2227's root-cause list:

- the swallow at `streaming_exchange` and `streaming_expr_exchange` (2 of the 4 `excepts_print_exc` sites)
- the client-side missing sentinel, i.e. the indefinite hang and the un-deliverable Ctrl-C
- the `options.debug` swallow at the RPC boundary (`log_excepts`), which #2227 names only in its test list

Of #2227's minimum test set:

- **1** (`SystemExit` → caller raises within timeout) — covered, `[systemexit]`
- **2** (`Exception` → caller raises) — covered, `[exception]`
- **3** (same with `options.debug=True`) — covered at the decorator level by `test_func_utils.py` (`maybe_log_excepts(..., debug=True)`), and the flight suite passes under `XORQ_DEBUG=1`; there is **no** end-to-end flight test that forces `options.debug` on
- **4** (input reader raises → caller raises, original exception preserved) — behavior verified manually during review, **not** pinned by a test
- **5** (exchanger returns full output without draining a large input) — not addressed
- **6** (metadata-only chunk mid-stream) — not addressed

Left open by this PR, all still live in #2227: `streaming_split_exchange` (both wraps) and its partial-failure policy, `_do_action`'s `None` → `TypeError`, the bare `assert` at `client.py:248`, `instrument_reader`'s `StopIteration`/PEP-479 path, the metadata-only-chunk truncation, thread-pool starvation, and the `queue.get(timeout=…)` watchdog.
