### PR TITLE
chore(lint): stop asserts from validating cross-boundary input; enable S101 as a ratchet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,7 @@ extend-select = [
     "FURB",   # refurb: modernize Python code
     "PLC0415",  # import-outside-toplevel: imports must be at module level
     "DTZ",      # flake8-datetimez: enforce timezone-aware datetime usage
+    "S101",     # assert used: see the per-file-ignores ratchet below
     # TODO: add PLW1514 (unspecified-encoding) when it graduates from ruff preview
 ]
 ignore = [
@@ -271,10 +272,46 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "python/xorq/__init__.py" = ["I001"]
 "python/xorq/api.py" = ["I001"]
-"python/xorq/vendor/**" = ["B", "PLC0415"]
+"python/xorq/vendor/**" = ["B", "PLC0415", "S101"]
 # Tutorial snippets are extracted block-by-block from .qmd files, so
 # imports appear next to the block that introduces them.
 "docs/tutorials/**/*.snippets.py" = ["E402", "I001"]
+
+# S101 (assert used) -- assert is the right tool in a test, and examples and
+# docs snippets assert as inline receipts, so those are exempt outright.
+"**/tests/**" = ["S101"]
+"**/test_*.py" = ["S101"]
+"**/conftest.py" = ["S101"]
+"examples/**" = ["S101"]
+"docs/**" = ["S101"]
+
+# Ratchet, not amnesty: every library file that holds an assert today is listed
+# here so the rule can be on without a repo-wide rewrite. The point of the rule
+# is that no *new* one lands. Delete a line when its file's last assert goes;
+# this list only shrinks. An assert stating an internal invariant can stay --
+# what must not stay is an assert validating input that crosses a process, file
+# or network boundary, where the right answer is a real exception with a
+# message (see xorq/catalog/zip_utils.py for the shape).
+"python/xorq/backends/pandas/executor.py" = ["S101"]
+"python/xorq/caching/storage.py" = ["S101"]
+"python/xorq/catalog/catalog.py" = ["S101"]
+"python/xorq/catalog/replay.py" = ["S101"]
+"python/xorq/common/utils/attr_utils.py" = ["S101"]
+"python/xorq/common/utils/download_utils.py" = ["S101"]
+"python/xorq/common/utils/gcloud_utils.py" = ["S101"]
+"python/xorq/common/utils/ibis_utils.py" = ["S101"]
+"python/xorq/common/utils/node_utils.py" = ["S101"]
+"python/xorq/common/utils/snowflake_keypair_utils.py" = ["S101"]
+"python/xorq/common/utils/snowflake_utils.py" = ["S101"]
+"python/xorq/common/utils/tls_utils.py" = ["S101"]
+"python/xorq/common/utils/trace_utils.py" = ["S101"]
+"python/xorq/expr/api.py" = ["S101"]
+"python/xorq/expr/ml/pipeline_lib.py" = ["S101"]
+"python/xorq/expr/ml/structer.py" = ["S101"]
+"python/xorq/flight/__init__.py" = ["S101"]
+"python/xorq/flight/client.py" = ["S101"]
+"python/xorq/flight/exchanger.py" = ["S101"]
+"python/xorq/ibis_yaml/compiler.py" = ["S101"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["xorq"]

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -72,6 +72,7 @@ from xorq.catalog.zip_utils import (
     with_pure_suffix,
     write_zip,
 )
+from xorq.common.exceptions import XorqInputError
 from xorq.common.utils.caching_utils import CacheKey
 from xorq.ibis_yaml.enums import REQUIRED_ARCHIVE_NAMES, ExprKind
 
@@ -1467,7 +1468,7 @@ def test_test_zip(elide, catalog, tmpdir):
         Path(tmpdir).joinpath("build.zip"),
         {name: b"" for name in _VALID_ARCHIVE_NAMES if name != elide},
     )
-    with pytest.raises(AssertionError, match=elide):
+    with pytest.raises(XorqInputError, match=elide):
         BuildZip(zip_path)
 
 
@@ -1476,7 +1477,7 @@ def test_test_zip_missing_wheel(catalog, tmpdir):
         Path(tmpdir).joinpath("build.zip"),
         dict.fromkeys(REQUIRED_ARCHIVE_NAMES, b""),
     )
-    with pytest.raises(AssertionError, match=r"\.whl"):
+    with pytest.raises(XorqInputError, match=r"\.whl"):
         BuildZip(zip_path)
 
 

