### PR TITLE
docs: correct three defects in the Release Flow steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,12 +218,12 @@ change is not present in PyPI.
 1. Ensure you're on upstream main: `git switch main && git pull`
 2. Compute the new version number (`$version_number`) according to [Semantic Versioning](https://semver.org/) rules.
 3. Create a branch that starts from the upstream main: `git switch --create=release-$version_number`
-4. Update the version number in `pyproject.toml`: `version = "$version_number"`
-5. Update the CHANGELOG using `git cliff --github-repo xorq-labs/xorq -p CHANGELOG.md --tag v$version_number -u`, manually add any additional notes (links to blogposts, etc.).
+4. Update the version number in `pyproject.toml`: `version = "$version_number"`, then run `uv lock` so xorq's own version is updated in `uv.lock`.
+5. Update the CHANGELOG using `git cliff --github-repo xorq-labs/xorq -p CHANGELOG.md --tag v$version_number -u`, manually add any additional notes (links to blogposts, etc.). The command prepends the new section above `## [Unreleased]`; move it below.
 6. Create commit with a message denoting the release: `git add --update && git commit -m "release: $version_number"`.
 7. Push the new branch: `git push --set-upstream upstream "release-$version_number"`
 8. Open a PR for the new branch `release-$version_number`
-9. Trigger the [ci-pre-release action](https://github.com/xorq-labs/xorq/actions/workflows/ci-pre-release.yml) from the branch created: Run workflow -> Use workflow from -> Branch `$version_number`
+9. Trigger the [ci-pre-release action](https://github.com/xorq-labs/xorq/actions/workflows/ci-pre-release.yml) from the branch created: Run workflow -> Use workflow from -> Branch `release-$version_number`
 10. Wait for all ci-pre-release tests to pass
 11. "Squash and merge" the PR
 12. Tag the updated main with `v$version_number` and push the tag: `git fetch && git tag v$version_number origin/main && git push --tags`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,12 +219,12 @@ change is not present in PyPI.
 2. Compute the new version number (`$version_number`) according to [Semantic Versioning](https://semver.org/) rules.
 3. Create a branch that starts from the upstream main: `git switch --create=release-$version_number`
 4. Update the version number in `pyproject.toml`: `version = "$version_number"`, then run `uv lock` so xorq's own version is updated in `uv.lock`.
-5. Update the CHANGELOG using `git cliff --github-repo xorq-labs/xorq -p CHANGELOG.md --tag v$version_number -u`, manually add any additional notes (links to blogposts, etc.). The command prepends the new section above `## [Unreleased]`; move it below.
+5. Update the CHANGELOG using `git cliff --github-repo xorq-labs/xorq -p CHANGELOG.md --tag v$version_number -u`, manually add any additional notes (links to blogposts, etc.). The command prepends the new section above `## [Unreleased]`; move it below the `## [Unreleased]` / `### Details` block, matching prior releases.
 6. Create commit with a message denoting the release: `git add --update && git commit -m "release: $version_number"`.
-7. Push the new branch: `git push --set-upstream upstream "release-$version_number"`
+7. Push the new branch: `git push --set-upstream origin "release-$version_number"`
 8. Open a PR for the new branch `release-$version_number`
 9. Trigger the [ci-pre-release action](https://github.com/xorq-labs/xorq/actions/workflows/ci-pre-release.yml) from the branch created: Run workflow -> Use workflow from -> Branch `release-$version_number`
 10. Wait for all ci-pre-release tests to pass
 11. "Squash and merge" the PR
-12. Tag the updated main with `v$version_number` and push that tag alone: `git fetch && git tag v$version_number origin/main && git push origin v$version_number`. Not `git push --tags`, which publishes every local tag, including any local-only archive or backup tags.
+12. Tag the updated main with `v$version_number` and push that tag alone: `git fetch origin && git tag v$version_number origin/main && git push origin v$version_number`. Not `git push --tags`, which publishes every local tag, including any local-only archive or backup tags.
 13. Create a [GitHub release](https://github.com/xorq-labs/xorq/releases/new) to trigger the publishing workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,5 +226,5 @@ change is not present in PyPI.
 9. Trigger the [ci-pre-release action](https://github.com/xorq-labs/xorq/actions/workflows/ci-pre-release.yml) from the branch created: Run workflow -> Use workflow from -> Branch `release-$version_number`
 10. Wait for all ci-pre-release tests to pass
 11. "Squash and merge" the PR
-12. Tag the updated main with `v$version_number` and push the tag: `git fetch && git tag v$version_number origin/main && git push --tags`
+12. Tag the updated main with `v$version_number` and push that tag alone: `git fetch && git tag v$version_number origin/main && git push origin v$version_number`. Not `git push --tags`, which publishes every local tag, including any local-only archive or backup tags.
 13. Create a [GitHub release](https://github.com/xorq-labs/xorq/releases/new) to trigger the publishing workflow.


### PR DESCRIPTION
Three fixes to the `## Release Flow` section of CONTRIBUTING.md. Docs only.

**1. Step 9 named a branch that does not exist** (CONTRIBUTING.md:226)

- Was: `Use workflow from -> Branch $version_number`. Step 3 (CONTRIBUTING.md:220) creates `release-$version_number`, and `git ls-remote --heads origin` has no bare-version branches (only `release-0.4.1`).
- Consequence: dispatching `ci-pre-release` on the wrong ref builds the *previous* version and publishes it via `uv publish --publish-url https://test.pypi.org/legacy/` (`.github/workflows/ci-pre-release.yml:36`). TestPyPI rejects a reused version, so it cannot be undone.

**2. Step 4 omitted `uv.lock`** (CONTRIBUTING.md:221)

- `git show 61a4758b --stat` (release: 0.4.0) touches CHANGELOG.md, pyproject.toml **and** uv.lock; the message reads "`uv.lock`: regenerated (xorq's own version only)".
- Consequence: a release commit that bumps only pyproject.toml leaves uv.lock pinning the old version.

**3. Step 5's command places the new changelog section in the wrong position** (CONTRIBUTING.md:222)

- Running `git cliff ... -p CHANGELOG.md --tag vX -u` against the current CHANGELOG puts the new `## [X]` block **above** `## [Unreleased]` (verified by running it on a scratch copy).
- `git show 61a4758b -- CHANGELOG.md` shows the `## [0.4.0]` block inserted **after** the `## [Unreleased]` / `### Details` lines.
- Consequence: without the manual move, the changelog ordering diverges from every prior release.

~~Left alone: step 7 pushes to a remote named `upstream` while the canonical checkout names it `origin` — fork-setup-dependent, out of scope.~~ No longer true — see defect 5 below.

---

## Defect 4 (added after the initial three)

**Step 12 pushed every local tag.** It read `git push --tags`, which publishes all tags in the local repository, not just the release tag. Found while cutting v0.4.1: the working checkout had **17 local-only tags** that command would have pushed to the public remote — `archive/pre-landing/*`, `backup/*` and similar throwaway refs.

Evidence:

```console
$ comm -23 <(git tag | sort) \
    <(git ls-remote --tags origin | sed 's/.*refs\/tags\///' | grep -v '\^{}' | sort) | wc -l
17
```

Now `git push origin v$version_number`, with a note on why `--tags` is the wrong tool.

All four defects were hit in practice while cutting 0.4.1, not found by reading.



## Defect 5 (added during review of defect 4)

**Steps 7 and 12 disagreed about the remote.** Step 7 pushed the release branch to `upstream`; step 12 tagged from `origin/main`. Only one can be right in a given checkout, and the step-12 rewrite above made the contradiction load-bearing on the one step that publishes a public, hard-to-retract ref.

`origin` is the correct name:

- CONTRIBUTING.md:14 documents setup as `git clone git@github.com:xorq-labs/xorq.git`, so `origin` is the canonical repo and no `upstream` remote exists.
- `git show 91cb4719` (release: 0.1.17) is where step 7 was flipped `origin` -> `upstream`, leaving step 12 on `origin/main`. Step 7 is the anomaly.

Step 7 is now `git push --set-upstream origin "release-$version_number"`, and step 12's bare `git fetch` is now `git fetch origin` so the tag base cannot be stale.

Also in the same commit: step 5 said to move the generated section "below" without naming the anchor. git-cliff emits `## [Unreleased]` and `### Details` as a two-line block, so "move it below" can be read as "below the `## [Unreleased]` heading" -- which orphans `### Details` onto the wrong version. It now names the whole block.

This one was found by review, not by cutting a release.
