### PR TITLE
docs(identity): state the READ_IDENTITY_KEYS / READ_EXCLUDE_KEYS relationship

### DIFF
--- a/python/xorq/caching/strategy.py
+++ b/python/xorq/caching/strategy.py
@@ -36,7 +36,15 @@ def _lazy_default_key_prefix():
 
 
 def snapshot_normalize_read(read: Read) -> tuple:
-    """Normalize Read for snapshot caching using path identity only, not file modification stats."""
+    """Normalize Read for snapshot caching using path identity only, not file modification stats.
+
+    The path half is deliberately regime-specific -- ``view_rules`` licenses
+    ``Read`` as the one op that may normalize differently under snapshot
+    (gh-1861), pinned by ``test_only_read_diverges_between_regimes``. The kwarg
+    half at the bottom is *not*: it filters the same ``READ_IDENTITY_KEYS`` as
+    ``_read_extra_kwargs`` in the global regime, and nothing pins the two
+    together. See ``constants.READ_IDENTITY_KEYS`` (gh-2206, gh-2217).
+    """
     read_kwargs = dict(read.read_kwargs)
     if "hash_path" not in read_kwargs:
         # path-less Read (e.g. an API-backed source): the registered

--- a/python/xorq/common/constants.py
+++ b/python/xorq/common/constants.py
@@ -7,6 +7,27 @@ HTTP_SCHEMES = ("http://", "https://")
 CLOUD_SCHEMES = ("s3://", "gs://", "gcs://")
 REMOTE_SCHEMES = HTTP_SCHEMES + CLOUD_SCHEMES
 
+# The two halves of a ``Read``'s kwargs, decided by opposite rules:
+#
+# * ``READ_EXCLUDE_KEYS`` is a *deny*-list over transport. ``Read.make_dt``
+#   passes every kwarg *not* listed here to the underlying read method, so a
+#   kwarg reaching the reader is by definition capable of changing the data.
+# * ``READ_IDENTITY_KEYS`` is an *allow*-list over identity. Only these four
+#   are folded into the hash, by ``_read_extra_kwargs``
+#   (``dasher/_relations.py``, global regime) and ``snapshot_normalize_read``
+#   (``caching/strategy.py``, snapshot regime) -- two call sites that must stay
+#   in agreement, since ``view_rules`` licenses ``Read`` as the one op allowed
+#   to normalize differently per regime and nothing else pins their kwarg half.
+#
+# Anything in neither set is passed to the reader and invisible to the hash:
+# two reads that return different data share an identity, and cached rows from
+# one are served as current for the other (gh-2206). gh-2217 proposes the
+# inversion -- identity as the complement of transport, a kwarg being
+# identity-bearing unless declared transport -- which is why the two sets are
+# stated together here rather than at their call sites.
+#
+# ``relocatable`` is deliberately in both: it changes identity but is consumed
+# before the read method sees it.
 READ_IDENTITY_KEYS = frozenset({"mode", "schema", "temporary", "relocatable"})
 
 READ_EXCLUDE_KEYS = frozenset({"hash_path", "read_path", "relocatable"})

