### PR TITLE
fix(api): make cases deferrable

### DIFF
--- a/python/xorq/backends/xorq_datafusion/tests/test_api.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_api.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -68,4 +69,26 @@ def test_cases_deferred(alltypes: ir.Table) -> None:
     result = expr.execute()
     expected = result.string_col.where(result.bool_col, None)
 
-    assert result.result.equals(expected)
+    pd.testing.assert_series_equal(result.result, expected, check_names=False)
+
+
+def test_cases_deferred_multiple_branches(alltypes: ir.Table) -> None:
+    deferred = xo.cases(
+        (xo._.int_col == 1, xo._.string_col),
+        (xo._.int_col == 2, "two"),
+        else_=xo._.string_col.upper(),
+    )
+
+    assert isinstance(deferred, xo.Deferred)
+
+    expr = alltypes.mutate(result=deferred)
+    result = expr.execute()
+    expected = pd.Series(
+        np.select(
+            (result.int_col == 1, result.int_col == 2),
+            (result.string_col, "two"),
+            default=result.string_col.str.upper(),
+        )
+    )
+
+    pd.testing.assert_series_equal(result.result, expected, check_names=False)

--- a/python/xorq/backends/xorq_datafusion/tests/test_api.py
+++ b/python/xorq/backends/xorq_datafusion/tests/test_api.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 import xorq.api as xo
+import xorq.vendor.ibis.expr.types as ir
 from xorq.api import SessionConfig
 
 
@@ -50,9 +51,21 @@ def test_with_config(
     assert len(result) == 10
 
 
-def test_cases(alltypes):
+def test_cases(alltypes: ir.Table) -> None:
     expr = xo.cases((alltypes["bool_col"], alltypes["string_col"]), else_=None).substr(
         0, 2
     )
 
     assert expr.execute() is not None
+
+
+def test_cases_deferred(alltypes: ir.Table) -> None:
+    deferred = xo.cases((xo._.bool_col, xo._.string_col), else_=None)
+
+    assert isinstance(deferred, xo.Deferred)
+
+    expr = alltypes.mutate(result=deferred)
+    result = expr.execute()
+    expected = result.string_col.where(result.bool_col, None)
+
+    assert result.result.equals(expected)

--- a/python/xorq/vendor/ibis/expr/api.py
+++ b/python/xorq/vendor/ibis/expr/api.py
@@ -1165,6 +1165,7 @@ def case() -> bl.SearchedCaseBuilder:
     return bl.SearchedCaseBuilder()
 
 
+@deferrable
 def cases(
     branch: tuple[Any, Any], *branches: tuple[Any, Any], else_: Any | None = None
 ) -> ir.Value:


### PR DESCRIPTION
## What

Adds the missing `@deferrable` decorator to the top-level `cases` in the vendored ibis API, plus regression tests.

## Why

The vendored `cases` was backported from upstream ibis 10.0.0 in #1480 without the `@deferrable` decorator, so calling it with deferred arguments failed instead of returning a `Deferred`:

```python
>>> xo.cases((xo._.a == 1, "x"), else_="y")
SignatureValidationError: Literal((_.a == 1), ...) has failed ...
  `value`: (_.a == 1) is not matching Any() then anything except a Deferred
```

Upstream carries the decorator, as do the other deferrable functions in the same file (`ifelse`, `coalesce`, `greatest`, `least`, `date`, `time`, `timestamp`). The decorator is a no-op when no `Deferred` argument is present, so the existing eager path is unchanged.

## Test

Two new tests in `python/xorq/backends/xorq_datafusion/tests/test_api.py`, both asserting the result is a `Deferred` and then comparing executed values against a pandas/numpy reference (not just non-`None`):

- `test_cases_deferred` — single branch plus `else_=None`, checked against `Series.where`.
- `test_cases_deferred_multiple_branches` — deferreds in the varargs branches *and* in `else_`, checked against `np.select`.

`test_api.py -k cases` passes (3 tests). Previously verified: full `test_string.py` and `ibis_yaml/test_string_ops.py` pass (the heaviest users of `.cases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
