### PR TITLE
chore: format with ruff

### DIFF
--- a/python/xorq/catalog/tests/test_cli_run_compose.py
+++ b/python/xorq/catalog/tests/test_cli_run_compose.py
@@ -1149,7 +1149,8 @@ def test_catalog_join_command_rebinds_same_profile_file_backed_entries(
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(
-        cli, ["--path", catalog_path, "run", "joined-file-backed", "-o", "-", "-f", "csv"]
+        cli,
+        ["--path", catalog_path, "run", "joined-file-backed", "-o", "-", "-f", "csv"],
     )
     assert result.exit_code == 0, result.output
     assert "a" in result.output
@@ -1170,9 +1171,11 @@ def test_catalog_join_command_rebinds_into_backend_entry(
 
     catalog = Catalog.from_kwargs(path=catalog_path, init=False)
     left = deferred_read_parquet(pq_path, xo.connect(), table_name="t")
-    right = deferred_read_parquet(
-        pq_path, xo.duckdb.connect(), table_name="t"
-    ).rename(b="a").into_backend(xo.connect(), name="t_remote")
+    right = (
+        deferred_read_parquet(pq_path, xo.duckdb.connect(), table_name="t")
+        .rename(b="a")
+        .into_backend(xo.connect(), name="t_remote")
+    )
     catalog.add(left, aliases=("hub-left",))
     catalog.add(right, aliases=("into-backend-right",))
 
@@ -1193,7 +1196,8 @@ def test_catalog_join_command_rebinds_into_backend_entry(
     assert result.exit_code == 0, result.output
 
     result = runner.invoke(
-        cli, ["--path", catalog_path, "run", "joined-into-backend", "-o", "-", "-f", "csv"]
+        cli,
+        ["--path", catalog_path, "run", "joined-into-backend", "-o", "-", "-f", "csv"],
     )
     assert result.exit_code == 0, result.output
     assert "a" in result.output
@@ -1227,9 +1231,9 @@ def test_catalog_join_command_into_backend_mixed_source_backends(
     duckdb_into_df = deferred_read_parquet(
         pq_a, xo.duckdb.connect(), table_name="a"
     ).into_backend(xo.connect(), name="a_remote")
-    df_into_df = deferred_read_parquet(
-        pq_b, xo.connect(), table_name="b"
-    ).into_backend(xo.connect(), name="b_remote")
+    df_into_df = deferred_read_parquet(pq_b, xo.connect(), table_name="b").into_backend(
+        xo.connect(), name="b_remote"
+    )
     catalog.add(duckdb_into_df, aliases=("duckdb-into-df",))
     catalog.add(df_into_df, aliases=("df-into-df",))
 

--- a/python/xorq/cli.py
+++ b/python/xorq/cli.py
@@ -464,7 +464,9 @@ def join_command(
     from xorq.ibis_yaml.combine import combine_errors, join_builds  # noqa: PLC0415
 
     cache_dir = _get_cache_dir(cache_dir)
-    _check_library_version_match((left_path, right_path), ignore_library_version_mismatch)
+    _check_library_version_match(
+        (left_path, right_path), ignore_library_version_mismatch
+    )
 
     click.echo(f"Joining {left_path} and {right_path} (how={how})", err=True)
     with combine_errors():

--- a/python/xorq/ibis_yaml/combine.py
+++ b/python/xorq/ibis_yaml/combine.py
@@ -224,9 +224,7 @@ def _rebind_same_profile_sources(*exprs: "Expr") -> tuple["Expr", ...]:
     return tuple(rebind_one(expr) for expr in exprs)
 
 
-def _reconcile_backends(
-    *exprs: "Expr", rebind_backends: bool
-) -> tuple["Expr", ...]:
+def _reconcile_backends(*exprs: "Expr", rebind_backends: bool) -> tuple["Expr", ...]:
     """Require *exprs* to jointly resolve to a single backend, rebinding
     same-profile connections onto one object first (unless
     `rebind_backends=False`).
@@ -322,8 +320,15 @@ def join_builds(
     left = load_expr(left_path, cache_dir=cache_dir, con_cache=con_cache)
     right = load_expr(right_path, cache_dir=cache_dir, con_cache=con_cache)
     expr = join_exprs(
-        left, right, on=on, left_on=left_on, right_on=right_on, how=how,
-        lname=lname, rname=rname, rebind_backends=rebind_backends,
+        left,
+        right,
+        on=on,
+        left_on=left_on,
+        right_on=right_on,
+        how=how,
+        lname=lname,
+        rname=rname,
+        rebind_backends=rebind_backends,
     )
     return build_expr(
         expr, builds_dir=builds_dir, cache_dir=cache_dir, relocate_reads=relocate_reads

--- a/python/xorq/ibis_yaml/tests/test_combine.py
+++ b/python/xorq/ibis_yaml/tests/test_combine.py
@@ -56,7 +56,9 @@ def file_backed_left(shared_parquet_path: str) -> xo.Expr:
     # A fresh `xo.duckdb.connect()` -- same profile params as the one in
     # `file_backed_right`, but a distinct connection object (this is what
     # two independent `load_expr()` calls of the same source look like).
-    return deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    return deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    )
 
 
 @pytest.fixture
@@ -194,7 +196,9 @@ def test_join_builds_rebind_survives_colliding_saved_idx(
     pins that the merge produces exactly one surviving profile -- no
     duplicate/colliding entries -- and the build round-trips correctly.
     """
-    left = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    left = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    )
     right = deferred_read_parquet(
         shared_parquet_path, xo.duckdb.connect(), table_name="t"
     ).rename(b="a")
@@ -205,7 +209,9 @@ def test_join_builds_rebind_survives_colliding_saved_idx(
     for path in (left_path, right_path):
         assert "idx: 0" in (path / "profiles.yaml").read_text()
 
-    result_path = join_builds(left_path, right_path, on="id", builds_dir=tmp_path / "joined")
+    result_path = join_builds(
+        left_path, right_path, on="id", builds_dir=tmp_path / "joined"
+    )
     profiles_text = (result_path / "profiles.yaml").read_text()
     assert profiles_text.count("idx:") == 1
 
@@ -275,8 +281,12 @@ def test_union_exprs_same_profile_in_memory_data_raises(
 def test_union_exprs_same_profile_file_backed_rebinds_by_default(
     shared_parquet_path: str,
 ) -> None:
-    left = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
-    right = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    left = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    )
+    right = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    )
     unioned = union_exprs(left, right)
     assert unioned.count().execute() == 6
 
@@ -284,7 +294,11 @@ def test_union_exprs_same_profile_file_backed_rebinds_by_default(
 def test_union_exprs_no_rebind_backends_still_raises(
     shared_parquet_path: str,
 ) -> None:
-    left = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
-    right = deferred_read_parquet(shared_parquet_path, xo.duckdb.connect(), table_name="t")
+    left = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    )
+    right = deferred_read_parquet(
+        shared_parquet_path, xo.duckdb.connect(), table_name="t"
+    )
     with pytest.raises(ValueError, match="different backend"):
         union_exprs(left, right, rebind_backends=False)

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1927,8 +1927,12 @@ def test_load_expr_con_cache_shares_same_profile_connections(
     loaded_left = load_expr(left_path, con_cache=con_cache)
     loaded_right = load_expr(right_path, con_cache=con_cache)
 
-    left_backends, _ = loaded_left._find_backends()  # xorq-style: disable=protected-access
-    right_backends, _ = loaded_right._find_backends()  # xorq-style: disable=protected-access
+    left_backends, _ = (
+        loaded_left._find_backends()
+    )  # xorq-style: disable=protected-access
+    right_backends, _ = (
+        loaded_right._find_backends()
+    )  # xorq-style: disable=protected-access
     assert left_backends[0] is right_backends[0]
 
 
@@ -1946,8 +1950,12 @@ def test_load_expr_without_con_cache_keeps_connections_independent(
     loaded_left = load_expr(left_path)
     loaded_right = load_expr(right_path)
 
-    left_backends, _ = loaded_left._find_backends()  # xorq-style: disable=protected-access
-    right_backends, _ = loaded_right._find_backends()  # xorq-style: disable=protected-access
+    left_backends, _ = (
+        loaded_left._find_backends()
+    )  # xorq-style: disable=protected-access
+    right_backends, _ = (
+        loaded_right._find_backends()
+    )  # xorq-style: disable=protected-access
     assert left_backends[0] is not right_backends[0]
 
 


### PR DESCRIPTION
Five files had drifted from `ruff format` output: four landed via #2258 and #2225, one via #2253. `ci-lint` runs `ruff check` but never `ruff format --check`, so nothing on the merge path caught them.

Reformatted with the ruff pinned in .pre-commit-config.yaml (v0.15.12).

Kept standalone so the reformat stays reviewable and blame-ignorable apart from the CI change that prevents a recurrence.

refs #2263