### PR TITLE
fix(ml): drop MetricComputation.__module__ property so builds can load

### DIFF
--- a/python/xorq/expr/ml/metrics.py
+++ b/python/xorq/expr/ml/metrics.py
@@ -341,14 +341,19 @@ class MetricComputation:
         return dict(self.metric_kwargs_tuple)
 
     @property
-    def __name__(self):
-        """Return the name of the metric function for UDF registration."""
-        return self.metric_fn.__name__
+    def __name__(self) -> str:
+        """Return the name of the metric function for UDF registration.
 
-    @property
-    def __module__(self):
-        """Return the module of the metric function for UDF registration."""
-        return self.metric_fn.__module__
+        Deliberately no matching ``__module__`` property: ``type.__module__``
+        reads ``cls.__dict__["__module__"]`` raw, so a property there leaks out
+        at the class level as a non-str. cloudpickle's module/qualname lookup
+        then fails, it falls back to pickling the class *by value*, and
+        reconstruction dies on ``setattr(cls, "__name__", <property>)`` --
+        making every build embedding a MetricComputation unloadable (#2227).
+        ``__name__`` is safe because ``type.__name__`` is a data descriptor on
+        the metaclass and shadows the class dict entry.
+        """
+        return self.metric_fn.__name__
 
     @staticmethod
     def _normalize_columns(value, name):

--- a/python/xorq/expr/ml/metrics.py
+++ b/python/xorq/expr/ml/metrics.py
@@ -342,16 +342,28 @@ class MetricComputation:
 
     @property
     def __name__(self) -> str:
-        """Return the name of the metric function for UDF registration.
+        """Name the metric function, for naming the generated UDF node type.
+
+        Required, not cosmetic: ``agg.pandas_df`` reads ``fn.__name__``
+        unconditionally to name the node class it builds
+        (``xorq/expr/udf.py``, ``_make_udf_name(fn.__name__)``). Deleting this
+        property raises ``AttributeError`` there -- the ``name=`` argument
+        ``on_expr`` passes covers only the UDF name, not the class name.
 
         Deliberately no matching ``__module__`` property: ``type.__module__``
         reads ``cls.__dict__["__module__"]`` raw, so a property there leaks out
         at the class level as a non-str. cloudpickle's module/qualname lookup
         then fails, it falls back to pickling the class *by value*, and
         reconstruction dies on ``setattr(cls, "__name__", <property>)`` --