--- a/python/xorq/catalog/tests/test_zip_utils.py
+++ b/python/xorq/catalog/tests/test_zip_utils.py
@@ -1,0 +1,53 @@
+"""Bad-input paths through the build-archive validators.
+
+These used to raise a bare ``AssertionError`` -- no type a caller could catch,
+and nothing at all under ``python -O``. Each test pins the exception a user
+hands bad input actually gets.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from xorq.catalog.zip_utils import (
+    BuildZip,
+    extract_build_zip_to,
+    write_zip,
+)
+from xorq.common.exceptions import XorqInputError
+from xorq.ibis_yaml.enums import REQUIRED_ARCHIVE_NAMES
+
+
+TEST_WHEEL_NAME = "xorq_test-0.0.0-py3-none-any.whl"
+
+
+def valid_archive(path: Path) -> Path:
+    return write_zip(
+        path, dict.fromkeys((*REQUIRED_ARCHIVE_NAMES, TEST_WHEEL_NAME), b"")
+    )
+
+
+def test_build_zip_missing_path_raises_file_not_found(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.zip"
+    with pytest.raises(FileNotFoundError, match="nope.zip"):
+        BuildZip(missing)
+
+
+def test_build_zip_bad_suffix_raises_input_error(tmp_path: Path) -> None:
+    path = valid_archive(tmp_path / "build.zip").rename(tmp_path / "build.tar")
+    with pytest.raises(XorqInputError, match="suffix"):
+        BuildZip(path)
+
+
+def test_extract_build_zip_rejects_multiple_top_level_dirs(tmp_path: Path) -> None:
+    path = tmp_path / "two-roots.zip"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("first/expr.yaml", b"")
+        zf.writestr("second/expr.yaml", b"")
+    target = tmp_path / "extracted"
+    target.mkdir()
+    with pytest.raises(XorqInputError, match="exactly one top-level directory"):
+        extract_build_zip_to(path, target)

--- a/python/xorq/catalog/zip_utils.py
+++ b/python/xorq/catalog/zip_utils.py
@@ -12,6 +12,7 @@ from xorq.catalog.constants import (
     PREFERRED_SUFFIX,
     VALID_SUFFIXES,
 )
+from xorq.common.exceptions import XorqInputError
 from xorq.common.utils.file_utils import file_digest
 from xorq.ibis_yaml.enums import REQUIRED_ARCHIVE_NAMES
 
@@ -28,15 +29,17 @@ def test_zip(zip_path):
             Path(info.filename).name for info in zf.infolist() if not info.is_dir()
         }
         missing = set(REQUIRED_ARCHIVE_NAMES).difference(names)
-        assert not missing, (
-            f"Archive is not a valid expression entry "
-            f"(missing {missing}); found: {sorted(names)}"
-        )
+        if missing:
+            raise XorqInputError(
+                f"Archive is not a valid expression entry "
+                f"(missing {missing}); found: {sorted(names)}"
+            )
         wheels = [name for name in names if name.endswith(".whl")]
-        assert len(wheels) >= 1, (
-            f"Archive must contain at least one .whl file, "
-            f"found {len(wheels)}: {sorted(names)}"
-        )
+        if not wheels:
+            raise XorqInputError(
+                f"Archive must contain at least one .whl file, "
+                f"found {len(wheels)}: {sorted(names)}"
+            )
 
 
 @contextmanager
@@ -68,7 +71,11 @@ def extract_build_zip_to(zip_path, td):
     with zipfile.ZipFile(zip_path, "r") as zf:
         zf.extractall(td)
     (build_dir, *rest) = Path(td).iterdir()
-    assert not rest
+    if rest:
+        raise XorqInputError(
+            f"Build archive must hold exactly one top-level directory, "
+            f"found {sorted(p.name for p in (build_dir, *rest))}"
+        )
     return build_dir
 
 
@@ -93,10 +100,12 @@ class BuildZip:
     path = field(validator=instance_of(Path), converter=Path)
 
     def __attrs_post_init__(self):
-        assert "".join(self.path.suffixes) in VALID_SUFFIXES, (
-            f"Invalid archive suffix '{self.path.suffixes}', expected one of {VALID_SUFFIXES}"
-        )
-        assert self.path.exists(), f"Build archive not found at {self.path}"
+        if "".join(self.path.suffixes) not in VALID_SUFFIXES:
+            raise XorqInputError(
+                f"Invalid archive suffix '{self.path.suffixes}', expected one of {VALID_SUFFIXES}"
+            )
+        if not self.path.exists():
+            raise FileNotFoundError(f"Build archive not found at {self.path}")
         test_zip(self.path)
 
     @property

--- a/python/xorq/common/utils/download_utils.py
+++ b/python/xorq/common/utils/download_utils.py
@@ -4,12 +4,14 @@ from shutil import move
 from tempfile import TemporaryDirectory
 from urllib.request import urlretrieve
 
+from xorq.common.exceptions import XorqInputError
 from xorq.init_templates import InitTemplates
 
 
 def download_github_archive(org, repo, branch, suffix=".zip", target=None):
     target = Path(target or f"{branch}{suffix}")
-    assert not target.exists()
+    if target.exists():
+        raise FileExistsError(f"refusing to overwrite {target}")
     archive_url = f"https://github.com/{org}/{repo}/archive/{branch}.zip"
     _, _ = urlretrieve(archive_url, target)
     return target
@@ -17,13 +19,18 @@ def download_github_archive(org, repo, branch, suffix=".zip", target=None):
 
 def extract_zip(source, target):
     (source, target) = map(Path, (source, target))
-    assert not target.exists()
+    if target.exists():
+        raise FileExistsError(f"refusing to overwrite {target}")
     with zipfile.ZipFile(source, "r") as zf:
         names = zf.namelist()
         (first, *rest) = names
         # strip trailing slash from directory entry
         first = first.rstrip("/")
-        assert all(member.startswith(first) for member in rest)
+        if not all(member.startswith(first) for member in rest):
+            raise XorqInputError(
+                f"archive {source} must hold a single top-level directory, "
+                f"found members outside {first!r}"
+            )
         with TemporaryDirectory() as td:
             zf.extractall(td)
             move(Path(td).joinpath(first), target)

--- a/python/xorq/common/utils/tests/test_download_utils.py
+++ b/python/xorq/common/utils/tests/test_download_utils.py
@@ -1,0 +1,39 @@
+"""Bad-input paths through the archive download/extract helpers.
+
+``extract_zip`` refuses to overwrite and requires a single-rooted archive; both
+used to be bare asserts, so the caller got an ``AssertionError`` with no message
+and nothing at all under ``python -O``.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from xorq.common.exceptions import XorqInputError
+from xorq.common.utils.download_utils import extract_zip
+
+
+def single_rooted_zip(path: Path) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("root/file.txt", b"")
+    return path
+
+
+def test_extract_zip_refuses_to_overwrite(tmp_path: Path) -> None:
+    source = single_rooted_zip(tmp_path / "archive.zip")
+    target = tmp_path / "target"
+    target.mkdir()
+    with pytest.raises(FileExistsError, match="target"):
+        extract_zip(source, target)
+
+
+def test_extract_zip_rejects_multi_rooted_archive(tmp_path: Path) -> None:
+    source = tmp_path / "archive.zip"
+    with zipfile.ZipFile(source, "w") as zf:
+        zf.writestr("first/file.txt", b"")
+        zf.writestr("second/file.txt", b"")
+    with pytest.raises(XorqInputError, match="single top-level directory"):
+        extract_zip(source, tmp_path / "target")

