### PR TITLE
docs: make blame.ignoreRevsFile discoverable and automatic

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,7 +1,16 @@
 # Commits excluded from `git blame` output (bulk reformats, import sorting).
 # Enable once per clone -- git deliberately never picks this up automatically:
-#   git config blame.ignoreRevsFile .git-blame-ignore-revs
-# `pre-commit install` also sets it, via the post-checkout hook in
-# .pre-commit-config.yaml. GitHub's web blame honors this file with no setup.
+#   git config --replace-all blame.ignoreRevsFile .git-blame-ignore-revs
+# The first checkout after `pre-commit install` sets it too, via the
+# post-checkout hook in .pre-commit-config.yaml; the install itself does not.
+# GitHub's web blame honors this file with no setup.
+#
+# Caveat: once set, `git blame` fails with "could not open object name list" at
+# any rev predating this file -- bisecting into early history, or checking out
+# a tag up to v0.1.2.post. There is no per-command override, because
+# blame.ignoreRevsFile is multi-valued and both `-c` and `--ignore-revs-file`
+# append to it rather than replace it. Unset it for the duration instead:
+#   git config --unset-all blame.ignoreRevsFile
+# The next checkout puts it back.
 # chore: fix import order using ruff
 01b9b5aa271d1b1f8f8ae127ca758d6b2a0fb3bd

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,16 +1,5 @@
-# Commits excluded from `git blame` output (bulk reformats, import sorting).
-# Enable once per clone -- git deliberately never picks this up automatically:
-#   git config --replace-all blame.ignoreRevsFile .git-blame-ignore-revs
-# The first checkout after `pre-commit install` sets it too, via the
-# post-checkout hook in .pre-commit-config.yaml; the install itself does not.
-# GitHub's web blame honors this file with no setup.
-#
-# Caveat: once set, `git blame` fails with "could not open object name list" at
-# any rev predating this file -- bisecting into early history, or checking out
-# a tag up to v0.1.2.post. There is no per-command override, because
-# blame.ignoreRevsFile is multi-valued and both `-c` and `--ignore-revs-file`
-# append to it rather than replace it. Unset it for the duration instead:
-#   git config --unset-all blame.ignoreRevsFile
-# The next checkout puts it back.
+# Commits `git blame` should skip (bulk reformats, import sorting). Takes effect
+# only where blame.ignoreRevsFile is set, which is per clone -- see "git blame
+# and bulk reformats" in CONTRIBUTING.md for how that happens and its one caveat.
 # chore: fix import order using ruff
 01b9b5aa271d1b1f8f8ae127ca758d6b2a0fb3bd

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,7 @@
+# Commits excluded from `git blame` output (bulk reformats, import sorting).
+# Enable once per clone -- git deliberately never picks this up automatically:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# `pre-commit install` also sets it, via the post-checkout hook in
+# .pre-commit-config.yaml. GitHub's web blame honors this file with no setup.
 # chore: fix import order using ruff
 01b9b5aa271d1b1f8f8ae127ca758d6b2a0fb3bd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: git-blame-ignore-revs
         name: configure blame.ignoreRevsFile
-        entry: git config blame.ignoreRevsFile .git-blame-ignore-revs
+        entry: git config --replace-all blame.ignoreRevsFile .git-blame-ignore-revs
         language: system
         stages:
           - post-checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,9 @@ ci:
   autoupdate_commit_msg: "chore(deps): pre-commit.ci autoupdate"
   skip:
     - ruff
+default_install_hook_types:
+  - pre-commit
+  - post-checkout
 default_stages:
   - pre-commit
 repos:
@@ -33,3 +36,13 @@ repos:
     hooks:
       # Update the uv lockfile
       - id: uv-lock
+  - repo: local
+    hooks:
+      - id: git-blame-ignore-revs
+        name: configure blame.ignoreRevsFile
+        entry: git config blame.ignoreRevsFile .git-blame-ignore-revs
+        language: system
+        stages:
+          - post-checkout
+        always_run: true
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,29 @@ uv run pre-commit install
 # ignore bulk-reformat commits in git blame (per clone; git never accepts this from the repo itself)
 git config --replace-all blame.ignoreRevsFile .git-blame-ignore-revs
 ```
-> [!NOTE]
-> `pre-commit install` also installs a `post-checkout` hook that keeps
-> `blame.ignoreRevsFile` set. Clones set up before that hook existed need to run
-> `uv run pre-commit install` once more to pick it up.
 > [!IMPORTANT]
 > Rename `.gitignore.template` to `.gitignore` 
+
+### git blame and bulk reformats
+
+`.git-blame-ignore-revs` lists the commits `git blame` should skip. Git
+deliberately never accepts `blame.ignoreRevsFile` from the repository itself,
+hence the `git config` line above. `pre-commit install` also installs a
+`post-checkout` hook that sets it -- not the install itself, the next checkout
+after it -- so clones set up before that hook existed need `uv run pre-commit
+install` once more. GitHub's web blame honors the file with no setup at all.
+
+One caveat: with the setting on, `git blame` exits 128 with `fatal: could not
+open object name list: .git-blame-ignore-revs` at any rev predating the file
+(2024-05-17), so bisecting into early history or checking out a tag up to
+`v0.1.2.post` breaks blame entirely. There is no per-command override --
+`blame.ignoreRevsFile` is multi-valued, so `-c blame.ignoreRevsFile=` and
+`--ignore-revs-file=""` append to the list rather than replace it. Unset it for
+the duration instead, and the next checkout puts it back:
+
+```bash
+git config --unset-all blame.ignoreRevsFile
+```
 
 ## Dev container
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,12 @@ source .venv/bin/activate
 # set up the git hook scripts
 uv run pre-commit install
 # ignore bulk-reformat commits in git blame (per clone; git never accepts this from the repo itself)
-git config blame.ignoreRevsFile .git-blame-ignore-revs
+git config --replace-all blame.ignoreRevsFile .git-blame-ignore-revs
 ```
