### PR TITLE
fix(flight)!: failing splits abort the exchange — excepts_print_exc defaults to reraise

### DIFF
--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 import traceback
 from collections.abc import Callable, Iterable
-from typing import NoReturn
+from typing import Any, NoReturn
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -17,10 +17,7 @@ from xorq.common.utils.otel_utils import (
 
 
 def reraise(exc: BaseException) -> NoReturn:
-    """``excepts_print_exc`` handler that propagates instead of swallowing.
-
-    The default returns ``None``, turning a failure into an empty result.
-    """
+    """``excepts_print_exc`` handler (the default) that propagates after printing."""
     raise exc
 
 
@@ -28,8 +25,15 @@ def reraise(exc: BaseException) -> NoReturn:
 def excepts_print_exc(
     func: Callable,
     exc: type[BaseException] = Exception,
-    handler: Callable = toolz.functoolz.return_none,
+    handler: Callable = reraise,
 ) -> Callable:
+    """Wrap ``func`` to print the traceback of ``exc``, then invoke ``handler``.
+
+    The default handler is :func:`reraise`: failures print server-side (the
+    behavior requested in #1277) and then propagate, so a failed exchange ends
+    in an error status instead of a clean empty or truncated stream. Pass
+    ``handler=toolz.functoolz.return_none`` to deliberately swallow.
+    """
     _handler = toolz.compose(handler, toolz.curried.do(traceback.print_exception))
     return toolz.excepts(exc, func, _handler)
 
@@ -121,8 +125,27 @@ def instrument_reader(reader, prefix=""):
 
 @excepts_print_exc
 def streaming_split_exchange(
-    split_key, f, context, reader, writer, options=None, **kwargs
-):
+    split_key: str,
+    f: Callable,
+    context: pa.flight.ServerCallContext,
+    reader: pa.flight.MetadataRecordBatchReader,
+    writer: pa.flight.MetadataRecordBatchWriter,
+    options: pa.ipc.IpcWriteOptions | None = None,
+    **kwargs: Any,
+) -> None:
+    """Run ``f`` on each ``split_key`` split of ``reader``, streaming to ``writer``.
+
+    Error policy: a failing split ABORTS the exchange. The exception is
+    printed server-side and re-raised (the ``excepts_print_exc`` default), so
+    the exchange ends in an error status rather than a clean stream that is
+    silently missing splits. Skip-and-continue over bad splits would be a
+    feature, not a fix: the wire format currently has no way to tell the
+    client which splits were dropped.
+
+    Abort is not atomic: when split N fails, splits 1..N-1 are already on the
+    wire and the client consumes them before its reader raises. A client that
+    persists batches incrementally can retain partial data.
+    """
     started = False
     g = excepts_print_exc(f)
     for split_reader in ReaderSplitter(

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import itertools
 import traceback
 from collections.abc import Callable, Iterable
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import pyarrow as pa
 import pyarrow.compute as pc
 import toolz
+
+
+if TYPE_CHECKING:
+    # the ``pa.flight.*`` annotations need the submodule, which is never
+    # imported at runtime here (annotations stay strings under
+    # ``from __future__ import annotations``)
+    import pyarrow.flight  # noqa: F401
 
 from xorq.common.utils.otel_utils import (
     create_link,
@@ -139,9 +146,10 @@ def streaming_split_exchange(
     printed server-side and re-raised (the ``excepts_print_exc`` default), so
     the exchange ends in an error status rather than a clean stream that is
     silently missing splits. ``exc=BaseException`` for the same reason as the
-    exchanges in ``xorq.flight.exchanger``: ``SystemExit`` must be printed too. Skip-and-continue over bad splits would be a
-    feature, not a fix: the wire format currently has no way to tell the
-    client which splits were dropped.
+    exchanges in ``xorq.flight.exchanger``: ``SystemExit`` must be printed
+    too. Skip-and-continue over bad splits would be a feature, not a fix: the
+    wire format currently has no way to tell the client which splits were
+    dropped.
 
     Abort is not atomic: when split N fails, splits 1..N-1 are already on the
     wire and the client consumes them before its reader raises. A client that

--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -123,7 +123,7 @@ def instrument_reader(reader, prefix=""):
     return pa.RecordBatchReader.from_batches(reader.schema, gen(reader))
 
 
-@excepts_print_exc
+@excepts_print_exc(exc=BaseException)
 def streaming_split_exchange(
     split_key: str,
     f: Callable,
@@ -138,7 +138,8 @@ def streaming_split_exchange(
     Error policy: a failing split ABORTS the exchange. The exception is
     printed server-side and re-raised (the ``excepts_print_exc`` default), so
     the exchange ends in an error status rather than a clean stream that is
-    silently missing splits. Skip-and-continue over bad splits would be a
+    silently missing splits. ``exc=BaseException`` for the same reason as the
+    exchanges in ``xorq.flight.exchanger``: ``SystemExit`` must be printed too. Skip-and-continue over bad splits would be a
     feature, not a fix: the wire format currently has no way to tell the
     client which splits were dropped.
 
@@ -147,12 +148,11 @@ def streaming_split_exchange(
     persists batches incrementally can retain partial data.
     """
     started = False
-    g = excepts_print_exc(f)
     for split_reader in ReaderSplitter(
         make_filtered_reader(reader),
         split_key,
     ):
-        batch = g(split_reader)
+        batch = f(split_reader)
         if not started:
             writer.begin(batch.schema, options=options)
             started = True

--- a/python/xorq/common/utils/tests/test_rbr_utils.py
+++ b/python/xorq/common/utils/tests/test_rbr_utils.py
@@ -1,7 +1,13 @@
+"""Unit-layer pins for ``excepts_print_exc`` and ``streaming_split_exchange``.
+
+The end-to-end pin of the abort policy through a real Flight exchange is
+``test_streaming_split_exchange_flight_failure_aborts`` in
+``xorq.flight.tests.test_flight_exchange``, where it joins the flight tests'
+xdist group instead of running concurrently with them.
+"""
+
 from __future__ import annotations
 
-import functools
-import threading
 from collections.abc import Callable, Iterator
 from types import SimpleNamespace
 from typing import Any
@@ -10,14 +16,10 @@ import pyarrow as pa
 import pytest
 import toolz
 
-import xorq.api as xo
 from xorq.common.utils.rbr_utils import (
     excepts_print_exc,
     streaming_split_exchange,
 )
-from xorq.flight import FlightServer
-from xorq.flight.action import AddExchangeAction
-from xorq.flight.exchanger import AbstractExchanger
 
 
 SPLIT_KEY = "split"
@@ -104,14 +106,21 @@ def test_excepts_print_exc_swallowing_is_opt_in(
     assert "boom-message" in capsys.readouterr().err
 
 
-def test_streaming_split_exchange_propagates_failure() -> None:
-    """A failing split aborts the exchange instead of yielding an empty stream."""
+def test_streaming_split_exchange_propagates_failure(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """A failing split aborts the exchange instead of yielding an empty stream.
+
+    The traceback is printed exactly once: only the decorator wraps ``f``'s
+    exceptions, there is no second wrap inside the loop.
+    """
     reader = FakeFlightReader((make_batch(0, 3), make_batch(1, 2)))
     writer = RecordingWriter()
     with pytest.raises(ValueError, match="boom on split 0"):
         streaming_split_exchange(SPLIT_KEY, make_split_f(0), None, reader, writer)
     assert writer.schema is None
     assert writer.batches == []
+    assert capsys.readouterr().err.count("Traceback (most recent call last)") == 1
 
 
 def test_streaming_split_exchange_delivers_splits_before_failure() -> None:
@@ -126,89 +135,3 @@ def test_streaming_split_exchange_delivers_splits_before_failure() -> None:
         streaming_split_exchange(SPLIT_KEY, make_split_f(1), None, reader, writer)
     assert writer.schema is not None
     assert [batch[SPLIT_KEY].to_pylist() for batch in writer.batches] == [[0]]
-
-
-class FailingSplitExchanger(AbstractExchanger):
-    """`streaming_split_exchange` exchanger whose ``f`` raises on split 1."""
-
-    @property
-    def exchange_f(self) -> Callable:
-        return functools.partial(streaming_split_exchange, SPLIT_KEY, make_split_f(1))
-
-    @property
-    def schema_in_required(self) -> None:
-        return None
-
-    @property
-    def schema_in_condition(self) -> Callable:
-        def condition(schema_in: Any) -> bool:
-            return any(name == SPLIT_KEY for name in schema_in)
-
-        return condition
-
-    @property
-    def calc_schema_out(self) -> Callable:
-        def f(schema_in: Any) -> Any:
-            return xo.schema({SPLIT_KEY: "int64", "n": "int64"})
-
-        return f
-
-    @property
-    def description(self) -> str:
-        return "raises on split 1"
-
-    @property
-    def command(self) -> str:
-        return "failing-split-exchange"
-
-    @property
-    def query_result(self) -> dict:
-        return {
-            "schema-in-required": self.schema_in_required,
-            "schema-in-condition": self.schema_in_condition,
-            "calc-schema-out": self.calc_schema_out,
-            "description": self.description,
-            "command": self.command,
-        }
-
-
-def test_streaming_split_exchange_flight_failure_aborts() -> None:
-    """End-to-end: a failing split surfaces as an error on the client's reader.
-
-    Runs on a daemon thread with a hard deadline (the ``execute_with_deadline``
-    pattern from ``test_flight_exchange.py``) so a regression to swallowing or
-    deadlocking fails instead of wedging CI. Also pins the non-atomicity
-    caveat end-to-end: the split-0 batch is delivered before the raise.
-    """
-    batches = (make_batch(0, 3), make_batch(1, 2), make_batch(2, 1))
-    rbr_in = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
-    exchanger = FailingSplitExchanger()
-    box: dict[str, Any] = {}
-
-    def run() -> None:
-        try:
-            with FlightServer() as server:
-                client = server.client
-                client.do_action(
-                    AddExchangeAction.name, exchanger, options=client._options
-                )
-                (_, rbr_out) = client.do_exchange_batches(exchanger.command, rbr_in)
-                delivered: list[pa.RecordBatch] = []
-                try:
-                    for batch in rbr_out:
-                        delivered.append(batch)
-                except BaseException as e:  # noqa: BLE001
-                    box["error"] = e
-                finally:
-                    box["delivered"] = delivered
-        except BaseException as e:  # noqa: BLE001
-            box["setup_error"] = e
-
-    thread = threading.Thread(target=run, daemon=True)
-    thread.start()
-    thread.join(90)
-    assert not thread.is_alive(), "exchange did not finish within 90s: deadlocked"
-    assert "setup_error" not in box, box.get("setup_error")
-    assert "error" in box, "failing split produced a clean stream instead of an error"
-    assert "boom on split 1" in str(box["error"])
-    assert [batch[SPLIT_KEY].to_pylist() for batch in box["delivered"]] == [[0]]

--- a/python/xorq/common/utils/tests/test_rbr_utils.py
+++ b/python/xorq/common/utils/tests/test_rbr_utils.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import functools
+import threading
+from collections.abc import Callable, Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pyarrow as pa
+import pytest
+import toolz
+
+import xorq.api as xo
+from xorq.common.utils.rbr_utils import (
+    excepts_print_exc,
+    streaming_split_exchange,
+)
+from xorq.flight import FlightServer
+from xorq.flight.action import AddExchangeAction
+from xorq.flight.exchanger import AbstractExchanger
+
+
+SPLIT_KEY = "split"
+
+
+def make_batch(split: int, n_rows: int) -> pa.RecordBatch:
+    return pa.RecordBatch.from_pydict(
+        {SPLIT_KEY: [split] * n_rows, "a": list(range(n_rows))}
+    )
+
+
+def make_split_f(fail_on: int) -> Callable:
+    """A per-split ``f`` that raises on the ``fail_on`` split."""
+
+    def f(split_reader: pa.RecordBatchReader) -> pa.RecordBatch:
+        table = split_reader.read_all()
+        (split,) = set(table[SPLIT_KEY].to_pylist())
+        if split == fail_on:
+            raise ValueError(f"boom on split {split}")
+        return pa.RecordBatch.from_pydict({SPLIT_KEY: [split], "n": [table.num_rows]})
+
+    return f
+
+
+class FakeFlightReader:
+    """Duck-types the flight reader `streaming_split_exchange` consumes.
+
+    ``make_filtered_reader`` needs ``.schema`` and iteration yielding chunks
+    with a ``.data`` record batch.
+    """
+
+    def __init__(self, batches: tuple[pa.RecordBatch, ...]) -> None:
+        self.schema: pa.Schema = batches[0].schema
+        self._chunks = tuple(SimpleNamespace(data=batch) for batch in batches)
+
+    def __iter__(self) -> Iterator[SimpleNamespace]:
+        return iter(self._chunks)
+
+
+class RecordingWriter:
+    """Duck-types the flight writer, recording what reached the wire."""
+
+    def __init__(self) -> None:
+        self.schema: pa.Schema | None = None
+        self.batches: list[pa.RecordBatch] = []
+
+    def begin(self, schema: pa.Schema, options: Any = None) -> None:
+        self.schema = schema
+
+    def write_batch(self, batch: pa.RecordBatch) -> None:
+        self.batches.append(batch)
+
+
+def test_excepts_print_exc_default_reraises(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """The default handler prints the traceback, then propagates.
+
+    Both halves matter: printing server-side is a feature (#1277), and
+    swallowing turned failures into empty results (#2227).
+    """
+
+    def boom() -> None:
+        raise ValueError("boom-message")
+
+    wrapped = excepts_print_exc(boom)
+    with pytest.raises(ValueError, match="boom-message"):
+        wrapped()
+    captured = capsys.readouterr()
+    assert "Traceback" in captured.err
+    assert "boom-message" in captured.err
+
+
+def test_excepts_print_exc_swallowing_is_opt_in(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Returning ``None`` on failure now requires an explicit handler."""
+
+    def boom() -> None:
+        raise ValueError("boom-message")
+
+    wrapped = excepts_print_exc(boom, handler=toolz.functoolz.return_none)
+    assert wrapped() is None
+    assert "boom-message" in capsys.readouterr().err
+
+
+def test_streaming_split_exchange_propagates_failure() -> None:
+    """A failing split aborts the exchange instead of yielding an empty stream."""
+    reader = FakeFlightReader((make_batch(0, 3), make_batch(1, 2)))
+    writer = RecordingWriter()
+    with pytest.raises(ValueError, match="boom on split 0"):
+        streaming_split_exchange(SPLIT_KEY, make_split_f(0), None, reader, writer)
+    assert writer.schema is None
+    assert writer.batches == []
+
+
+def test_streaming_split_exchange_delivers_splits_before_failure() -> None:
+    """Abort is not atomic: splits before the failing one are already written.
+
+    This pins the documented caveat -- a client that persists batches
+    incrementally can retain partial data.
+    """
+    reader = FakeFlightReader((make_batch(0, 3), make_batch(1, 2), make_batch(2, 1)))
+    writer = RecordingWriter()
+    with pytest.raises(ValueError, match="boom on split 1"):
+        streaming_split_exchange(SPLIT_KEY, make_split_f(1), None, reader, writer)
+    assert writer.schema is not None
+    assert [batch[SPLIT_KEY].to_pylist() for batch in writer.batches] == [[0]]
+
+
+class FailingSplitExchanger(AbstractExchanger):
+    """`streaming_split_exchange` exchanger whose ``f`` raises on split 1."""
+
+    @property
+    def exchange_f(self) -> Callable:
+        return functools.partial(streaming_split_exchange, SPLIT_KEY, make_split_f(1))
+
+    @property
+    def schema_in_required(self) -> None:
+        return None
+
+    @property
+    def schema_in_condition(self) -> Callable:
+        def condition(schema_in: Any) -> bool:
+            return any(name == SPLIT_KEY for name in schema_in)
+
+        return condition
+
+    @property
+    def calc_schema_out(self) -> Callable:
+        def f(schema_in: Any) -> Any:
+            return xo.schema({SPLIT_KEY: "int64", "n": "int64"})
+
+        return f
+
+    @property
+    def description(self) -> str:
+        return "raises on split 1"
+
+    @property
+    def command(self) -> str:
+        return "failing-split-exchange"
+
+    @property
+    def query_result(self) -> dict:
+        return {
+            "schema-in-required": self.schema_in_required,
+            "schema-in-condition": self.schema_in_condition,
+            "calc-schema-out": self.calc_schema_out,
+            "description": self.description,
+            "command": self.command,
+        }
+
+
+def test_streaming_split_exchange_flight_failure_aborts() -> None:
+    """End-to-end: a failing split surfaces as an error on the client's reader.
+
+    Runs on a daemon thread with a hard deadline (the ``execute_with_deadline``
+    pattern from ``test_flight_exchange.py``) so a regression to swallowing or
+    deadlocking fails instead of wedging CI. Also pins the non-atomicity
+    caveat end-to-end: the split-0 batch is delivered before the raise.
+    """
+    batches = (make_batch(0, 3), make_batch(1, 2), make_batch(2, 1))
+    rbr_in = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
+    exchanger = FailingSplitExchanger()
+    box: dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            with FlightServer() as server:
+                client = server.client
+                client.do_action(
+                    AddExchangeAction.name, exchanger, options=client._options
+                )
+                (_, rbr_out) = client.do_exchange_batches(exchanger.command, rbr_in)
+                delivered: list[pa.RecordBatch] = []
+                try:
+                    for batch in rbr_out:
+                        delivered.append(batch)
+                except BaseException as e:  # noqa: BLE001
+                    box["error"] = e
+                finally:
+                    box["delivered"] = delivered
+        except BaseException as e:  # noqa: BLE001
+            box["setup_error"] = e
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(90)
+    assert not thread.is_alive(), "exchange did not finish within 90s: deadlocked"
+    assert "setup_error" not in box, box.get("setup_error")
+    assert "error" in box, "failing split produced a clean stream instead of an error"
+    assert "boom on split 1" in str(box["error"])
+    assert [batch[SPLIT_KEY].to_pylist() for batch in box["delivered"]] == [[0]]

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import itertools
-import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
+from typing import Any
 
 import pyarrow as pa
 from cloudpickle import dumps, loads
@@ -10,6 +12,7 @@ from pyarrow.flight import (
     FlightClient as _FlightClient,
 )
 
+from xorq.common.utils.logging_utils import get_logger
 from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
 )
@@ -19,7 +22,7 @@ from xorq.vendor import ibis
 executor = ThreadPoolExecutor()
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class FlightClient:
@@ -172,28 +175,29 @@ class FlightClient:
         writer.done_writing()
         writer.close()
 
-    def _do_action(self, action_type, action_body=None, options=None):
+    def _do_action(
+        self,
+        action_type: str,
+        action_body: Any = None,
+        options: pa.flight.FlightCallOptions | None = None,
+    ) -> map:
         if action_body is None:
             action_body = {}
 
-        try:
-            action = pa.flight.Action(
-                action_type,
-                dumps(action_body),
-            )
-            logger.info(f"Running action {action_type}")
-            return map(
-                loads,
-                (
-                    result.body.to_pybytes()
-                    for result in self._client.do_action(
-                        action, options=options or self._options
-                    )
-                ),
-            )
-
-        except pa.lib.ArrowIOError as e:
-            logger.debug(f"Error calling action: {e}")
+        action = pa.flight.Action(
+            action_type,
+            dumps(action_body),
+        )
+        logger.info(f"Running action {action_type}")
+        return map(
+            loads,
+            (
+                result.body.to_pybytes()
+                for result in self._client.do_action(
+                    action, options=options or self._options
+                )
+            ),
+        )
 
     def do_action_one(self, action_type, action_body=None, options=None):
         return next(

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import time
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from typing import Any
@@ -180,7 +181,7 @@ class FlightClient:
         action_type: str,
         action_body: Any = None,
         options: pa.flight.FlightCallOptions | None = None,
-    ) -> map:
+    ) -> Iterator[Any]:
         if action_body is None:
             action_body = {}
 

--- a/python/xorq/flight/exchanger.py
+++ b/python/xorq/flight/exchanger.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import functools
 from abc import (
     ABC,
     abstractmethod,
 )
-from typing import Callable
+from typing import Any, Callable
 
 import pyarrow as pa
 import toolz
@@ -24,7 +26,6 @@ from xorq.common.utils.rbr_utils import (
     copy_rbr_batches,
     excepts_print_exc,
     make_filtered_reader,
-    reraise,
 )
 from xorq.vendor import ibis
 
@@ -59,14 +60,20 @@ def replace_one_unbound(unbound_expr, table):
     return replace_unbound(unbound_expr, dt, target=unbound)
 
 
-# print the traceback server-side, with the fetcher's frames, then let it out:
-# the exchange must end in an error status, not a clean empty stream the client
-# would cache. `BaseException` because `SystemExit` is the case that used to
-# escape and hang the client's reader.
-@excepts_print_exc(exc=BaseException, handler=reraise)
+# print the traceback server-side, with the fetcher's frames, then let it out
+# (the `excepts_print_exc` default): the exchange must end in an error status,
+# not a clean empty stream the client would cache. `BaseException` because
+# `SystemExit` is the case that used to escape and hang the client's reader.
+@excepts_print_exc(exc=BaseException)
 def streaming_exchange(
-    f, context, reader, writer, options=None, out_schema=None, **kwargs
-):
+    f: Callable,
+    context: pa.flight.ServerCallContext,
+    reader: pa.flight.MetadataRecordBatchReader,
+    writer: pa.flight.MetadataRecordBatchWriter,
+    options: pa.ipc.IpcWriteOptions | None = None,
+    out_schema: pa.Schema | None = None,
+    **kwargs: Any,
+) -> None:
     started = False
     for chunk in (chunk for chunk in reader if chunk.data):
         out = f(chunk.data, metadata=chunk.app_metadata)
@@ -103,10 +110,16 @@ def find_unbound_next_con(unbound_expr):
             raise ValueError("unexpected match case in find_unbound_next_con")
 
 
-@excepts_print_exc(exc=BaseException, handler=reraise)
+@excepts_print_exc(exc=BaseException)
 def streaming_expr_exchange(
-    unbound_expr, make_connection, context, reader, writer, options=None, **kwargs
-):
+    unbound_expr: ibis.Table,
+    make_connection: Callable,
+    context: pa.flight.ServerCallContext,
+    reader: pa.flight.MetadataRecordBatchReader,
+    writer: pa.flight.MetadataRecordBatchWriter,
+    options: pa.ipc.IpcWriteOptions | None = None,
+    **kwargs: Any,
+) -> None:
     filtered_reader = copy_rbr_batches(make_filtered_reader(reader))
     con = find_unbound_next_con(unbound_expr) or make_connection()
     bound_expr = replace_one_unbound(

--- a/python/xorq/flight/exchanger.py
+++ b/python/xorq/flight/exchanger.py
@@ -5,10 +5,17 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import pyarrow as pa
 import toolz
+
+
+if TYPE_CHECKING:
+    # the ``pa.flight.*`` annotations need the submodule, which this module
+    # never imports at runtime (annotations stay strings under
+    # ``from __future__ import annotations``)
+    import pyarrow.flight  # noqa: F401
 
 import xorq.expr.relations as rel
 import xorq.vendor.ibis.expr.operations as ops

--- a/python/xorq/flight/tests/test_flight_exchange.py
+++ b/python/xorq/flight/tests/test_flight_exchange.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import functools
 import operator
 import threading
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import cloudpickle
 import pandas as pd
@@ -13,11 +16,15 @@ from pytest import param
 
 import xorq.api as xo
 from xorq.caching import ParquetCache
+from xorq.common.utils.rbr_utils import streaming_split_exchange
 from xorq.expr.relations import (
     FlightExpr,
     FlightUDXF,
 )
+from xorq.flight import FlightServer
+from xorq.flight.action import AddExchangeAction
 from xorq.flight.exchanger import (
+    AbstractExchanger,
     UnboundExprExchanger,
     make_udxf,
 )
@@ -330,3 +337,117 @@ def test_failed_udxf_writes_no_cache(tmp_path: Path) -> None:
     with pytest.raises(Exception, match="plain exception"):
         execute_with_deadline(expr)
     assert not tuple(tmp_path.glob("*.parquet"))
+
+
+# `make_batch`/`make_split_f` are shared with the unit-layer pins of the abort
+# policy in xorq.common.utils.tests.test_rbr_utils; duplicated rather than
+# imported across test packages.
+SPLIT_KEY = "split"
+
+
+def make_batch(split: int, n_rows: int) -> pa.RecordBatch:
+    return pa.RecordBatch.from_pydict(
+        {SPLIT_KEY: [split] * n_rows, "a": list(range(n_rows))}
+    )
+
+
+def make_split_f(fail_on: int) -> Callable:
+    """A per-split ``f`` that raises on the ``fail_on`` split."""
+
+    def f(split_reader: pa.RecordBatchReader) -> pa.RecordBatch:
+        table = split_reader.read_all()
+        (split,) = set(table[SPLIT_KEY].to_pylist())
+        if split == fail_on:
+            raise ValueError(f"boom on split {split}")
+        return pa.RecordBatch.from_pydict({SPLIT_KEY: [split], "n": [table.num_rows]})
+
+    return f
+
+
+class FailingSplitExchanger(AbstractExchanger):
+    """`streaming_split_exchange` exchanger whose ``f`` raises on split 1."""
+
+    @property
+    def exchange_f(self) -> Callable:
+        return functools.partial(streaming_split_exchange, SPLIT_KEY, make_split_f(1))
+
+    @property
+    def schema_in_required(self) -> None:
+        return None
+
+    @property
+    def schema_in_condition(self) -> Callable:
+        def condition(schema_in: Any) -> bool:
+            return any(name == SPLIT_KEY for name in schema_in)
+
+        return condition
+
+    @property
+    def calc_schema_out(self) -> Callable:
+        def f(schema_in: Any) -> Any:
+            return xo.schema({SPLIT_KEY: "int64", "n": "int64"})
+
+        return f
+
+    @property
+    def description(self) -> str:
+        return "raises on split 1"
+
+    @property
+    def command(self) -> str:
+        return "failing-split-exchange"
+
+    @property
+    def query_result(self) -> dict:
+        return {
+            "schema-in-required": self.schema_in_required,
+            "schema-in-condition": self.schema_in_condition,
+            "calc-schema-out": self.calc_schema_out,
+            "description": self.description,
+            "command": self.command,
+        }
+
+
+def test_streaming_split_exchange_flight_failure_aborts() -> None:
+    """End-to-end: a failing split surfaces as an error on the client's reader.
+
+    The unit-layer pins of the abort policy live in
+    ``xorq.common.utils.tests.test_rbr_utils``. Runs on a daemon thread with a
+    hard deadline (the ``execute_with_deadline`` scaffolding, hand-rolled here
+    because this drives ``do_exchange_batches`` directly rather than an expr)
+    so a regression to swallowing or deadlocking fails instead of wedging CI.
+    Also pins the non-atomicity caveat end-to-end: the split-0 batch is
+    delivered before the raise.
+    """
+    batches = (make_batch(0, 3), make_batch(1, 2), make_batch(2, 1))
+    rbr_in = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
+    exchanger = FailingSplitExchanger()
+    box: dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            with FlightServer() as server:
+                client = server.client
+                client.do_action(
+                    AddExchangeAction.name, exchanger, options=client._options
+                )
+                (_, rbr_out) = client.do_exchange_batches(exchanger.command, rbr_in)
+                delivered: list[pa.RecordBatch] = []
+                try:
+                    for batch in rbr_out:
+                        delivered.append(batch)
+                except BaseException as e:  # noqa: BLE001
+                    box["error"] = e
+                finally:
+                    box["delivered"] = delivered
+        except BaseException as e:  # noqa: BLE001
+            box["setup_error"] = e
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(90)
+    assert not thread.is_alive(), "exchange did not finish within 90s: deadlocked"
+    assert "setup_error" not in box, box.get("setup_error")
+    assert "error" in box, "failing split produced a clean stream instead of an error"
+    assert "boom on split 1" in str(box["error"])
+    assert [batch[SPLIT_KEY].to_pylist() for batch in box["delivered"]] == [[0]]


### PR DESCRIPTION
## Abort is now the policy

Confirmed decision on #2227: a failing split in `streaming_split_exchange` **aborts the exchange**. `excepts_print_exc` (`python/xorq/common/utils/rbr_utils.py`) now defaults its handler to `reraise` instead of `toolz.functoolz.return_none`, so failures print the traceback server-side (the #1277 feature, kept) and then propagate, ending the exchange in an error status instead of a clean empty or truncated stream the client would consume and cache.

`streaming_split_exchange` is decorated `@excepts_print_exc(exc=BaseException)` — the same `SystemExit` rationale as the other two exchanges — and no longer wraps `f` a second time, so each failure prints exactly once (pinned by test).

Skip-and-continue over bad splits is not the fix: it would be a subsequent feature with an open wire-format question (the client has no way to learn which splits were dropped). This is stated in the `streaming_split_exchange` docstring so the behavior reads as policy, not accident.

The explicit `handler=reraise` at `streaming_exchange` / `streaming_expr_exchange` (added by #2231) is reduced to `@excepts_print_exc(exc=BaseException)` — byte-identical behavior via the new default.

The `pa.flight.*` type annotations in `rbr_utils.py` / `exchanger.py` are backed by `TYPE_CHECKING` imports of `pyarrow.flight` — neither module imports the submodule at runtime, so without them runtime annotation introspection (`typing.get_type_hints`) raises in a fresh process.

Operational note on the `BaseException` widening: benign client-disconnect cancellations (`FlightCancelledError` on `write_batch`) now print full tracebacks server-side where `streaming_split_exchange` previously printed-and-swallowed them — deliberate, consistent with the other two exchanges, but server logs are noisier on disconnects.

## Caveat: abort ≠ atomic

When split N fails, splits 1..N-1 are already on the wire and the client consumes them before `queue_to_gen` raises. A client that persists batches incrementally can retain partial data — and a truncated stream is structurally valid (right columns, fewer rows), so this is undetectable by construction. Documented in the docstring and pinned by tests, including end-to-end through a real Flight exchange.

## Also: dead-code removal in `FlightClient._do_action`

The `except pa.lib.ArrowIOError` in `_do_action` is deleted as **dead code with no behavior change** (separate commit, honestly framed): errors surface when the returned iterator is consumed, not inside the `try` — `_wait_on_healthcheck` catching `pa.ArrowIOError` around its own `do_action` call at the consumption site is the proof. That commit also carries style-hook-mandated annotations (`_do_action` returns `Iterator[Any]`) and a stdlib-logging → `logging_utils.get_logger` migration on touched code (same "xorq" logger tree, handlers, and level).

## Hashes

Moves **no** expression/build hashes: `make_udxf`'s `exchange_f` is a bare `functools.partial` since #2231, and the decorated module-level functions are not tokenized.

## Tests

`python/xorq/common/utils/tests/test_rbr_utils.py` — unit layer (4 tests):
- default handler prints the traceback then re-raises; swallowing is now explicit opt-in
- a failing split propagates instead of yielding an empty stream (fake writer), and the traceback prints exactly once
- non-atomicity pinned at the unit layer: splits before the failure are already written

`python/xorq/flight/tests/test_flight_exchange.py` — end-to-end:
- a failing split surfaces as an error on the client's reader, and the split-0 batch is delivered first (non-atomicity pinned end-to-end)
- lives in `flight/tests` so it joins the `"flight"` xdist group that conftest applies to everything under that directory, instead of running concurrently with the flight suite on another worker
- runs on a daemon thread with a hard 90s deadline (the `execute_with_deadline` pattern), so a regression fails instead of wedging CI

The ~20 lines of split helpers are duplicated across the two files rather than imported across test packages; docstrings in each cross-reference the other half.

Verified the behavior tests fail on `main` and pass here. An independent fresh-context review re-verified every claim in this body, including the two least obvious: the dead-code claim (pyarrow 21's `do_action` is a Cython generator function — confirmed against a dead endpoint that the call returns without raising and the error surfaces only at `next()`) and the negative check (the e2e test run against `origin/main` fails with a clean truncated stream, only split 0 delivered). Flight suite in that environment: 85 passed, 0 failed (the 11 failures previously reported here were environment fixtures and don't reproduce there); the e2e test also passes under `pytest-xdist -n 2`. `test_examples.py -k flight_exchange_example` passes.

Refs #2227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPF2S91s6HzesgN6V8Zex6
