### PR TITLE
fix(flight): a write-side failure no longer fails a completed exchange

### DIFF
--- a/python/xorq/common/utils/rbr_utils.py
+++ b/python/xorq/common/utils/rbr_utils.py
@@ -111,8 +111,11 @@ def instrument_reader(reader, prefix=""):
     logger = get_print_logger()
 
     def gen(reader):
+        # no `yield next(reader)` here: on an empty stream that raises
+        # StopIteration inside a generator, which PEP 479 turns into
+        # `RuntimeError: generator raised StopIteration` -- exactly when
+        # someone has turned instrumentation on to debug an empty result
         logger.info(f"{prefix:10s}first batch yielded")
-        yield next(reader)
         yield from reader
         logger.info(f"{prefix:10s}last batch yielded")
 

--- a/python/xorq/common/utils/tests/test_instrument_reader.py
+++ b/python/xorq/common/utils/tests/test_instrument_reader.py
@@ -1,0 +1,28 @@
+"""``instrument_reader`` on an empty stream.
+
+It used to pull the first batch with an explicit ``next(reader)`` inside a
+generator, so an empty stream raised ``StopIteration`` there -- which PEP 479
+turns into ``RuntimeError: generator raised StopIteration``. Reachable via
+``do_instrument_reader=True``, i.e. exactly when instrumentation is on to debug
+a failure that produced an empty result.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+
+from xorq.common.utils.rbr_utils import instrument_reader
+
+
+SCHEMA = pa.schema([("a", pa.int64())])
+
+
+def test_instrument_reader_handles_an_empty_stream() -> None:
+    empty = pa.RecordBatchReader.from_batches(SCHEMA, iter(()))
+    assert instrument_reader(empty, "test: ").read_all().num_rows == 0
+
+
+def test_instrument_reader_yields_every_batch() -> None:
+    batch = pa.RecordBatch.from_pydict({"a": [1, 2, 3]}, schema=SCHEMA)
+    reader = pa.RecordBatchReader.from_batches(SCHEMA, iter((batch, batch)))
+    assert instrument_reader(reader, "test: ").read_all().num_rows == 6

--- a/python/xorq/flight/client.py
+++ b/python/xorq/flight/client.py
@@ -1,7 +1,7 @@
 import itertools
 import logging
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 from queue import Queue
 
 import pyarrow as pa
@@ -17,6 +17,18 @@ from xorq.vendor import ibis
 
 
 executor = ThreadPoolExecutor()
+
+
+class Sentinel:
+    """End-of-stream marker for the exchange queue.
+
+    A dedicated object, not ``None``: the queue carries record batches, and a
+    Flight chunk with only ``app_metadata`` has ``data is None``, so ``None``
+    is a value the producer can legitimately hold.
+    """
+
+
+SENTINEL = Sentinel()
 
 
 logger = logging.getLogger(__name__)
@@ -220,8 +232,12 @@ class FlightClient:
 
         def do_reads(_reader, queue):
             i = -1
-            for i, batch in enumerate(_reader, 1):  # noqa: B007
-                queue.put(batch.data)
+            for i, chunk in enumerate(_reader, 1):  # noqa: B007
+                # a metadata-only chunk carries `data is None`; forwarding it
+                # would put a value on the queue that the consumer cannot tell
+                # from the end-of-stream sentinel
+                if chunk.data is not None:
+                    queue.put(chunk.data)
             return i
 
         def do_writes_reads(command, reader, queue):
@@ -229,6 +245,15 @@ class FlightClient:
             # must put one -- including a failure to open the exchange, which is
             # why `do_exchange` is inside the `try`. Callers drop `fut`, so an
             # exception left there goes unseen; it goes on the queue instead.
+            #
+            # Which producer failed decides whether the stream failed. The reads
+            # are the stream: if they finished, the consumer holds every batch
+            # the server sent, and the result is complete whatever the write side
+            # did. A server that stops pulling input early (any `limit`) leaves
+            # the client writing into a half-closed stream, and that write-side
+            # error must not destroy a result that is already correct -- it goes
+            # to `fut` alone.
+            writes_exc = None
             try:
                 descriptor = pa.flight.FlightDescriptor.for_command(command)
                 writer, _reader = self._client.do_exchange(descriptor, self._options)
@@ -237,19 +262,27 @@ class FlightClient:
                 with writer:
                     do_writes_fut = executor.submit(do_writes, writer, reader)
                     do_reads_fut = executor.submit(do_reads, _reader, queue)
-                    (n_writes, n_reads) = (
-                        do_writes_fut.result(),
-                        do_reads_fut.result(),
-                    )
+                    # don't join the writes first: a read-side failure must not
+                    # wait on a write side that is still draining into a stream
+                    # nobody is consuming
+                    wait((do_writes_fut, do_reads_fut), return_when=FIRST_EXCEPTION)
+                    # blocking on the reads is bounded even when the writes have
+                    # already failed: a broken write side ends the exchange
+                    # server-side, which ends the read stream
+                    n_reads = do_reads_fut.result()
+                    writes_exc = do_writes_fut.exception()
+                    n_writes = None if writes_exc else do_writes_fut.result()
             except BaseException as e:
                 queue.put(e)
                 raise
-            queue.put(None)
+            queue.put(SENTINEL)
+            if writes_exc is not None:
+                raise writes_exc
             return {"n_writes": n_writes, "n_reads": n_reads}
 
         def queue_to_rbr(schema, queue):
             def queue_to_gen(queue):
-                while (value := queue.get()) is not None:
+                while (value := queue.get()) is not SENTINEL:
                     # re-raise where the caller can see it: the pulling thread
                     if isinstance(value, BaseException):
                         raise value

--- a/python/xorq/flight/tests/test_exchange_control_channel.py
+++ b/python/xorq/flight/tests/test_exchange_control_channel.py
@@ -18,6 +18,7 @@ hang, and a hang inside pytest is a faulthandler dump rather than a failure.
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -38,6 +39,28 @@ SCHEMA = pa.schema([("a", pa.int64())])
 def make_batches(n_batches: int, n_rows: int = 100) -> pa.RecordBatchReader:
     batch = pa.RecordBatch.from_pydict({"a": list(range(n_rows))}, schema=SCHEMA)
     return pa.RecordBatchReader.from_batches(SCHEMA, (batch for _ in range(n_batches)))
+
+
+def batches_then_raise(settle: float = 2.0) -> pa.RecordBatchReader:
+    """One batch, a pause long enough for the server to answer and close, then a raise.
+
+    The pause is what makes the test deterministic. Provoking the write-side
+    error through gRPC flow control instead -- writing past the window until the
+    half-closed stream rejects a batch -- races the server's reply: whether the
+    already-sent output batch survives the torn-down call is up to the
+    transport, and it did not on CI. Failing the *client's* input reader after
+    the reads have demonstrably finished isolates the same rule with no
+    transport race: the write side fails, and the completed stream must survive
+    it.
+    """
+    batch = pa.RecordBatch.from_pydict({"a": list(range(100))}, schema=SCHEMA)
+
+    def gen():
+        yield batch
+        time.sleep(settle)
+        raise ValueError("write side died")
+
+    return pa.RecordBatchReader.from_batches(SCHEMA, gen())
 
 
 def drain_with_deadline(rbr: pa.RecordBatchReader, seconds: int = 60) -> pa.Table:
@@ -139,16 +162,17 @@ def test_write_side_failure_does_not_fail_a_completed_exchange() -> None:
     in full.
     """
     with serving(EarlyStopExchanger) as client:
