### PR TITLE
fix(catalog): source tag records the alias the caller named, not the entry's first

### DIFF
--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -78,6 +78,7 @@ from xorq.ibis_yaml.enums import DumpFiles, ExprKind
 
 if TYPE_CHECKING:
     from xorq.api import Expr
+    from xorq.vendor.ibis.backends import BaseBackend
 
 
 logger = get_logger(__name__)
@@ -748,13 +749,21 @@ class Catalog:
         catalog_entry = CatalogEntry(name, self)
         return catalog_entry
 
-    def load(self, name_or_alias, con=None):
+    def maybe_alias(self, name_or_alias: str) -> str | None:
+        """Return *name_or_alias* if it names a registered alias, else None.
+
+        The return value is what ``_make_source_tag`` wants for its ``alias``
+        argument: the alias the caller actually addressed the entry by, or
+        None to let the tag fall back to the entry's first alias.
+        """
+        return name_or_alias if name_or_alias in self.list_aliases() else None
+
+    def load(self, name_or_alias: str, con: "BaseBackend | None" = None) -> "Expr":
         """Return a tagged RemoteTable expression for a catalog entry (by hash or alias)."""
         from xorq.catalog.bind import _make_source_expr  # noqa: PLC0415
 
         entry = self.get_catalog_entry(name_or_alias, maybe_alias=True)
-        alias = name_or_alias if name_or_alias in self.list_aliases() else None
-        return _make_source_expr(entry, con=con, alias=alias)
+        return _make_source_expr(entry, con=con, alias=self.maybe_alias(name_or_alias))
 
     def bind(self, source_entry, *transforms, con=None):
         """Bind a source entry through one or more transform entries."""

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1659,6 +1659,7 @@ def _compose_expr(catalog, entries, code, rename_map=None, cache_dir=None):
             source=source_entry,
             transforms=transform_entries,
             code=code,
+            alias=catalog.maybe_alias(source_name),
         ).expr
 
     def _load(entry):

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -22,10 +22,12 @@ from xorq.catalog import constants as catalog_constants
 
 
 if TYPE_CHECKING:
+    from typing import BinaryIO
+
     from opentelemetry.trace import Span
 
     from xorq.api import Expr
-    from xorq.catalog.catalog import Catalog
+    from xorq.catalog.catalog import Catalog, CatalogEntry
     from xorq.catalog.content_store import ContentStoreConfig
     from xorq.common.utils.lineage_utils import LineageDAG
     from xorq.ibis_yaml.packager import JointBundle
@@ -1568,8 +1570,18 @@ def _get_catalog_entry(catalog, name):
         ) from err
 
 
-def _eval_entry(catalog_entry, code, instream=None, cache_dir=None):
-    """Evaluate a single catalog entry to an expression."""
+def _eval_entry(
+    catalog_entry: "CatalogEntry",
+    code: str | None,
+    instream: "str | BinaryIO | None" = None,
+    cache_dir: str | None = None,
+    alias: str | None = None,
+) -> "Expr":
+    """Evaluate a single catalog entry to an expression.
+
+    *alias* is the alias the caller addressed the entry by, threaded through to
+    the source tag; None lets it fall back to the entry's first alias.
+    """
     from xorq.catalog.bind import _eval_code, _make_source_expr  # noqa: PLC0415
 
     match catalog_entry.kind:
@@ -1592,7 +1604,7 @@ def _eval_entry(catalog_entry, code, instream=None, cache_dir=None):
                 ) from err
             expr = replace_unbound(loaded_expr, input_expr.op())
         case ExprKind.Source | ExprKind.Expr | ExprKind.Composed | ExprKind.ExprBuilder:
-            expr = _make_source_expr(catalog_entry, cache_dir=cache_dir)
+            expr = _make_source_expr(catalog_entry, alias=alias, cache_dir=cache_dir)
         case _:
             raise click.ClickException(
                 f"Unsupported entry kind {catalog_entry.kind!r} for 'run'."
@@ -2328,7 +2340,13 @@ def _resolve_single_entry(
     catalog_entry = _get_catalog_entry(catalog, entry)
 
     span.set_attribute("kind", str(catalog_entry.kind))
-    expr = _eval_entry(catalog_entry, code, instream, cache_dir=cache_dir)
+    expr = _eval_entry(
+        catalog_entry,
+        code,
+        instream,
+        cache_dir=cache_dir,
+        alias=catalog.maybe_alias(entry),
+    )
 
     if rename_map and entry in rename_map:
         from xorq.common.utils.graph_utils import rename_params  # noqa: PLC0415

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -21,6 +21,7 @@ from xorq.catalog.cli import (
     _entry_run_bundle,
     _forward_ctx_params,
     _has_expr_modifications,
+    _resolve_single_entry,
     _stage_bundle_into_build,
     cli,
 )
@@ -345,6 +346,33 @@ def test_compose_by_hash_falls_back_to_an_arbitrary_alias(
     expr = _compose_expr(catalog, (source_name, "trn"), None)
 
     assert _source_tag(expr).metadata["alias"] == "src"
+
+
+@pytest.mark.parametrize(
+    "addressed_by",
+    (
+        pytest.param("src", id="first-alias"),
+        pytest.param("prod", id="second-alias"),
+    ),
+)
+def test_single_entry_records_the_alias_the_caller_named(
+    catalog_with_source_and_transform: tuple, addressed_by: str
+) -> None:
+    """A single-entry run tags the same alias a multi-entry compose would.
+
+    `_resolve_and_execute` sends one entry to `_resolve_single_entry` and two or
+    more to `_compose_expr`; both reach `_make_source_tag`, so the alias must
+    not depend on which arm ran. Goes through `_resolve_single_entry` rather
+    than `_eval_entry` so the alias is derived from the name the caller typed
+    instead of being handed in by the test.
+    """
+    catalog_path, source_name, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    catalog.add_alias(source_name, "prod")
+
+    expr = _resolve_single_entry(catalog, addressed_by, None, None, None, MagicMock())
+
+    assert _source_tag(expr).metadata["alias"] == addressed_by
 
 
 # --- compose + run roundtrip tests ---

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -1235,7 +1235,8 @@ def test_catalog_join_command_rebinds_same_profile_file_backed_entries(
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(
-        cli, ["--path", catalog_path, "run", "joined-file-backed", "-o", "-", "-f", "csv"]
+        cli,
+        ["--path", catalog_path, "run", "joined-file-backed", "-o", "-", "-f", "csv"],
     )
     assert result.exit_code == 0, result.output
     assert "a" in result.output
@@ -1256,9 +1257,11 @@ def test_catalog_join_command_rebinds_into_backend_entry(
 
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     left = deferred_read_parquet(pq_path, xo.connect(), table_name="t")
-    right = deferred_read_parquet(
-        pq_path, xo.duckdb.connect(), table_name="t"
-    ).rename(b="a").into_backend(xo.connect(), name="t_remote")
+    right = (
+        deferred_read_parquet(pq_path, xo.duckdb.connect(), table_name="t")
+        .rename(b="a")
+        .into_backend(xo.connect(), name="t_remote")
+    )
     catalog.add(left, aliases=("hub-left",))
     catalog.add(right, aliases=("into-backend-right",))
 
@@ -1279,7 +1282,8 @@ def test_catalog_join_command_rebinds_into_backend_entry(
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(
-        cli, ["--path", catalog_path, "run", "joined-into-backend", "-o", "-", "-f", "csv"]
+        cli,
+        ["--path", catalog_path, "run", "joined-into-backend", "-o", "-", "-f", "csv"],
     )
     assert result.exit_code == 0, result.output
     assert "a" in result.output
@@ -1313,9 +1317,9 @@ def test_catalog_join_command_into_backend_mixed_source_backends(
     duckdb_into_df = deferred_read_parquet(
         pq_a, xo.duckdb.connect(), table_name="a"
     ).into_backend(xo.connect(), name="a_remote")
-    df_into_df = deferred_read_parquet(
-        pq_b, xo.connect(), table_name="b"
-    ).into_backend(xo.connect(), name="b_remote")
+    df_into_df = deferred_read_parquet(pq_b, xo.connect(), table_name="b").into_backend(
+        xo.connect(), name="b_remote"
+    )
     catalog.add(duckdb_into_df, aliases=("duckdb-into-df",))
     catalog.add(df_into_df, aliases=("df-into-df",))
 

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import click
@@ -16,15 +17,23 @@ from xorq.catalog import cli as cli_mod
 from xorq.catalog.catalog import Catalog
 from xorq.catalog.cli import (
     _assert_requirements_identical,
+    _compose_expr,
     _entry_run_bundle,
     _forward_ctx_params,
     _has_expr_modifications,
     _stage_bundle_into_build,
     cli,
 )
+from xorq.catalog.enums import CatalogTag
 from xorq.cli import cli as top_cli
 from xorq.common.utils.defer_utils import deferred_read_parquet
+from xorq.common.utils.graph_utils import walk_nodes
+from xorq.expr.relations import HashingTag
 from xorq.ibis_yaml.enums import DumpFiles
+
+
+if TYPE_CHECKING:
+    from xorq.api import Expr
 
 
 # --- run command ---
@@ -287,6 +296,55 @@ def test_compose_without_alias_catalogs_by_hash(
     )
     assert result.exit_code == 0, result.output
     assert "Cataloged as" in result.output
+
+
+def _source_tag(expr: "Expr") -> HashingTag:
+    """Return the sole catalog SOURCE tag on *expr*."""
+    (source_tag,) = tuple(
+        ht
+        for ht in walk_nodes(HashingTag, expr)
+        if ht.metadata.get("tag") == CatalogTag.SOURCE
+    )
+    return source_tag
+
+
+@pytest.mark.parametrize(
+    "addressed_by",
+    (
+        pytest.param("src", id="first-alias"),
+        pytest.param("prod", id="second-alias"),
+    ),
+)
+def test_compose_records_the_alias_the_caller_named(
+    catalog_with_source_and_transform: tuple, addressed_by: str
+) -> None:
+    """The SOURCE tag records the alias the caller addressed the source by.
+
+    With two aliases on the entry, `_make_source_tag`'s fallback to the first
+    alias gets one of these two cases wrong whichever way the alias list is
+    ordered, so the pair pins the behavior without depending on that order.
+    """
+    catalog_path, source_name, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    catalog.add_alias(source_name, "prod")
+
+    expr = _compose_expr(catalog, (addressed_by, "trn"), None)
+
+    assert _source_tag(expr).metadata["alias"] == addressed_by
+
+
+def test_compose_by_hash_falls_back_to_an_arbitrary_alias(
+    catalog_with_source_and_transform: tuple,
+) -> None:
+    """Addressing by hash still records an alias, because `_make_source_tag`
+    falls back to the entry's first one. So a recorded alias does not mean the
+    caller named it — this pins the fallback, it does not endorse it."""
+    catalog_path, source_name, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+
+    expr = _compose_expr(catalog, (source_name, "trn"), None)
+
+    assert _source_tag(expr).metadata["alias"] == "src"
 
 
 # --- compose + run roundtrip tests ---


### PR DESCRIPTION
## What

The catalog SOURCE tag recorded the wrong alias: it fell back to `entry.aliases[0]` instead of the alias the caller actually addressed the entry by. An entry addressed as `prod` recorded whichever alias happened to sort first in `catalog.yaml` — provenance for a name the caller never mentioned.

`Catalog.load` already had the right conditional. This lifts it to `Catalog.maybe_alias` and uses it from every path that reaches `_make_source_tag`.

## The two paths fixed

`_resolve_and_execute` sends one entry to `_resolve_single_entry` and two or more to `_compose_expr`. Both were wrong, so both are fixed:

| Path | Command | Before | After |
|---|---|---|---|
| `_compose_expr` fast path | `xorq catalog compose prod trn` | `src` | `prod` |
| `_eval_entry` | `xorq catalog run prod` | `src` | `prod` |

`_eval_entry` needed the alias threaded in explicitly — it receives an already resolved `CatalogEntry`, so the string the caller typed was lost before `_make_source_expr` was reached. `_resolve_single_entry` still has it.

## Not fixed here

`_compose_expr`'s **slow path** (`--rename-params`, `--cache-dir`) emits no source tag at all — it pre-loads the entry, so `_resolve_source` hits its untagged `case Expr()` branch. That is a different defect: adding a tag makes an expression newly eligible for `fuse_catalog_source`, which changes the executed plan rather than just recorded metadata. Tracked in #2255.

Addressing an entry **by hash** still records the entry's first alias. `test_compose_by_hash_falls_back_to_an_arbitrary_alias` pins that so it is a decision on the record rather than an accident — a recorded alias does not tell you the caller asked to follow one, which matters to anything built on this metadata.

## ⚠️ Build hash change

The alias is `HashingTag` metadata and so is tokenized. This shifts the build hash of any CLI compose **or** single-entry run addressed by a non-first alias.

## Tests

Both fixes are parametrized over `first-alias` / `second-alias` on the same entry, so the old fallback gets exactly one of each pair wrong whichever way the alias list is ordered — the pairs pin the behavior without depending on that order.

Each was verified to fail against unfixed code (`second-alias` fails on all three backend parametrizations, `first-alias` passes) rather than merely to pass against the fix. `test_single_entry_records_the_alias_the_caller_named` goes through `_resolve_single_entry` rather than calling `_eval_entry` with an explicit alias, which would have passed either way.

Local: `test_cli_run_compose.py` + `test_bind.py` 244 passed; `test_replay_rebuild*.py` 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Gn9aHyPL8yNnoZsdMepEt