+> [!NOTE]
+> `pre-commit install` also installs a `post-checkout` hook that keeps
+> `blame.ignoreRevsFile` set. Clones set up before that hook existed need to run
+> `uv run pre-commit install` once more to pick it up.
 > [!IMPORTANT]
 > Rename `.gitignore.template` to `.gitignore` 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ uv sync --all-extras --all-groups
 source .venv/bin/activate
 # set up the git hook scripts
 uv run pre-commit install
+# ignore bulk-reformat commits in git blame (per clone; git never accepts this from the repo itself)
+git config blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 > [!IMPORTANT]
 > Rename `.gitignore.template` to `.gitignore` 


### PR DESCRIPTION
## Problem

The repo has a `.git-blame-ignore-revs` file, but it does nothing in a fresh clone. Git deliberately refuses to read `blame.ignoreRevsFile` from repository-tracked config (that would let a repo change local git behavior), so every contributor has to set it by hand — and nothing in the repo says so. GitHub's web blame reads the file automatically, so the local/web mismatch is easy to miss.

## Changes

- **`CONTRIBUTING.md`** — document the one-liner (`git config --replace-all blame.ignoreRevsFile .git-blame-ignore-revs`) right after the existing `pre-commit install` step, and a "git blame and bulk reformats" subsection covering how the hook sets it, that existing clones must re-run `pre-commit install` to pick up the new hook type, and the caveat below. This is the one place any of it is written down.
- **`.git-blame-ignore-revs`** — a three-line header saying what the file is and pointing at that subsection, rather than restating it in a file that is mostly machine-read.
- **`.pre-commit-config.yaml`** — a `post-checkout` hook that sets the config, plus `default_install_hook_types: [pre-commit, post-checkout]` so `pre-commit install` wires both. Contributors who follow the setup steps get it without running the extra command.

`--replace-all` rather than plain `git config <name> <value>`: the single-value form hard-fails (exit 5, `cannot overwrite multiple values with a single value`) when a clone's local config already holds more than one `blame.ignoreRevsFile` entry, which git explicitly supports. The hook would then print `Failed` on every checkout with no way to recover, since each retry hits the same error. `--replace-all` collapses the list to the one correct value.

## Verification

In a fresh clone of this branch (pre-commit 4.6.0, git 2.55):

- `blame.ignoreRevsFile` starts unset.
- `pre-commit install` reports `installed at .git/hooks/pre-commit` **and** `installed at .git/hooks/post-checkout`.
- The next checkout runs `configure blame.ignoreRevsFile...Passed`, after which `git config --get blame.ignoreRevsFile` returns `.git-blame-ignore-revs`.
- Seeded with two local `blame.ignoreRevsFile` values, the hook still passes and leaves exactly one value. (With the single-value form it exited 5 and failed on every subsequent checkout.)
- An existing `post-checkout` hook (e.g. git-lfs) is preserved — pre-commit migrates it via its `.legacy` mechanism.

## Caveats

- **`git blame` fails at revs predating this file.** Once the config is set, `git blame` on any file exits 128 with `fatal: could not open object name list: .git-blame-ignore-revs` whenever the working tree is at a rev older than `14a30475` (2024-05-17) — bisecting into early history, or checking out a tag up to `v0.1.2.post`. There is no per-command override: `blame.ignoreRevsFile` is multi-valued, so `-c blame.ignoreRevsFile=` and `--ignore-revs-file=""`/`=/dev/null` all *append* rather than replace, and blame still tries to open the configured path. The workaround is `git config --unset-all blame.ignoreRevsFile` for the duration; the next checkout restores it. This is documented in `CONTRIBUTING.md`.
- **No visible blame difference today.** The single rev currently listed (`01b9b5aa`, the ruff import-order pass) no longer owns any lines in any file. This PR is about the mechanism being in place and correct for the next bulk reformat, not about fixing blame output right now.

## Notes

- `default_install_hook_types` changes what `pre-commit install` installs, so **existing** clones need to re-run `pre-commit install` once to pick up the post-checkout hook. New clones get it from the documented setup flow.
- The hook is `stages: [post-checkout]` only, so it never runs on `git commit` and `pre-commit.ci` is unaffected (it doesn't run post-checkout hooks). It does run on *file* checkouts, though: `git checkout -- <file>` measured 0.153s with the hook vs 0.004s without, and `git restore <file>` prints a `configure blame.ignoreRevsFile...Passed` line each time.
- Branch is named `docs-blame-ignore-revs` rather than `docs/blame-ignore-revs`: origin already has a branch literally named `docs`, which blocks any `docs/*` ref.