-        # more than the gRPC flow-control window, so the client is still writing
-        # when the server stops reading
         (fut, rbr) = client.do_exchange_batches(
-            EarlyStopExchanger.command, make_batches(5_000)
+            EarlyStopExchanger.command, batches_then_raise()
         )
         table = drain_with_deadline(rbr)
+    # the server answered in full before the write side died, so the consumer
+    # gets the whole result
     assert table.num_rows == 100
-    # the write side's failure, if any, is the caller's to inspect -- never the
+    # and the write side's failure is the caller's to inspect -- never the
     # stream's
-    assert fut.done()
+    with pytest.raises(ValueError, match="write side died"):
+        fut.result()
 
 
 def test_metadata_only_chunk_does_not_truncate_the_stream() -> None:

--- a/python/xorq/flight/tests/test_exchange_control_channel.py
+++ b/python/xorq/flight/tests/test_exchange_control_channel.py
@@ -1,0 +1,201 @@
+"""The exchange queue's control protocol: what ends a stream, and what fails it.
+
+The queue between ``do_reads`` and the consumer carries record batches, an
+end-of-stream marker and failures down one channel. These tests pin which is
+which:
+
+* a **read-side** failure is the stream's failure -- it must reach the consumer
+  (that is the deadlock fix from #2231, guarded here against regression)
+* a **write-side** failure of an exchange whose output already arrived is not --
+  the result is complete and must be delivered
+* a metadata-only chunk is data-shaped ``None`` and must not be mistaken for the
+  end of the stream
+
+Each drain runs under a deadline: the failure mode being guarded against is a
+hang, and a hang inside pytest is a faulthandler dump rather than a failure.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+import xorq.api as xo
+from xorq.common.utils import classproperty
+from xorq.flight import FlightServer
+from xorq.flight.action import AddExchangeAction
+from xorq.flight.exchanger import EchoExchanger
+
+
+SCHEMA = pa.schema([("a", pa.int64())])
+
+
+def make_batches(n_batches: int, n_rows: int = 100) -> pa.RecordBatchReader:
+    batch = pa.RecordBatch.from_pydict({"a": list(range(n_rows))}, schema=SCHEMA)
+    return pa.RecordBatchReader.from_batches(SCHEMA, (batch for _ in range(n_batches)))
+
+
+def drain_with_deadline(rbr: pa.RecordBatchReader, seconds: int = 60) -> pa.Table:
+    """``rbr.read_all()`` on a daemon thread, so a deadlock fails the test."""
+    box = {}
+
+    def run() -> None:
+        try:
+            box["value"] = rbr.read_all()
+        except BaseException as e:  # noqa: BLE001
+            box["error"] = e
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(seconds)
+    if thread.is_alive():
+        raise AssertionError(f"exchange did not finish within {seconds}s: deadlocked")
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
+class EarlyStopExchanger(EchoExchanger):
+    """Writes the first batch back, then stops reading -- like any `limit`.
+
+    The client is left writing into a half-closed stream, which is where the
+    write-side error comes from.
+    """
+
+    @classproperty
+    def exchange_f(cls) -> Any:
+        def exchange(context, reader, writer, options=None, **kwargs) -> None:
+            for chunk in reader:
+                if chunk.data is not None:
+                    writer.begin(chunk.data.schema, options=options)
+                    writer.write_batch(chunk.data)
+                    return
+
+        return exchange
+
+    @classproperty
+    def command(cls) -> str:
+        return "early-stop"
+
+
+class MetadataChunkExchanger(EchoExchanger):
+    """Emits a metadata-only chunk between two data batches."""
+
+    @classproperty
+    def exchange_f(cls) -> Any:
+        def exchange(context, reader, writer, options=None, **kwargs) -> None:
+            started = False
+            for chunk in reader:
+                if chunk.data is None:
+                    continue
+                if not started:
+                    writer.begin(chunk.data.schema, options=options)
+                    started = True
+                writer.write_batch(chunk.data)
+                writer.write_metadata(b"progress")
+                writer.write_batch(chunk.data)
+
+        return exchange
+
+    @classproperty
+    def command(cls) -> str:
+        return "metadata-chunks"
+
+
+class BoomExchanger(EchoExchanger):
+    """Fails on the server side, mid-exchange."""
+
+    @classproperty
+    def exchange_f(cls) -> Any:
+        def exchange(context, reader, writer, options=None, **kwargs) -> None:
+            raise ValueError("boom")
+
+        return exchange
+
+    @classproperty
+    def command(cls) -> str:
+        return "boom"
+
+
+@contextmanager
+def serving(exchanger: type[EchoExchanger]) -> Iterator[Any]:
+    with FlightServer(verify_client=False) as server:
+        client = server.client
+        client.do_action(AddExchangeAction.name, exchanger, options=client._options)
+        yield client
+
+
+def test_write_side_failure_does_not_fail_a_completed_exchange() -> None:
+    """A server that stops reading early still returns its (complete) output.
+
+    Regression guard for #2247: termination moved to `do_writes_reads`, which
+    made *any* exception fatal to the stream -- including the client's own
+    `Destination already closed` on an exchange the server had already answered
+    in full.
+    """
+    with serving(EarlyStopExchanger) as client:
+        # more than the gRPC flow-control window, so the client is still writing
+        # when the server stops reading
+        (fut, rbr) = client.do_exchange_batches(
+            EarlyStopExchanger.command, make_batches(5_000)
+        )
+        table = drain_with_deadline(rbr)
+    assert table.num_rows == 100
+    # the write side's failure, if any, is the caller's to inspect -- never the
+    # stream's
+    assert fut.done()
+
+
+def test_metadata_only_chunk_does_not_truncate_the_stream() -> None:
+    """`chunk.data is None` is not end-of-stream (#2247)."""
+    with serving(MetadataChunkExchanger) as client:
+        (fut, rbr) = client.do_exchange_batches(
+            MetadataChunkExchanger.command, make_batches(1)
+        )
+        table = drain_with_deadline(rbr)
+        fut.result()
+    # both data batches, not just the one before the metadata chunk
+    assert table.num_rows == 200
+
+
+def test_read_side_failure_still_reaches_the_consumer() -> None:
+    """The #2231 deadlock fix, guarded: a server-side failure is the stream's."""
+    with serving(BoomExchanger) as client:
+        (_fut, rbr) = client.do_exchange_batches(BoomExchanger.command, make_batches(1))
+        with pytest.raises(Exception, match="boom"):
+            drain_with_deadline(rbr)
+
+
+def test_udxf_failure_still_raises_end_to_end() -> None:
+    """The same guard one layer up, through `flight_udxf`."""
+
+    def boom(df: Any) -> Any:
+        raise ValueError("udxf boom")
+
+    schema = xo.schema({"unit": "int64"})
+    udxf = xo.expr.relations.flight_udxf(
+        process_df=boom,
+        maybe_schema_in=schema,
+        maybe_schema_out=schema,
+        name="Boom",
+    )
+    expr = udxf(xo.memtable([{"unit": 1}], name="unit_tbl"))
+    box = {}
+
+    def run() -> None:
+        try:
+            box["value"] = xo.execute(expr)
+        except BaseException as e:  # noqa: BLE001
+            box["error"] = e
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(60)
+    assert not thread.is_alive(), "execute deadlocked"
+    assert isinstance(box.get("error"), Exception)
+    assert "udxf boom" in str(box["error"])


### PR DESCRIPTION
Fixes #2247. Two commits: the exchange queue's control channel, then the one-line `instrument_reader` crash that lives in the same lock set.

## The queue conflated data with control

`client.py`'s exchange queue carried batches, the end-of-stream marker and failures down one channel, and neither control value was distinguishable from a payload. Two defects came out of that.

**A write-side failure destroyed a completed exchange** (regression from #2231). Termination moved into `do_writes_reads` and *every* exception out of it became fatal to the stream. That closed the deadlock, but a server that stops pulling input — any `limit`, any early-terminating exchanger — leaves the client writing into a half-closed stream, and the resulting `Destination already closed` reached the consumer even though every output batch had already arrived.

The rule now: **the reads are the stream.** If they finished, the consumer holds everything the server sent and the exchange succeeded whatever the write side did — so a write-side error goes to `fut` alone. A read-side or setup failure is still the stream's failure and still reaches the consumer, which is the deadlock fix from #2231, guarded here by its own test. The futures are joined with `FIRST_EXCEPTION` so a read-side failure no longer waits on a write side draining into a stream nobody is consuming.

**A metadata-only chunk truncated the stream.** `None` was the end-of-stream marker, but a Flight chunk carrying only `app_metadata` has `data is None` — `EchoExchanger` emits exactly that. Termination is now a dedicated `SENTINEL` object, and metadata-only chunks are skipped rather than forwarded (forwarding a bare `None` into `RecordBatchReader.from_batches` would crash the consumer).

## `instrument_reader` on an empty stream

`yield next(reader)` inside a generator turns an empty stream into `RuntimeError: generator raised StopIteration` (PEP 479). `yield from reader` already covers the first batch; the explicit `next` only existed to hang a log line off it, and that line fires before the first pull either way. Reachable via `do_instrument_reader=True` — i.e. exactly when instrumentation is on to debug a failure that produced an empty result.

## Verification

New tests **fail against main's code and pass here**:

* `test_write_side_failure_does_not_fail_a_completed_exchange` — an exchanger that answers from the first batch and stops reading, with the client still writing (5k batches, past the flow-control window)
* `test_metadata_only_chunk_does_not_truncate_the_stream` — data, metadata-only, data → both data batches arrive
* `test_instrument_reader_handles_an_empty_stream`

Guards that pass either way, so the #2231 fix cannot regress: `test_read_side_failure_still_reaches_the_consumer`, `test_udxf_failure_still_raises_end_to_end`, `test_instrument_reader_yields_every_batch`. Every drain runs under a deadline on a daemon thread — the failure mode is a hang, and a hang inside pytest is a faulthandler dump rather than a failure.

`python/xorq/flight/tests/` — 11 failed / 81 passed, with the **identical 11 failing on pristine main** in this environment; zero delta.

## Sequencing

Touches `client.py` + `rbr_utils.py`, which is the #2242 → Q5 → Q11 lock set. Based on `main`, so whichever lands second rebases. New tests live in **new files** (`test_exchange_control_channel.py`, `test_instrument_reader.py`) specifically to keep out of #2242's `test_rbr_utils.py` / `test_flight_exchange.py` footprint.

Not done here, deliberately: the style hook flags two **pre-existing** issues in `client.py` (missing `from __future__ import annotations`, stdlib `logging` instead of structlog). #2242 already migrates that logging, so fixing it here would manufacture a conflict in a locked file.
