### PR TITLE
feat(cli): add join/union commands for combining build artifacts and catalog entries

### DIFF
--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -75,6 +75,10 @@ MAIN_GROUPS = (
         ),
     ),
     (
+        "Combine",
+        ("join", "union"),
+    ),
+    (
         "Serve",
         ("serve-flight-udxf", "serve-unbound"),
     ),
@@ -106,7 +110,7 @@ CATALOG_GROUPS = (
     ),
     (
         "Composition and execution",
-        ("compose", "run", "run-cached", "serve-unbound"),
+        ("compose", "join", "union", "run", "run-cached", "serve-unbound"),
     ),
     (
         "Cache",

--- a/python/xorq/api.py
+++ b/python/xorq/api.py
@@ -25,6 +25,12 @@ from xorq.ibis_yaml.compiler import (
     build_expr,
     load_expr,
 )
+from xorq.ibis_yaml.combine import (
+    join_builds,
+    join_exprs,
+    union_builds,
+    union_exprs,
+)
 from xorq.common.utils.graph_utils import (
     replace_sources,
 )
@@ -44,6 +50,10 @@ __all__ = [  # noqa: PLE0604
     "udf",
     "build_expr",
     "load_expr",
+    "join_builds",
+    "join_exprs",
+    "union_builds",
+    "union_exprs",
     "replace_sources",
     *api.__all__,
     *caching.__all__,

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -1450,7 +1450,13 @@ class CatalogEntry:
         ).with_suffix(PREFERRED_SUFFIX)
         return catalog_path
 
-    def load_expr(self, lazy=False, read_only_parquet_metadata=False, cache_dir=None):
+    def load_expr(
+        self,
+        lazy=False,
+        read_only_parquet_metadata=False,
+        cache_dir=None,
+        con_cache=None,
+    ):
         if not self.is_content_local:
             self.fetch()
         return load_expr_from_zip(
@@ -1458,6 +1464,7 @@ class CatalogEntry:
             lazy=lazy,
             read_only_parquet_metadata=read_only_parquet_metadata,
             cache_dir=cache_dir,
+            con_cache=con_cache,
         )
 
     @property

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from functools import cache, partial, reduce
 from pathlib import Path
@@ -22,6 +22,9 @@ from xorq.catalog import constants as catalog_constants
 
 
 if TYPE_CHECKING:
+    from opentelemetry.trace import Span
+
+    from xorq.api import Expr
     from xorq.catalog.catalog import Catalog
     from xorq.catalog.content_store import ContentStoreConfig
     from xorq.common.utils.lineage_utils import LineageDAG
@@ -44,6 +47,8 @@ from xorq.cli_options import (
     env_options,
     fuse_option,
     gcs_option,
+    ignore_venv_mismatch_option,
+    join_predicate_options,
     json_option,
     limit_option,
     output_options,
@@ -1841,6 +1846,41 @@ def _entry_run_bundle(
             )
 
 
+def _combine_and_catalog(
+    catalog: "Catalog",
+    entries: tuple[str, ...],
+    make_expr: Callable[[], "Expr"],
+    *,
+    cache_dir: str | Path | None,
+    sync: bool,
+    alias: str | None,
+    ignore_mismatch: bool,
+    span: "Span",
+) -> str:
+    """Validate compatibility, build+stage the combined expr, and catalog it.
+
+    Shared tail for `catalog join`/`catalog union`. Enters `_entry_run_bundle`
+    (and therefore its wheel/Python-minor mismatch check) *before* calling
+    `make_expr`/`build_expr`, so a mismatch fails before the expensive
+    load/build work runs rather than after.
+    """
+    from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
+
+    with _entry_run_bundle(catalog, entries, ignore_mismatch=ignore_mismatch) as bundle:
+        expr = make_expr()
+        build_kwargs = {} if cache_dir is None else {"cache_dir": Path(cache_dir)}
+        build_path = build_expr(expr, **build_kwargs)
+        _stage_bundle_into_build(bundle, build_path)
+
+    entry_name = build_path.name
+    aliases = (alias,) if alias else ()
+    catalog.add(build_path, sync=sync, aliases=aliases, exist_ok=True)
+    label = alias or entry_name
+    click.echo(f"Cataloged as {label!r}", err=True)
+    span.set_attribute("cataloged", label)
+    return label
+
+
 @contextmanager
 def _uv_reinvoke_xorq_cli(catalog, entries, *inner_args, **uv_kwargs):
     from xorq.ibis_yaml.packager import uv_tool_run  # noqa: PLC0415
@@ -2100,40 +2140,7 @@ def compose(
 @cli.command("join")
 @click.argument("left_entry", shell_complete=_complete_entry_or_alias_names)
 @click.argument("right_entry", shell_complete=_complete_entry_or_alias_names)
-@click.option(
-    "--on",
-    default=None,
-    help="Comma-separated column(s) present in both entries to join on.",
-)
-@click.option(
-    "--left-on",
-    default=None,
-    help="Comma-separated left-entry columns (paired with --right-on).",
-)
-@click.option(
-    "--right-on",
-    default=None,
-    help="Comma-separated right-entry columns (paired with --left-on).",
-)
-@click.option(
-    "--how",
-    type=click.Choice(("inner", "left", "right", "outer", "semi", "anti", "cross")),
-    default="inner",
-    show_default=True,
-    help="Join method.",
-)
-@click.option(
-    "--lname",
-    default="",
-    show_default=True,
-    help="Rename format string for overlapping left columns.",
-)
-@click.option(
-    "--rname",
-    default="{name}_right",
-    show_default=True,
-    help="Rename format string for overlapping right columns.",
-)
+@join_predicate_options(noun="entry")
 @sync_option
 @click.option(
     "-a",
@@ -2142,12 +2149,7 @@ def compose(
     help="Also register this alias for the cataloged entry.",
 )
 @cache_dir_option
-@click.option(
-    "--ignore-venv-mismatch",
-    is_flag=True,
-    default=False,
-    help="Proceed even if the entries' wheel requirements or Python minor differ.",
-)
+@ignore_venv_mismatch_option
 @click.pass_context
 def join(
     ctx: click.Context,
@@ -2180,49 +2182,41 @@ def join(
       xorq catalog join orders customers --on customer_id --alias enriched-orders
     """
     from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
-    from xorq.ibis_yaml.combine import join_exprs  # noqa: PLC0415
-    from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import combine_errors, join_exprs  # noqa: PLC0415
+
+    def make_expr():
+        left_expr = _get_catalog_entry(catalog, left_entry).load_expr(
+            cache_dir=cache_dir
+        )
+        right_expr = _get_catalog_entry(catalog, right_entry).load_expr(
+            cache_dir=cache_dir
+        )
+        return join_exprs(
+            left_expr,
+            right_expr,
+            on=on,
+            left_on=left_on,
+            right_on=right_on,
+            how=how,
+            lname=lname,
+            rname=rname,
+        )
 
     with tracer.start_as_current_span("catalog.join") as span:
         span.set_attributes({"left_entry": left_entry, "right_entry": right_entry})
         with click_context_catalog(ctx):
             catalog = ctx.obj.make_catalog(init=False)
-            left_expr = _get_catalog_entry(catalog, left_entry).load_expr(
-                cache_dir=cache_dir
-            )
-            right_expr = _get_catalog_entry(catalog, right_entry).load_expr(
-                cache_dir=cache_dir
-            )
-
-            try:
-                expr = join_exprs(
-                    left_expr,
-                    right_expr,
-                    on=on,
-                    left_on=left_on,
-                    right_on=right_on,
-                    how=how,
-                    lname=lname,
-                    rname=rname,
+            with combine_errors():
+                _combine_and_catalog(
+                    catalog,
+                    (left_entry, right_entry),
+                    make_expr,
+                    cache_dir=cache_dir,
+                    sync=sync,
+                    alias=alias,
+                    ignore_mismatch=ignore_venv_mismatch,
+                    span=span,
                 )
-            except ValueError as e:
-                raise click.BadParameter(str(e)) from None
-
-            build_kwargs = {} if cache_dir is None else {"cache_dir": Path(cache_dir)}
-            build_path = build_expr(expr, **build_kwargs)
-
-            entries = (left_entry, right_entry)
-            with _entry_run_bundle(
-                catalog, entries, ignore_mismatch=ignore_venv_mismatch
-            ) as bundle:
-                _stage_bundle_into_build(bundle, build_path)
-
-            entry_name = build_path.name
-            aliases = (alias,) if alias else ()
-            catalog.add(build_path, sync=sync, aliases=aliases, exist_ok=True)
-            label = alias or entry_name
-            click.echo(f"Cataloged as {label!r}", err=True)
-            span.set_attribute("cataloged", label)
 
 
 @cli.command("union")
@@ -2241,12 +2235,7 @@ def join(
     help="Also register this alias for the cataloged entry.",
 )
 @cache_dir_option
-@click.option(
-    "--ignore-venv-mismatch",
-    is_flag=True,
-    default=False,
-    help="Proceed even if the entries' wheel requirements or Python minor differ.",
-)
+@ignore_venv_mismatch_option
 @click.pass_context
 def union(
     ctx: click.Context,
@@ -2274,41 +2263,31 @@ def union(
     if len(entries) < 2:
         raise click.UsageError("At least two entries are required.")
 
-    from xorq.common.exceptions import RelationError  # noqa: PLC0415
     from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
-    from xorq.ibis_yaml.combine import union_exprs  # noqa: PLC0415
-    from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import combine_errors, union_exprs  # noqa: PLC0415
+
+    def make_expr():
+        exprs = [
+            _get_catalog_entry(catalog, name).load_expr(cache_dir=cache_dir)
+            for name in entries
+        ]
+        return union_exprs(*exprs, distinct=distinct)
 
     with tracer.start_as_current_span("catalog.union") as span:
         span.set_attribute("entries", entries)
         with click_context_catalog(ctx):
             catalog = ctx.obj.make_catalog(init=False)
-            exprs = [
-                _get_catalog_entry(catalog, name).load_expr(cache_dir=cache_dir)
-                for name in entries
-            ]
-
-            try:
-                expr = union_exprs(*exprs, distinct=distinct)
-            except ValueError as e:
-                raise click.BadParameter(str(e)) from None
-            except RelationError as e:
-                raise click.ClickException(str(e)) from e
-
-            build_kwargs = {} if cache_dir is None else {"cache_dir": Path(cache_dir)}
-            build_path = build_expr(expr, **build_kwargs)
-
-            with _entry_run_bundle(
-                catalog, entries, ignore_mismatch=ignore_venv_mismatch
-            ) as bundle:
-                _stage_bundle_into_build(bundle, build_path)
-
-            entry_name = build_path.name
-            aliases = (alias,) if alias else ()
-            catalog.add(build_path, sync=sync, aliases=aliases, exist_ok=True)
-            label = alias or entry_name
-            click.echo(f"Cataloged as {label!r}", err=True)
-            span.set_attribute("cataloged", label)
+            with combine_errors():
+                _combine_and_catalog(
+                    catalog,
+                    entries,
+                    make_expr,
+                    cache_dir=cache_dir,
+                    sync=sync,
+                    alias=alias,
+                    ignore_mismatch=ignore_venv_mismatch,
+                    span=span,
+                )
 
 
 def _resolve_single_entry(

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -22,8 +22,10 @@ from xorq.catalog import constants as catalog_constants
 
 
 if TYPE_CHECKING:
+    from xorq.catalog.catalog import Catalog
     from xorq.catalog.content_store import ContentStoreConfig
     from xorq.common.utils.lineage_utils import LineageDAG
+    from xorq.ibis_yaml.packager import JointBundle
 
 from xorq.cli import (
     _get_cache_dir,
@@ -1762,7 +1764,9 @@ def _harvest_entry_from_zip(zf, harvest_dir, entry_name=None, seen_wheels=None):
 
 
 @contextmanager
-def _entry_run_bundle(catalog, entries):
+def _entry_run_bundle(
+    catalog: "Catalog", entries: tuple[str, ...], *, ignore_mismatch: bool = False
+) -> Iterator["JointBundle"]:
     from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
     from xorq.ibis_yaml.packager import JointBundle  # noqa: PLC0415
 
@@ -1800,7 +1804,8 @@ def _entry_run_bundle(catalog, entries):
 
             if not all_wheel_paths:
                 raise click.ClickException("no wheels found in entries")
-            _assert_requirements_identical(req_contents)
+            if not ignore_mismatch:
+                _assert_requirements_identical(req_contents)
             req_path = harvest_dir / DumpFiles.requirements
             req_path.write_bytes(req_contents[0][1])
 
@@ -1808,9 +1813,16 @@ def _entry_run_bundle(catalog, entries):
             unpinned = [e for e, pin in python_pins if pin is None]
             if len(distinct_pins) > 1:
                 detail = ", ".join(f"{e!r}={pin}" for e, pin in python_pins)
-                raise click.ClickException(
-                    f"entries built on different Python minors: {detail}"
+                if not ignore_mismatch:
+                    raise click.ClickException(
+                        f"entries built on different Python minors: {detail}"
+                    )
+                click.echo(
+                    f"WARNING: ignoring Python-minor mismatch ({detail}); "
+                    f"using {python_pins[0][0]!r}'s environment.",
+                    err=True,
                 )
+                distinct_pins = {python_pins[0][1]}
             if distinct_pins and unpinned:
                 joint = next(iter(distinct_pins))
                 click.echo(
@@ -2082,6 +2094,220 @@ def compose(
                     click.echo(f"Entry {entry_name!r} already exists", err=True)
             else:
                 click.echo(f"Cataloged as {label!r}", err=True)
+            span.set_attribute("cataloged", label)
+
+
+@cli.command("join")
+@click.argument("left_entry", shell_complete=_complete_entry_or_alias_names)
+@click.argument("right_entry", shell_complete=_complete_entry_or_alias_names)
+@click.option(
+    "--on",
+    default=None,
+    help="Comma-separated column(s) present in both entries to join on.",
+)
+@click.option(
+    "--left-on",
+    default=None,
+    help="Comma-separated left-entry columns (paired with --right-on).",
+)
+@click.option(
+    "--right-on",
+    default=None,
+    help="Comma-separated right-entry columns (paired with --left-on).",
+)
+@click.option(
+    "--how",
+    type=click.Choice(("inner", "left", "right", "outer", "semi", "anti", "cross")),
+    default="inner",
+    show_default=True,
+    help="Join method.",
+)
+@click.option(
+    "--lname",
+    default="",
+    show_default=True,
+    help="Rename format string for overlapping left columns.",
+)
+@click.option(
+    "--rname",
+    default="{name}_right",
+    show_default=True,
+    help="Rename format string for overlapping right columns.",
+)
+@sync_option
+@click.option(
+    "-a",
+    "--alias",
+    default=None,
+    help="Also register this alias for the cataloged entry.",
+)
+@cache_dir_option
+@click.option(
+    "--ignore-venv-mismatch",
+    is_flag=True,
+    default=False,
+    help="Proceed even if the entries' wheel requirements or Python minor differ.",
+)
+@click.pass_context
+def join(
+    ctx: click.Context,
+    left_entry: str,
+    right_entry: str,
+    on: str | None,
+    left_on: str | None,
+    right_on: str | None,
+    how: str,
+    lname: str,
+    rname: str,
+    sync: bool,
+    alias: str | None,
+    cache_dir: str | None,
+    ignore_venv_mismatch: bool,
+) -> None:
+    """Join two catalog entries into a new cataloged entry.
+
+    Resolves both entries to expressions, joins them, builds the result,
+    and registers it in the catalog.
+
+    \b
+    Arguments:
+      LEFT_ENTRY   Name or alias of the left catalog entry.
+      RIGHT_ENTRY  Name or alias of the right catalog entry.
+
+    \b
+    Examples:
+      # Inner-join two entries on a shared column and alias the result
+      xorq catalog join orders customers --on customer_id --alias enriched-orders
+    """
+    from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import join_exprs  # noqa: PLC0415
+    from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
+
+    with tracer.start_as_current_span("catalog.join") as span:
+        span.set_attributes({"left_entry": left_entry, "right_entry": right_entry})
+        with click_context_catalog(ctx):
+            catalog = ctx.obj.make_catalog(init=False)
+            left_expr = _get_catalog_entry(catalog, left_entry).load_expr(
+                cache_dir=cache_dir
+            )
+            right_expr = _get_catalog_entry(catalog, right_entry).load_expr(
+                cache_dir=cache_dir
+            )
+
+            try:
+                expr = join_exprs(
+                    left_expr,
+                    right_expr,
+                    on=on,
+                    left_on=left_on,
+                    right_on=right_on,
+                    how=how,
+                    lname=lname,
+                    rname=rname,
+                )
+            except ValueError as e:
+                raise click.BadParameter(str(e)) from None
+
+            build_kwargs = {} if cache_dir is None else {"cache_dir": Path(cache_dir)}
+            build_path = build_expr(expr, **build_kwargs)
+
+            entries = (left_entry, right_entry)
+            with _entry_run_bundle(
+                catalog, entries, ignore_mismatch=ignore_venv_mismatch
+            ) as bundle:
+                _stage_bundle_into_build(bundle, build_path)
+
+            entry_name = build_path.name
+            aliases = (alias,) if alias else ()
+            catalog.add(build_path, sync=sync, aliases=aliases, exist_ok=True)
+            label = alias or entry_name
+            click.echo(f"Cataloged as {label!r}", err=True)
+            span.set_attribute("cataloged", label)
+
+
+@cli.command("union")
+@click.argument("entries", nargs=-1, shell_complete=_complete_entry_or_alias_names)
+@click.option(
+    "--distinct",
+    is_flag=True,
+    default=False,
+    help="Deduplicate rows (default is union-all).",
+)
+@sync_option
+@click.option(
+    "-a",
+    "--alias",
+    default=None,
+    help="Also register this alias for the cataloged entry.",
+)
+@cache_dir_option
+@click.option(
+    "--ignore-venv-mismatch",
+    is_flag=True,
+    default=False,
+    help="Proceed even if the entries' wheel requirements or Python minor differ.",
+)
+@click.pass_context
+def union(
+    ctx: click.Context,
+    entries: tuple[str, ...],
+    distinct: bool,
+    sync: bool,
+    alias: str | None,
+    cache_dir: str | None,
+    ignore_venv_mismatch: bool,
+) -> None:
+    """Union two-or-more catalog entries into a new cataloged entry.
+
+    Resolves all entries to expressions, unions them (they must share an
+    identical schema), builds the result, and registers it in the catalog.
+
+    \b
+    Arguments:
+      ENTRIES  Two or more entries (names or aliases) to union.
+
+    \b
+    Examples:
+      # Union-all (the default) two entries and alias the result
+      xorq catalog union orders-jan orders-feb --alias orders-q1
+    """
+    if len(entries) < 2:
+        raise click.UsageError("At least two entries are required.")
+
+    from xorq.common.exceptions import RelationError  # noqa: PLC0415
+    from xorq.common.utils.otel_utils import tracer  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import union_exprs  # noqa: PLC0415
+    from xorq.ibis_yaml.compiler import build_expr  # noqa: PLC0415
+
+    with tracer.start_as_current_span("catalog.union") as span:
+        span.set_attribute("entries", entries)
+        with click_context_catalog(ctx):
+            catalog = ctx.obj.make_catalog(init=False)
+            exprs = [
+                _get_catalog_entry(catalog, name).load_expr(cache_dir=cache_dir)
+                for name in entries
+            ]
+
+            try:
+                expr = union_exprs(*exprs, distinct=distinct)
+            except ValueError as e:
+                raise click.BadParameter(str(e)) from None
+            except RelationError as e:
+                raise click.ClickException(str(e)) from e
+
+            build_kwargs = {} if cache_dir is None else {"cache_dir": Path(cache_dir)}
+            build_path = build_expr(expr, **build_kwargs)
+
+            with _entry_run_bundle(
+                catalog, entries, ignore_mismatch=ignore_venv_mismatch
+            ) as bundle:
+                _stage_bundle_into_build(bundle, build_path)
+
+            entry_name = build_path.name
+            aliases = (alias,) if alias else ()
+            catalog.add(build_path, sync=sync, aliases=aliases, exist_ok=True)
+            label = alias or entry_name
+            click.echo(f"Cataloged as {label!r}", err=True)
             span.set_attribute("cataloged", label)
 
 

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -2198,11 +2198,17 @@ def join(
     from xorq.ibis_yaml.combine import combine_errors, join_exprs  # noqa: PLC0415
 
     def make_expr():
+        # Shared so a same-profile connection between the two entries is one
+        # object from the moment each loads, not two independently-constructed
+        # ones that join_exprs's rebind then has to reconcile after the fact.
+        # Gated on rebind_backends so --no-rebind-backends still gets fully
+        # isolated connections, matching join_builds/union_builds.
+        con_cache = {} if rebind_backends else None
         left_expr = _get_catalog_entry(catalog, left_entry).load_expr(
-            cache_dir=cache_dir
+            cache_dir=cache_dir, con_cache=con_cache
         )
         right_expr = _get_catalog_entry(catalog, right_entry).load_expr(
-            cache_dir=cache_dir
+            cache_dir=cache_dir, con_cache=con_cache
         )
         return join_exprs(
             left_expr,
@@ -2283,8 +2289,11 @@ def union(
     from xorq.ibis_yaml.combine import combine_errors, union_exprs  # noqa: PLC0415
 
     def make_expr():
+        con_cache = {} if rebind_backends else None
         exprs = [
-            _get_catalog_entry(catalog, name).load_expr(cache_dir=cache_dir)
+            _get_catalog_entry(catalog, name).load_expr(
+                cache_dir=cache_dir, con_cache=con_cache
+            )
             for name in entries
         ]
         return union_exprs(*exprs, distinct=distinct, rebind_backends=rebind_backends)

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -53,6 +53,7 @@ from xorq.cli_options import (
     limit_option,
     output_options,
     params_option,
+    rebind_backends_option,
     relocate_reads_option,
     rename_params_option,
     serve_options,
@@ -1822,12 +1823,22 @@ def _entry_run_bundle(
                     raise click.ClickException(
                         f"entries built on different Python minors: {detail}"
                     )
+                # Fall back to the first entry that actually has a pin, not
+                # just the first entry overall -- python_pins[0] could be
+                # unpinned, which previously collapsed distinct_pins to
+                # {None}: a truthy set that made the unpinned-entries warning
+                # below claim "running under None" and left JointBundle with
+                # no real pin, silently dropping both recorded Python minors
+                # in favor of whatever Python happened to be ambient.
+                fallback_entry, fallback_pin = next(
+                    (e, pin) for e, pin in python_pins if pin is not None
+                )
                 click.echo(
                     f"WARNING: ignoring Python-minor mismatch ({detail}); "
-                    f"using {python_pins[0][0]!r}'s environment.",
+                    f"using {fallback_entry!r}'s environment.",
                     err=True,
                 )
-                distinct_pins = {python_pins[0][1]}
+                distinct_pins = {fallback_pin}
             if distinct_pins and unpinned:
                 joint = next(iter(distinct_pins))
                 click.echo(
@@ -2150,6 +2161,7 @@ def compose(
 )
 @cache_dir_option
 @ignore_venv_mismatch_option
+@rebind_backends_option
 @click.pass_context
 def join(
     ctx: click.Context,
@@ -2165,6 +2177,7 @@ def join(
     alias: str | None,
     cache_dir: str | None,
     ignore_venv_mismatch: bool,
+    rebind_backends: bool,
 ) -> None:
     """Join two catalog entries into a new cataloged entry.
 
@@ -2200,6 +2213,7 @@ def join(
             how=how,
             lname=lname,
             rname=rname,
+            rebind_backends=rebind_backends,
         )
 
     with tracer.start_as_current_span("catalog.join") as span:
@@ -2236,6 +2250,7 @@ def join(
 )
 @cache_dir_option
 @ignore_venv_mismatch_option
+@rebind_backends_option
 @click.pass_context
 def union(
     ctx: click.Context,
@@ -2245,6 +2260,7 @@ def union(
     alias: str | None,
     cache_dir: str | None,
     ignore_venv_mismatch: bool,
+    rebind_backends: bool,
 ) -> None:
     """Union two-or-more catalog entries into a new cataloged entry.
 
@@ -2271,7 +2287,7 @@ def union(
             _get_catalog_entry(catalog, name).load_expr(cache_dir=cache_dir)
             for name in entries
         ]
-        return union_exprs(*exprs, distinct=distinct)
+        return union_exprs(*exprs, distinct=distinct, rebind_backends=rebind_backends)
 
     with tracer.start_as_current_span("catalog.union") as span:
         span.set_attribute("entries", entries)

--- a/python/xorq/catalog/expr_utils.py
+++ b/python/xorq/catalog/expr_utils.py
@@ -118,6 +118,7 @@ def load_expr_from_zip(
     lazy: bool = False,
     read_only_parquet_metadata: bool = False,
     cache_dir: str | None = None,
+    con_cache: dict | None = None,
 ) -> "Expr":
     from xorq.ibis_yaml.compiler import load_expr  # noqa: PLC0415
 
@@ -135,6 +136,7 @@ def load_expr_from_zip(
             lazy=lazy,
             read_only_parquet_metadata=read_only_parquet_metadata,
             cache_dir=cache_dir,
+            con_cache=con_cache,
         )
     except BaseException:
         _cleanup_one(td)

--- a/python/xorq/catalog/tests/conftest.py
+++ b/python/xorq/catalog/tests/conftest.py
@@ -375,6 +375,24 @@ def catalog_with_source_and_transform(catalog_path):
 
 
 @pytest.fixture
+def catalog_with_two_sources(catalog_path: str) -> tuple[str, str, str]:
+    """Populate a catalog with two independent, joinable/unionable source entries."""
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+
+    left = xo.memtable(
+        {"user_id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}, name="left_source"
+    )
+    left_entry = catalog.add(left, aliases=("left-src",))
+
+    right = xo.memtable(
+        {"user_id": [1, 2, 4], "name": ["a", "b", "d"]}, name="right_source"
+    )
+    right_entry = catalog.add(right, aliases=("right-src",))
+
+    return catalog_path, left_entry.name, right_entry.name
+
+
+@pytest.fixture
 def repo_cloned_bare(catalog_populated, backend_type, tmpdir):
     if backend_type != "annex":
         pytest.skip("repo_cloned_bare requires annex backend")

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import click
+import pandas as pd
 import pyarrow as pa
 import pytest
 from click.testing import CliRunner
@@ -22,6 +23,7 @@ from xorq.catalog.cli import (
     cli,
 )
 from xorq.cli import cli as top_cli
+from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.ibis_yaml.enums import DumpFiles
 
 
@@ -1112,6 +1114,48 @@ def test_catalog_join_command_run_roundtrip(
     assert "name" in result.output
 
 
+def test_catalog_join_command_rebinds_same_profile_file_backed_entries(
+    runner: CliRunner, catalog_path: str, tmp_path: Path
+) -> None:
+    """Two entries reading the *same* file via *separate* `xo.duckdb.connect()`
+    calls: `CatalogEntry.load_expr()` always constructs a fresh connection
+    per call, so this used to always fail regardless of the data being
+    identical -- now fixed by --rebind-backends (on by default)."""
+    pq_path = tmp_path / "shared.parquet"
+    pd.DataFrame({"id": [1, 2, 3], "a": ["x", "y", "z"]}).to_parquet(pq_path)
+
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    left = deferred_read_parquet(pq_path, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(pq_path, xo.duckdb.connect(), table_name="t").rename(
+        b="a"
+    )
+    catalog.add(left, aliases=("left-src",))
+    catalog.add(right, aliases=("right-src",))
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "join",
+            "left-src",
+            "right-src",
+            "--on",
+            "id",
+            "-a",
+            "joined-file-backed",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "run", "joined-file-backed", "-o", "-", "-f", "csv"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "a" in result.output
+    assert "b" in result.output
+
+
 def test_catalog_union_command(runner: CliRunner, catalog_path: str) -> None:
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     jan = xo.memtable({"user_id": [1, 2], "amount": [10.0, 20.0]}, name="jan_source")
@@ -1209,6 +1253,31 @@ def test_join_or_union_bundle_ignore_mismatch_warns_on_python_minor_mismatch(
         with _entry_run_bundle(catalog, ("src", "trn"), ignore_mismatch=True) as bundle:
             pass
     assert bundle.python_version == "3.10"
+
+
+def test_join_or_union_bundle_ignore_mismatch_skips_unpinned_first_entry(
+    catalog_with_source_and_transform: tuple[str, str, str],
+) -> None:
+    """When the *first* entry is unpinned but later entries disagree, the
+    fallback must pick a real pin (not `None`) and name an entry that
+    actually has one -- previously `distinct_pins = {python_pins[0][1]}`
+    collapsed to `{None}` here, producing `JointBundle(python_version=None)`
+    (silently dropping both recorded pins) and a warning claiming the
+    unpinned entry's "environment" was used."""
+    catalog_path, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    third = xo.memtable({"user_id": [1, 2]}, name="extra_source")
+    catalog.add(third, aliases=("extra",))
+
+    with patch(
+        "xorq.ibis_yaml.packager._python_minor_from_metadata_text",
+        side_effect=[None, "3.10", "3.11"],
+    ):
+        with _entry_run_bundle(
+            catalog, ("src", "trn", "extra"), ignore_mismatch=True
+        ) as bundle:
+            pass
+    assert bundle.python_version in {"3.10", "3.11"}
 
 
 # --- _has_expr_modifications ---

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -1141,15 +1141,25 @@ def test_catalog_union_command_requires_two_entries(
 def test_catalog_union_command_schema_mismatch(
     runner: CliRunner, catalog_with_two_sources: tuple[str, str, str]
 ) -> None:
-    """left/right sources have different schemas -- union must fail cleanly."""
+    """left/right sources have different schemas -- union must fail cleanly.
+
+    A nonzero exit code alone would also pass on an uncaught exception
+    escaping past click, so check that it was actually handled cleanly: a
+    handled ClickException surfaces as `result.exception` being the
+    `SystemExit` click raises internally, not the raw exception.
+    """
     catalog_path, left_name, right_name = catalog_with_two_sources
     result = runner.invoke(
         cli, ["--path", catalog_path, "union", left_name, right_name]
     )
     assert result.exit_code != 0
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean ClickException exit, got {result.exception!r}"
+    )
+    assert "schemas must be equal" in result.output.lower()
 
 
-def test_entry_run_bundle_ignore_mismatch_skips_requirements_check(
+def test_join_or_union_bundle_ignore_mismatch_skips_requirements_check(
     catalog_with_source_and_transform: tuple[str, str, str],
 ) -> None:
     catalog_path, _, _ = catalog_with_source_and_transform
@@ -1160,7 +1170,7 @@ def test_entry_run_bundle_ignore_mismatch_skips_requirements_check(
         mock_assert.assert_not_called()
 
 
-def test_entry_run_bundle_default_calls_requirements_check(
+def test_join_or_union_bundle_default_calls_requirements_check(
     catalog_with_source_and_transform: tuple[str, str, str],
 ) -> None:
     catalog_path, _, _ = catalog_with_source_and_transform
@@ -1169,6 +1179,36 @@ def test_entry_run_bundle_default_calls_requirements_check(
         with _entry_run_bundle(catalog, ("src", "trn")):
             pass
         mock_assert.assert_called_once()
+
+
+def test_join_or_union_bundle_python_minor_mismatch_raises_by_default(
+    catalog_with_source_and_transform: tuple[str, str, str],
+) -> None:
+    catalog_path, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    with patch(
+        "xorq.ibis_yaml.packager._python_minor_from_metadata_text",
+        side_effect=["3.10", "3.11"],
+    ):
+        with pytest.raises(click.ClickException, match="different Python minors"):
+            with _entry_run_bundle(catalog, ("src", "trn")):
+                pass
+
+
+def test_join_or_union_bundle_ignore_mismatch_warns_on_python_minor_mismatch(
+    catalog_with_source_and_transform: tuple[str, str, str],
+) -> None:
+    """With ignore_mismatch=True, a Python-minor mismatch downgrades to a
+    WARNING and the bundle is built under the *first* entry's pin."""
+    catalog_path, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    with patch(
+        "xorq.ibis_yaml.packager._python_minor_from_metadata_text",
+        side_effect=["3.10", "3.11"],
+    ):
+        with _entry_run_bundle(catalog, ("src", "trn"), ignore_mismatch=True) as bundle:
+            pass
+    assert bundle.python_version == "3.10"
 
 
 # --- _has_expr_modifications ---

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -1200,6 +1200,74 @@ def test_catalog_join_command_rebinds_into_backend_entry(
     assert "b" in result.output
 
 
+@pytest.mark.parametrize(
+    "left_name,right_name",
+    [
+        pytest.param("duckdb-into-df", "df-into-df", id="duckdb-left"),
+        pytest.param("df-into-df", "duckdb-into-df", id="df-left"),
+    ],
+)
+def test_catalog_join_command_into_backend_mixed_source_backends(
+    runner: CliRunner,
+    catalog_path: str,
+    tmp_path: Path,
+    left_name: str,
+    right_name: str,
+) -> None:
+    """Both entries end up on the xorq hub via `.into_backend()`, but read
+    from *different* source backends first (one duckdb, one already
+    xorq-datafusion) -- and check both argument orderings, since the
+    rebind/merge logic must not care which side is "left"/"right"."""
+    pq_a = tmp_path / "a.parquet"
+    pq_b = tmp_path / "b.parquet"
+    pd.DataFrame({"id": [1, 2, 3], "x": ["x1", "x2", "x3"]}).to_parquet(pq_a)
+    pd.DataFrame({"id": [1, 2, 3], "y": ["y1", "y2", "y3"]}).to_parquet(pq_b)
+
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    duckdb_into_df = deferred_read_parquet(
+        pq_a, xo.duckdb.connect(), table_name="a"
+    ).into_backend(xo.connect(), name="a_remote")
+    df_into_df = deferred_read_parquet(
+        pq_b, xo.connect(), table_name="b"
+    ).into_backend(xo.connect(), name="b_remote")
+    catalog.add(duckdb_into_df, aliases=("duckdb-into-df",))
+    catalog.add(df_into_df, aliases=("df-into-df",))
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "join",
+            left_name,
+            right_name,
+            "--on",
+            "id",
+            "-a",
+            f"joined-{left_name}-{right_name}",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "run",
+            f"joined-{left_name}-{right_name}",
+            "-o",
+            "-",
+            "-f",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "x1" in result.output and "y1" in result.output
+    assert "x2" in result.output and "y2" in result.output
+    assert "x3" in result.output and "y3" in result.output
+
+
 def test_catalog_union_command(runner: CliRunner, catalog_path: str) -> None:
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     jan = xo.memtable({"user_id": [1, 2], "amount": [10.0, 20.0]}, name="jan_source")

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import click
 import pyarrow as pa
 import pytest
 from click.testing import CliRunner
 
+import xorq.api as xo
 from xorq.catalog import cli as cli_mod
 from xorq.catalog.catalog import Catalog
 from xorq.catalog.cli import (
@@ -1045,6 +1048,127 @@ def test_catalog_compose_uv_path_end_to_end(
     assert result.returncode == 0, result.stderr
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     assert catalog.catalog_yaml.contains_alias("e2e-composed")
+
+
+# --- catalog join / union commands ---
+
+
+def test_catalog_join_command(
+    runner: CliRunner, catalog_with_two_sources: tuple[str, str, str]
+) -> None:
+    catalog_path, left_name, right_name = catalog_with_two_sources
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "join",
+            left_name,
+            right_name,
+            "--on",
+            "user_id",
+            "-a",
+            "joined",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    assert catalog.catalog_yaml.contains_alias("joined")
+
+
+def test_catalog_join_command_requires_two_arguments(
+    runner: CliRunner, catalog_with_two_sources: tuple[str, str, str]
+) -> None:
+    catalog_path, left_name, _ = catalog_with_two_sources
+    result = runner.invoke(cli, ["--path", catalog_path, "join", left_name])
+    assert result.exit_code != 0
+
+
+def test_catalog_join_command_run_roundtrip(
+    runner: CliRunner, catalog_with_two_sources: tuple[str, str, str]
+) -> None:
+    catalog_path, left_name, right_name = catalog_with_two_sources
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "join",
+            left_name,
+            right_name,
+            "--on",
+            "user_id",
+            "-a",
+            "joined",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "run", "joined", "-o", "-", "-f", "csv"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "amount" in result.output
+    assert "name" in result.output
+
+
+def test_catalog_union_command(runner: CliRunner, catalog_path: str) -> None:
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    jan = xo.memtable({"user_id": [1, 2], "amount": [10.0, 20.0]}, name="jan_source")
+    feb = xo.memtable({"user_id": [3, 4], "amount": [30.0, 40.0]}, name="feb_source")
+    catalog.add(jan, aliases=("jan",))
+    catalog.add(feb, aliases=("feb",))
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "union", "jan", "feb", "-a", "q1"]
+    )
+    assert result.exit_code == 0, result.output
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    assert catalog.catalog_yaml.contains_alias("q1")
+
+
+def test_catalog_union_command_requires_two_entries(
+    runner: CliRunner, catalog_path: str
+) -> None:
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    jan = xo.memtable({"user_id": [1, 2], "amount": [10.0, 20.0]}, name="jan_source")
+    catalog.add(jan, aliases=("jan",))
+
+    result = runner.invoke(cli, ["--path", catalog_path, "union", "jan"])
+    assert result.exit_code != 0
+
+
+def test_catalog_union_command_schema_mismatch(
+    runner: CliRunner, catalog_with_two_sources: tuple[str, str, str]
+) -> None:
+    """left/right sources have different schemas -- union must fail cleanly."""
+    catalog_path, left_name, right_name = catalog_with_two_sources
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "union", left_name, right_name]
+    )
+    assert result.exit_code != 0
+
+
+def test_entry_run_bundle_ignore_mismatch_skips_requirements_check(
+    catalog_with_source_and_transform: tuple[str, str, str],
+) -> None:
+    catalog_path, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    with patch.object(cli_mod, "_assert_requirements_identical") as mock_assert:
+        with _entry_run_bundle(catalog, ("src", "trn"), ignore_mismatch=True):
+            pass
+        mock_assert.assert_not_called()
+
+
+def test_entry_run_bundle_default_calls_requirements_check(
+    catalog_with_source_and_transform: tuple[str, str, str],
+) -> None:
+    catalog_path, _, _ = catalog_with_source_and_transform
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    with patch.object(cli_mod, "_assert_requirements_identical") as mock_assert:
+        with _entry_run_bundle(catalog, ("src", "trn")):
+            pass
+        mock_assert.assert_called_once()
 
 
 # --- _has_expr_modifications ---

--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -1156,6 +1156,50 @@ def test_catalog_join_command_rebinds_same_profile_file_backed_entries(
     assert "b" in result.output
 
 
+def test_catalog_join_command_rebinds_into_backend_entry(
+    runner: CliRunner, catalog_path: str, tmp_path: Path
+) -> None:
+    """One entry reads a file directly on the xorq hub (`xo.connect()`); the
+    other reads it via duckdb and `.into_backend()`s onto a *separate*
+    `xo.connect()` instance -- same profile as the first entry's hub, but a
+    distinct connection object once each entry is loaded independently.
+    `.into_backend()` is lazy (no registration until execution), so this is
+    exactly as rebind-eligible as two plain same-profile reads."""
+    pq_path = tmp_path / "shared.parquet"
+    pd.DataFrame({"id": [1, 2, 3], "a": ["x", "y", "z"]}).to_parquet(pq_path)
+
+    catalog = Catalog.from_kwargs(path=catalog_path, init=False)
+    left = deferred_read_parquet(pq_path, xo.connect(), table_name="t")
+    right = deferred_read_parquet(
+        pq_path, xo.duckdb.connect(), table_name="t"
+    ).rename(b="a").into_backend(xo.connect(), name="t_remote")
+    catalog.add(left, aliases=("hub-left",))
+    catalog.add(right, aliases=("into-backend-right",))
+
+    result = runner.invoke(
+        cli,
+        [
+            "--path",
+            catalog_path,
+            "join",
+            "hub-left",
+            "into-backend-right",
+            "--on",
+            "id",
+            "-a",
+            "joined-into-backend",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "run", "joined-into-backend", "-o", "-", "-f", "csv"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "a" in result.output
+    assert "b" in result.output
+
+
 def test_catalog_union_command(runner: CliRunner, catalog_path: str) -> None:
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     jan = xo.memtable({"user_id": [1, 2], "amount": [10.0, 20.0]}, name="jan_source")

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -434,6 +434,15 @@ def _check_library_version_match(
         raise click.ClickException(f"cannot read build metadata: {e}") from e
 
 
+def _emit_combine_result(
+    kind: str, build_path: Path, emit_build_path_to: str | None
+) -> None:
+    click.echo(f"Written {kind} result to {build_path}", err=True)
+    if emit_build_path_to:
+        Path(emit_build_path_to).write_text(str(build_path))
+    click.echo(str(build_path))
+
+
 @_lazy_span("cli.join_command")
 def join_command(
     left_path: str,
@@ -474,10 +483,7 @@ def join_command(
             rebind_backends=rebind_backends,
         )
 
-    click.echo(f"Written join result to {build_path}", err=True)
-    if emit_build_path_to:
-        Path(emit_build_path_to).write_text(str(build_path))
-    click.echo(str(build_path))
+    _emit_combine_result("join", build_path, emit_build_path_to)
 
 
 @_lazy_span("cli.union_command")
@@ -508,10 +514,7 @@ def union_command(
             rebind_backends=rebind_backends,
         )
 
-    click.echo(f"Written union result to {build_path}", err=True)
-    if emit_build_path_to:
-        Path(emit_build_path_to).write_text(str(build_path))
-    click.echo(str(build_path))
+    _emit_combine_result("union", build_path, emit_build_path_to)
 
 
 @_lazy_span("cli.run_cached_command")

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc
 import contextlib
 import datetime
+import json
 import os
 import pdb
 import sys
@@ -26,6 +27,7 @@ from xorq.cli_options import (
     limit_option,
     output_options,
     params_option,
+    rebind_backends_option,
     relocate_reads_option,
     serve_options,
     unbind_options,
@@ -428,6 +430,8 @@ def _check_library_version_match(
         assert_matching_library_versions(*build_paths)
     except BuildVersionMismatchError as e:
         raise click.ClickException(str(e)) from e
+    except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
+        raise click.ClickException(f"cannot read build metadata: {e}") from e
 
 
 @_lazy_span("cli.join_command")
@@ -444,6 +448,7 @@ def join_command(
     cache_dir: str | None = None,
     relocate_reads: bool = True,
     ignore_library_version_mismatch: bool = False,
+    rebind_backends: bool = True,
     emit_build_path_to: str | None = None,
 ) -> None:
     """Join two build artifacts into a new build artifact."""
@@ -466,6 +471,7 @@ def join_command(
             how=how,
             lname=lname,
             rname=rname,
+            rebind_backends=rebind_backends,
         )
 
     click.echo(f"Written join result to {build_path}", err=True)
@@ -482,6 +488,7 @@ def union_command(
     cache_dir: str | None = None,
     relocate_reads: bool = True,
     ignore_library_version_mismatch: bool = False,
+    rebind_backends: bool = True,
     emit_build_path_to: str | None = None,
 ) -> None:
     """Union two-or-more build artifacts into a new build artifact."""
@@ -498,6 +505,7 @@ def union_command(
             builds_dir=builds_dir,
             relocate_reads=relocate_reads,
             distinct=distinct,
+            rebind_backends=rebind_backends,
         )
 
     click.echo(f"Written union result to {build_path}", err=True)
@@ -1275,6 +1283,7 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
 @cache_dir_option
 @relocate_reads_option()
 @ignore_library_version_mismatch_option
+@rebind_backends_option
 @emit_build_path_option
 def join(
     left_path: str,
@@ -1289,6 +1298,7 @@ def join(
     cache_dir: str | None,
     relocate_reads: bool,
     ignore_library_version_mismatch: bool,
+    rebind_backends: bool,
     emit_build_path_to: str | None,
 ) -> None:
     """Join two build artifacts into a new build artifact.
@@ -1323,6 +1333,7 @@ def join(
             cache_dir=cache_dir,
             relocate_reads=relocate_reads,
             ignore_library_version_mismatch=ignore_library_version_mismatch,
+            rebind_backends=rebind_backends,
             emit_build_path_to=emit_build_path_to,
         )
 
@@ -1344,6 +1355,7 @@ def join(
 @cache_dir_option
 @relocate_reads_option()
 @ignore_library_version_mismatch_option
+@rebind_backends_option
 @emit_build_path_option
 def union(
     paths: tuple[str, ...],
@@ -1352,6 +1364,7 @@ def union(
     cache_dir: str | None,
     relocate_reads: bool,
     ignore_library_version_mismatch: bool,
+    rebind_backends: bool,
     emit_build_path_to: str | None,
 ) -> None:
     """Union two-or-more build artifacts into a new build artifact.
@@ -1381,6 +1394,7 @@ def union(
             cache_dir=cache_dir,
             relocate_reads=relocate_reads,
             ignore_library_version_mismatch=ignore_library_version_mismatch,
+            rebind_backends=rebind_backends,
             emit_build_path_to=emit_build_path_to,
         )
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -19,7 +19,10 @@ from xorq.cli_options import (
     apply_in_help_order,
     cache_dir_option,
     cache_strategy_options,
+    emit_build_path_option,
     ensure_materialized_option,
+    ignore_library_version_mismatch_option,
+    join_predicate_options,
     limit_option,
     output_options,
     params_option,
@@ -413,10 +416,10 @@ def run_command(
         raise
 
 
-def _check_venv_match(
-    build_paths: collections.abc.Sequence[str], ignore_venv_mismatch: bool
+def _check_library_version_match(
+    build_paths: collections.abc.Sequence[str], ignore_library_version_mismatch: bool
 ) -> None:
-    if ignore_venv_mismatch:
+    if ignore_library_version_mismatch:
         return
     from xorq.common.exceptions import BuildVersionMismatchError  # noqa: PLC0415
     from xorq.ibis_yaml.combine import assert_matching_library_versions  # noqa: PLC0415
@@ -440,18 +443,17 @@ def join_command(
     builds_dir: str = "builds",
     cache_dir: str | None = None,
     relocate_reads: bool = True,
-    ignore_venv_mismatch: bool = False,
+    ignore_library_version_mismatch: bool = False,
     emit_build_path_to: str | None = None,
 ) -> None:
     """Join two build artifacts into a new build artifact."""
-    from xorq.common.exceptions import RelationError  # noqa: PLC0415
-    from xorq.ibis_yaml.combine import join_builds  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import combine_errors, join_builds  # noqa: PLC0415
 
     cache_dir = _get_cache_dir(cache_dir)
-    _check_venv_match((left_path, right_path), ignore_venv_mismatch)
+    _check_library_version_match((left_path, right_path), ignore_library_version_mismatch)
 
     click.echo(f"Joining {left_path} and {right_path} (how={how})", err=True)
-    try:
+    with combine_errors():
         build_path = join_builds(
             left_path,
             right_path,
@@ -465,10 +467,6 @@ def join_command(
             lname=lname,
             rname=rname,
         )
-    except ValueError as e:
-        raise click.BadParameter(str(e)) from None
-    except RelationError as e:
-        raise click.ClickException(str(e)) from e
 
     click.echo(f"Written join result to {build_path}", err=True)
     if emit_build_path_to:
@@ -483,18 +481,17 @@ def union_command(
     builds_dir: str = "builds",
     cache_dir: str | None = None,
     relocate_reads: bool = True,
-    ignore_venv_mismatch: bool = False,
+    ignore_library_version_mismatch: bool = False,
     emit_build_path_to: str | None = None,
 ) -> None:
     """Union two-or-more build artifacts into a new build artifact."""
-    from xorq.common.exceptions import RelationError  # noqa: PLC0415
-    from xorq.ibis_yaml.combine import union_builds  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import combine_errors, union_builds  # noqa: PLC0415
 
     cache_dir = _get_cache_dir(cache_dir)
-    _check_venv_match(paths, ignore_venv_mismatch)
+    _check_library_version_match(paths, ignore_library_version_mismatch)
 
     click.echo(f"Unioning {', '.join(str(p) for p in paths)}", err=True)
-    try:
+    with combine_errors():
         build_path = union_builds(
             *paths,
             cache_dir=Path(cache_dir),
@@ -502,10 +499,6 @@ def union_command(
             relocate_reads=relocate_reads,
             distinct=distinct,
         )
-    except ValueError as e:
-        raise click.BadParameter(str(e)) from None
-    except RelationError as e:
-        raise click.ClickException(str(e)) from e
 
     click.echo(f"Written union result to {build_path}", err=True)
     if emit_build_path_to:
@@ -971,16 +964,7 @@ def uv_group(ctx):
     help="Output SQL files and other debug artifacts.",
 )
 @relocate_reads_option()
-@click.option(
-    "--emit-build-path-to",
-    type=click.Path(),
-    default=None,
-    help=(
-        "Write the resulting build directory path to this file. Use when "
-        "stdout may be polluted (for example by OTel console fallback) and a "
-        "subprocess consumer needs the path unambiguously."
-    ),
-)
+@emit_build_path_option
 def uv_build(
     script_path: str,
     expr_name: str,
@@ -1209,16 +1193,7 @@ def uv_run_unbound(
     help="Output SQL files and other debug artifacts.",
 )
 @relocate_reads_option()
-@click.option(
-    "--emit-build-path-to",
-    type=click.Path(),
-    default=None,
-    help=(
-        "Write the resulting build directory path to this file. Use when "
-        "stdout may be polluted (for example by OTel console fallback) and a "
-        "subprocess consumer needs the path unambiguously."
-    ),
-)
+@emit_build_path_option
 def build(
     script_path: str,
     expr_name: str,
@@ -1290,40 +1265,7 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
 @cli.command("join")
 @click.argument("left_path")
 @click.argument("right_path")
-@click.option(
-    "--on",
-    default=None,
-    help="Comma-separated column(s) present in both tables to join on.",
-)
-@click.option(
-    "--left-on",
-    default=None,
-    help="Comma-separated left-table columns (paired with --right-on).",
-)
-@click.option(
-    "--right-on",
-    default=None,
-    help="Comma-separated right-table columns (paired with --left-on).",
-)
-@click.option(
-    "--how",
-    type=click.Choice(("inner", "left", "right", "outer", "semi", "anti", "cross")),
-    default="inner",
-    show_default=True,
-    help="Join method.",
-)
-@click.option(
-    "--lname",
-    default="",
-    show_default=True,
-    help="Rename format string for overlapping left columns.",
-)
-@click.option(
-    "--rname",
-    default="{name}_right",
-    show_default=True,
-    help="Rename format string for overlapping right columns.",
-)
+@join_predicate_options(noun="table")
 @click.option(
     "--builds-dir",
     default="builds",
@@ -1332,22 +1274,8 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
 )
 @cache_dir_option
 @relocate_reads_option()
-@click.option(
-    "--ignore-venv-mismatch",
-    is_flag=True,
-    default=False,
-    help="Proceed even if the two builds recorded different xorq library versions.",
-)
-@click.option(
-    "--emit-build-path-to",
-    type=click.Path(),
-    default=None,
-    help=(
-        "Write the resulting build directory path to this file. Use when "
-        "stdout may be polluted (for example by OTel console fallback) and a "
-        "subprocess consumer needs the path unambiguously."
-    ),
-)
+@ignore_library_version_mismatch_option
+@emit_build_path_option
 def join(
     left_path: str,
     right_path: str,
@@ -1360,7 +1288,7 @@ def join(
     builds_dir: str,
     cache_dir: str | None,
     relocate_reads: bool,
-    ignore_venv_mismatch: bool,
+    ignore_library_version_mismatch: bool,
     emit_build_path_to: str | None,
 ) -> None:
     """Join two build artifacts into a new build artifact.
@@ -1394,7 +1322,7 @@ def join(
             builds_dir=builds_dir,
             cache_dir=cache_dir,
             relocate_reads=relocate_reads,
-            ignore_venv_mismatch=ignore_venv_mismatch,
+            ignore_library_version_mismatch=ignore_library_version_mismatch,
             emit_build_path_to=emit_build_path_to,
         )
 
@@ -1415,29 +1343,15 @@ def join(
 )
 @cache_dir_option
 @relocate_reads_option()
-@click.option(
-    "--ignore-venv-mismatch",
-    is_flag=True,
-    default=False,
-    help="Proceed even if the builds recorded different xorq library versions.",
-)
-@click.option(
-    "--emit-build-path-to",
-    type=click.Path(),
-    default=None,
-    help=(
-        "Write the resulting build directory path to this file. Use when "
-        "stdout may be polluted (for example by OTel console fallback) and a "
-        "subprocess consumer needs the path unambiguously."
-    ),
-)
+@ignore_library_version_mismatch_option
+@emit_build_path_option
 def union(
     paths: tuple[str, ...],
     distinct: bool,
     builds_dir: str,
     cache_dir: str | None,
     relocate_reads: bool,
-    ignore_venv_mismatch: bool,
+    ignore_library_version_mismatch: bool,
     emit_build_path_to: str | None,
 ) -> None:
     """Union two-or-more build artifacts into a new build artifact.
@@ -1466,7 +1380,7 @@ def union(
             builds_dir=builds_dir,
             cache_dir=cache_dir,
             relocate_reads=relocate_reads,
-            ignore_venv_mismatch=ignore_venv_mismatch,
+            ignore_library_version_mismatch=ignore_library_version_mismatch,
             emit_build_path_to=emit_build_path_to,
         )
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -413,6 +413,106 @@ def run_command(
         raise
 
 
+def _check_venv_match(
+    build_paths: collections.abc.Sequence[str], ignore_venv_mismatch: bool
+) -> None:
+    if ignore_venv_mismatch:
+        return
+    from xorq.common.exceptions import BuildVersionMismatchError  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import assert_matching_library_versions  # noqa: PLC0415
+
+    try:
+        assert_matching_library_versions(*build_paths)
+    except BuildVersionMismatchError as e:
+        raise click.ClickException(str(e)) from e
+
+
+@_lazy_span("cli.join_command")
+def join_command(
+    left_path: str,
+    right_path: str,
+    on: str | None = None,
+    left_on: str | None = None,
+    right_on: str | None = None,
+    how: str = "inner",
+    lname: str = "",
+    rname: str = "{name}_right",
+    builds_dir: str = "builds",
+    cache_dir: str | None = None,
+    relocate_reads: bool = True,
+    ignore_venv_mismatch: bool = False,
+    emit_build_path_to: str | None = None,
+) -> None:
+    """Join two build artifacts into a new build artifact."""
+    from xorq.common.exceptions import RelationError  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import join_builds  # noqa: PLC0415
+
+    cache_dir = _get_cache_dir(cache_dir)
+    _check_venv_match((left_path, right_path), ignore_venv_mismatch)
+
+    click.echo(f"Joining {left_path} and {right_path} (how={how})", err=True)
+    try:
+        build_path = join_builds(
+            left_path,
+            right_path,
+            cache_dir=Path(cache_dir),
+            builds_dir=builds_dir,
+            relocate_reads=relocate_reads,
+            on=on,
+            left_on=left_on,
+            right_on=right_on,
+            how=how,
+            lname=lname,
+            rname=rname,
+        )
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from None
+    except RelationError as e:
+        raise click.ClickException(str(e)) from e
+
+    click.echo(f"Written join result to {build_path}", err=True)
+    if emit_build_path_to:
+        Path(emit_build_path_to).write_text(str(build_path))
+    click.echo(str(build_path))
+
+
+@_lazy_span("cli.union_command")
+def union_command(
+    paths: collections.abc.Sequence[str],
+    distinct: bool = False,
+    builds_dir: str = "builds",
+    cache_dir: str | None = None,
+    relocate_reads: bool = True,
+    ignore_venv_mismatch: bool = False,
+    emit_build_path_to: str | None = None,
+) -> None:
+    """Union two-or-more build artifacts into a new build artifact."""
+    from xorq.common.exceptions import RelationError  # noqa: PLC0415
+    from xorq.ibis_yaml.combine import union_builds  # noqa: PLC0415
+
+    cache_dir = _get_cache_dir(cache_dir)
+    _check_venv_match(paths, ignore_venv_mismatch)
+
+    click.echo(f"Unioning {', '.join(str(p) for p in paths)}", err=True)
+    try:
+        build_path = union_builds(
+            *paths,
+            cache_dir=Path(cache_dir),
+            builds_dir=builds_dir,
+            relocate_reads=relocate_reads,
+            distinct=distinct,
+        )
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from None
+    except RelationError as e:
+        raise click.ClickException(str(e)) from e
+
+    click.echo(f"Written union result to {build_path}", err=True)
+    if emit_build_path_to:
+        Path(emit_build_path_to).write_text(str(build_path))
+    click.echo(str(build_path))
+
+
 @_lazy_span("cli.run_cached_command")
 def run_cached_command(
     expr_path,
@@ -1185,6 +1285,190 @@ def run(build_path, cache_dir, output_path, output_format, limit, raw_params):
     """
     with maybe_unzip(build_path) as p:
         run_command(p, output_path, output_format, cache_dir, limit, raw_params)
+
+
+@cli.command("join")
+@click.argument("left_path")
+@click.argument("right_path")
+@click.option(
+    "--on",
+    default=None,
+    help="Comma-separated column(s) present in both tables to join on.",
+)
+@click.option(
+    "--left-on",
+    default=None,
+    help="Comma-separated left-table columns (paired with --right-on).",
+)
+@click.option(
+    "--right-on",
+    default=None,
+    help="Comma-separated right-table columns (paired with --left-on).",
+)
+@click.option(
+    "--how",
+    type=click.Choice(("inner", "left", "right", "outer", "semi", "anti", "cross")),
+    default="inner",
+    show_default=True,
+    help="Join method.",
+)
+@click.option(
+    "--lname",
+    default="",
+    show_default=True,
+    help="Rename format string for overlapping left columns.",
+)
+@click.option(
+    "--rname",
+    default="{name}_right",
+    show_default=True,
+    help="Rename format string for overlapping right columns.",
+)
+@click.option(
+    "--builds-dir",
+    default="builds",
+    show_default=True,
+    help="Directory for the generated build artifact.",
+)
+@cache_dir_option
+@relocate_reads_option()
+@click.option(
+    "--ignore-venv-mismatch",
+    is_flag=True,
+    default=False,
+    help="Proceed even if the two builds recorded different xorq library versions.",
+)
+@click.option(
+    "--emit-build-path-to",
+    type=click.Path(),
+    default=None,
+    help=(
+        "Write the resulting build directory path to this file. Use when "
+        "stdout may be polluted (for example by OTel console fallback) and a "
+        "subprocess consumer needs the path unambiguously."
+    ),
+)
+def join(
+    left_path: str,
+    right_path: str,
+    on: str | None,
+    left_on: str | None,
+    right_on: str | None,
+    how: str,
+    lname: str,
+    rname: str,
+    builds_dir: str,
+    cache_dir: str | None,
+    relocate_reads: bool,
+    ignore_venv_mismatch: bool,
+    emit_build_path_to: str | None,
+) -> None:
+    """Join two build artifacts into a new build artifact.
+
+    Loads both builds, joins them with the given predicate and join method,
+    and writes the result as a new build artifact. Execute it later with
+    `xorq run`, or add it to a catalog with `xorq catalog add`.
+
+    \b
+    Arguments:
+      LEFT_PATH   Path to the left build directory.
+      RIGHT_PATH  Path to the right build directory.
+
+    \b
+    Examples:
+      # Inner-join two builds on a shared column
+      xorq join builds/left builds/right --on id
+      # Left join on differently-named columns
+      xorq join builds/left builds/right --left-on user_id --right-on id --how left
+    """
+    with maybe_unzip(left_path) as lp, maybe_unzip(right_path) as rp:
+        join_command(
+            lp,
+            rp,
+            on=on,
+            left_on=left_on,
+            right_on=right_on,
+            how=how,
+            lname=lname,
+            rname=rname,
+            builds_dir=builds_dir,
+            cache_dir=cache_dir,
+            relocate_reads=relocate_reads,
+            ignore_venv_mismatch=ignore_venv_mismatch,
+            emit_build_path_to=emit_build_path_to,
+        )
+
+
+@cli.command("union")
+@click.argument("paths", nargs=-1)
+@click.option(
+    "--distinct",
+    is_flag=True,
+    default=False,
+    help="Deduplicate rows (default is union-all).",
+)
+@click.option(
+    "--builds-dir",
+    default="builds",
+    show_default=True,
+    help="Directory for the generated build artifact.",
+)
+@cache_dir_option
+@relocate_reads_option()
+@click.option(
+    "--ignore-venv-mismatch",
+    is_flag=True,
+    default=False,
+    help="Proceed even if the builds recorded different xorq library versions.",
+)
+@click.option(
+    "--emit-build-path-to",
+    type=click.Path(),
+    default=None,
+    help=(
+        "Write the resulting build directory path to this file. Use when "
+        "stdout may be polluted (for example by OTel console fallback) and a "
+        "subprocess consumer needs the path unambiguously."
+    ),
+)
+def union(
+    paths: tuple[str, ...],
+    distinct: bool,
+    builds_dir: str,
+    cache_dir: str | None,
+    relocate_reads: bool,
+    ignore_venv_mismatch: bool,
+    emit_build_path_to: str | None,
+) -> None:
+    """Union two-or-more build artifacts into a new build artifact.
+
+    Loads all builds, unions them (they must share an identical schema), and
+    writes the result as a new build artifact.
+
+    \b
+    Arguments:
+      PATHS  Two or more build directory paths to union.
+
+    \b
+    Examples:
+      # Union-all (the default) two builds
+      xorq union builds/a builds/b
+      # Deduplicate rows across three builds
+      xorq union builds/a builds/b builds/c --distinct
+    """
+    if len(paths) < 2:
+        raise click.UsageError("At least two paths are required.")
+    with contextlib.ExitStack() as stack:
+        unzipped = tuple(stack.enter_context(maybe_unzip(p)) for p in paths)
+        union_command(
+            unzipped,
+            distinct=distinct,
+            builds_dir=builds_dir,
+            cache_dir=cache_dir,
+            relocate_reads=relocate_reads,
+            ignore_venv_mismatch=ignore_venv_mismatch,
+            emit_build_path_to=emit_build_path_to,
+        )
 
 
 def raise_for_missing_relocation_source(

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -121,6 +121,83 @@ ensure_materialized_option = click.option(
 )
 
 
+emit_build_path_option = click.option(
+    "--emit-build-path-to",
+    type=click.Path(),
+    default=None,
+    help=(
+        "Write the resulting build directory path to this file. Use when "
+        "stdout may be polluted (for example by OTel console fallback) and a "
+        "subprocess consumer needs the path unambiguously."
+    ),
+)
+
+
+# Shared by `xorq join` and `xorq catalog join` so the predicate flags stay
+# identical across both tiers. Only the noun (build vs catalog entry) varies.
+def join_predicate_options(noun: str = "table") -> Callable[[_F], _F]:
+    noun_plural = f"{noun[:-1]}ies" if noun.endswith("y") else f"{noun}s"
+
+    def decorator(fn: _F) -> _F:
+        return apply_in_help_order(
+            fn,
+            click.option(
+                "--on",
+                default=None,
+                help=f"Comma-separated column(s) present in both {noun_plural} to join on.",
+            ),
+            click.option(
+                "--left-on",
+                default=None,
+                help=f"Comma-separated left-{noun} columns (paired with --right-on).",
+            ),
+            click.option(
+                "--right-on",
+                default=None,
+                help=f"Comma-separated right-{noun} columns (paired with --left-on).",
+            ),
+            click.option(
+                "--how",
+                type=click.Choice(
+                    ("inner", "left", "right", "outer", "semi", "anti", "cross")
+                ),
+                default="inner",
+                show_default=True,
+                help="Join method.",
+            ),
+            click.option(
+                "--lname",
+                default="",
+                show_default=True,
+                help="Rename format string for overlapping left columns.",
+            ),
+            click.option(
+                "--rname",
+                default="{name}_right",
+                show_default=True,
+                help="Rename format string for overlapping right columns.",
+            ),
+        )
+
+    return decorator
+
+
+ignore_library_version_mismatch_option = click.option(
+    "--ignore-library-version-mismatch",
+    is_flag=True,
+    default=False,
+    help="Proceed even if the builds recorded different xorq library versions.",
+)
+
+
+ignore_venv_mismatch_option = click.option(
+    "--ignore-venv-mismatch",
+    is_flag=True,
+    default=False,
+    help="Proceed even if the entries' wheel requirements or Python minor differ.",
+)
+
+
 def cache_strategy_options(fn):
     fn = click.option(
         "--ttl",

--- a/python/xorq/cli_options.py
+++ b/python/xorq/cli_options.py
@@ -198,6 +198,18 @@ ignore_venv_mismatch_option = click.option(
 )
 
 
+# Shared by `xorq join`/`union` and `xorq catalog join`/`union`.
+rebind_backends_option = click.option(
+    "--rebind-backends/--no-rebind-backends",
+    default=True,
+    show_default=True,
+    help=(
+        "In multi-root mode, rebind same-profile backend sources to one "
+        "backend before execution. Never transfers table data."
+    ),
+)
+
+
 def cache_strategy_options(fn):
     fn = click.option(
         "--ttl",

--- a/python/xorq/common/exceptions.py
+++ b/python/xorq/common/exceptions.py
@@ -62,6 +62,10 @@ class UnboundExpressionError(ValueError, XorqError):
     """UnboundExpressionError."""
 
 
+class BuildVersionMismatchError(ValueError, XorqError):
+    """Raised when combining build artifacts recorded under different xorq library versions."""
+
+
 class NormalizeMethodError(TranslationError):
     """A Read's normalize_method could not be resolved by name (see #2155)."""
 

--- a/python/xorq/common/utils/graph_utils.py
+++ b/python/xorq/common/utils/graph_utils.py
@@ -725,6 +725,29 @@ def exclusively_pinned_leaves(
     return frozenset(under_pin - live)
 
 
+# Every node type that carries a backend-bearing `.source` (or, for
+# TeeNode, `.writer.cons`). Single source of truth for "what can hold a
+# backend" -- consumers that need to reason about backend-bearing nodes
+# individually (not just get the deduplicated sources, like find_all_sources
+# does) must walk this same tuple rather than keep their own copy: a second,
+# hand-maintained list silently stops covering a node type added here later,
+# which is a fail-*open* bug (the omitted type's backend looks untouched by
+# anything, instead of looking untouched-by-nothing-we-checked).
+BACKEND_LEAF_NODE_TYPES = (
+    ops.DatabaseTable,
+    ops.SQLQueryResult,
+    rel.CachedNode,
+    rel.Read,
+    rel.RemoteTable,
+    rel.FlightUDXF,
+    rel.FlightExpr,
+    # TeeNode holds its write target's backend(s) inside its writer
+    rel.TeeNode,
+    # ExprScalarUDF has an expr we need to get to
+    # FlightOperator has a dynamically generated connection: it should be passed a Profile instead
+)
+
+
 def find_all_sources(
     expr: Expr | Node, *, execution_only: bool = False
 ) -> Tuple[Any, ...]:
@@ -743,20 +766,7 @@ def find_all_sources(
     shared between ``uncached`` and a live branch is still found via the live
     branch.
     """
-    node_types = (
-        ops.DatabaseTable,
-        ops.SQLQueryResult,
-        rel.CachedNode,
-        rel.Read,
-        rel.RemoteTable,
-        rel.FlightUDXF,
-        rel.FlightExpr,
-        # TeeNode holds its write target's backend(s) inside its writer
-        rel.TeeNode,
-        # ExprScalarUDF has an expr we need to get to
-        # FlightOperator has a dynamically generated connection: it should be passed a Profile instead
-    )
     gen_children = _gen_children_exec if execution_only else gen_children_of
-    nodes = walk_nodes(node_types, expr, gen_children=gen_children)
+    nodes = walk_nodes(BACKEND_LEAF_NODE_TYPES, expr, gen_children=gen_children)
     sources = get_ordered_unique_sources(nodes)
     return sources

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -300,8 +300,15 @@ def join_builds(
     """Load two build artifacts, join them, and write the result as a new build."""
     from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
 
-    left = load_expr(left_path, cache_dir=cache_dir)
-    right = load_expr(right_path, cache_dir=cache_dir)
+    # Shared so a same-profile connection in both builds is one object from
+    # the moment each is loaded, not two independently-constructed ones that
+    # `join_exprs`'s rebind then has to reconcile after the fact. Gated on
+    # rebind_backends -- same policy toggle, applied proactively here instead
+    # of reactively in `join_exprs` -- so `--no-rebind-backends` still gets
+    # the fully-isolated-connections behavior it promises.
+    con_cache: dict | None = {} if rebind_backends else None
+    left = load_expr(left_path, cache_dir=cache_dir, con_cache=con_cache)
+    right = load_expr(right_path, cache_dir=cache_dir, con_cache=con_cache)
     expr = join_exprs(
         left, right, on=on, left_on=left_on, right_on=right_on, how=how,
         lname=lname, rname=rname, rebind_backends=rebind_backends,
@@ -322,7 +329,10 @@ def union_builds(
     """Load two-or-more build artifacts, union them, and write the result as a new build."""
     from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
 
-    exprs: Sequence[Expr] = [load_expr(path, cache_dir=cache_dir) for path in paths]
+    con_cache: dict | None = {} if rebind_backends else None
+    exprs: Sequence[Expr] = [
+        load_expr(path, cache_dir=cache_dir, con_cache=con_cache) for path in paths
+    ]
     expr = union_exprs(*exprs, distinct=distinct, rebind_backends=rebind_backends)
     return build_expr(
         expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -158,13 +158,13 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
     ValueError.
     """
     import xorq.expr.relations as rel  # noqa: PLC0415
-    from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
     from xorq.common.utils.graph_utils import (  # noqa: PLC0415
         BACKEND_LEAF_NODE_TYPES,
         find_all_sources,
         replace_sources,
         walk_nodes,
     )
+    from xorq.ibis_yaml.compiler import profile_content_key  # noqa: PLC0415
 
     # Walk the same node-type list find_all_sources uses (not a hand-copied
     # subset) so a future backend-bearing leaf type is unsafe by default --
@@ -188,8 +188,9 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
         return exprs
 
     def content_key(backend):
-        profile = backend._profile  # xorq-style: disable=protected-access
-        return tokenize({k: v for k, v in profile.as_dict().items() if k != "idx"})
+        return profile_content_key(
+            backend._profile  # xorq-style: disable=protected-access
+        )
 
     groups: dict[str, list] = {}
     for backend in backends:

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -158,28 +158,23 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
     ValueError.
     """
     import xorq.expr.relations as rel  # noqa: PLC0415
-    import xorq.vendor.ibis.expr.operations as ops  # noqa: PLC0415
     from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
     from xorq.common.utils.graph_utils import (  # noqa: PLC0415
+        BACKEND_LEAF_NODE_TYPES,
         find_all_sources,
         replace_sources,
         walk_nodes,
     )
 
+    # Walk the same node-type list find_all_sources uses (not a hand-copied
+    # subset) so a future backend-bearing leaf type is unsafe by default --
+    # added there, it's excluded here automatically -- rather than silently
+    # skipping this exclusion check until someone remembers to update both.
     safe_node_types = (rel.Read, rel.RemoteTable)
-    backend_node_types = (
-        ops.DatabaseTable,
-        ops.SQLQueryResult,
-        rel.CachedNode,
-        *safe_node_types,
-        rel.FlightUDXF,
-        rel.FlightExpr,
-        rel.TeeNode,
-    )
     unsafe_ids = {
         id(source)
         for expr in exprs
-        for node in walk_nodes(backend_node_types, expr)
+        for node in walk_nodes(BACKEND_LEAF_NODE_TYPES, expr)
         if not isinstance(node, safe_node_types)
         for source in (
             node.writer.cons if isinstance(node, rel.TeeNode) else (node.source,)

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -29,18 +29,36 @@ def combine_errors() -> "Iterator[None]":
     """Map `join_exprs`/`union_exprs`'s exceptions to clean CLI errors.
 
     Shared by both CLI tiers (`xorq join`/`union` and `xorq catalog
-    join`/`union`) so the ValueError/RelationError -> click mapping can't
-    drift out of sync between call sites the way it already had (catalog
-    `join` was missing the `RelationError` arm `union` had).
+    join`/`union`) so this mapping can't drift out of sync between call
+    sites the way it already had (catalog `join` was missing the
+    `RelationError` arm `union` had). Covers the exceptions actually
+    observed escaping `join_exprs`/`union_exprs` uncaught:
+    - `ValueError`/`XorqTypeError`: bad user input (a malformed predicate
+      spec, a typo'd `--on`/`--left-on`/`--right-on` column -- the latter
+      raises `XorqTypeError`, a `TypeError` subclass, not `ValueError`).
+    - `RelationError`/`IntegrityError`: the join/union is well-formed but
+      the tables don't fit together (schema mismatch, or an lname/rname
+      collision left unresolved).
+    - `KeyError`: an `--lname`/`--rname` template referencing a field that
+      doesn't exist (e.g. `--rname "{bogus}"` raises `KeyError('bogus')`
+      from the bare `str.format` call inside ibis's join disambiguation).
     """
-    from xorq.common.exceptions import RelationError  # noqa: PLC0415
+    from xorq.common.exceptions import (  # noqa: PLC0415
+        IntegrityError,
+        RelationError,
+        XorqTypeError,
+    )
 
     try:
         yield
-    except ValueError as e:
+    except (ValueError, XorqTypeError) as e:
         raise click.BadParameter(str(e)) from None
-    except RelationError as e:
+    except (RelationError, IntegrityError) as e:
         raise click.ClickException(str(e)) from e
+    except KeyError as e:
+        raise click.BadParameter(
+            f"unknown placeholder {e} in --lname/--rname template"
+        ) from None
 
 
 def _split_columns(value: str) -> tuple[str, ...]:
@@ -59,12 +77,26 @@ def _build_join_predicates(
     if (left_on is None) != (right_on is None):
         raise ValueError("--left-on and --right-on must be given together")
 
+    if how == "cross":
+        if on is not None or left_on is not None:
+            raise ValueError(
+                "--how=cross takes no predicates; omit --on/--left-on/--right-on"
+            )
+        return ()
+
     if on is not None:
-        return _split_columns(on)
+        columns = _split_columns(on)
+        if not columns:
+            raise ValueError("--on must name at least one non-empty column")
+        return columns
 
     if left_on is not None:
         left_cols = _split_columns(left_on)
         right_cols = _split_columns(right_on)
+        if not left_cols or not right_cols:
+            raise ValueError(
+                "--left-on/--right-on must each name at least one non-empty column"
+            )
         if len(left_cols) != len(right_cols):
             raise ValueError(
                 f"--left-on has {len(left_cols)} column(s) but "
@@ -72,22 +104,123 @@ def _build_join_predicates(
             )
         return tuple(zip(left_cols, right_cols))
 
-    if how != "cross":
-        raise ValueError(
-            "must specify --on or --left-on/--right-on, unless --how=cross"
-        )
-    return ()
+    raise ValueError("must specify --on or --left-on/--right-on, unless --how=cross")
 
 
-def _assert_single_backend(*exprs: "Expr") -> None:
-    """Raise `ValueError` if the exprs are bound to more than one backend/connection.
+def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
+    """Collapse same-profile backend connections across *exprs* onto one object.
 
-    Two connections of the same backend class (e.g. two `xo.connect()` calls)
-    are distinct here too -- `Expr._find_backend()` distinguishes them by
-    connection identity, not backend class, and combining them raises an
-    opaque `XorqError` deep inside execution/build rather than failing here
-    with an actionable message.
+    Independently-loaded exprs being joined/unioned ("multi-root" combining)
+    can carry several backend connection objects that share the same
+    `Profile` content (con_name + kwargs, ignoring the session-local `idx`)
+    -- e.g. two `xo.connect()` calls, or two `load_expr()` calls of the same
+    source, each of which always constructs a fresh connection object
+    (`Profile.get_con()` has no caching). For a plain file/table `Read` (e.g.
+    `deferred_read_parquet`), same profile means the same physical resource,
+    so rewriting every reference onto one connection object is safe and
+    never touches table data -- the same rewrite `replace_sources` already
+    does for `normalize_profiles`, just deduping instead of reindexing.
+
+    Same profile does *not* imply interchangeable for anything else that
+    carries a backend:
+    - An in-memory `DatabaseTable` (`.create_table(...)`): two connections
+      with identical params are still two independent sessions, each with
+      its own registered data. `replace_sources(transfer_tables=False)`
+      already refuses to rewrite these.
+    - A `RemoteTable` (`.into_backend(...)`), `CachedNode`, `FlightExpr`/
+      `FlightUDXF`, or `TeeNode`: each ties a node to state that lives only
+      on the *specific* connection instance that produced it -- rewriting
+      `.source` there is not blocked by `replace_sources` (it only guards
+      `DatabaseTable`) but silently produces a connection missing that
+      state. Confirmed live: a `RemoteTable` rebound onto a same-profile
+      xorq-datafusion connection it was never registered on raised
+      `AttributeError: 'Backend' object has no attribute
+      'read_record_batches'` at execution time, well past this check.
+
+    So a backend is only rebind-eligible if *every* node referencing it
+    (across all of *exprs*) is a plain `Read`; a backend touched by any
+    other node type is left alone entirely, as both a merge source and a
+    merge target. `replace_sources` failing for an eligible group (e.g. a
+    `DatabaseTable` sharing that backend after all) is caught per expr and
+    treated as "can't rebind that one", falling through to the standard
+    multi-backend error rather than leaking that internal ValueError.
     """
+    import xorq.expr.relations as rel  # noqa: PLC0415
+    import xorq.vendor.ibis.expr.operations as ops  # noqa: PLC0415
+    from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
+    from xorq.common.utils.graph_utils import (  # noqa: PLC0415
+        find_all_sources,
+        replace_sources,
+        walk_nodes,
+    )
+
+    backend_node_types = (
+        ops.DatabaseTable,
+        ops.SQLQueryResult,
+        rel.CachedNode,
+        rel.Read,
+        rel.RemoteTable,
+        rel.FlightUDXF,
+        rel.FlightExpr,
+        rel.TeeNode,
+    )
+    unsafe_ids = {
+        id(source)
+        for expr in exprs
+        for node in walk_nodes(backend_node_types, expr)
+        if not isinstance(node, rel.Read)
+        for source in (
+            node.writer.cons if isinstance(node, rel.TeeNode) else (node.source,)
+        )
+    }
+
+    backends = [
+        b for expr in exprs for b in find_all_sources(expr) if id(b) not in unsafe_ids
+    ]
+    if len(backends) < 2:
+        return exprs
+
+    def content_key(backend):
+        profile = backend._profile  # xorq-style: disable=protected-access
+        return tokenize({k: v for k, v in profile.as_dict().items() if k != "idx"})
+
+    groups: dict[str, list] = {}
+    for backend in backends:
+        groups.setdefault(content_key(backend), []).append(backend)
+
+    source_mapping = {
+        id(duplicate): canonical
+        for canonical, *duplicates in groups.values()
+        for duplicate in duplicates
+    }
+    if not source_mapping:
+        return exprs
+
+    def rebind_one(expr):
+        try:
+            return replace_sources(source_mapping, expr)
+        except ValueError:
+            return expr
+
+    return tuple(rebind_one(expr) for expr in exprs)
+
+
+def _reconcile_backends(
+    *exprs: "Expr", rebind_backends: bool
+) -> tuple["Expr", ...]:
+    """Require *exprs* to jointly resolve to a single backend, rebinding
+    same-profile connections onto one object first (unless
+    `rebind_backends=False`).
+
+    Raises `ValueError` if, after rebinding, more than one distinct backend
+    remains across *exprs* -- a genuine multi-engine combination this does
+    not attempt to solve automatically (see `_rebind_same_profile_sources`).
+    Runs before the exprs are combined so a schema mismatch in `Table.join`/
+    `Table.union` doesn't mask a backend mismatch (or vice versa).
+    """
+    if rebind_backends:
+        exprs = _rebind_same_profile_sources(*exprs)
+
     seen: dict[int, object] = {}
     for expr in exprs:
         backends, _ = expr._find_backends()  # xorq-style: disable=protected-access
@@ -97,9 +230,10 @@ def _assert_single_backend(*exprs: "Expr") -> None:
         named = ", ".join(sorted(type(b).__name__ for b in seen.values()))
         raise ValueError(
             f"cannot combine exprs bound to {len(seen)} different backend "
-            f"connections ({named}); use `.into_backend(...)` to bring them "
-            "onto one connection first"
+            f"connections ({named}); bridge them onto one connection yourself "
+            "with `.into_backend(...)` first"
         )
+    return exprs
 
 
 def join_exprs(
@@ -112,18 +246,31 @@ def join_exprs(
     how: str = "inner",
     lname: str = "",
     rname: str = "{name}_right",
+    rebind_backends: bool = True,
 ) -> "Expr":
     """Join two already-resolved exprs; a thin wrapper around `Table.join`."""
-    _assert_single_backend(left, right)
+    left, right = _reconcile_backends(left, right, rebind_backends=rebind_backends)
     predicates = _build_join_predicates(on, left_on, right_on, how)
-    return left.join(right, predicates, how=how, lname=lname, rname=rname)
+    joined = left.join(right, predicates, how=how, lname=lname, rname=rname)
+    # `Table.join` returns a lazy, "unfinished" `Join` chain object: its
+    # `lname`/`rname` name-collision check lives in a side-channel Python
+    # attribute (`_collisions`), not the op graph, and only fires when a
+    # `finished`-wrapped method (e.g. `.execute()`) is called on it directly.
+    # `build_expr`/`load_expr` don't go through one of those, so an
+    # unresolved collision would silently round-trip through YAML with the
+    # colliding column dropped -- force resolution now so it raises here,
+    # every time, instead of only for callers who happen to `.execute()` the
+    # object returned from this call before doing anything else with it.
+    return joined._finish()  # xorq-style: disable=protected-access
 
 
-def union_exprs(*exprs: "Expr", distinct: bool = False) -> "Expr":
+def union_exprs(
+    *exprs: "Expr", distinct: bool = False, rebind_backends: bool = True
+) -> "Expr":
     """Union two-or-more already-resolved exprs; a thin wrapper around `Table.union`."""
     if len(exprs) < 2:
         raise ValueError("union requires at least 2 sources")
-    _assert_single_backend(*exprs)
+    exprs = _reconcile_backends(*exprs, rebind_backends=rebind_backends)
     first, *rest = exprs
     return first.union(*rest, distinct=distinct)
 
@@ -141,6 +288,7 @@ def join_builds(
     how: str = "inner",
     lname: str = "",
     rname: str = "{name}_right",
+    rebind_backends: bool = True,
 ) -> Path:
     """Load two build artifacts, join them, and write the result as a new build."""
     from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
@@ -149,7 +297,7 @@ def join_builds(
     right = load_expr(right_path, cache_dir=cache_dir)
     expr = join_exprs(
         left, right, on=on, left_on=left_on, right_on=right_on, how=how,
-        lname=lname, rname=rname,
+        lname=lname, rname=rname, rebind_backends=rebind_backends,
     )
     return build_expr(
         expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads
@@ -162,12 +310,13 @@ def union_builds(
     builds_dir: str | Path = "builds",
     relocate_reads: bool = True,
     distinct: bool = False,
+    rebind_backends: bool = True,
 ) -> Path:
     """Load two-or-more build artifacts, union them, and write the result as a new build."""
     from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
 
     exprs: Sequence[Expr] = [load_expr(path, cache_dir=cache_dir) for path in paths]
-    expr = union_exprs(*exprs, distinct=distinct)
+    expr = union_exprs(*exprs, distinct=distinct, rebind_backends=rebind_backends)
     return build_expr(
         expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads
     )

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -11,14 +11,36 @@ strings (used by the top-level tier).
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import click
+
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     from xorq.api import Expr
+
+
+@contextmanager
+def combine_errors() -> "Iterator[None]":
+    """Map `join_exprs`/`union_exprs`'s exceptions to clean CLI errors.
+
+    Shared by both CLI tiers (`xorq join`/`union` and `xorq catalog
+    join`/`union`) so the ValueError/RelationError -> click mapping can't
+    drift out of sync between call sites the way it already had (catalog
+    `join` was missing the `RelationError` arm `union` had).
+    """
+    from xorq.common.exceptions import RelationError  # noqa: PLC0415
+
+    try:
+        yield
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from None
+    except RelationError as e:
+        raise click.ClickException(str(e)) from e
 
 
 def _split_columns(value: str) -> tuple[str, ...]:
@@ -57,6 +79,29 @@ def _build_join_predicates(
     return ()
 
 
+def _assert_single_backend(*exprs: "Expr") -> None:
+    """Raise `ValueError` if the exprs are bound to more than one backend/connection.
+
+    Two connections of the same backend class (e.g. two `xo.connect()` calls)
+    are distinct here too -- `Expr._find_backend()` distinguishes them by
+    connection identity, not backend class, and combining them raises an
+    opaque `XorqError` deep inside execution/build rather than failing here
+    with an actionable message.
+    """
+    seen: dict[int, object] = {}
+    for expr in exprs:
+        backends, _ = expr._find_backends()  # xorq-style: disable=protected-access
+        for backend in backends:
+            seen.setdefault(id(backend), backend)
+    if len(seen) > 1:
+        named = ", ".join(sorted(type(b).__name__ for b in seen.values()))
+        raise ValueError(
+            f"cannot combine exprs bound to {len(seen)} different backend "
+            f"connections ({named}); use `.into_backend(...)` to bring them "
+            "onto one connection first"
+        )
+
+
 def join_exprs(
     left: "Expr",
     right: "Expr",
@@ -69,6 +114,7 @@ def join_exprs(
     rname: str = "{name}_right",
 ) -> "Expr":
     """Join two already-resolved exprs; a thin wrapper around `Table.join`."""
+    _assert_single_backend(left, right)
     predicates = _build_join_predicates(on, left_on, right_on, how)
     return left.join(right, predicates, how=how, lname=lname, rname=rname)
 
@@ -77,6 +123,7 @@ def union_exprs(*exprs: "Expr", distinct: bool = False) -> "Expr":
     """Union two-or-more already-resolved exprs; a thin wrapper around `Table.union`."""
     if len(exprs) < 2:
         raise ValueError("union requires at least 2 sources")
+    _assert_single_backend(*exprs)
     first, *rest = exprs
     return first.union(*rest, distinct=distinct)
 
@@ -143,5 +190,5 @@ def assert_matching_library_versions(*build_paths: str | Path) -> None:
         detail = ", ".join(f"{p}={v}" for p, v in versions.items())
         raise BuildVersionMismatchError(
             f"builds recorded different xorq library versions: {detail}. "
-            "Pass --ignore-venv-mismatch to proceed anyway."
+            "Pass --ignore-library-version-mismatch to proceed anyway."
         )

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -115,11 +115,26 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
     `Profile` content (con_name + kwargs, ignoring the session-local `idx`)
     -- e.g. two `xo.connect()` calls, or two `load_expr()` calls of the same
     source, each of which always constructs a fresh connection object
-    (`Profile.get_con()` has no caching). For a plain file/table `Read` (e.g.
-    `deferred_read_parquet`), same profile means the same physical resource,
-    so rewriting every reference onto one connection object is safe and
-    never touches table data -- the same rewrite `replace_sources` already
-    does for `normalize_profiles`, just deduping instead of reindexing.
+    (`Profile.get_con()` has no caching). Rewriting every reference in a
+    same-profile group onto one connection object is a pure graph rewrite
+    (the same one `replace_sources` already does for `normalize_profiles`,
+    just deduping instead of reindexing) and safe for:
+    - A plain file/table `Read` (e.g. `deferred_read_parquet`): same profile
+      means the same physical resource.
+    - A `RemoteTable` (`.into_backend(...)`): lazy by construction --
+      `into_backend` just stores `(source=con, remote_expr)`, no
+      registration happens until `read_record_batches` runs at execution
+      time -- so repointing `.source` onto a same-profile connection is as
+      safe as for a `Read`. Confirmed live with two `xo.connect()` hub
+      connections and a `.into_backend()` on one side: rewriting `.source`
+      and executing produces the correct joined result. (An earlier version
+      of this excluded `RemoteTable` after hitting `AttributeError: 'Backend'
+      object has no attribute 'read_record_batches'` -- that backend
+      (`xo.datafusion.connect()`, not the `xo.connect()` hub) doesn't
+      implement `read_record_batches` at all and would fail identically
+      with zero rebinding involved; `con_name` is part of the profile
+      content-key, so a backend lacking a capability is never grouped with
+      one that has it in the first place.)
 
     Same profile does *not* imply interchangeable for anything else that
     carries a backend:
@@ -127,23 +142,20 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
       with identical params are still two independent sessions, each with
       its own registered data. `replace_sources(transfer_tables=False)`
       already refuses to rewrite these.
-    - A `RemoteTable` (`.into_backend(...)`), `CachedNode`, `FlightExpr`/
-      `FlightUDXF`, or `TeeNode`: each ties a node to state that lives only
-      on the *specific* connection instance that produced it -- rewriting
-      `.source` there is not blocked by `replace_sources` (it only guards
-      `DatabaseTable`) but silently produces a connection missing that
-      state. Confirmed live: a `RemoteTable` rebound onto a same-profile
-      xorq-datafusion connection it was never registered on raised
-      `AttributeError: 'Backend' object has no attribute
-      'read_record_batches'` at execution time, well past this check.
+    - `CachedNode`, `FlightExpr`/`FlightUDXF`, or `TeeNode`: each may tie a
+      node to state living only on the specific connection instance that
+      produced it, unverified either way -- left excluded conservatively;
+      rewriting `.source` there is not blocked by `replace_sources` itself
+      (it only guards `DatabaseTable`).
 
     So a backend is only rebind-eligible if *every* node referencing it
-    (across all of *exprs*) is a plain `Read`; a backend touched by any
-    other node type is left alone entirely, as both a merge source and a
-    merge target. `replace_sources` failing for an eligible group (e.g. a
-    `DatabaseTable` sharing that backend after all) is caught per expr and
-    treated as "can't rebind that one", falling through to the standard
-    multi-backend error rather than leaking that internal ValueError.
+    (across all of *exprs*) is a `Read` or `RemoteTable`; a backend touched
+    by any other node type is left alone entirely, as both a merge source
+    and a merge target. `replace_sources` failing for an eligible group
+    (e.g. a `DatabaseTable` sharing that backend after all) is caught per
+    expr and treated as "can't rebind that one", falling through to the
+    standard multi-backend error rather than leaking that internal
+    ValueError.
     """
     import xorq.expr.relations as rel  # noqa: PLC0415
     import xorq.vendor.ibis.expr.operations as ops  # noqa: PLC0415
@@ -154,12 +166,12 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
         walk_nodes,
     )
 
+    safe_node_types = (rel.Read, rel.RemoteTable)
     backend_node_types = (
         ops.DatabaseTable,
         ops.SQLQueryResult,
         rel.CachedNode,
-        rel.Read,
-        rel.RemoteTable,
+        *safe_node_types,
         rel.FlightUDXF,
         rel.FlightExpr,
         rel.TeeNode,
@@ -168,7 +180,7 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
         id(source)
         for expr in exprs
         for node in walk_nodes(backend_node_types, expr)
-        if not isinstance(node, rel.Read)
+        if not isinstance(node, safe_node_types)
         for source in (
             node.writer.cons if isinstance(node, rel.TeeNode) else (node.source,)
         )

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -1,0 +1,147 @@
+"""Combine build artifacts (or already-loaded exprs) via join/union.
+
+Shared core for the ``xorq join``/``xorq union`` and ``xorq catalog
+join``/``xorq catalog union`` CLI commands: `join_exprs`/`union_exprs`
+operate on already-resolved `Expr` objects (used directly by the catalog
+tier, whose entries resolve to exprs via `CatalogEntry.load_expr`), while
+`join_builds`/`union_builds` additionally load/build from plain build-path
+strings (used by the top-level tier).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from xorq.api import Expr
+
+
+def _split_columns(value: str) -> tuple[str, ...]:
+    return tuple(c.strip() for c in value.split(",") if c.strip())
+
+
+def _build_join_predicates(
+    on: str | None,
+    left_on: str | None,
+    right_on: str | None,
+    how: str,
+) -> tuple[str | tuple[str, str], ...]:
+    """Turn CLI-style --on/--left-on/--right-on into ibis's `predicates` shape."""
+    if on is not None and (left_on is not None or right_on is not None):
+        raise ValueError("--on is mutually exclusive with --left-on/--right-on")
+    if (left_on is None) != (right_on is None):
+        raise ValueError("--left-on and --right-on must be given together")
+
+    if on is not None:
+        return _split_columns(on)
+
+    if left_on is not None:
+        left_cols = _split_columns(left_on)
+        right_cols = _split_columns(right_on)
+        if len(left_cols) != len(right_cols):
+            raise ValueError(
+                f"--left-on has {len(left_cols)} column(s) but "
+                f"--right-on has {len(right_cols)}"
+            )
+        return tuple(zip(left_cols, right_cols))
+
+    if how != "cross":
+        raise ValueError(
+            "must specify --on or --left-on/--right-on, unless --how=cross"
+        )
+    return ()
+
+
+def join_exprs(
+    left: "Expr",
+    right: "Expr",
+    *,
+    on: str | None = None,
+    left_on: str | None = None,
+    right_on: str | None = None,
+    how: str = "inner",
+    lname: str = "",
+    rname: str = "{name}_right",
+) -> "Expr":
+    """Join two already-resolved exprs; a thin wrapper around `Table.join`."""
+    predicates = _build_join_predicates(on, left_on, right_on, how)
+    return left.join(right, predicates, how=how, lname=lname, rname=rname)
+
+
+def union_exprs(*exprs: "Expr", distinct: bool = False) -> "Expr":
+    """Union two-or-more already-resolved exprs; a thin wrapper around `Table.union`."""
+    if len(exprs) < 2:
+        raise ValueError("union requires at least 2 sources")
+    first, *rest = exprs
+    return first.union(*rest, distinct=distinct)
+
+
+def join_builds(
+    left_path: str | Path,
+    right_path: str | Path,
+    *,
+    cache_dir: str | Path | None = None,
+    builds_dir: str | Path = "builds",
+    relocate_reads: bool = True,
+    on: str | None = None,
+    left_on: str | None = None,
+    right_on: str | None = None,
+    how: str = "inner",
+    lname: str = "",
+    rname: str = "{name}_right",
+) -> Path:
+    """Load two build artifacts, join them, and write the result as a new build."""
+    from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
+
+    left = load_expr(left_path, cache_dir=cache_dir)
+    right = load_expr(right_path, cache_dir=cache_dir)
+    expr = join_exprs(
+        left, right, on=on, left_on=left_on, right_on=right_on, how=how,
+        lname=lname, rname=rname,
+    )
+    return build_expr(
+        expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads
+    )
+
+
+def union_builds(
+    *paths: str | Path,
+    cache_dir: str | Path | None = None,
+    builds_dir: str | Path = "builds",
+    relocate_reads: bool = True,
+    distinct: bool = False,
+) -> Path:
+    """Load two-or-more build artifacts, union them, and write the result as a new build."""
+    from xorq.ibis_yaml.compiler import build_expr, load_expr  # noqa: PLC0415
+
+    exprs: Sequence[Expr] = [load_expr(path, cache_dir=cache_dir) for path in paths]
+    expr = union_exprs(*exprs, distinct=distinct)
+    return build_expr(
+        expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads
+    )
+
+
+def _read_build_library_version(build_path: str | Path) -> str:
+    from xorq.ibis_yaml.enums import DumpFiles  # noqa: PLC0415
+
+    metadata_path = Path(build_path) / DumpFiles.build_metadata
+    metadata = json.loads(metadata_path.read_text())
+    return metadata["current_library_version"]
+
+
+def assert_matching_library_versions(*build_paths: str | Path) -> None:
+    """Raise `BuildVersionMismatchError` if the builds pin different xorq versions."""
+    from xorq.common.exceptions import BuildVersionMismatchError  # noqa: PLC0415
+
+    versions = {str(p): _read_build_library_version(p) for p in build_paths}
+    if len(set(versions.values())) > 1:
+        detail = ", ".join(f"{p}={v}" for p, v in versions.items())
+        raise BuildVersionMismatchError(
+            f"builds recorded different xorq library versions: {detail}. "
+            "Pass --ignore-venv-mismatch to proceed anyway."
+        )

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -42,6 +42,15 @@ def combine_errors() -> "Iterator[None]":
     - `KeyError`: an `--lname`/`--rname` template referencing a field that
       doesn't exist (e.g. `--rname "{bogus}"` raises `KeyError('bogus')`
       from the bare `str.format` call inside ibis's join disambiguation).
+    - `OSError` (including `FileNotFoundError`): a build path that doesn't
+      exist or can't be read. The top-level CLI's
+      `_check_library_version_match` already maps a missing path cleanly
+      when it runs (the default), but it's a no-op under
+      `--ignore-library-version-mismatch` -- this arm is the backstop that
+      catches it regardless, once `load_expr` reaches the missing path.
+      `load_expr` reads its YAML via the Rust-backed `yaml12` reader, which
+      raises a bare `OSError` (not `FileNotFoundError`) on a missing file,
+      so this must catch the broader type to cover both I/O paths.
     """
     from xorq.common.exceptions import (  # noqa: PLC0415
         IntegrityError,
@@ -55,6 +64,8 @@ def combine_errors() -> "Iterator[None]":
         raise click.BadParameter(str(e)) from None
     except (RelationError, IntegrityError) as e:
         raise click.ClickException(str(e)) from e
+    except OSError as e:
+        raise click.ClickException(f"cannot load build: {e}") from e
     except KeyError as e:
         raise click.BadParameter(
             f"unknown placeholder {e} in --lname/--rname template"

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -406,6 +406,18 @@ def canonicalize_expr(expr, read_normalize_method=normalize_read_path_stat):
     return expr
 
 
+def profile_content_key(profile: Profile) -> str:
+    """Content-only identity of a `Profile`, ignoring the session-local `idx`.
+
+    Shared by every place that needs to tell whether two `Profile`s describe
+    the same underlying connection regardless of which session constructed
+    them: `normalize_profiles` (canonical `idx` ordering), `hydrate_cons`
+    (connection cache keying), and `combine._rebind_same_profile_sources`
+    (same-profile backend rebinding).
+    """
+    return tokenize(toolz.dissoc(profile.as_dict(), "idx"))
+
+
 def normalize_profiles(expr):
     """Rewrite the expression graph so Profile.idx values are canonical.
 
@@ -422,8 +434,9 @@ def normalize_profiles(expr):
         return expr
 
     def content_key(backend):
-        p = backend._profile
-        return tokenize(toolz.dissoc(p.as_dict(), "idx"))
+        return profile_content_key(
+            backend._profile  # xorq-style: disable=protected-access
+        )
 
     # sort by content hash → deterministic canonical order
     # Python sort is stable so backends with the same content hash
@@ -478,9 +491,6 @@ def hydrate_cons(
         an unrelated single load, which keeps today's per-call behavior.
     """
 
-    def content_key(profile):
-        return tokenize({k: v for k, v in profile.as_dict().items() if k != "idx"})
-
     def kwargs_to_con(kwargs):
         match dct := dict(kwargs):
             case {"kwargs_tuple": dict()}:
@@ -490,7 +500,7 @@ def hydrate_cons(
         profile = Profile(**dct)
         if con_cache is None:
             return profile.get_con(lazy=lazy)
-        key = content_key(profile)
+        key = profile_content_key(profile)
         if key not in con_cache:
             con_cache[key] = profile.get_con(lazy=lazy)
         return con_cache[key]

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -413,9 +413,10 @@ def profile_content_key(profile: Profile) -> str:
     the same underlying connection regardless of which session constructed
     them: `normalize_profiles` (canonical `idx` ordering), `hydrate_cons`
     (connection cache keying), and `combine._rebind_same_profile_sources`
-    (same-profile backend rebinding).
+    (same-profile backend rebinding). Delegates to `Profile.content_hash`,
+    which also backs `hash_name` -- one computation, not two.
     """
-    return tokenize(toolz.dissoc(profile.as_dict(), "idx"))
+    return profile.content_hash
 
 
 def normalize_profiles(expr):

--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -461,14 +461,39 @@ def dehydrate_cons(cons):
     return dehydrated
 
 
-def hydrate_cons(hash_to_profile_kwargs, lazy=False):
+def hydrate_cons(
+    hash_to_profile_kwargs: dict, lazy: bool = False, con_cache: dict | None = None
+) -> dict:
+    """Reconstruct connections from their dumped profile kwargs.
+
+    con_cache : dict[str, BaseBackend] | None
+        When given, connections are shared across calls by profile *content*
+        (con_name + kwargs, matching `normalize_profiles`'s own comparison --
+        `idx` is session-local and excluded): a caller loading several builds
+        that share a same-config connection (e.g. `join_builds`/`union_builds`
+        loading each side) gets one connection object per distinct config
+        instead of a fresh one per build, the way a single `load_expr` call
+        already shares one connection across every read in that build. Pass
+        the *same* dict across those calls; leave it `None` (the default) for
+        an unrelated single load, which keeps today's per-call behavior.
+    """
+
+    def content_key(profile):
+        return tokenize({k: v for k, v in profile.as_dict().items() if k != "idx"})
+
     def kwargs_to_con(kwargs):
         match dct := dict(kwargs):
             case {"kwargs_tuple": dict()}:
                 dct["kwargs_tuple"] = tuple(dct["kwargs_tuple"].items())
             case _:
                 dct["kwargs_tuple"] = tuple(map(tuple, dct["kwargs_tuple"]))
-        return Profile(**dct).get_con(lazy=lazy)
+        profile = Profile(**dct)
+        if con_cache is None:
+            return profile.get_con(lazy=lazy)
+        key = content_key(profile)
+        if key not in con_cache:
+            con_cache[key] = profile.get_con(lazy=lazy)
+        return con_cache[key]
 
     profiles = toolz.valmap(
         kwargs_to_con,
@@ -884,6 +909,9 @@ class ExprLoader:
     cache_dir = field(
         validator=optional(or_(instance_of(Path), instance_of(str))), default=None
     )
+    # Shared with `hydrate_cons` -- see its docstring. `None` (the default)
+    # keeps this load's connections private to it, matching prior behavior.
+    con_cache = field(validator=optional(instance_of(dict)), default=None)
 
     @property
     def expr_hash(self):
@@ -900,7 +928,9 @@ class ExprLoader:
         read_only_parquet_metadata: bool = False,
     ):
         profiles = hydrate_cons(
-            self.artifact_store.load_yaml(DumpFiles.profiles), lazy=lazy
+            self.artifact_store.load_yaml(DumpFiles.profiles),
+            lazy=lazy,
+            con_cache=self.con_cache,
         )
         yaml_dict = self.artifact_store.load_yaml(DumpFiles.expr)
         entry = self.artifact_store.read_json(DumpFiles.expr_metadata)

--- a/python/xorq/ibis_yaml/tests/test_combine.py
+++ b/python/xorq/ibis_yaml/tests/test_combine.py
@@ -9,9 +9,11 @@ import xorq.api as xo
 from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.ibis_yaml.combine import (
     _build_join_predicates,
+    join_builds,
     join_exprs,
     union_exprs,
 )
+from xorq.ibis_yaml.compiler import build_expr, load_expr
 
 
 @pytest.fixture
@@ -175,6 +177,39 @@ def test_join_exprs_same_profile_file_backed_rebinds_by_default(
     # `rebind_backends` (on by default) fixes.
     joined = join_exprs(file_backed_left, file_backed_right, on="id")
     result = joined.execute()
+    assert set(result.columns) == {"id", "a", "b"}
+    assert len(result) == 3
+
+
+def test_join_builds_rebind_survives_colliding_saved_idx(
+    shared_parquet_path: str, tmp_path: Path
+) -> None:
+    """`Profile.idx` is a session-local counter, but a *single-source* build
+    always canonicalizes its one backend to idx=0 before serializing (see
+    `normalize_profiles`) -- so any two independently-built, single-source
+    builds are saved with the *same* idx=0 regardless of their actual
+    content. Loading both back reconstructs two backends that: (a) may
+    coincidentally share idx=0, and (b) are grouped for rebinding purely by
+    content (idx excluded from the comparison already), not by idx. This
+    pins that the merge produces exactly one surviving profile -- no
+    duplicate/colliding entries -- and the build round-trips correctly.
+    """
+    left = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    ).rename(b="a")
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+
+    # Confirm the premise: both independently saved with idx=0.
+    for path in (left_path, right_path):
+        assert "idx: 0" in (path / "profiles.yaml").read_text()
+
+    result_path = join_builds(left_path, right_path, on="id", builds_dir=tmp_path / "joined")
+    profiles_text = (result_path / "profiles.yaml").read_text()
+    assert profiles_text.count("idx:") == 1
+
+    result = load_expr(result_path).execute()
     assert set(result.columns) == {"id", "a", "b"}
     assert len(result) == 3
 

--- a/python/xorq/ibis_yaml/tests/test_combine.py
+++ b/python/xorq/ibis_yaml/tests/test_combine.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pandas as pd
 import pytest
 
 import xorq.api as xo
+from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.ibis_yaml.combine import (
     _build_join_predicates,
     join_exprs,
@@ -36,6 +40,28 @@ def datafusion_right() -> xo.Expr:
     return xo.datafusion.connect().create_table(
         "right_t", {"id": [1, 2, 4], "name": ["a", "b", "d"]}
     )
+
+
+@pytest.fixture
+def shared_parquet_path(tmp_path: Path) -> str:
+    path = str(tmp_path / "shared.parquet")
+    pd.DataFrame({"id": [1, 2, 3], "a": ["x", "y", "z"]}).to_parquet(path)
+    return path
+
+
+@pytest.fixture
+def file_backed_left(shared_parquet_path: str) -> xo.Expr:
+    # A fresh `xo.duckdb.connect()` -- same profile params as the one in
+    # `file_backed_right`, but a distinct connection object (this is what
+    # two independent `load_expr()` calls of the same source look like).
+    return deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+
+
+@pytest.fixture
+def file_backed_right(shared_parquet_path: str) -> xo.Expr:
+    return deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    ).rename(b="a")
 
 
 @pytest.fixture
@@ -129,13 +155,57 @@ def test_join_exprs_different_backend_classes_raises(
         join_exprs(duckdb_left, datafusion_right, on="id")
 
 
-def test_join_exprs_same_backend_different_profile_raises(
+def test_join_exprs_same_profile_in_memory_data_raises(
     datafusion_left: xo.Expr, datafusion_right: xo.Expr
 ) -> None:
-    # Two separate `xo.datafusion.connect()` calls: same backend class, but
-    # distinct connections (profile idx N vs N+1) -- not interchangeable.
+    # Two separate `xo.datafusion.connect()` calls with matching params share
+    # a `Profile` (idx aside), but each `.create_table(...)` registers data
+    # only on its own session -- same profile does not imply same data here,
+    # so rebind_backends (on by default) correctly declines to touch it and
+    # this still raises.
     with pytest.raises(ValueError, match="different backend"):
         join_exprs(datafusion_left, datafusion_right, on="id")
+
+
+def test_join_exprs_same_profile_file_backed_rebinds_by_default(
+    file_backed_left: xo.Expr, file_backed_right: xo.Expr
+) -> None:
+    # Same scenario as above, but reading a real file: same profile really
+    # does mean the same physical data, so this is exactly the case
+    # `rebind_backends` (on by default) fixes.
+    joined = join_exprs(file_backed_left, file_backed_right, on="id")
+    result = joined.execute()
+    assert set(result.columns) == {"id", "a", "b"}
+    assert len(result) == 3
+
+
+def test_join_exprs_no_rebind_backends_still_raises(
+    file_backed_left: xo.Expr, file_backed_right: xo.Expr
+) -> None:
+    with pytest.raises(ValueError, match="different backend"):
+        join_exprs(file_backed_left, file_backed_right, on="id", rebind_backends=False)
+
+
+def test_join_exprs_into_backend_remote_table_raises_not_silently_broken(
+    shared_parquet_path: str,
+) -> None:
+    """A `RemoteTable` (from `.into_backend(...)`) sharing a profile with
+    another source is *not* rebind-eligible: unlike a plain `Read`, its data
+    is tied to the specific connection instance that produced it. Before
+    excluding non-`Read` nodes from rebinding, this same-profile match was
+    rebound anyway and only failed at `.execute()` with an unrelated
+    `AttributeError` (missing `read_record_batches`) -- now it fails at
+    `join_exprs` time with the standard, actionable message instead.
+    """
+    datafusion_direct = deferred_read_parquet(
+        shared_parquet_path, xo.datafusion.connect(), table_name="t"
+    )
+    duckdb_into_datafusion = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    ).into_backend(xo.datafusion.connect(), name="t_remote")
+
+    with pytest.raises(ValueError, match="different backend"):
+        join_exprs(datafusion_direct, duckdb_into_datafusion, on="id")
 
 
 def test_union_exprs_different_backend_classes_raises(
@@ -147,8 +217,26 @@ def test_union_exprs_different_backend_classes_raises(
         union_exprs(duckdb_left, datafusion_right)
 
 
-def test_union_exprs_same_backend_different_profile_raises(
+def test_union_exprs_same_profile_in_memory_data_raises(
     datafusion_left: xo.Expr, datafusion_right: xo.Expr
 ) -> None:
     with pytest.raises(ValueError, match="different backend"):
         union_exprs(datafusion_left, datafusion_right)
+
+
+def test_union_exprs_same_profile_file_backed_rebinds_by_default(
+    shared_parquet_path: str,
+) -> None:
+    left = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    unioned = union_exprs(left, right)
+    assert unioned.count().execute() == 6
+
+
+def test_union_exprs_no_rebind_backends_still_raises(
+    shared_parquet_path: str,
+) -> None:
+    left = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    with pytest.raises(ValueError, match="different backend"):
+        union_exprs(left, right, rebind_backends=False)

--- a/python/xorq/ibis_yaml/tests/test_combine.py
+++ b/python/xorq/ibis_yaml/tests/test_combine.py
@@ -186,26 +186,39 @@ def test_join_exprs_no_rebind_backends_still_raises(
         join_exprs(file_backed_left, file_backed_right, on="id", rebind_backends=False)
 
 
-def test_join_exprs_into_backend_remote_table_raises_not_silently_broken(
+def test_join_exprs_into_backend_remote_table_rebinds_by_default(
     shared_parquet_path: str,
 ) -> None:
     """A `RemoteTable` (from `.into_backend(...)`) sharing a profile with
-    another source is *not* rebind-eligible: unlike a plain `Read`, its data
-    is tied to the specific connection instance that produced it. Before
-    excluding non-`Read` nodes from rebinding, this same-profile match was
-    rebound anyway and only failed at `.execute()` with an unrelated
-    `AttributeError` (missing `read_record_batches`) -- now it fails at
-    `join_exprs` time with the standard, actionable message instead.
-    """
-    datafusion_direct = deferred_read_parquet(
-        shared_parquet_path, xo.datafusion.connect(), table_name="t"
-    )
-    duckdb_into_datafusion = deferred_read_parquet(
+    another source is safe to rebind, same as a plain `Read`: `into_backend`
+    is lazy (stores `source`/`remote_expr`, no registration happens until
+    execution), so repointing `.source` onto a same-profile connection is
+    equivalent to letting it register there in the first place. Confirmed
+    with the actual hub backend (`xo.connect()`, not a bare `xo.datafusion
+    .connect()`, which doesn't implement `read_record_batches` at all and
+    would fail identically with zero rebinding involved)."""
+    left = deferred_read_parquet(shared_parquet_path, xo.connect(), table_name="t")
+    right_raw = deferred_read_parquet(
         shared_parquet_path, xo.duckdb.connect(), table_name="t"
-    ).into_backend(xo.datafusion.connect(), name="t_remote")
+    ).rename(b="a")
+    right = right_raw.into_backend(xo.connect(), name="t_remote")
+
+    joined = join_exprs(left, right, on="id")
+    result = joined.execute()
+    assert set(result.columns) == {"id", "a", "b"}
+    assert len(result) == 3
+
+
+def test_join_exprs_into_backend_no_rebind_backends_still_raises(
+    shared_parquet_path: str,
+) -> None:
+    left = deferred_read_parquet(shared_parquet_path, xo.connect(), table_name="t")
+    right = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    ).into_backend(xo.connect(), name="t_remote")
 
     with pytest.raises(ValueError, match="different backend"):
-        join_exprs(datafusion_direct, duckdb_into_datafusion, on="id")
+        join_exprs(left, right, on="id", rebind_backends=False)
 
 
 def test_union_exprs_different_backend_classes_raises(

--- a/python/xorq/ibis_yaml/tests/test_combine.py
+++ b/python/xorq/ibis_yaml/tests/test_combine.py
@@ -11,6 +11,34 @@ from xorq.ibis_yaml.combine import (
 
 
 @pytest.fixture
+def duckdb_left() -> xo.Expr:
+    return xo.duckdb.connect().create_table(
+        "left_t", {"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}
+    )
+
+
+@pytest.fixture
+def duckdb_right() -> xo.Expr:
+    return xo.duckdb.connect().create_table(
+        "right_t", {"id": [1, 2, 4], "name": ["a", "b", "d"]}
+    )
+
+
+@pytest.fixture
+def datafusion_left() -> xo.Expr:
+    return xo.datafusion.connect().create_table(
+        "left_t", {"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}
+    )
+
+
+@pytest.fixture
+def datafusion_right() -> xo.Expr:
+    return xo.datafusion.connect().create_table(
+        "right_t", {"id": [1, 2, 4], "name": ["a", "b", "d"]}
+    )
+
+
+@pytest.fixture
 def left() -> xo.Expr:
     return xo.memtable({"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}, name="left_t")
 
@@ -92,3 +120,35 @@ def test_union_exprs_distinct(left: xo.Expr) -> None:
 def test_union_exprs_requires_at_least_two(left: xo.Expr) -> None:
     with pytest.raises(ValueError, match="at least 2"):
         union_exprs(left)
+
+
+def test_join_exprs_different_backend_classes_raises(
+    duckdb_left: xo.Expr, datafusion_right: xo.Expr
+) -> None:
+    with pytest.raises(ValueError, match="different backend"):
+        join_exprs(duckdb_left, datafusion_right, on="id")
+
+
+def test_join_exprs_same_backend_different_profile_raises(
+    datafusion_left: xo.Expr, datafusion_right: xo.Expr
+) -> None:
+    # Two separate `xo.datafusion.connect()` calls: same backend class, but
+    # distinct connections (profile idx N vs N+1) -- not interchangeable.
+    with pytest.raises(ValueError, match="different backend"):
+        join_exprs(datafusion_left, datafusion_right, on="id")
+
+
+def test_union_exprs_different_backend_classes_raises(
+    duckdb_left: xo.Expr, datafusion_right: xo.Expr
+) -> None:
+    # Backend check runs before the schema check, so mismatched columns here
+    # (amount/name) don't matter -- the backend error fires first.
+    with pytest.raises(ValueError, match="different backend"):
+        union_exprs(duckdb_left, datafusion_right)
+
+
+def test_union_exprs_same_backend_different_profile_raises(
+    datafusion_left: xo.Expr, datafusion_right: xo.Expr
+) -> None:
+    with pytest.raises(ValueError, match="different backend"):
+        union_exprs(datafusion_left, datafusion_right)

--- a/python/xorq/ibis_yaml/tests/test_combine.py
+++ b/python/xorq/ibis_yaml/tests/test_combine.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+import xorq.api as xo
+from xorq.ibis_yaml.combine import (
+    _build_join_predicates,
+    join_exprs,
+    union_exprs,
+)
+
+
+@pytest.fixture
+def left() -> xo.Expr:
+    return xo.memtable({"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}, name="left_t")
+
+
+@pytest.fixture
+def right() -> xo.Expr:
+    return xo.memtable({"id": [1, 2, 4], "name": ["a", "b", "d"]}, name="right_t")
+
+
+def test_build_join_predicates_on() -> None:
+    assert _build_join_predicates("id", None, None, "inner") == ("id",)
+
+
+def test_build_join_predicates_on_multiple_columns() -> None:
+    assert _build_join_predicates("id, amount", None, None, "inner") == (
+        "id",
+        "amount",
+    )
+
+
+def test_build_join_predicates_left_right_on() -> None:
+    assert _build_join_predicates(None, "a", "b", "inner") == (("a", "b"),)
+
+
+def test_build_join_predicates_left_right_on_multiple() -> None:
+    assert _build_join_predicates(None, "a,b", "c,d", "inner") == (
+        ("a", "c"),
+        ("b", "d"),
+    )
+
+
+def test_build_join_predicates_on_mutually_exclusive_with_left_on() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _build_join_predicates("id", "a", None, "inner")
+
+
+def test_build_join_predicates_left_on_requires_right_on() -> None:
+    with pytest.raises(ValueError, match="must be given together"):
+        _build_join_predicates(None, "a", None, "inner")
+
+
+def test_build_join_predicates_mismatched_column_counts() -> None:
+    with pytest.raises(ValueError, match="column"):
+        _build_join_predicates(None, "a,b", "c", "inner")
+
+
+def test_build_join_predicates_none_requires_cross() -> None:
+    with pytest.raises(ValueError, match="must specify --on"):
+        _build_join_predicates(None, None, None, "inner")
+
+
+def test_build_join_predicates_none_allowed_for_cross() -> None:
+    assert _build_join_predicates(None, None, None, "cross") == ()
+
+
+def test_join_exprs_inner(left: xo.Expr, right: xo.Expr) -> None:
+    joined = join_exprs(left, right, on="id", how="inner")
+    assert set(joined.columns) == {"id", "amount", "name"}
+    assert joined.count().execute() == 2
+
+
+def test_join_exprs_left_on_right_on(left: xo.Expr, right: xo.Expr) -> None:
+    joined = join_exprs(left, right, left_on="id", right_on="id", how="left")
+    assert joined.count().execute() == 3
+
+
+def test_union_exprs_default_all(left: xo.Expr) -> None:
+    other = xo.memtable({"id": [1, 2], "amount": [10.0, 20.0]}, name="dup")
+    unioned = union_exprs(left, other)
+    assert unioned.count().execute() == 5
+
+
+def test_union_exprs_distinct(left: xo.Expr) -> None:
+    other = xo.memtable({"id": [1, 2], "amount": [10.0, 20.0]}, name="dup")
+    unioned = union_exprs(left, other, distinct=True)
+    assert unioned.count().execute() == 3
+
+
+def test_union_exprs_requires_at_least_two(left: xo.Expr) -> None:
+    with pytest.raises(ValueError, match="at least 2"):
+        union_exprs(left)

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1791,6 +1791,53 @@ def test_loaded_non_relocatable_becomes_database_table(
 
 
 # ---------------------------------------------------------------------------
+# load_expr's con_cache shares same-profile connections across independent loads
+# ---------------------------------------------------------------------------
+
+
+def test_load_expr_con_cache_shares_same_profile_connections(
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
+) -> None:
+    """Two independent `load_expr` calls sharing a `con_cache` dict get the
+    *same* connection object for a matching profile, instead of two distinct
+    objects that a later rebind pass has to reconcile. This is the proactive
+    counterpart to `combine.py`'s `_rebind_same_profile_sources` -- callers
+    that load several builds up front (join_builds/union_builds, catalog
+    join/union) share one cache across all their loads."""
+    left = deferred_read_parquet(sample_parquet, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(sample_parquet, xo.duckdb.connect(), table_name="t")
+    left_path = build_expr(left, builds_dir=builds_dir)
+    right_path = build_expr(right, builds_dir=builds_dir)
+
+    con_cache: dict = {}
+    loaded_left = load_expr(left_path, con_cache=con_cache)
+    loaded_right = load_expr(right_path, con_cache=con_cache)
+
+    left_backends, _ = loaded_left._find_backends()  # xorq-style: disable=protected-access
+    right_backends, _ = loaded_right._find_backends()  # xorq-style: disable=protected-access
+    assert left_backends[0] is right_backends[0]
+
+
+def test_load_expr_without_con_cache_keeps_connections_independent(
+    builds_dir: pathlib.Path, sample_parquet: pathlib.Path
+) -> None:
+    """Default behavior (no `con_cache` passed) is unchanged: each `load_expr`
+    call still constructs its own fresh connection, matching every caller
+    that predates this parameter (e.g. `catalog run`, `compose`)."""
+    left = deferred_read_parquet(sample_parquet, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(sample_parquet, xo.duckdb.connect(), table_name="t")
+    left_path = build_expr(left, builds_dir=builds_dir)
+    right_path = build_expr(right, builds_dir=builds_dir)
+
+    loaded_left = load_expr(left_path)
+    loaded_right = load_expr(right_path)
+
+    left_backends, _ = loaded_left._find_backends()  # xorq-style: disable=protected-access
+    right_backends, _ = loaded_right._find_backends()  # xorq-style: disable=protected-access
+    assert left_backends[0] is not right_backends[0]
+
+
+# ---------------------------------------------------------------------------
 # _prepare_relocatable_reads(mark=True) is idempotent
 # ---------------------------------------------------------------------------
 

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -360,11 +360,18 @@ def test_union_command_requires_two_paths(tmp_path: Path) -> None:
 
 
 def test_union_command_schema_mismatch(tmp_path: Path) -> None:
-    """left/right sources have different schemas -- union must fail cleanly."""
+    """left/right sources have different schemas -- union must fail cleanly.
+
+    A nonzero exit code alone would also pass on an uncaught traceback, so
+    assert on the clean-failure shape too: no traceback, and the expected
+    RelationError message surfaced via click.ClickException.
+    """
     left_path, right_path = _build_joinable_sources(tmp_path)
     test_args = ["xorq", "union", str(left_path), str(right_path)]
     (returncode, _, stderr) = subprocess_run(test_args)
     assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"schemas must be equal" in stderr.lower()
 
 
 def test_join_command_version_mismatch(tmp_path: Path) -> None:
@@ -380,7 +387,7 @@ def test_join_command_version_mismatch(tmp_path: Path) -> None:
     assert b"different xorq library versions" in stderr
 
 
-def test_join_command_ignore_venv_mismatch(tmp_path: Path) -> None:
+def test_join_command_ignore_library_version_mismatch(tmp_path: Path) -> None:
     left_path, right_path = _build_joinable_sources(tmp_path)
     metadata_path = right_path / DumpFiles.build_metadata
     metadata = json.loads(metadata_path.read_text())
@@ -394,9 +401,50 @@ def test_join_command_ignore_venv_mismatch(tmp_path: Path) -> None:
         str(right_path),
         "--on",
         "id",
-        "--ignore-venv-mismatch",
+        "--ignore-library-version-mismatch",
         "--builds-dir",
         str(tmp_path / "joined-builds"),
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode == 0, stderr
+
+
+def _build_unionable_sources(tmp_path: Path) -> tuple[Path, Path]:
+    left = xo.memtable({"id": [1, 2], "amount": [10.0, 20.0]}, name="jan")
+    right = xo.memtable({"id": [3, 4], "amount": [30.0, 40.0]}, name="feb")
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+    return left_path, right_path
+
+
+def test_union_command_version_mismatch(tmp_path: Path) -> None:
+    left_path, right_path = _build_unionable_sources(tmp_path)
+    metadata_path = right_path / DumpFiles.build_metadata
+    metadata = json.loads(metadata_path.read_text())
+    metadata["current_library_version"] = "0.0.0-test-mismatch"
+    metadata_path.write_text(json.dumps(metadata))
+
+    test_args = ["xorq", "union", str(left_path), str(right_path)]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"different xorq library versions" in stderr
+
+
+def test_union_command_ignore_library_version_mismatch(tmp_path: Path) -> None:
+    left_path, right_path = _build_unionable_sources(tmp_path)
+    metadata_path = right_path / DumpFiles.build_metadata
+    metadata = json.loads(metadata_path.read_text())
+    metadata["current_library_version"] = "0.0.0-test-mismatch"
+    metadata_path.write_text(json.dumps(metadata))
+
+    test_args = [
+        "xorq",
+        "union",
+        str(left_path),
+        str(right_path),
+        "--ignore-library-version-mismatch",
+        "--builds-dir",
+        str(tmp_path / "unioned-builds"),
     ]
     (returncode, _, stderr) = subprocess_run(test_args)
     assert returncode == 0, stderr

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import contextlib
 import io
+import json
 import os
 import re
 import shutil
@@ -56,6 +59,7 @@ from xorq.ibis_yaml.compiler import (
     build_expr,
     load_expr,
 )
+from xorq.ibis_yaml.enums import DumpFiles
 from xorq.init_templates import InitTemplates
 
 
@@ -267,6 +271,135 @@ def test_run_command_raises_on_unbound_expr(tmp_path):
     build_dir = build_expr(expr, builds_dir=tmp_path)
     with pytest.raises(ValueError, match="Cannot run unbound expression"):
         run_command(build_dir)
+
+
+def _build_joinable_sources(tmp_path: Path) -> tuple[Path, Path]:
+    left = xo.memtable({"id": [1, 2, 3], "amount": [10.0, 20.0, 30.0]}, name="left_t")
+    right = xo.memtable({"id": [1, 2, 4], "name": ["a", "b", "d"]}, name="right_t")
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+    return left_path, right_path
+
+
+def test_join_command_default(tmp_path: Path) -> None:
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--on",
+        "id",
+        "--builds-dir",
+        str(tmp_path / "joined-builds"),
+    ]
+    (returncode, stdout, stderr) = subprocess_run(test_args)
+    assert returncode == 0, stderr
+
+    result_path = stdout.decode("ascii").strip().splitlines()[-1]
+    assert Path(result_path).is_dir()
+    loaded = load_expr(result_path)
+    assert set(loaded.columns) == {"id", "amount", "name"}
+
+
+def test_join_command_left_on_right_on(tmp_path: Path) -> None:
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--left-on",
+        "id",
+        "--right-on",
+        "id",
+        "--how",
+        "left",
+        "--builds-dir",
+        str(tmp_path / "joined-builds"),
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode == 0, stderr
+
+
+def test_join_command_missing_predicate_fails(tmp_path: Path) -> None:
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = ["xorq", "join", str(left_path), str(right_path)]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"must specify --on" in stderr
+
+
+def test_union_command_default(tmp_path: Path) -> None:
+    left = xo.memtable({"id": [1, 2], "amount": [10.0, 20.0]}, name="jan")
+    right = xo.memtable({"id": [3, 4], "amount": [30.0, 40.0]}, name="feb")
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+
+    test_args = [
+        "xorq",
+        "union",
+        str(left_path),
+        str(right_path),
+        "--builds-dir",
+        str(tmp_path / "union-builds"),
+    ]
+    (returncode, stdout, stderr) = subprocess_run(test_args)
+    assert returncode == 0, stderr
+
+    result_path = stdout.decode("ascii").strip().splitlines()[-1]
+    loaded = load_expr(result_path)
+    assert loaded.count().execute() == 4
+
+
+def test_union_command_requires_two_paths(tmp_path: Path) -> None:
+    left_path, _ = _build_joinable_sources(tmp_path)
+    test_args = ["xorq", "union", str(left_path)]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+
+
+def test_union_command_schema_mismatch(tmp_path: Path) -> None:
+    """left/right sources have different schemas -- union must fail cleanly."""
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = ["xorq", "union", str(left_path), str(right_path)]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+
+
+def test_join_command_version_mismatch(tmp_path: Path) -> None:
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    metadata_path = right_path / DumpFiles.build_metadata
+    metadata = json.loads(metadata_path.read_text())
+    metadata["current_library_version"] = "0.0.0-test-mismatch"
+    metadata_path.write_text(json.dumps(metadata))
+
+    test_args = ["xorq", "join", str(left_path), str(right_path), "--on", "id"]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"different xorq library versions" in stderr
+
+
+def test_join_command_ignore_venv_mismatch(tmp_path: Path) -> None:
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    metadata_path = right_path / DumpFiles.build_metadata
+    metadata = json.loads(metadata_path.read_text())
+    metadata["current_library_version"] = "0.0.0-test-mismatch"
+    metadata_path.write_text(json.dumps(metadata))
+
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--on",
+        "id",
+        "--ignore-venv-mismatch",
+        "--builds-dir",
+        str(tmp_path / "joined-builds"),
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode == 0, stderr
 
 
 @pytest.mark.slow(level=1)

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -436,6 +436,30 @@ def test_join_command_nonexistent_path_fails_cleanly(tmp_path: Path) -> None:
     assert b"cannot read build metadata" in stderr
 
 
+def test_join_command_nonexistent_path_fails_cleanly_with_ignore_flag(
+    tmp_path: Path,
+) -> None:
+    """`--ignore-library-version-mismatch` skips the metadata read that
+    normally turns a missing path into a clean error -- `combine_errors`
+    must still catch the `OSError` that `load_expr` then raises (the
+    Rust-backed YAML reader raises a bare `OSError`, not
+    `FileNotFoundError`, for a missing file)."""
+    _, right_path = _build_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(tmp_path / "does-not-exist"),
+        str(right_path),
+        "--on",
+        "id",
+        "--ignore-library-version-mismatch",
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"cannot load build" in stderr
+
+
 def test_union_command_default(tmp_path: Path) -> None:
     left = xo.memtable({"id": [1, 2], "amount": [10.0, 20.0]}, name="jan")
     right = xo.memtable({"id": [3, 4], "amount": [30.0, 40.0]}, name="feb")

--- a/python/xorq/tests/test_cli.py
+++ b/python/xorq/tests/test_cli.py
@@ -43,6 +43,7 @@ from xorq.cli_options import (
     serve_options,
     unbind_options,
 )
+from xorq.common.utils.defer_utils import deferred_read_parquet
 from xorq.common.utils.io_utils import Peeker
 from xorq.common.utils.logging_utils import Run, Runs
 from xorq.common.utils.node_utils import (
@@ -330,6 +331,111 @@ def test_join_command_missing_predicate_fails(tmp_path: Path) -> None:
     assert b"must specify --on" in stderr
 
 
+def test_join_command_empty_on_fails_instead_of_cross_joining(tmp_path: Path) -> None:
+    """An empty --on (e.g. from an unset shell variable) must not silently
+    fall through to a predicate-less (cartesian-product) join."""
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = ["xorq", "join", str(left_path), str(right_path), "--on", ""]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"at least one non-empty column" in stderr
+
+
+def test_join_command_cross_with_on_fails(tmp_path: Path) -> None:
+    """--how=cross takes no predicates; combining it with --on must be
+    rejected up front rather than building an artifact that always fails
+    at `xorq run` time."""
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--how",
+        "cross",
+        "--on",
+        "id",
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"takes no predicates" in stderr
+
+
+def test_join_command_typo_column_fails_cleanly(tmp_path: Path) -> None:
+    left_path, right_path = _build_joinable_sources(tmp_path)
+    test_args = ["xorq", "join", str(left_path), str(right_path), "--on", "nope"]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"nope" in stderr
+
+
+def test_join_command_bad_rname_template_fails_cleanly(tmp_path: Path) -> None:
+    # Needs an overlapping non-join column for --rname's template to ever be
+    # applied -- _build_joinable_sources's only shared column is the join key.
+    left = xo.memtable({"id": [1, 2, 3], "val": [10, 20, 30]}, name="left_t")
+    right = xo.memtable({"id": [1, 2, 4], "val": [1, 2, 3]}, name="right_t")
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--on",
+        "id",
+        "--rname",
+        "{bogus}",
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"unknown placeholder" in stderr
+
+
+def test_join_command_rname_collision_fails_cleanly(tmp_path: Path) -> None:
+    """--rname "{name}" collides overlapping right columns back onto the
+    left's names; the join is well-formed enough to build a schema (so the
+    collision doesn't surface at predicate-validation time) but must not
+    silently drop the colliding column through the build/YAML round-trip."""
+    left = xo.memtable({"id": [1, 2, 3], "val": [10, 20, 30]}, name="left_t")
+    right = xo.memtable({"id": [1, 2, 4], "val": [1, 2, 3]}, name="right_t")
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--on",
+        "id",
+        "--rname",
+        "{name}",
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"Name collisions" in stderr
+
+
+def test_join_command_nonexistent_path_fails_cleanly(tmp_path: Path) -> None:
+    _, right_path = _build_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(tmp_path / "does-not-exist"),
+        str(right_path),
+        "--on",
+        "id",
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"cannot read build metadata" in stderr
+
+
 def test_union_command_default(tmp_path: Path) -> None:
     left = xo.memtable({"id": [1, 2], "amount": [10.0, 20.0]}, name="jan")
     right = xo.memtable({"id": [3, 4], "amount": [30.0, 40.0]}, name="feb")
@@ -448,6 +554,73 @@ def test_union_command_ignore_library_version_mismatch(tmp_path: Path) -> None:
     ]
     (returncode, _, stderr) = subprocess_run(test_args)
     assert returncode == 0, stderr
+
+
+def _build_file_backed_joinable_sources(tmp_path: Path) -> tuple[Path, Path]:
+    """Two builds reading the *same* parquet file via *separate* connections.
+
+    Each `xo.duckdb.connect()` call constructs a fresh connection object even
+    with identical params, so loading these two builds independently (as
+    `join`/`union` always do) produces two distinct backend connections for
+    what is physically the same data source -- exactly the case
+    `--rebind-backends` (on by default) is meant to fix.
+    """
+    pq_path = tmp_path / "shared.parquet"
+    pd.DataFrame({"id": [1, 2, 3], "a": ["x", "y", "z"]}).to_parquet(pq_path)
+    left = deferred_read_parquet(pq_path, xo.duckdb.connect(), table_name="t")
+    right = deferred_read_parquet(pq_path, xo.duckdb.connect(), table_name="t").rename(
+        b="a"
+    )
+    left_path = build_expr(left, builds_dir=tmp_path / "builds")
+    right_path = build_expr(right, builds_dir=tmp_path / "builds")
+    return left_path, right_path
+
+
+def test_join_command_rebinds_same_profile_file_backed_sources_by_default(
+    tmp_path: Path,
+) -> None:
+    """Two independently-built/loaded reads of the same file, same backend
+    class, same connection params -- previously always failed with an
+    unhandled `XorqError` regardless; now succeeds by default."""
+    left_path, right_path = _build_file_backed_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--on",
+        "id",
+        "--builds-dir",
+        str(tmp_path / "joined-builds"),
+    ]
+    (returncode, stdout, stderr) = subprocess_run(test_args)
+    assert returncode == 0, stderr
+
+    result_path = stdout.decode("ascii").strip().splitlines()[-1]
+    run_args = ["xorq", "run", result_path, "-o", "-", "-f", "csv"]
+    (run_returncode, run_stdout, run_stderr) = subprocess_run(run_args)
+    assert run_returncode == 0, run_stderr
+    output = run_stdout.decode("ascii")
+    assert "id" in output and "a" in output and "b" in output
+
+
+def test_join_command_no_rebind_backends_fails_cleanly(tmp_path: Path) -> None:
+    left_path, right_path = _build_file_backed_joinable_sources(tmp_path)
+    test_args = [
+        "xorq",
+        "join",
+        str(left_path),
+        str(right_path),
+        "--on",
+        "id",
+        "--no-rebind-backends",
+        "--builds-dir",
+        str(tmp_path / "joined-builds"),
+    ]
+    (returncode, _, stderr) = subprocess_run(test_args)
+    assert returncode != 0
+    assert b"Traceback (most recent call last)" not in stderr
+    assert b"different backend" in stderr
 
 
 @pytest.mark.slow(level=1)

--- a/python/xorq/vendor/ibis/backends/profiles.py
+++ b/python/xorq/vendor/ibis/backends/profiles.py
@@ -200,11 +200,21 @@ class Profile:
         return dict(self.kwargs_tuple)
 
     @property
-    def hash_name(self):
+    def content_hash(self):
+        """Digest of this profile's connection content, excluding session-local `idx`.
+
+        Two `Profile`s describing the same backend config hash equal here
+        even if their `idx` differs (e.g. two independently-constructed
+        profiles for the same connection in the same process). This is
+        what `xorq.ibis_yaml.compiler.profile_content_key` returns.
+        """
         from xorq.common.utils.dasher import tokenize  # noqa: PLC0415
 
-        dasher_hash = tokenize(toolz.dissoc(self.as_dict(), "idx"))
-        return f"{dasher_hash}_{self.idx}"
+        return tokenize(toolz.dissoc(self.as_dict(), "idx"))
+
+    @property
+    def hash_name(self):
+        return f"{self.content_hash}_{self.idx}"
 
     def get_con(self, lazy=False, **kwargs):
         """Create a connection using this profile's parameters.


### PR DESCRIPTION
## Summary

Adds `join`/`union` commands at both CLI tiers, for combining two-or-more sources into one:

- `xorq join LEFT_PATH RIGHT_PATH` / `xorq union PATH...` — combine plain build-artifact paths into a new build, mirroring `xorq build`/`xorq run`'s conventions.
- `xorq catalog join ENTRY ENTRY` / `xorq catalog union ENTRY...` — combine catalog entries and auto-register the result, mirroring `xorq catalog compose`.

Both tiers share one public core, `xorq.ibis_yaml.combine` (re-exported via `xorq.api`: `join_exprs`/`union_exprs`/`join_builds`/`union_builds`), that wraps ibis's existing `Table.join`/`Table.union` — no new relational logic.

## Command surface

```
xorq join LEFT_PATH RIGHT_PATH [--on COL | --left-on COL --right-on COL]
                                [--how inner|left|right|outer|semi|anti|cross]
                                [--lname TMPL] [--rname TMPL]
                                [--builds-dir DIR] [--cache-dir DIR] [--relocate-reads/--no-relocate-reads]
                                [--ignore-library-version-mismatch]
                                [--rebind-backends/--no-rebind-backends]
                                [--emit-build-path-to PATH]

xorq union PATH... [--distinct] [--builds-dir DIR] [--cache-dir DIR] [--relocate-reads/--no-relocate-reads]
                    [--ignore-library-version-mismatch] [--rebind-backends/--no-rebind-backends]
                    [--emit-build-path-to PATH]

xorq catalog join LEFT_ENTRY RIGHT_ENTRY [--on COL | --left-on COL --right-on COL] [--how ...]
                                          [--lname TMPL] [--rname TMPL] [--sync/--no-sync] [--alias NAME]
                                          [--cache-dir DIR] [--ignore-venv-mismatch]
                                          [--rebind-backends/--no-rebind-backends]

xorq catalog union ENTRY... [--distinct] [--sync/--no-sync] [--alias NAME] [--cache-dir DIR]
                             [--ignore-venv-mismatch] [--rebind-backends/--no-rebind-backends]
```

`--on`/`--left-on`+`--right-on` accept comma-separated column lists; `--how=cross` takes no predicate. Both tiers load their sources, combine them, and (top-level) write a new build artifact, or (catalog tier) build and register a new cataloged entry — an `--alias` can be attached at catalog time.

## Version-mismatch guard

Combining fails fast by default if the sources recorded different environments, with a per-tier override:

- Top level: compares `build_metadata.json`'s `current_library_version` across the input builds; overridden with `--ignore-library-version-mismatch`.
- Catalog tier: reuses the existing wheel/requirements-merge check (`_entry_run_bundle`, run *before* loading/building so a mismatch doesn't waste a full load+build cycle); overridden with `--ignore-venv-mismatch`.

The two override flags are named differently on purpose — they check different things (a recorded library version vs. wheel/Python-minor compatibility) and living at different tiers.

## Execution model

v1 runs fully in-process — no per-build venv reinvocation like `catalog run`'s default subprocess path. Two-or-more input builds pinned to different venvs is a separate, harder problem, deferred for later.

## Cross-backend / cross-source combining

Two independently-loaded builds or catalog entries normally get two distinct connection objects even when they describe the identical backend config (`Profile.get_con()` never caches), which would otherwise make every non-memtable join/union fail with an opaque backend-mismatch error regardless of whether the underlying data is actually the same.

This is handled by `--rebind-backends`/`--no-rebind-backends` (default **on**, both tiers), implemented in two complementary layers:

- **Load-time connection sharing**: `join_builds`/`union_builds` and the catalog tier's `join`/`union` share one `con_cache` (keyed by `Profile` content, `idx` excluded) across every load they do, so a same-profile connection is a single object from the moment each source is loaded.
- **Graph-level rebind backstop**: `_rebind_same_profile_sources` collapses any same-profile backend connections still present after loading (e.g. for exprs assembled outside these load sites) via `replace_sources`/`find_all_sources` — a pure graph rewrite that never transfers table data.

A backend is only rebind-eligible if every node referencing it is a `Read` (e.g. `deferred_read_parquet`) or a `RemoteTable` (`.into_backend()`'s op, safe because it's lazy — no registration happens until execution). An in-memory `DatabaseTable` (`.create_table()`) or anything tying state to a specific connection instance (`CachedNode`, `FlightExpr`/`FlightUDXF`, `TeeNode`) is excluded and left alone as both a merge source and target. The rebind-eligible node-type list (`BACKEND_LEAF_NODE_TYPES` in `graph_utils.py`) is the same one `find_all_sources` walks, so a future backend-bearing node type is unsafe-by-default rather than silently rebindable.

Genuinely different backends (different engine, or different underlying resource under the same engine) still correctly fail, with a message pointing at bridging them with `.into_backend(...)` first.

**Known limitation:** combining two independently-loaded entries that each reference an *existing* persistent table on the same remote database (Postgres, Snowflake, ...) via `.table(name)` is not covered — `Backend.table(name)` constructs `ops.DatabaseTable`, the same op type an in-memory `.create_table()` registration produces, and there's currently no way to distinguish "a real server-side table, safe to re-derive from an equivalent connection" from "ephemeral client-side data that only exists in this session" at that op. `.into_backend()` bridges and file-backed reads (`deferred_read_parquet`/`deferred_read_csv`) are unaffected. Fixing this needs per-instance metadata on the table reference (a node-type-level flag isn't expressive enough, since the same backend can hold both persistent and session-scoped tables under the same op type) — filed as a follow-up.

**Filed, not implemented:** the rebind-safety fact for each node type (`Read`/`RemoteTable` safe, others not) currently lives as a local tuple + prose in `combine.py`, rather than in the codebase's existing registered, tripwire-enforced pattern for per-op-type facts (`OPAQUE_SPECS` in `graph_utils.py`). A `session_bound: bool` field on that registry would unify it; not done here since the current allowlist is correct and tested.

## Error handling

`join_exprs`/`union_exprs`'s exceptions are mapped to clean CLI errors by a shared `combine_errors()` context manager (used by both tiers, so the mapping can't drift out of sync between call sites):

- `ValueError`/`XorqTypeError` (bad predicate spec, typo'd `--on`/`--left-on`/`--right-on` column) → `click.BadParameter`
- `RelationError`/`IntegrityError` (schema mismatch, or an unresolved `--lname`/`--rname` collision) → `click.ClickException`
- `KeyError` (an `--lname`/`--rname` template referencing a nonexistent field) → `click.BadParameter`
- `OSError` (a build path that doesn't exist or can't be read — including the case where `--ignore-library-version-mismatch` skips the earlier metadata check that would otherwise catch it) → `click.ClickException`

`--how=cross` combined with a predicate, and an empty/whitespace `--on` (e.g. from an unset shell variable), are both rejected up front rather than building an artifact that fails later. A colliding `--rname`/`--lname` is caught immediately at join time — `Table.join()` returns a lazy "unfinished" chain whose collision check normally only fires on `.execute()`, which `build_expr`/`load_expr` never call, so `join_exprs` forces that check before returning.

## Registration

Both commands are registered in `docs/generate_cli_reference.py`'s CI-checked groups.

## Test plan

- `pytest python/xorq/ibis_yaml/tests/test_combine.py` — `_build_join_predicates`/`join_exprs`/`union_exprs` unit tests, including the backend-rebind guard (same-backend-class, same-profile-file-backed, same-profile-`.into_backend()`, idx-collision, and genuinely-different-backend cases) and the predicate/collision fixes
- `pytest python/xorq/ibis_yaml/tests/test_compiler.py` — `load_expr`/`hydrate_cons`'s `con_cache` parameter: shares same-profile connections when passed, preserves independent-per-call behavior when omitted
- `pytest python/xorq/tests/test_cli.py -k "join or union"` — top-level CLI happy path, predicate variants, schema-mismatch failure, library-version-mismatch guard, and error-path regressions (including the `OSError`/`--ignore-library-version-mismatch` combination)
- `pytest python/xorq/catalog/tests/test_cli_run_compose.py` — catalog-tier CLI happy path (including `.into_backend()` entries from mixed source backends, both join orderings), schema-mismatch failure, `_entry_run_bundle`'s requirements/Python-minor branches
- `python docs/generate_cli_reference.py` — confirms `join`/`union` are registered in the CI docs-lint groups
- Manual: `xorq build` two scripts, `xorq join <left> <right> --on id`, `xorq run <result>`; `xorq catalog add` + `xorq catalog join --alias`, `xorq catalog run <alias>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