--- a/python/xorq/common/utils/dasher/_relations.py
+++ b/python/xorq/common/utils/dasher/_relations.py
@@ -46,6 +46,7 @@ from xorq.common.utils.dasher._paths import (
 
 
 if TYPE_CHECKING:
+    from xorq.expr.relations import Read
     from xorq.vendor.ibis.expr import operations as ops
 
 
@@ -116,7 +117,14 @@ def _normalize_single_path(path, read_kwargs, read):
         raise FileNotFoundError(f"local path does not exist: {path!r}")
 
 
-def _read_extra_kwargs(read):
+def _read_extra_kwargs(read: Read) -> tuple:
+    """Fold the identity-bearing read kwargs in (global regime).
+
+    ``snapshot_normalize_read`` in ``xorq.caching.strategy`` filters the same
+    set for the snapshot regime; keep the two in step. See
+    ``constants.READ_IDENTITY_KEYS`` for why the set is an allow-list and what
+    that costs (gh-2206, gh-2217).
+    """
     return tuple((k, v) for k, v in read.read_kwargs if k in READ_IDENTITY_KEYS)
 
 


### PR DESCRIPTION
Docs only. Refs #2206, #2217.

> **UNVERIFIED — see [What is not done](#what-is-not-done).** Authored in a worktree with
> no usable venv; nothing beyond `ruff` and `py_compile` has been run. Draft for pickup.

## What this says

A `Read`'s kwargs are split by two sets decided under **opposite rules**, and nothing in
the tree said so:

* **`READ_EXCLUDE_KEYS` is a deny-list over transport.** `Read.make_dt`
  (`expr/relations.py:831-838`) passes every kwarg *not* listed to the underlying read
  method — so a kwarg that reaches the reader is by definition capable of changing the
  data.
* **`READ_IDENTITY_KEYS` is an allow-list over identity.** Only those four are folded
  into the hash.

Anything in **neither** set is passed to the reader and invisible to the hash: two reads
that return different data share an identity, and cached rows from one are served as
current for the other. That is #2206's bug class, stated as a set relation:

```
leaked = read_kwargs - (READ_EXCLUDE_KEYS | READ_IDENTITY_KEYS)
```

Which also makes **#2217's proposed inversion computable from the two sets already in the
tree** — "identity is the complement of transport" is `read_kwargs - READ_EXCLUDE_KEYS`,
i.e. exactly what `make_dt` passes to the reader. #2217's body notes that "the two newer
surfaces in the tree already have the deny-list shape"; `READ_EXCLUDE_KEYS` is one of
them, sitting two lines above the allow-list it is the counterpart to.

`relocatable` is deliberately in **both** sets: it changes identity but is consumed before
the read method sees it. (`test_compiler.py:1569` pins its membership in the allow-list.)

## The coupling this documents

The allow-list is filtered at **two** call sites that must stay in agreement:

| Regime | Site |
|---|---|
| global | `_read_extra_kwargs` (`dasher/_relations.py`) |
| snapshot | `snapshot_normalize_read` (`caching/strategy.py`) |

**Nothing pins them together.** `test_only_read_diverges_between_regimes`
(`test_view_rules.py:200-215`, from #2230) asserts *callable identity per `view_rules`
row* — so `Read` is licensed to diverge wholesale (gh-1861, the path half) and the kwarg
half rides along unchecked. Change one site and the suite stays green.

Each site now points at the other, with the canonical explanation on the constants
(the one-home + pointers pattern).

## Why this and not a comment on #2217

A GitHub comment is not read by default: `gh pr view` / `gh issue view` return the body
but not comments, and nothing in this repo (no `CLAUDE.md`, no `.claude/skills/`) fetches
them. Whoever implements #2217 — human or agent — opens the ADR and the code, so that is
where the constraint has to live.

## What is not done

**Nothing was executed.** `ruff check` passes and `py_compile` passes; that is the whole
verification. Before landing, please run:

* `pytest python/xorq/common/utils/tests/test_view_rules.py python/xorq/common/utils/tests/test_hash_contract.py` — the goldens are the tripwire that this really is docs-only
* `pytest python/xorq/ibis_yaml/tests/test_compiler.py -k read_identity`
* `xorq-check-style` in hook mode on the three files (full-file mode reports **pre-existing**
  missing annotations on untouched functions in both files — `_relations.py:66,106,131,183`
  and `strategy.py:111` — not introduced here)

One ride-along the style hook forced: `_read_extra_kwargs` gained `read: Read` / `-> tuple`
annotations and a `TYPE_CHECKING` import for `Read`, because the hook requires annotations
on any def it sees touched.

**Claims worth re-checking rather than trusting:**

1. that `leaked` is genuinely non-empty in practice — I derived it from the two constants
   and `make_dt`, and did not enumerate real `read_kwargs` from a live read;
2. that no other test pins the two kwarg halves together — I grepped `READ_IDENTITY_KEYS`
   across `dasher/tests/`, `caching/`, and `flight/tests/` and found only the definition
   and the two call sites.

## Not in scope

The branch name is `docs-read-identity-crossref`, not `docs/…`: a remote branch literally
named `docs` exists, so no `docs/*` ref can be created (`directory file conflict`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYj2GhkAjNWC3f6vsfbSg8