--- a/python/xorq/expr/builders/tests/test_builders.py
+++ b/python/xorq/expr/builders/tests/test_builders.py
@@ -11,6 +11,7 @@ import pytest
 
 import xorq.api as xo
 from xorq.catalog.zip_utils import test_zip as validate_zip
+from xorq.common.exceptions import XorqInputError
 from xorq.expr.builders import (
     _FROM_TAG_NODE_REGISTRY,
     TagHandler,
@@ -328,7 +329,7 @@ def test_zip_rejects_invalid():
         zip_path = Path(tmp) / "invalid.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
             zf.writestr("random.txt", "nope")
-        with pytest.raises(AssertionError, match="not a valid expression"):
+        with pytest.raises(XorqInputError, match="not a valid expression"):
             validate_zip(zip_path)
 
 


### PR DESCRIPTION
Two commits: the bug, then the rule that stops it recurring.

## The bug

`assert` was doing input validation on artifacts that cross a process or file boundary — the build archive a user names on the command line, and the zip a template download just fetched. That hands the caller an `AssertionError`: no type worth catching, no contract, and under `python -O` no validation at all.

* `BuildZip` → `FileNotFoundError` for a missing archive, `XorqInputError` for a bad suffix or missing/wheel-less members
* `extract_build_zip_to` → `XorqInputError` for a multi-rooted archive
* `extract_zip` → `FileExistsError` rather than clobbering an existing target, `XorqInputError` for a multi-rooted archive

Asserts stating internal invariants are left alone — e.g. the post-move `assert target.exists()` in `extract_zip`, which is a postcondition, not input validation.

Blast radius: two tests in `test_catalog.py` pinned `AssertionError` and now pin `XorqInputError`. Five new tests cover the paths that previously had none.

## The rule

`S101` (assert-used) is now on, with **every library file that holds an assert today listed in `per-file-ignores`**. That is deliberate: the point is that no *new* assert lands in either role, not that 60-odd existing ones get rewritten in one diff. Delete a line when its file's last assert goes; the list only shrinks. `zip_utils.py` is already off it.

Tests, examples, docs snippets and vendor are exempt outright — `assert` is the right tool in a test, and the examples assert as inline receipts (same rationale as the existing `[tool.xorq-style.print]` allowance).

Ruff already ships this rule, so this is config, not a new `xorq-style` check.

## Verification

* `ruff check .` — clean
* new: `python/xorq/catalog/tests/test_zip_utils.py`, `python/xorq/common/utils/tests/test_download_utils.py` — 5 passed
* `test_catalog.py` + `test_packager.py` — 329 passed, 5 failed, and **the identical 5 fail on pristine `main`** in this environment (packager wheel-build fixtures); zero delta

## Not in this PR

`client.py:262`'s `assert dct["schema-in-condition"](...)` is the same defect — it validates a schema condition on data from a remote exchanger — but `client.py` is inside the live file lock for #2242 → Q5 → Q11, so it is left grandfathered here and should ride whichever of those touches the file. Same for `exchanger.py`.
