### PR TITLE
release: 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Details
 
+## [0.4.1] - 2026-09-01
+### Details
+#### Fixed
+- Make cases deferrable by @hussainsultan in [#2265](https://github.com/xorq-labs/xorq/pull/2265)
+- Declare packaging, numpy, pygments and xxhash as runtime dependencies by @dlovell in [#2268](https://github.com/xorq-labs/xorq/pull/2268)
+
 ## [0.4.0] - 2026-08-25
 ### Details
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ only-include = ["python"]
 
 [project]
 name = "xorq"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
     "attrs>=24.1.0; python_version >= '3.10' and python_version < '4.0'",
     "pyarrow>=18.0.0,<22; python_version >= '3.10' and python_version < '4.0'",

--- a/uv.lock
+++ b/uv.lock
@@ -6151,7 +6151,7 @@ wheels = [
 
 [[package]]
 name = "xorq"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "atpublic" },


### PR DESCRIPTION
Patch bump to ship #2268.

## Why now

0.4.0 as published is missing a `packaging` declaration. On any install that has only the declared dependencies, `xorq run`, `xorq catalog` and the TUI raise `ModuleNotFoundError` — `xorq build` and every `--help` path still work, which is why it shipped. Merging #2268 fixed `main`; it does nothing for anyone already on 0.4.0.

## Contents

Both commits since `v0.4.0` are fixes; no `feat` and no breaking change in the range, so patch is the right bump.

- Make cases deferrable — #2265
- Declare packaging, numpy, pygments and xxhash as runtime dependencies — #2268

## Changes

- `pyproject.toml`: `0.4.0` → `0.4.1`
- `uv.lock`: regenerated (xorq's own version only — the sole line changed)
- `CHANGELOG.md`: 6 insertions

## On the changelog

Prepended, not regenerated. `git cliff --tag v0.4.1 -o CHANGELOG.md` rewrites the entire file — 912 lines changed — and in doing so:

- drops the `**Breaking:**` marker on #2242 that the 0.4.0 release added by hand,
- deletes the `## [Unreleased]` header,
- re-adds a release-commit entry for #2260 that had been removed.

`--unreleased --tag v0.4.1 --prepend` keeps it to 6 insertions and 0 deletions, matching how 0.4.0 was cut. The new section is placed below `## [Unreleased]`.

## Verification

Built the wheel from this branch and ran the invocation that fails on 0.4.0:

```console
$ uv tool run --isolated --python 3.12 --with xorq-0.4.1-py3-none-any.whl xorq build expr.py -e expr
Written 'expr' to builds/f68b0e436e96

$ uv tool run --isolated --python 3.12 --with xorq-0.4.1-py3-none-any.whl xorq run builds/f68b0e436e96
xorq run: OK (exit 0)
```

Wheel metadata carries all four declarations: `packaging` 1, `numpy` 4, `pygments` 1, `xxhash` 4 (the markered per-interpreter entries).

## Remaining step

Publishing is triggered by a GitHub **release published** event (`.github/workflows/ci-release.yml`). Merging this PR does not publish — cutting the `v0.4.1` tag and release does. That step is deliberately not taken here.