-        making every build embedding a MetricComputation unloadable (#2227).
-        ``__name__`` is safe because ``type.__name__`` is a data descriptor on
-        the metaclass and shadows the class dict entry.
+        making every build embedding a MetricComputation unloadable (#2233).
+
+        ``__name__`` is safe only *given by-reference pickling*, which keeping
+        ``__module__`` a str preserves: ``type.__name__`` is a data descriptor
+        on the metaclass, so class-level access returns the real str and
+        cloudpickle's lookup succeeds. Force by-value anyway --
+        ``cloudpickle.register_pickle_by_value(xorq.expr.ml.metrics)``, a
+        module that is not importable on the loading side -- and the identical
+        TypeError returns. Do not add a dunder property here.
         """
         return self.metric_fn.__name__
 

--- a/python/xorq/expr/ml/tests/test_build_pipeline.py
+++ b/python/xorq/expr/ml/tests/test_build_pipeline.py
@@ -1,5 +1,8 @@
 """Tests for YAML build serialization of sklearn pipeline expressions."""
 
+import pathlib
+
+import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pyarrow as pa
@@ -9,6 +12,7 @@ import pytest
 import xorq.api as xo
 import xorq.ibis_yaml.translate as translate_mod
 from xorq.expr.ml.cross_validation import _make_folds_from_sklearn
+from xorq.expr.ml.metrics import deferred_sklearn_metric
 from xorq.ibis_yaml.common import FROM_YAML_HANDLERS
 from xorq.ibis_yaml.compiler import build_expr, load_expr
 
@@ -16,6 +20,7 @@ from xorq.ibis_yaml.compiler import build_expr, load_expr
 sklearn = pytest.importorskip("sklearn")
 
 from sklearn.datasets import make_regression  # noqa: E402
+from sklearn.metrics import r2_score  # noqa: E402
 from sklearn.model_selection import TimeSeriesSplit  # noqa: E402
 
 
@@ -122,3 +127,33 @@ def test_lasso_timeseries_cv_yaml_roundtrip(lasso_timeseries_fold_expr, tmp_path
         roundtrip_expr.execute().sort_values(sort_cols).reset_index(drop=True)
     )
     tm.assert_frame_equal(original_df, roundtrip_df)
+
+
+def test_deferred_metric_build_load_roundtrip(tmp_path: pathlib.Path) -> None:
+    """A build embedding a metric loads and executes (#2233).
+
+    The pickle-layer tests in test_metrics.py cover the mechanism; this covers
+    the symptom -- ``build`` succeeding while the artifact it wrote is
+    unloadable. A MetricComputation reaches the payload via the UDAF config
+    (``agg.pandas_df(fn=self)`` in ``MetricComputation.on_expr``), so a dunder
+    that breaks cloudpickle's by-reference lookup fails here and nowhere
+    earlier.
+    """
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"y": rng.normal(size=50)}).assign(
+        yhat=lambda t: t["y"] + rng.normal(scale=0.1, size=50)
+    )
+    parquet_path = tmp_path / "metric_data.parquet"
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), parquet_path)
+
+    metric_expr = deferred_sklearn_metric(
+        xo.deferred_read_parquet(parquet_path),
+        target="y",
+        pred="yhat",
+        metric=r2_score,
+    )
+    expected = metric_expr.execute()
+
+    expr_path = build_expr(metric_expr, builds_dir=tmp_path / "builds")
+
+    assert load_expr(expr_path).execute() == pytest.approx(expected)

--- a/python/xorq/expr/ml/tests/test_metrics.py
+++ b/python/xorq/expr/ml/tests/test_metrics.py
@@ -1979,7 +1979,7 @@ def test_pipeline_score_methods_score_regressor(regression_data):
     assert isinstance(result, (float, np.floating))
 
 
-def test_metric_computation_module_is_a_str():
+def test_metric_computation_module_is_a_str() -> None:
     """MetricComputation must not shadow __module__ with a property.
 
     ``type.__module__`` returns ``cls.__dict__["__module__"]`` verbatim, so a
@@ -1990,8 +1990,8 @@ def test_metric_computation_module_is_a_str():
     assert isinstance(MetricComputation.__module__, str)
 
 
-def test_metric_computation_cloudpickle_round_trip():
-    """A MetricComputation survives cloudpickle (#2227)."""
+def test_metric_computation_cloudpickle_round_trip() -> None:
+    """A MetricComputation survives cloudpickle (#2233)."""
     mc = MetricComputation(target="y", pred="yhat", metric_fn=r2_score)
 
     restored = cloudpickle.loads(cloudpickle.dumps(mc))
@@ -2000,11 +2000,12 @@ def test_metric_computation_cloudpickle_round_trip():
     assert restored.__name__ == "r2_score"
 
 
-def test_metric_computation_survives_build_serde():
-    """The build/load path (serialize_callable -> deserialize_callable) round-trips.
+def test_metric_computation_survives_build_serde() -> None:
+    """serialize_callable -> deserialize_callable round-trips a bare instance.
 
-    Exercises the exact frames a catalog load hits; a regression here makes
-    every build embedding a metric unloadable rather than merely unpicklable.
+    The pickle layer only; see
+    ``test_build_pipeline.test_deferred_metric_build_load_roundtrip`` for the
+    end-to-end build artifact that #2233 actually broke.
     """
     mc = MetricComputation(target="y", pred="yhat", metric_fn=r2_score)
 

--- a/python/xorq/expr/ml/tests/test_metrics.py
+++ b/python/xorq/expr/ml/tests/test_metrics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import cloudpickle
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,12 +11,14 @@ import xorq.expr.datatypes as dt
 from xorq.expr import api
 from xorq.expr.ml.enums import ResponseMethod
 from xorq.expr.ml.metrics import (
+    MetricComputation,
     Scorer,
     _default_scorer_for_model,
     deferred_auc_from_curve,
     deferred_sklearn_metric,
 )
 from xorq.expr.ml.pipeline_lib import Pipeline
+from xorq.ibis_yaml.common import deserialize_callable, serialize_callable
 
 
 # Skip all tests in this module if sklearn is not installed
@@ -1974,3 +1977,37 @@ def test_pipeline_score_methods_score_regressor(regression_data):
     y_test = test_df["target"].values
     result = fitted.score(X_test, y_test)
     assert isinstance(result, (float, np.floating))
+
+
+def test_metric_computation_module_is_a_str():
+    """MetricComputation must not shadow __module__ with a property.
+
+    ``type.__module__`` returns ``cls.__dict__["__module__"]`` verbatim, so a
+    property defined there surfaces as a non-str at the class level and breaks
+    cloudpickle's by-reference lookup. This is the cheap invariant guarding
+    the round-trip tests below.
+    """
+    assert isinstance(MetricComputation.__module__, str)
+
+
+def test_metric_computation_cloudpickle_round_trip():
+    """A MetricComputation survives cloudpickle (#2227)."""
+    mc = MetricComputation(target="y", pred="yhat", metric_fn=r2_score)
+
+    restored = cloudpickle.loads(cloudpickle.dumps(mc))
+
+    assert restored == mc
+    assert restored.__name__ == "r2_score"
+
+
+def test_metric_computation_survives_build_serde():
+    """The build/load path (serialize_callable -> deserialize_callable) round-trips.
+
+    Exercises the exact frames a catalog load hits; a regression here makes
+    every build embedding a metric unloadable rather than merely unpicklable.
+    """
+    mc = MetricComputation(target="y", pred="yhat", metric_fn=r2_score)
+
+    restored = deserialize_callable(serialize_callable(mc))
+
+    assert restored == mc


### PR DESCRIPTION
## Problem

Any build embedding a `MetricComputation` is unloadable. `xorq build` succeeds, then the load fails in `xorq/ibis_yaml/common.py:deserialize_callable`:

```
TypeError: can only assign string to MetricComputation.__name__, not 'property'
```

## Root cause

`MetricComputation` defined both `__name__` and `__module__` as properties. The error names `__name__`, but that one is a red herring — the trigger is `__module__`.

- `type.__name__` is a data descriptor on the metaclass, so it shadows the class dict entry: `MC.__name__` still returns the real `str`.
- `type.__module__` has no such protection — its getter returns `cls.__dict__["__module__"]` verbatim, so the property object leaks out at class level:

```python
>>> MetricComputation.__module__
<property object at 0x73fecf19bec0>   # not a str
```

cloudpickle's `_lookup_module_and_qualname` therefore fails, so it pickles the class **by value** instead of by reference, and reconstruction dies in `_class_setstate` doing `setattr(cls, "__name__", <property>)`.

Confirmed with a two-class control at module scope: a class with only `__name__` round-trips under both `pickle` and `cloudpickle`; adding `__module__` breaks both.

## Fix

Remove the `__module__` property, with a comment on `__name__` recording why it must not come back.

The only consumer is `udf.agg.pandas_df`, which copies `fn.__module__` onto the generated node type. That now reads `xorq.expr.ml.metrics` instead of `sklearn.metrics` — metadata only:

- **Expr hash is unchanged**: `2d88eb20b648` before and after.
- A full `build_expr` → `load_expr` round-trip executes and returns the correct result; it raises on `main`.

No other class in the codebase defines `__module__` or `__qualname__` as a property.

## Tests

Three regression tests in `test_metrics.py`, all of which **fail on `main` and pass here**:

- `test_metric_computation_module_is_a_str` — the cheap invariant; fails immediately and legibly if the property is ever re-added
- `test_metric_computation_cloudpickle_round_trip`
- `test_metric_computation_survives_build_serde` — drives the real `serialize_callable` → `deserialize_callable` frames a catalog load hits

`test_metrics.py`: 89 passed. Whole `expr/ml/tests/` dir: 481 passed. `test_split_lib.py` has 7 failures that reproduce on unmodified `main` and are unrelated to this change.

## ⚠️ Does not rescue existing artifacts

The pickle payload in already-written builds embeds the broken class *by value*, so upgrading does not make them loadable — I verified that building on `main` and loading with this fix still raises. **Builds produced by 0.3.39 or earlier that use metrics must be rebuilt.** Since `build` succeeded silently, anyone using metrics has been accumulating unloadable artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ozUTdLxjMyUfa9wzAYbbS
