### PR TITLE
fix(deps): declare packaging, numpy, pygments and xxhash as runtime dependencies

### DIFF
--- a/.github/workflows/ci-test-install.yaml
+++ b/.github/workflows/ci-test-install.yaml
@@ -111,7 +111,7 @@ jobs:
           mkdir -p test-wheel && cd test-wheel
           python -c "import pathlib; print(f'Current working directory: {pathlib.Path.cwd()}')"
           python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
-          python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
+          python "$GITHUB_WORKSPACE/python/xorq/tests/check_bare_imports.py"
           cd ..
           deactivate
           
@@ -126,7 +126,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install dist/*.tar.gz
           python -c "import xorq; print(f'Successfully installed xorq {xorq.__version__} from source distribution')"
-          python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
+          python "$GITHUB_WORKSPACE/python/xorq/tests/check_bare_imports.py"
           deactivate
 
       - name: Test extras installation from wheel

--- a/.github/workflows/ci-test-install.yaml
+++ b/.github/workflows/ci-test-install.yaml
@@ -111,6 +111,7 @@ jobs:
           mkdir -p test-wheel && cd test-wheel
           python -c "import pathlib; print(f'Current working directory: {pathlib.Path.cwd()}')"
           python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
+          python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
           cd ..
           deactivate
           
@@ -125,6 +126,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install dist/*.tar.gz
           python -c "import xorq; print(f'Successfully installed xorq {xorq.__version__} from source distribution')"
+          python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
           deactivate
 
       - name: Test extras installation from wheel

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -53,11 +53,21 @@ jobs:
       - name: test wheel
         run: | 
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
+          # The modules on the build, run and catalog paths must import with the
+          # declared dependencies and nothing else.  Deliberately kept out of the
+          # pytest invocation below: pytest depends on `packaging`, so running these
+          # imports in that environment would mask a missing declaration.
+          uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl --with pytest --with pytest-cov -- pytest --import-mode=importlib --cov --cov-report=xml -m "library or xorq"
 
       - name: test source distribution
         run: | 
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
+          # The modules on the build, run and catalog paths must import with the
+          # declared dependencies and nothing else.  Deliberately kept out of the
+          # pytest invocation below: pytest depends on `packaging`, so running these
+          # imports in that environment would mask a missing declaration.
+          uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz --with pytest --with pytest-cov -- pytest --import-mode=importlib --cov --cov-report=xml -m "library or xorq"
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -53,20 +53,14 @@ jobs:
       - name: test wheel
         run: | 
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
-          # The modules on the build, run and catalog paths must import with the
-          # declared dependencies and nothing else.  Deliberately kept out of the
-          # pytest invocation below: pytest depends on `packaging`, so running these
-          # imports in that environment would mask a missing declaration.
+          # Kept out of the pytest run below, which supplies `packaging` itself.
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl --with pytest --with pytest-cov -- pytest --import-mode=importlib --cov --cov-report=xml -m "library or xorq"
 
       - name: test source distribution
         run: | 
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
-          # The modules on the build, run and catalog paths must import with the
-          # declared dependencies and nothing else.  Deliberately kept out of the
-          # pytest invocation below: pytest depends on `packaging`, so running these
-          # imports in that environment would mask a missing declaration.
+          # Kept out of the pytest run below, which supplies `packaging` itself.
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz --with pytest --with pytest-cov -- pytest --import-mode=importlib --cov --cov-report=xml -m "library or xorq"
 

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -54,14 +54,14 @@ jobs:
         run: | 
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
           # Kept out of the pytest run below, which supplies `packaging` itself.
-          uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
+          uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl -- python python/xorq/tests/check_bare_imports.py
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.whl --with pytest --with pytest-cov -- pytest --import-mode=importlib --cov --cov-report=xml -m "library or xorq"
 
       - name: test source distribution
         run: | 
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python -c "import xorq; print(f'Successfully imported {xorq.__name__} version {xorq.__version__}')"
           # Kept out of the pytest run below, which supplies `packaging` itself.
-          uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python -c "import xorq.api, xorq.cli, xorq.catalog.cli, xorq.ibis_yaml.compiler, xorq.ibis_yaml.packager, xorq.ibis_yaml.pep723"
+          uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz -- python python/xorq/tests/check_bare_imports.py
           uv run --isolated --no-project -p ${{ matrix.python-version }} --with dist/*.tar.gz --with pytest --with pytest-cov -- pytest --import-mode=importlib --cov --cov-report=xml -m "library or xorq"
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -157,6 +157,20 @@ jobs:
           POSTGRES_PORT: 5432
           POSTGRES_DATABASE: ibis_testing
 
+      # Builds the wheel and drives the CLI through `uv tool run --isolated`, so
+      # the environment under test holds [project].dependencies and nothing else.
+      # Kept out of the pytest step above: that environment has the dev and test
+      # groups installed, which supply distributions xorq must declare itself.
+      - name: bare-install CLI round trip
+        if: matrix.backend.name == 'core'
+        timeout-minutes: 10
+        run: >
+          uv run --no-sync pytest
+          --import-mode=importlib
+          -m bare_install
+          -v --durations=20
+        working-directory: ${{ github.workspace }}
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.5.4
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -157,10 +157,8 @@ jobs:
           POSTGRES_PORT: 5432
           POSTGRES_DATABASE: ibis_testing
 
-      # Builds the wheel and drives the CLI through `uv tool run --isolated`, so
-      # the environment under test holds [project].dependencies and nothing else.
-      # Kept out of the pytest step above: that environment has the dev and test
-      # groups installed, which supply distributions xorq must declare itself.
+      # Builds its own wheel and isolated env, so the dev/test groups installed
+      # here cannot mask a missing declaration.
       - name: bare-install CLI round trip
         if: matrix.backend.name == 'core'
         timeout-minutes: 10

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -165,6 +165,7 @@ jobs:
         run: >
           uv run --no-sync pytest
           --import-mode=importlib
+          python/xorq/tests/test_bare_install.py
           -m bare_install
           -v --durations=20
         working-directory: ${{ github.workspace }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,19 +34,17 @@ dependencies = [
     "atpublic>=5.1",
     "parsy>=2",
     "packaging>=22",
-    # numpy and xxhash floors are per-interpreter: each is the first release
-    # shipping wheels for that Python, so `--resolution lowest-direct` resolves
-    # to a wheel instead of falling back to a source build (numpy from source
-    # needs BLAS, which CI runners do not have).
+    # Per-interpreter floors: the first release with wheels for that Python, so
+    # `--resolution lowest-direct` gets a wheel and not a source build.
     "numpy>=1.22.4; python_version < '3.11'",
     "numpy>=1.23.2; python_version == '3.11'",
     "numpy>=1.26.0; python_version == '3.12'",
-    "numpy>=2.1.0; python_version >= '3.13'",  # 2.1.0 is first numpy with cp313 wheels
+    "numpy>=2.1.0; python_version >= '3.13'",
     "xxhash>=3.0; python_version < '3.11'",
     "xxhash>=3.2; python_version == '3.11'",
     "xxhash>=3.4; python_version == '3.12'",
-    "xxhash>=3.5; python_version >= '3.13'",  # 3.5.0 is first xxhash with cp313 wheels
-    "pygments>=2.13",  # pure python, wheels work on every supported interpreter
+    "xxhash>=3.5; python_version >= '3.13'",
+    "pygments>=2.13",
     "python-dateutil>=2.8.2",
     "pytz>=2022.7",
     "sqlglot>=23.4,!=26.32.0,<28.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
     # Per-interpreter floors so `--resolution lowest-direct` gets a wheel and not
     # a source build.  Each is the first release with wheels for that Python,
     # except numpy on 3.10, where 1.22.4 is pandas' own floor (1.21.3 was the
-    # first with cp310 wheels).
+    # first with cp310 wheels).  The `>= '3.13'` rows are open upward and only
+    # safe while requires-python caps at <3.14; raising that cap needs a new row
+    # per interpreter, or lowest-direct picks a release with no wheel for it.
     "numpy>=1.22.4; python_version < '3.11'",
     "numpy>=1.23.2; python_version == '3.11'",
     "numpy>=1.26.0; python_version == '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,10 @@ dependencies = [
     "atpublic>=5.1",
     "parsy>=2",
     "packaging>=22",
-    # Per-interpreter floors: the first release with wheels for that Python, so
-    # `--resolution lowest-direct` gets a wheel and not a source build.
+    # Per-interpreter floors so `--resolution lowest-direct` gets a wheel and not
+    # a source build.  Each is the first release with wheels for that Python,
+    # except numpy on 3.10, where 1.22.4 is pandas' own floor (1.21.3 was the
+    # first with cp310 wheels).
     "numpy>=1.22.4; python_version < '3.11'",
     "numpy>=1.23.2; python_version == '3.11'",
     "numpy>=1.26.0; python_version == '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,19 @@ dependencies = [
     "atpublic>=5.1",
     "parsy>=2",
     "packaging>=22",
-    "numpy>=1.22.4",
-    "pygments>=2.13",
-    "xxhash>=3.0",
+    # numpy and xxhash floors are per-interpreter: each is the first release
+    # shipping wheels for that Python, so `--resolution lowest-direct` resolves
+    # to a wheel instead of falling back to a source build (numpy from source
+    # needs BLAS, which CI runners do not have).
+    "numpy>=1.22.4; python_version < '3.11'",
+    "numpy>=1.23.2; python_version == '3.11'",
+    "numpy>=1.26.0; python_version == '3.12'",
+    "numpy>=2.1.0; python_version >= '3.13'",  # 2.1.0 is first numpy with cp313 wheels
+    "xxhash>=3.0; python_version < '3.11'",
+    "xxhash>=3.2; python_version == '3.11'",
+    "xxhash>=3.4; python_version == '3.12'",
+    "xxhash>=3.5; python_version >= '3.13'",  # 3.5.0 is first xxhash with cp313 wheels
+    "pygments>=2.13",  # pure python, wheels work on every supported interpreter
     "python-dateutil>=2.8.2",
     "pytz>=2022.7",
     "sqlglot>=23.4,!=26.32.0,<28.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     "pandas>=2.2.3,<3 ; python_version >= '3.10' and python_version < '4.0'",
     "atpublic>=5.1",
     "parsy>=2",
+    "packaging>=22",
+    "numpy>=1.22.4",
+    "pygments>=2.13",
+    "xxhash>=3.0",
     "python-dateutil>=2.8.2",
     "pytz>=2022.7",
     "sqlglot>=23.4,!=26.32.0,<28.7.0",
@@ -324,6 +328,7 @@ markers = [
     "databricks: Databricks tests",
     "xorq_datafusion: xorq DataFusion backend tests",
     "uv_export: tests that call uv export against the project lockfile",
+    "bare_install: tests that build the wheel and drive the CLI against declared dependencies only",
     "bigquery: BigQuery tests",
 ]
 consider_namespace_packages = true

--- a/python/xorq/tests/bare_install_modules.txt
+++ b/python/xorq/tests/bare_install_modules.txt
@@ -10,3 +10,4 @@ xorq.ibis_yaml.compiler
 xorq.ibis_yaml.packager
 xorq.ibis_yaml.pep723
 xorq.backends.pandas.executor
+xorq.common.utils.dasher

--- a/python/xorq/tests/bare_install_modules.txt
+++ b/python/xorq/tests/bare_install_modules.txt
@@ -1,0 +1,12 @@
+# Modules that must import with only [project].dependencies installed.
+# Read by python/xorq/tests/test_bare_install.py and by the bare-environment
+# smoke steps in ci-test-library.yml and ci-test-install.yaml.
+xorq
+xorq.api
+xorq.cli
+xorq.catalog.cli
+xorq.catalog.tui
+xorq.ibis_yaml.compiler
+xorq.ibis_yaml.packager
+xorq.ibis_yaml.pep723
+xorq.backends.pandas.executor

--- a/python/xorq/tests/check_bare_imports.py
+++ b/python/xorq/tests/check_bare_imports.py
@@ -1,4 +1,4 @@
-"""Import every module in bare-install-modules.txt; exit non-zero on the first failure.
+"""Import every module in bare_install_modules.txt; exit non-zero on the first failure.
 
 Run inside an environment holding only [project].dependencies, so it must not
 import anything beyond the standard library and xorq itself.

--- a/python/xorq/tests/check_bare_imports.py
+++ b/python/xorq/tests/check_bare_imports.py
@@ -11,11 +11,8 @@ import sys
 
 def main():
     listing = pathlib.Path(__file__).with_name("bare_install_modules.txt")
-    names = [
-        line.strip()
-        for line in listing.read_text().splitlines()
-        if line.strip() and not line.startswith("#")
-    ]
+    lines = (line.strip() for line in listing.read_text().splitlines())
+    names = [line for line in lines if line and not line.startswith("#")]
     if not names:
         sys.exit(f"no modules listed in {listing}")
     for name in names:

--- a/python/xorq/tests/check_bare_imports.py
+++ b/python/xorq/tests/check_bare_imports.py
@@ -1,0 +1,28 @@
+"""Import every module in bare-install-modules.txt; exit non-zero on the first failure.
+
+Run inside an environment holding only [project].dependencies, so it must not
+import anything beyond the standard library and xorq itself.
+"""
+
+import importlib
+import pathlib
+import sys
+
+
+def main():
+    listing = pathlib.Path(__file__).with_name("bare_install_modules.txt")
+    names = [
+        line.strip()
+        for line in listing.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+    if not names:
+        sys.exit(f"no modules listed in {listing}")
+    for name in names:
+        importlib.import_module(name)
+        print(f"ok {name}")
+    print(f"imported {len(names)} modules with declared dependencies only")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/xorq/tests/conftest.py
+++ b/python/xorq/tests/conftest.py
@@ -223,7 +223,12 @@ def struct_df(struct):
 @pytest.fixture(scope="session")
 def project_root():
     """The source checkout containing pyproject.toml; skip if installed."""
-    root = Path(__file__).parents[3]
-    if not root.joinpath("pyproject.toml").exists():
+    from xorq.ibis_yaml.packager import (  # noqa: PLC0415
+        PYPROJECT_NAME,
+        find_file_upwards,
+    )
+
+    try:
+        return find_file_upwards(Path(__file__).parent, PYPROJECT_NAME).parent
+    except ValueError:
         pytest.skip("not running from a source checkout")
-    return root

--- a/python/xorq/tests/conftest.py
+++ b/python/xorq/tests/conftest.py
@@ -218,17 +218,3 @@ def struct(con):
 @pytest.fixture(scope="session")
 def struct_df(struct):
     return struct.execute()
-
-
-@pytest.fixture(scope="session")
-def project_root():
-    """The source checkout containing pyproject.toml; skip if installed."""
-    from xorq.ibis_yaml.packager import (  # noqa: PLC0415
-        PYPROJECT_NAME,
-        find_file_upwards,
-    )
-
-    try:
-        return find_file_upwards(Path(__file__).parent, PYPROJECT_NAME).parent
-    except ValueError:
-        pytest.skip("not running from a source checkout")

--- a/python/xorq/tests/conftest.py
+++ b/python/xorq/tests/conftest.py
@@ -222,11 +222,7 @@ def struct_df(struct):
 
 @pytest.fixture(scope="session")
 def project_root():
-    """The source checkout containing pyproject.toml.
-
-    Skips when xorq is imported from an installed wheel rather than a checkout,
-    since the packaging tests have nothing to read in that case.
-    """
+    """The source checkout containing pyproject.toml; skip if installed."""
     root = Path(__file__).parents[3]
     if not root.joinpath("pyproject.toml").exists():
         pytest.skip("not running from a source checkout")

--- a/python/xorq/tests/conftest.py
+++ b/python/xorq/tests/conftest.py
@@ -218,3 +218,16 @@ def struct(con):
 @pytest.fixture(scope="session")
 def struct_df(struct):
     return struct.execute()
+
+
+@pytest.fixture(scope="session")
+def project_root():
+    """The source checkout containing pyproject.toml.
+
+    Skips when xorq is imported from an installed wheel rather than a checkout,
+    since the packaging tests have nothing to read in that case.
+    """
+    root = Path(__file__).parents[3]
+    if not root.joinpath("pyproject.toml").exists():
+        pytest.skip("not running from a source checkout")
+    return root

--- a/python/xorq/tests/test_bare_install.py
+++ b/python/xorq/tests/test_bare_install.py
@@ -70,8 +70,10 @@ def test_core_modules_import(wheel, root_dir):
 def test_module_listing_covers_the_new_declarations(root_dir):
     """pygments and xxhash are only reached through tui and the pandas executor.
 
-    Without those two entries the round trip never imports either, so three of
-    the four declarations this branch adds would go unexercised end to end.
+    This exercises those import paths; it does not guard the declarations.
+    Removing numpy, pygments or xxhash from pyproject.toml leaves these tests
+    green, because each still arrives transitively via pandas, rich/textual and
+    xorq-dasher.  test_declared_dependencies is what fails on removal.
     """
     listing = root_dir.joinpath(MODULE_LISTING).read_text()
     for module in ("xorq.catalog.tui", "xorq.backends.pandas.executor"):

--- a/python/xorq/tests/test_bare_install.py
+++ b/python/xorq/tests/test_bare_install.py
@@ -1,0 +1,114 @@
+"""Exercise the CLI against an environment holding only the declared dependencies.
+
+``test_declared_dependencies`` reasons statically about module-level imports.
+It cannot see an import deferred inside a function body, and most of the
+packager imports in ``xorq/cli.py`` are exactly that.  These tests close the
+gap by building the wheel and driving the CLI through ``uv tool run
+--isolated``, which installs ``[project].dependencies`` and nothing else.
+
+This is what distinguishes a real regression from a plausible one: the
+``packaging`` omission left ``xorq build`` fully working while ``xorq run``
+raised ``ModuleNotFoundError`` at import time, so any test that only built, or
+only checked ``--help``, stayed green.
+"""
+
+import sys
+
+import pytest
+
+from xorq.common.utils.process_utils import subprocess_run
+
+
+pytestmark = pytest.mark.bare_install
+
+
+PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+EXPR_PY = """
+import xorq.api as xo
+
+t = xo.memtable({"a": [1, 2, 3]})
+expr = t.filter(t.a > 1)
+"""
+
+# Modules on the build, run and catalog paths.  Each must import with only the
+# declared dependencies present.
+CORE_MODULES = (
+    "xorq",
+    "xorq.api",
+    "xorq.cli",
+    "xorq.catalog.cli",
+    "xorq.ibis_yaml.compiler",
+    "xorq.ibis_yaml.packager",
+    "xorq.ibis_yaml.pep723",
+)
+
+
+def run_bare(wheel, args, cwd):
+    """Run a command against an env holding only xorq's declared dependencies."""
+    return subprocess_run(
+        (
+            "uv",
+            "tool",
+            "run",
+            "--isolated",
+            "--python",
+            PYTHON_VERSION,
+            "--with",
+            str(wheel),
+            *args,
+        ),
+        cwd=cwd,
+        text=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def wheel(project_root, tmp_path_factory):
+    dist = tmp_path_factory.mktemp("dist")
+    returncode, stdout, stderr = subprocess_run(
+        ("uv", "build", "--wheel", "-o", str(dist)),
+        cwd=project_root,
+        text=True,
+    )
+    assert returncode == 0, stderr
+    (wheel,) = dist.glob("*.whl")
+    return wheel
+
+
+def test_core_modules_import(wheel, tmp_path):
+    """The static scan cannot see function-level imports; this can."""
+    source = ";".join(f"import {module}" for module in CORE_MODULES)
+    returncode, stdout, stderr = run_bare(wheel, ("python", "-c", source), cwd=tmp_path)
+    assert returncode == 0, stderr
+
+
+def test_build_then_run_round_trip(wheel, tmp_path):
+    """`xorq build` succeeded even while `xorq run` was broken, so test both."""
+    tmp_path.joinpath("expr.py").write_text(EXPR_PY)
+
+    returncode, stdout, stderr = run_bare(
+        wheel, ("xorq", "build", "expr.py", "-e", "expr"), cwd=tmp_path
+    )
+    assert returncode == 0, stderr
+    build_path = stdout.strip().splitlines()[-1]
+    assert tmp_path.joinpath(build_path).exists()
+
+    returncode, stdout, stderr = run_bare(
+        wheel, ("xorq", "run", build_path), cwd=tmp_path
+    )
+    assert returncode == 0, stderr
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ("xorq", "--help"),
+        ("xorq", "build", "--help"),
+        ("xorq", "run", "--help"),
+        ("xorq", "catalog", "--help"),
+    ),
+)
+def test_help_is_reachable(wheel, tmp_path, args):
+    returncode, stdout, stderr = run_bare(wheel, args, cwd=tmp_path)
+    assert returncode == 0, stderr

--- a/python/xorq/tests/test_bare_install.py
+++ b/python/xorq/tests/test_bare_install.py
@@ -1,15 +1,8 @@
-"""Exercise the CLI against an environment holding only the declared dependencies.
+"""Drive the CLI against an environment holding only the declared dependencies.
 
-``test_declared_dependencies`` reasons statically about module-level imports.
-It cannot see an import deferred inside a function body, and most of the
-packager imports in ``xorq/cli.py`` are exactly that.  These tests close the
-gap by building the wheel and driving the CLI through ``uv tool run
---isolated``, which installs ``[project].dependencies`` and nothing else.
-
-This is what distinguishes a real regression from a plausible one: the
-``packaging`` omission left ``xorq build`` fully working while ``xorq run``
-raised ``ModuleNotFoundError`` at import time, so any test that only built, or
-only checked ``--help``, stayed green.
+Covers what the static scan in ``test_declared_dependencies`` cannot: imports
+deferred inside a function body, which is most of the packager imports in
+``xorq/cli.py``.
 """
 
 import sys
@@ -31,8 +24,7 @@ t = xo.memtable({"a": [1, 2, 3]})
 expr = t.filter(t.a > 1)
 """
 
-# Modules on the build, run and catalog paths.  Each must import with only the
-# declared dependencies present.
+# Modules on the build, run and catalog paths.
 CORE_MODULES = (
     "xorq",
     "xorq.api",
@@ -45,7 +37,6 @@ CORE_MODULES = (
 
 
 def run_bare(wheel, args, cwd):
-    """Run a command against an env holding only xorq's declared dependencies."""
     return subprocess_run(
         (
             "uv",

--- a/python/xorq/tests/test_bare_install.py
+++ b/python/xorq/tests/test_bare_install.py
@@ -47,11 +47,11 @@ def run_bare(wheel, args, cwd):
 
 
 @pytest.fixture(scope="module")
-def wheel(project_root, tmp_path_factory):
+def wheel(root_dir, tmp_path_factory):
     dist = tmp_path_factory.mktemp("dist")
     returncode, stdout, stderr = subprocess_run(
         ("uv", "build", "--wheel", "-o", str(dist)),
-        cwd=project_root,
+        cwd=root_dir,
         text=True,
     )
     assert returncode == 0, stderr
@@ -59,21 +59,21 @@ def wheel(project_root, tmp_path_factory):
     return wheel
 
 
-def test_core_modules_import(wheel, project_root):
+def test_core_modules_import(wheel, root_dir):
     """The static scan cannot see function-level imports; this can."""
     returncode, stdout, stderr = run_bare(
-        wheel, ("python", BARE_IMPORT_CHECK), cwd=project_root
+        wheel, ("python", BARE_IMPORT_CHECK), cwd=root_dir
     )
     assert returncode == 0, stderr
 
 
-def test_module_listing_covers_the_new_declarations(project_root):
+def test_module_listing_covers_the_new_declarations(root_dir):
     """pygments and xxhash are only reached through tui and the pandas executor.
 
     Without those two entries the round trip never imports either, so three of
     the four declarations this branch adds would go unexercised end to end.
     """
-    listing = project_root.joinpath(MODULE_LISTING).read_text()
+    listing = root_dir.joinpath(MODULE_LISTING).read_text()
     for module in ("xorq.catalog.tui", "xorq.backends.pandas.executor"):
         assert module in listing
 

--- a/python/xorq/tests/test_bare_install.py
+++ b/python/xorq/tests/test_bare_install.py
@@ -68,7 +68,12 @@ def test_core_modules_import(wheel, root_dir):
 
 
 def test_module_listing_covers_the_new_declarations(root_dir):
-    """pygments and xxhash are only reached through tui and the pandas executor.
+    """Each declaration needs a module that imports it named in the listing.
+
+    pygments comes from catalog/tui.py, numpy from backends/pandas/executor.py,
+    xxhash from common/utils/dasher.  dasher is reached incidentally through
+    xorq.api today, so name it explicitly: coverage should not depend on
+    xorq.api continuing to import it.
 
     This exercises those import paths; it does not guard the declarations.
     Removing numpy, pygments or xxhash from pyproject.toml leaves these tests
@@ -76,7 +81,11 @@ def test_module_listing_covers_the_new_declarations(root_dir):
     xorq-dasher.  test_declared_dependencies is what fails on removal.
     """
     listing = root_dir.joinpath(MODULE_LISTING).read_text()
-    for module in ("xorq.catalog.tui", "xorq.backends.pandas.executor"):
+    for module in (
+        "xorq.catalog.tui",
+        "xorq.backends.pandas.executor",
+        "xorq.common.utils.dasher",
+    ):
         assert module in listing
 
 

--- a/python/xorq/tests/test_bare_install.py
+++ b/python/xorq/tests/test_bare_install.py
@@ -24,16 +24,8 @@ t = xo.memtable({"a": [1, 2, 3]})
 expr = t.filter(t.a > 1)
 """
 
-# Modules on the build, run and catalog paths.
-CORE_MODULES = (
-    "xorq",
-    "xorq.api",
-    "xorq.cli",
-    "xorq.catalog.cli",
-    "xorq.ibis_yaml.compiler",
-    "xorq.ibis_yaml.packager",
-    "xorq.ibis_yaml.pep723",
-)
+BARE_IMPORT_CHECK = "python/xorq/tests/check_bare_imports.py"
+MODULE_LISTING = "python/xorq/tests/bare_install_modules.txt"
 
 
 def run_bare(wheel, args, cwd):
@@ -67,11 +59,23 @@ def wheel(project_root, tmp_path_factory):
     return wheel
 
 
-def test_core_modules_import(wheel, tmp_path):
+def test_core_modules_import(wheel, project_root):
     """The static scan cannot see function-level imports; this can."""
-    source = ";".join(f"import {module}" for module in CORE_MODULES)
-    returncode, stdout, stderr = run_bare(wheel, ("python", "-c", source), cwd=tmp_path)
+    returncode, stdout, stderr = run_bare(
+        wheel, ("python", BARE_IMPORT_CHECK), cwd=project_root
+    )
     assert returncode == 0, stderr
+
+
+def test_module_listing_covers_the_new_declarations(project_root):
+    """pygments and xxhash are only reached through tui and the pandas executor.
+
+    Without those two entries the round trip never imports either, so three of
+    the four declarations this branch adds would go unexercised end to end.
+    """
+    listing = project_root.joinpath(MODULE_LISTING).read_text()
+    for module in ("xorq.catalog.tui", "xorq.backends.pandas.executor"):
+        assert module in listing
 
 
 def test_build_then_run_round_trip(wheel, tmp_path):
@@ -79,10 +83,14 @@ def test_build_then_run_round_trip(wheel, tmp_path):
     tmp_path.joinpath("expr.py").write_text(EXPR_PY)
 
     returncode, stdout, stderr = run_bare(
-        wheel, ("xorq", "build", "expr.py", "-e", "expr"), cwd=tmp_path
+        wheel,
+        # not stdout: OTel's ConsoleSpanExporter flushes there at shutdown, after
+        # the path is printed, whenever OTEL_EXPORTER_CONSOLE_FALLBACK is set.
+        ("xorq", "build", "expr.py", "-e", "expr", "--emit-build-path-to", "path.txt"),
+        cwd=tmp_path,
     )
     assert returncode == 0, stderr
-    build_path = stdout.strip().splitlines()[-1]
+    build_path = tmp_path.joinpath("path.txt").read_text().strip()
     assert tmp_path.joinpath(build_path).exists()
 
     returncode, stdout, stderr = run_bare(

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -16,18 +16,26 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
 
-# Optional backends are excluded: their imports are extras-gated and lazy.
-# `backends/pandas` and `common/utils/dasher` are in scope because pandas is a
-# core dependency and dasher is always loaded; they are also the only module-level
-# import sites for numpy and xxhash, so without them those declarations have no
-# guard at all.
-CORE_PACKAGES = (
-    "python/xorq/backends/pandas",
-    "python/xorq/caching",
-    "python/xorq/catalog",
-    "python/xorq/common/utils/dasher",
-    "python/xorq/flight",
-    "python/xorq/ibis_yaml",
+SCANNED_PACKAGE = "python/xorq"
+
+# Modules whose module-level third-party imports belong to an optional backend.
+# Excluded by path rather than by scanning an allowlist of packages, so a new
+# module anywhere in xorq is in scope by default and has to be excluded
+# deliberately.  test_extras_gated_modules_are_all_still_needed keeps this from
+# accumulating entries that no longer apply.
+EXTRAS_GATED_MODULES = (
+    "python/xorq/backends/databricks/backend.py",
+    "python/xorq/backends/postgres/__init__.py",
+    "python/xorq/backends/pyiceberg/__init__.py",
+    "python/xorq/backends/pyiceberg/compiler.py",
+    "python/xorq/common/utils/bigquery_utils.py",
+    "python/xorq/common/utils/databricks_utils.py",
+    "python/xorq/common/utils/gcloud_utils.py",
+    "python/xorq/common/utils/ibis_utils.py",
+    "python/xorq/common/utils/postgres_utils.py",
+    "python/xorq/common/utils/snowflake_utils.py",
+    "python/xorq/common/utils/sqlite_utils.py",
+    "python/xorq/expr/ml/sklearn_utils.py",
 )
 
 # Import root -> distribution name, for the cases where they differ.
@@ -52,12 +60,25 @@ def declared_dependency_names(root_dir):
 
 
 def iter_core_modules(root_dir):
-    for package in CORE_PACKAGES:
-        for path in sorted(root_dir.joinpath(package).rglob("*.py")):
-            parts = path.relative_to(root_dir).parts
-            if "tests" in parts or path.name == "conftest.py":
-                continue
-            yield path
+    """Every xorq module that must import with only the declared dependencies."""
+    excluded = {root_dir.joinpath(module) for module in EXTRAS_GATED_MODULES}
+    for path in sorted(root_dir.joinpath(SCANNED_PACKAGE).rglob("*.py")):
+        parts = path.relative_to(root_dir).parts
+        if "tests" in parts or "vendor" in parts or path.name == "conftest.py":
+            continue
+        if path in excluded:
+            continue
+        yield path
+
+
+def undeclared_imports(path, declared):
+    """Module-level import roots of *path* that are not declared dependencies."""
+    return {
+        import_root
+        for import_root in module_level_import_roots(path)
+        if canonicalize_name(IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root))
+        not in declared
+    }
 
 
 def module_level_import_roots(path):
@@ -87,12 +108,29 @@ def test_root_dir_is_the_repo_checkout(root_dir):
     assert pyproject["project"]["name"] == "xorq"
 
 
-def test_core_packages_all_exist(root_dir):
-    """A typo in CORE_PACKAGES would silently scan nothing."""
-    missing = [
-        package for package in CORE_PACKAGES if not root_dir.joinpath(package).is_dir()
+def test_extras_gated_modules_all_exist(root_dir):
+    """A stale path silently excludes nothing and hides a typo."""
+    missing = [m for m in EXTRAS_GATED_MODULES if not root_dir.joinpath(m).is_file()]
+    assert not missing, f"EXTRAS_GATED_MODULES entries do not exist: {missing}"
+
+
+def test_extras_gated_modules_are_all_still_needed(root_dir):
+    """Every exclusion must still have an undeclared module-level import.
+
+    Without this the list becomes a place to park problems: an entry whose
+    import was since declared, or removed, would keep a whole module out of
+    scope for no reason.
+    """
+    declared = declared_dependency_names(root_dir)
+    unnecessary = [
+        module
+        for module in EXTRAS_GATED_MODULES
+        if not undeclared_imports(root_dir.joinpath(module), declared)
     ]
-    assert not missing, f"CORE_PACKAGES entries do not exist: {missing}"
+    assert not unnecessary, (
+        f"EXTRAS_GATED_MODULES entries no longer have an undeclared "
+        f"module-level import and should be removed: {unnecessary}"
+    )
 
 
 def test_core_module_scan_is_non_empty(root_dir):
@@ -104,10 +142,8 @@ def test_core_module_imports_are_declared(root_dir):
     declared = declared_dependency_names(root_dir)
     undeclared = {}
     for path in iter_core_modules(root_dir):
-        for import_root in module_level_import_roots(path):
+        for import_root in undeclared_imports(path, declared):
             distribution = IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root)
-            if canonicalize_name(distribution) in declared:
-                continue
             undeclared.setdefault(distribution, set()).add(
                 str(path.relative_to(root_dir))
             )

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -42,19 +42,19 @@ IMPORT_ROOT_TO_DISTRIBUTION = {
 pytestmark = pytest.mark.core
 
 
-def declared_dependency_names(project_root):
+def declared_dependency_names(root_dir):
     """Canonical distribution names from [project].dependencies."""
-    pyproject = tomlkit.parse(project_root.joinpath("pyproject.toml").read_text())
+    pyproject = tomlkit.parse(root_dir.joinpath("pyproject.toml").read_text())
     return {
         canonicalize_name(Requirement(str(dependency)).name)
         for dependency in pyproject["project"]["dependencies"]
     }
 
 
-def iter_core_modules(project_root):
+def iter_core_modules(root_dir):
     for package in CORE_PACKAGES:
-        for path in sorted(project_root.joinpath(package).rglob("*.py")):
-            parts = path.relative_to(project_root).parts
+        for path in sorted(root_dir.joinpath(package).rglob("*.py")):
+            parts = path.relative_to(root_dir).parts
             if "tests" in parts or path.name == "conftest.py":
                 continue
             yield path
@@ -80,38 +80,36 @@ def module_level_import_roots(path):
     }
 
 
-def test_project_root_is_the_repo_checkout(project_root):
+def test_root_dir_is_the_repo_checkout(root_dir):
     """The other tests are vacuous if we resolve the wrong pyproject.toml."""
-    assert project_root.joinpath("python", "xorq", "__init__.py").exists()
-    pyproject = tomlkit.parse(project_root.joinpath("pyproject.toml").read_text())
+    assert root_dir.joinpath("python", "xorq", "__init__.py").exists()
+    pyproject = tomlkit.parse(root_dir.joinpath("pyproject.toml").read_text())
     assert pyproject["project"]["name"] == "xorq"
 
 
-def test_core_packages_all_exist(project_root):
+def test_core_packages_all_exist(root_dir):
     """A typo in CORE_PACKAGES would silently scan nothing."""
     missing = [
-        package
-        for package in CORE_PACKAGES
-        if not project_root.joinpath(package).is_dir()
+        package for package in CORE_PACKAGES if not root_dir.joinpath(package).is_dir()
     ]
     assert not missing, f"CORE_PACKAGES entries do not exist: {missing}"
 
 
-def test_core_module_scan_is_non_empty(project_root):
-    modules = list(iter_core_modules(project_root))
+def test_core_module_scan_is_non_empty(root_dir):
+    modules = list(iter_core_modules(root_dir))
     assert len(modules) > 20, f"expected to scan many modules, found {len(modules)}"
 
 
-def test_core_module_imports_are_declared(project_root):
-    declared = declared_dependency_names(project_root)
+def test_core_module_imports_are_declared(root_dir):
+    declared = declared_dependency_names(root_dir)
     undeclared = {}
-    for path in iter_core_modules(project_root):
+    for path in iter_core_modules(root_dir):
         for import_root in module_level_import_roots(path):
             distribution = IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root)
             if canonicalize_name(distribution) in declared:
                 continue
             undeclared.setdefault(distribution, set()).add(
-                str(path.relative_to(project_root))
+                str(path.relative_to(root_dir))
             )
     assert not undeclared, "\n".join(
         f"{name!r} is imported at module level by {sorted(paths)} "
@@ -120,10 +118,10 @@ def test_core_module_imports_are_declared(project_root):
     )
 
 
-def test_import_root_mapping_has_no_stale_entries(project_root):
+def test_import_root_mapping_has_no_stale_entries(root_dir):
     imported = {
         import_root
-        for path in iter_core_modules(project_root)
+        for path in iter_core_modules(root_dir)
         for import_root in module_level_import_roots(path)
     }
     stale = sorted(set(IMPORT_ROOT_TO_DISTRIBUTION) - imported)
@@ -155,22 +153,22 @@ def test_module_level_import_roots_classification(tmp_path, source, expected):
     assert module_level_import_roots(path) == expected
 
 
-def test_declared_dependency_names_strips_specifiers(project_root):
-    declared = declared_dependency_names(project_root)
+def test_declared_dependency_names_strips_specifiers(root_dir):
+    declared = declared_dependency_names(root_dir)
     assert {"pyarrow", "pandas", "gitpython", "py-yaml12"} <= declared
     assert all(name == canonicalize_name(name) for name in declared)
 
 
-def test_regression_packaging_is_declared(project_root):
+def test_regression_packaging_is_declared(root_dir):
     """Undeclared, this broke `xorq run` while leaving `xorq build` green."""
-    assert "packaging" in declared_dependency_names(project_root)
+    assert "packaging" in declared_dependency_names(root_dir)
     assert "packaging" in module_level_import_roots(
-        project_root.joinpath("python", "xorq", "ibis_yaml", "packager.py")
+        root_dir.joinpath("python", "xorq", "ibis_yaml", "packager.py")
     )
 
 
 @pytest.mark.parametrize("distribution", ("packaging", "numpy", "pygments", "xxhash"))
-def test_declaration_is_covered_by_the_scan(project_root, distribution):
+def test_declaration_is_covered_by_the_scan(root_dir, distribution):
     """Deleting any of these from pyproject.toml must fail the scan.
 
     Without this, a declaration can sit outside CORE_PACKAGES and a future
@@ -178,8 +176,8 @@ def test_declaration_is_covered_by_the_scan(project_root, distribution):
     """
     imported = {
         IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root)
-        for path in iter_core_modules(project_root)
+        for path in iter_core_modules(root_dir)
         for import_root in module_level_import_roots(path)
     }
     assert distribution in imported
-    assert distribution in declared_dependency_names(project_root)
+    assert distribution in declared_dependency_names(root_dir)

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -15,9 +15,16 @@ import tomlkit
 
 
 # Optional backends are excluded: their imports are extras-gated and lazy.
+# `backends/pandas` and `common/utils/dasher` are in scope because pandas is a
+# core dependency and dasher is always loaded; they are also the only module-level
+# import sites for numpy and xxhash, so without them those declarations have no
+# guard at all.
 CORE_PACKAGES = (
+    "python/xorq/backends/pandas",
     "python/xorq/caching",
     "python/xorq/catalog",
+    "python/xorq/common/utils/dasher",
+    "python/xorq/flight",
     "python/xorq/ibis_yaml",
 )
 
@@ -26,6 +33,8 @@ IMPORT_ROOT_TO_DISTRIBUTION = {
     "attr": "attrs",
     "git": "gitpython",
     "yaml12": "py-yaml12",
+    # namespace root: several declared opentelemetry-* distributions provide it
+    "opentelemetry": "opentelemetry-sdk",
 }
 
 pytestmark = pytest.mark.core
@@ -169,3 +178,19 @@ def test_regression_packaging_is_declared(project_root):
     assert "packaging" in module_level_import_roots(
         project_root.joinpath("python", "xorq", "ibis_yaml", "packager.py")
     )
+
+
+@pytest.mark.parametrize("distribution", ("packaging", "numpy", "pygments", "xxhash"))
+def test_declaration_is_covered_by_the_scan(project_root, distribution):
+    """Deleting any of these from pyproject.toml must fail the scan.
+
+    Without this, a declaration can sit outside CORE_PACKAGES and a future
+    lowest-direct failure invites deleting it with nothing going red.
+    """
+    imported = {
+        IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root)
+        for path in iter_core_modules(project_root)
+        for import_root in module_level_import_roots(path)
+    }
+    assert distribution in imported
+    assert distribution in declared_dependency_names(project_root)

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -18,6 +18,11 @@ from packaging.utils import canonicalize_name
 
 SCANNED_PACKAGE = "python/xorq"
 
+# vendor/ is skipped: its module-level third-party imports are upstream ibis's,
+# and re-vendoring would churn any exclusion list kept here.  It is not
+# unguarded -- xorq.api imports vendor/ibis, so test_bare_install catches an
+# undeclared import there that is genuinely absent from a bare install.
+
 # Modules whose module-level third-party imports belong to an optional backend.
 # Excluded by path rather than by scanning an allowlist of packages, so a new
 # module anywhere in xorq is in scope by default and has to be excluded
@@ -148,9 +153,15 @@ def test_core_module_imports_are_declared(root_dir):
                 str(path.relative_to(root_dir))
             )
     assert not undeclared, "\n".join(
-        f"{name!r} is imported at module level by {sorted(paths)} "
-        f"but is not in [project].dependencies"
-        for name, paths in sorted(undeclared.items())
+        (
+            *(
+                f"{name!r} is imported at module level by {sorted(paths)} "
+                f"but is not in [project].dependencies"
+                for name, paths in sorted(undeclared.items())
+            ),
+            "Declare it, or -- if the import root differs from the distribution "
+            "name -- add the mapping to IMPORT_ROOT_TO_DISTRIBUTION.",
+        )
     )
 
 
@@ -207,7 +218,7 @@ def test_regression_packaging_is_declared(root_dir):
 def test_declaration_is_covered_by_the_scan(root_dir, distribution):
     """Deleting any of these from pyproject.toml must fail the scan.
 
-    Without this, a declaration can sit outside CORE_PACKAGES and a future
+    Without this, a declaration can sit outside the scan and a future
     lowest-direct failure invites deleting it with nothing going red.
     """
     imported = {

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -1,15 +1,8 @@
-"""Guard against importing a distribution xorq does not declare a dependency on.
+"""Assert xorq declares every distribution it imports at module level.
 
-The failure this prevents: a module-level ``import foo`` in always-loaded code
-where ``foo`` is absent from ``[project].dependencies`` and only reaches the
-developer's environment transitively through a dev/test dependency.  Every
-local check passes; a user's ``uv tool run --isolated --with xorq`` raises
-``ModuleNotFoundError``.
-
-There is deliberately no allowlist for "it arrives via some other dependency".
-Those edges live in other projects' metadata under open version ranges, so an
-allowlist records a belief rather than a guarantee.  If xorq imports it at
-module level, xorq declares it.
+An undeclared import reaches dev environments transitively (pytest, black) and
+fails only on a user's bare install.  No allowlist for "it arrives via another
+dependency": if xorq imports it at module level, xorq declares it.
 """
 
 import ast
@@ -21,9 +14,7 @@ import pytest
 import tomlkit
 
 
-# Packages loaded on the build, run and catalog paths.  Optional backends are
-# excluded: their third-party imports are gated behind extras and reached only
-# through a lazy import in the caller.
+# Optional backends are excluded: their imports are extras-gated and lazy.
 CORE_PACKAGES = (
     "python/xorq/caching",
     "python/xorq/catalog",
@@ -74,10 +65,8 @@ def iter_core_modules(project_root):
 def module_level_import_roots(path):
     """Third-party import roots imported unconditionally at module scope.
 
-    Walking ``tree.body`` rather than ``ast.walk`` is what makes this
-    unconditional: imports nested in ``try``/``except ImportError``, ``if``
-    blocks or function bodies are deferred or guarded on purpose, so their
-    absence is already handled and is not a packaging bug.
+    ``tree.body`` not ``ast.walk``: guarded and deferred imports already handle
+    their own absence.
     """
     tree = ast.parse(path.read_text())
     roots = set()
@@ -134,7 +123,6 @@ def test_core_module_imports_are_declared(project_root):
 
 
 def test_import_root_mapping_has_no_stale_entries(project_root):
-    """The alias map should not accumulate entries nothing imports any more."""
     imported = {
         import_root
         for path in iter_core_modules(project_root)
@@ -176,11 +164,7 @@ def test_declared_dependency_names_strips_specifiers(project_root):
 
 
 def test_regression_packaging_is_declared(project_root):
-    """xorq.ibis_yaml.packager imports packaging at module level.
-
-    Undeclared, this broke every ``xorq run`` on a clean install while leaving
-    ``xorq build`` working, so no existing test noticed.
-    """
+    """Undeclared, this broke `xorq run` while leaving `xorq build` green."""
     assert "packaging" in declared_dependency_names(project_root)
     assert "packaging" in module_level_import_roots(
         project_root.joinpath("python", "xorq", "ibis_yaml", "packager.py")

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -1,0 +1,187 @@
+"""Guard against importing a distribution xorq does not declare a dependency on.
+
+The failure this prevents: a module-level ``import foo`` in always-loaded code
+where ``foo`` is absent from ``[project].dependencies`` and only reaches the
+developer's environment transitively through a dev/test dependency.  Every
+local check passes; a user's ``uv tool run --isolated --with xorq`` raises
+``ModuleNotFoundError``.
+
+There is deliberately no allowlist for "it arrives via some other dependency".
+Those edges live in other projects' metadata under open version ranges, so an
+allowlist records a belief rather than a guarantee.  If xorq imports it at
+module level, xorq declares it.
+"""
+
+import ast
+import sys
+
+import pytest
+
+# tomlkit rather than tomllib: xorq supports 3.10, where tomllib does not exist.
+import tomlkit
+
+
+# Packages loaded on the build, run and catalog paths.  Optional backends are
+# excluded: their third-party imports are gated behind extras and reached only
+# through a lazy import in the caller.
+CORE_PACKAGES = (
+    "python/xorq/caching",
+    "python/xorq/catalog",
+    "python/xorq/ibis_yaml",
+)
+
+# Import root -> distribution name, for the cases where they differ.
+IMPORT_ROOT_TO_DISTRIBUTION = {
+    "attr": "attrs",
+    "git": "gitpython",
+    "yaml12": "py-yaml12",
+}
+
+pytestmark = pytest.mark.core
+
+
+def declared_dependency_names(project_root):
+    """Normalized distribution names from [project].dependencies."""
+    pyproject = tomlkit.parse(project_root.joinpath("pyproject.toml").read_text())
+    dependencies = pyproject["project"]["dependencies"]
+    # strip extras, version specifiers and environment markers
+    return {
+        str(dependency)
+        .split(";")[0]
+        .strip()
+        .split("[")[0]
+        .split("<")[0]
+        .split(">")[0]
+        .split("=")[0]
+        .split("!")[0]
+        .split("~")[0]
+        .strip()
+        .lower()
+        .replace("_", "-")
+        for dependency in dependencies
+    }
+
+
+def iter_core_modules(project_root):
+    for package in CORE_PACKAGES:
+        for path in sorted(project_root.joinpath(package).rglob("*.py")):
+            parts = path.relative_to(project_root).parts
+            if "tests" in parts or path.name == "conftest.py":
+                continue
+            yield path
+
+
+def module_level_import_roots(path):
+    """Third-party import roots imported unconditionally at module scope.
+
+    Walking ``tree.body`` rather than ``ast.walk`` is what makes this
+    unconditional: imports nested in ``try``/``except ImportError``, ``if``
+    blocks or function bodies are deferred or guarded on purpose, so their
+    absence is already handled and is not a packaging bug.
+    """
+    tree = ast.parse(path.read_text())
+    roots = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            # node.level > 0 is a relative, intra-package import
+            if node.level == 0 and node.module:
+                roots.add(node.module.split(".")[0])
+    return {
+        root for root in roots if root != "xorq" and root not in sys.stdlib_module_names
+    }
+
+
+def test_project_root_is_the_repo_checkout(project_root):
+    """The other tests are vacuous if we resolve the wrong pyproject.toml."""
+    assert project_root.joinpath("python", "xorq", "__init__.py").exists()
+    pyproject = tomlkit.parse(project_root.joinpath("pyproject.toml").read_text())
+    assert pyproject["project"]["name"] == "xorq"
+
+
+def test_core_packages_all_exist(project_root):
+    """A typo in CORE_PACKAGES would silently scan nothing."""
+    missing = [
+        package
+        for package in CORE_PACKAGES
+        if not project_root.joinpath(package).is_dir()
+    ]
+    assert not missing, f"CORE_PACKAGES entries do not exist: {missing}"
+
+
+def test_core_module_scan_is_non_empty(project_root):
+    modules = list(iter_core_modules(project_root))
+    assert len(modules) > 20, f"expected to scan many modules, found {len(modules)}"
+
+
+def test_core_module_imports_are_declared(project_root):
+    declared = declared_dependency_names(project_root)
+    undeclared = {}
+    for path in iter_core_modules(project_root):
+        for import_root in module_level_import_roots(path):
+            distribution = IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root)
+            if distribution.lower().replace("_", "-") in declared:
+                continue
+            undeclared.setdefault(distribution, set()).add(
+                str(path.relative_to(project_root))
+            )
+    assert not undeclared, "\n".join(
+        f"{name!r} is imported at module level by {sorted(paths)} "
+        f"but is not in [project].dependencies"
+        for name, paths in sorted(undeclared.items())
+    )
+
+
+def test_import_root_mapping_has_no_stale_entries(project_root):
+    """The alias map should not accumulate entries nothing imports any more."""
+    imported = {
+        import_root
+        for path in iter_core_modules(project_root)
+        for import_root in module_level_import_roots(path)
+    }
+    stale = sorted(set(IMPORT_ROOT_TO_DISTRIBUTION) - imported)
+    assert not stale, f"IMPORT_ROOT_TO_DISTRIBUTION entries no longer imported: {stale}"
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    (
+        ("import foo", {"foo"}),
+        ("from foo.bar import baz", {"foo"}),
+        ("import foo.bar, qux", {"foo", "qux"}),
+        # relative imports are intra-package, never a declared dependency
+        ("from . import sibling", set()),
+        ("from .mod import thing", set()),
+        # guarded: absence is handled, so it is not a packaging bug
+        ("try:\n    import foo\nexcept ImportError:\n    foo = None", set()),
+        # deferred on purpose, usually for an optional backend
+        ("def f():\n    import foo", set()),
+        ("if True:\n    import foo", set()),
+        # stdlib and xorq itself are not third-party
+        ("import os", set()),
+        ("import xorq.api", set()),
+    ),
+)
+def test_module_level_import_roots_classification(tmp_path, source, expected):
+    path = tmp_path.joinpath("mod.py")
+    path.write_text(source)
+    assert module_level_import_roots(path) == expected
+
+
+def test_declared_dependency_names_strips_specifiers(project_root):
+    declared = declared_dependency_names(project_root)
+    assert {"pyarrow", "pandas", "gitpython", "py-yaml12"} <= declared
+    assert not any(character in name for name in declared for character in "<>=!;[ ")
+
+
+def test_regression_packaging_is_declared(project_root):
+    """xorq.ibis_yaml.packager imports packaging at module level.
+
+    Undeclared, this broke every ``xorq run`` on a clean install while leaving
+    ``xorq build`` working, so no existing test noticed.
+    """
+    assert "packaging" in declared_dependency_names(project_root)
+    assert "packaging" in module_level_import_roots(
+        project_root.joinpath("python", "xorq", "ibis_yaml", "packager.py")
+    )

--- a/python/xorq/tests/test_declared_dependencies.py
+++ b/python/xorq/tests/test_declared_dependencies.py
@@ -12,6 +12,8 @@ import pytest
 
 # tomlkit rather than tomllib: xorq supports 3.10, where tomllib does not exist.
 import tomlkit
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 
 # Optional backends are excluded: their imports are extras-gated and lazy.
@@ -41,24 +43,11 @@ pytestmark = pytest.mark.core
 
 
 def declared_dependency_names(project_root):
-    """Normalized distribution names from [project].dependencies."""
+    """Canonical distribution names from [project].dependencies."""
     pyproject = tomlkit.parse(project_root.joinpath("pyproject.toml").read_text())
-    dependencies = pyproject["project"]["dependencies"]
-    # strip extras, version specifiers and environment markers
     return {
-        str(dependency)
-        .split(";")[0]
-        .strip()
-        .split("[")[0]
-        .split("<")[0]
-        .split(">")[0]
-        .split("=")[0]
-        .split("!")[0]
-        .split("~")[0]
-        .strip()
-        .lower()
-        .replace("_", "-")
-        for dependency in dependencies
+        canonicalize_name(Requirement(str(dependency)).name)
+        for dependency in pyproject["project"]["dependencies"]
     }
 
 
@@ -119,7 +108,7 @@ def test_core_module_imports_are_declared(project_root):
     for path in iter_core_modules(project_root):
         for import_root in module_level_import_roots(path):
             distribution = IMPORT_ROOT_TO_DISTRIBUTION.get(import_root, import_root)
-            if distribution.lower().replace("_", "-") in declared:
+            if canonicalize_name(distribution) in declared:
                 continue
             undeclared.setdefault(distribution, set()).add(
                 str(path.relative_to(project_root))
@@ -169,7 +158,7 @@ def test_module_level_import_roots_classification(tmp_path, source, expected):
 def test_declared_dependency_names_strips_specifiers(project_root):
     declared = declared_dependency_names(project_root)
     assert {"pyarrow", "pandas", "gitpython", "py-yaml12"} <= declared
-    assert not any(character in name for name in declared for character in "<>=!;[ ")
+    assert all(name == canonicalize_name(name) for name in declared)
 
 
 def test_regression_packaging_is_declared(project_root):

--- a/uv.lock
+++ b/uv.lock
@@ -6341,7 +6341,10 @@ requires-dist = [
     { name = "matplotlib", marker = "python_full_version >= '3.13' and extra == 'examples'", specifier = ">=3.9.2" },
     { name = "matplotlib", marker = "python_full_version < '3.13' and extra == 'examples'", specifier = ">=3.8.0" },
     { name = "mcp", marker = "extra == 'examples'", specifier = ">=1.5.0" },
-    { name = "numpy", specifier = ">=1.22.4" },
+    { name = "numpy", marker = "python_full_version < '3.11'", specifier = ">=1.22.4" },
+    { name = "numpy", marker = "python_full_version == '3.11.*'", specifier = ">=1.23.2" },
+    { name = "numpy", marker = "python_full_version == '3.12.*'", specifier = ">=1.26.0" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
     { name = "openai", marker = "extra == 'examples'", specifier = ">=1.65.4" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.32.1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.32.1" },
@@ -6381,7 +6384,10 @@ requires-dist = [
     { name = "xorq-datafusion", specifier = "==0.2.10" },
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
-    { name = "xxhash", specifier = ">=3.0" },
+    { name = "xxhash", marker = "python_full_version < '3.11'", specifier = ">=3.0" },
+    { name = "xxhash", marker = "python_full_version == '3.11.*'", specifier = ">=3.2" },
+    { name = "xxhash", marker = "python_full_version == '3.12.*'", specifier = ">=3.4" },
+    { name = "xxhash", marker = "python_full_version >= '3.13'", specifier = ">=3.5" },
 ]
 provides-extras = ["pyiceberg", "duckdb", "datafusion", "snowflake", "examples", "postgres", "sqlite", "gizmosql", "ibis", "geospatial", "trino", "bigquery", "bsl", "databricks", "annex"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6162,15 +6162,19 @@ dependencies = [
     { name = "cryptography" },
     { name = "filelock" },
     { name = "gitpython" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-sdk" },
+    { name = "packaging" },
     { name = "pandas" },
     { name = "parsy" },
     { name = "prometheus-client" },
     { name = "py-yaml12" },
     { name = "pyarrow" },
+    { name = "pygments" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "rich" },
@@ -6184,6 +6188,7 @@ dependencies = [
     { name = "uv" },
     { name = "xorq-dasher" },
     { name = "xorq-datafusion" },
+    { name = "xxhash" },
 ]
 
 [package.optional-dependencies]
@@ -6336,11 +6341,13 @@ requires-dist = [
     { name = "matplotlib", marker = "python_full_version >= '3.13' and extra == 'examples'", specifier = ">=3.9.2" },
     { name = "matplotlib", marker = "python_full_version < '3.13' and extra == 'examples'", specifier = ">=3.8.0" },
     { name = "mcp", marker = "extra == 'examples'", specifier = ">=1.5.0" },
+    { name = "numpy", specifier = ">=1.22.4" },
     { name = "openai", marker = "extra == 'examples'", specifier = ">=1.65.4" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.32.1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.32.1" },
     { name = "opentelemetry-exporter-prometheus", specifier = ">=0.55b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.32.1" },
+    { name = "packaging", specifier = ">=22" },
     { name = "pandas", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=2.2.3,<3" },
     { name = "parsy", specifier = ">=2" },
     { name = "pins", extras = ["gcs"], marker = "python_full_version >= '3.10' and python_full_version < '4' and extra == 'examples'", specifier = ">=0.8.3,<1" },
@@ -6350,6 +6357,7 @@ requires-dist = [
     { name = "py-yaml12" },
     { name = "pyarrow", marker = "python_full_version >= '3.10' and python_full_version < '4'", specifier = ">=18.0.0,<22" },
     { name = "pydata-google-auth", marker = "extra == 'bigquery'", specifier = ">=1.4.0,<2" },
+    { name = "pygments", specifier = ">=2.13" },
     { name = "pyiceberg", extras = ["sql-sqlite", "sql-postgres"], marker = "extra == 'examples'", specifier = ">=0.9.0" },
     { name = "pyiceberg", extras = ["sql-sqlite", "sql-postgres"], marker = "extra == 'pyiceberg'", specifier = ">=0.9.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
@@ -6373,6 +6381,7 @@ requires-dist = [
     { name = "xorq-datafusion", specifier = "==0.2.10" },
     { name = "xorq-feature-utils", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-feature-utils?branch=main" },
     { name = "xorq-weather-lib", marker = "extra == 'examples'", git = "https://github.com/xorq-labs/xorq-weather-lib?branch=main" },
+    { name = "xxhash", specifier = ">=3.0" },
 ]
 provides-extras = ["pyiceberg", "duckdb", "datafusion", "snowflake", "examples", "postgres", "sqlite", "gizmosql", "ibis", "geospatial", "trino", "bigquery", "bsl", "databricks", "annex"]
 


### PR DESCRIPTION
## The bug

`python/xorq/ibis_yaml/packager.py:40` imports `packaging` at module level, but `packaging` was never declared in `[project].dependencies`. It reaches every development environment transitively — `pytest`, `black`, `matplotlib` and `snowflake-connector-python` all depend on it — so nothing local ever noticed.

Installing only the declared dependencies fails:

```console
$ uv tool run --isolated --python 3.12 --with xorq==0.4.0 xorq run builds/f68b0e436e96
  File ".../xorq/ibis_yaml/packager.py", line 40, in <module>
    from packaging.specifiers import SpecifierSet
ModuleNotFoundError: No module named 'packaging'
```

`xorq build` survives, because it doesn't reach `packager` on that path. `xorq run`, `xorq catalog` and the TUI (`catalog/tui.py:82`) are dead on a clean install, as is `backends/pandas/executor.py`.

**This affects 0.4.0 as published, so it needs a patch release, not just a fix on main.**

## The fix

Declared `packaging`. Auditing the rest of the always-loaded code surfaced three more module-level imports of undeclared distributions, arriving via `pandas`, `rich`/`textual` and `xorq-dasher`:

| import | reached today via | declared range of the provider |
| --- | --- | --- |
| `numpy` | `pandas` | `pandas>=2.2.3,<3` |
| `pygments` | `rich`, `textual` | `rich>=13.9.4` |
| `xxhash` | `xorq-dasher` | `xorq-dasher>=0.1.1` |

Every one of those is an open-ended range in someone else's metadata. Declared all three rather than depend on them.

### Correction: declaring is not free under `--resolution lowest-direct`

My first pass claimed this "adds no install surface". That was wrong, and `ci-test-lowest-direct (3.13)` caught it. Floor-lowering applies to **direct** dependencies, so promoting `numpy` and `xxhash` from transitive to declared newly subjected them to the floor lock, where a bare `>=` selects a release predating the interpreter:

```
numpy==1.26.0   # no cp313 wheel -> sdist -> meson: "No BLAS library detected!"
xxhash==3.0.0   # no cp313 wheel either; queued to fail right after numpy
```

Previously `pandas`' own per-interpreter numpy floors happened to keep this installable. Floors are now the first release shipping wheels for each supported interpreter, following the existing precedent for `matplotlib` and `scikit-learn` in the `examples` extra:

|  | 3.10 | 3.11 | 3.12 | 3.13 |
| --- | --- | --- | --- | --- |
| `numpy` | 1.22.4 | 1.23.2 | 1.26.0 | 2.1.0 |
| `xxhash` | 3.0 | 3.2 | 3.4 | 3.5 |

Gated rather than raised outright, so numpy 1.x stays usable on older interpreters — xorq only touches `numpy.ndarray` and `numpy.dtype`, so forcing 2.1 everywhere would constrain downstreams for nothing. `pygments` is pure python and needs no gate.

Verified with `uv pip compile --resolution lowest-direct` for each of 3.10–3.13, cross-checking every resolved version against the PyPI file list — all twelve now ship a usable wheel.

Everything else that turned up in the audit is either extras-gated (`pyiceberg`, `adbc_*`, `snowflake`, `databricks`, `sklearn`, `gcsfs`) or `try`/`except ImportError`-guarded (`regex` in `backends/pandas/kernels.py:10`, `importlib_metadata` in `__init__.py:1`).

## Tests

### `python/xorq/tests/test_declared_dependencies.py` — static, `core` marker

AST-scans **all of `python/xorq`**, minus twelve extras-gated modules named by path, for third-party imports at module scope and asserts each is declared. Scoping by exclusion rather than inclusion means a new module anywhere in xorq is guarded by default; `test_extras_gated_modules_are_all_still_needed` stops the exclusion list becoming a place to park problems. Walking `tree.body` rather than `ast.walk` is what makes it precise: imports nested in `try`/`except ImportError`, `if` blocks or function bodies are guarded or deferred on purpose, so their absence is already handled. That classification is itself parametrized and tested.

**There is deliberately no allowlist** for "it arrives via some other dependency":

- An allowlist encodes the *same* inference that shipped this bug. `packaging` was already an unwritten allowlist entry — *"pytest pulls it, we're fine."* True in every dev env, false in every user env. Writing it down makes it auditable, not true.
- It asserts a fact that isn't ours to hold. "pygments comes via rich" is a claim about rich's metadata under an open range; rich can drop it and nothing in this repo changes.
- A guard test over `uv.lock` doesn't fix that. The lock is one dev resolution at one moment, while users resolve fresh from PyPI. And *reachable ≠ present*: `pandas` lists `numpy` twice under split `python_version` markers, so a naive graph walk reports "covered" for an edge whose marker is false on the user's interpreter.
- The cost is upside down — lock parsing plus marker evaluation, maintained forever, to avoid writing three lines.

Since there's no exception mechanism, there's no configuration surface to argue about: an undeclared module-level import is a hard failure with a one-line fix.

Runs in the `core` job and in `ci-test-lowest-direct`, which also exercises the new floors under `--resolution lowest-direct`.

### `python/xorq/tests/test_bare_install.py` — end-to-end, `bare_install` marker

Builds the wheel and drives the CLI through `uv tool run --isolated`, which installs `[project].dependencies` and nothing else. This covers what the static scan structurally cannot: most packager imports in `cli.py` are lazy, inside function bodies (`# noqa: PLC0415`).

It asserts a **build → run round trip**, not just `--help`, because that distinction is the whole bug.

## Verified both tests fail before the fix

Deleting `"packaging>=22"` from `pyproject.toml` and re-running:

```
drop packaging -> 3 failed, 19 passed     # static scan
               -> 2 failed,  5 passed     # bare install
drop numpy     -> 2 failed, 20 passed
drop xxhash    -> 2 failed, 20 passed
drop pygments  -> 2 failed, 20 passed
```

with the original traceback reproduced through `cli.py:348 -> packager.py:40`. Note what still passes on a `packaging` drop: **every `--help` test stayed green** — which is why the round trip, not `--help`, is the thing worth asserting.

### What each layer actually guards

Only `packaging` is caught by *both* layers. Removing `numpy`, `pygments` or `xxhash` leaves all bare-install tests green, because each still arrives transitively via `pandas`, `rich`/`textual` and `xorq-dasher`. The bare-install layer exercises those import paths; **the static scan is what guards the declarations.** An earlier revision of this PR overstated that, and the docstring now says it plainly.

Restored, all 29 pass.

## CI

`ci-test-library` and `ci-test-install` already installed the wheel into a bare environment — but only smoke-imported `xorq` itself, which succeeds even when broken. Worse, `ci-test-library`'s pytest step runs `--with pytest --with pytest-cov`, and **pytest depends on `packaging`**, so that environment is contaminated against exactly this class of bug.

Both workflows now import the modules on the build, run and catalog paths in the bare environment, with no pytest present, on wheel and sdist. `ci-test-install` covers that across 3.10–3.13 and three operating systems.

The module list lives in one place — `python/xorq/tests/bare_install_modules.txt`, driven by `check_bare_imports.py` — read by the test and by all four workflow steps, rather than being repeated as five hand-maintained `python -c "import …"` one-liners.

The `bare_install` tests also needed a step of their own: `ci-test.yml` filters on the backend matrix name, `ci-test-library` on `"library or xorq"`, and every other workflow names explicit paths — so nothing selected that marker and the round trip ran only locally. Now wired into the `core` matrix entry, which already has uv and a synced project; the test builds its own wheel and spawns its own isolated environment, so the surrounding dev/test groups don't contaminate what's under test.

## Known limitations

Stated rather than left to be discovered:

- **`vendor/` is outside the static scan.** Its module-level imports are upstream ibis's and re-vendoring would churn any exclusion list kept here. Not a hole: `xorq.api` imports `vendor/ibis`, so the bare-install layer catches an undeclared import there that is genuinely absent from a bare install.
- **The exclusion-minimality guard only catches import roots that match their distribution name.** An aliased one (`sklearn` → `scikit-learn`) would not be flagged as stale, because pre-registering that alias collides with `test_import_root_mapping_has_no_stale_entries`.
- **The twelve exclusions are verified non-stale, not verified extras-gated.** Several of those distributions aren't declared in any extra — pre-existing, and out of scope here.
- **The `>= '3.13'` floors are open upward**, safe only while `requires-python` caps at `<3.14`. Noted in `pyproject.toml` where the next bump will see it.

## Follow-ups

- **0.4.0 on PyPI carries this bug.** Merging fixes `main`; it does not help anyone already installed. Needs a patch release.
- **#2269** — unrelated, found while diagnosing CI here: Flight replaces exception messages over ~1–2 KB with an opaque gRPC metadata-size error, so real failures with chained tracebacks surface as transport errors.
