### PR TITLE
chore: drop dead xorq-style pragmas, ignore reformat in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,5 @@
 # and bulk reformats" in CONTRIBUTING.md for how that happens and its one caveat.
 # chore: fix import order using ruff
 01b9b5aa271d1b1f8f8ae127ca758d6b2a0fb3bd
+# chore: format with ruff
+e67f468abe3027d92eb369c2cac52eaa30ba6174

--- a/python/xorq/ibis_yaml/tests/test_compiler.py
+++ b/python/xorq/ibis_yaml/tests/test_compiler.py
@@ -1927,12 +1927,8 @@ def test_load_expr_con_cache_shares_same_profile_connections(
     loaded_left = load_expr(left_path, con_cache=con_cache)
     loaded_right = load_expr(right_path, con_cache=con_cache)
 
-    left_backends, _ = (
-        loaded_left._find_backends()
-    )  # xorq-style: disable=protected-access
-    right_backends, _ = (
-        loaded_right._find_backends()
-    )  # xorq-style: disable=protected-access
+    left_backends, _ = loaded_left._find_backends()
+    right_backends, _ = loaded_right._find_backends()
     assert left_backends[0] is right_backends[0]
 
 
@@ -1950,12 +1946,8 @@ def test_load_expr_without_con_cache_keeps_connections_independent(
     loaded_left = load_expr(left_path)
     loaded_right = load_expr(right_path)
 
-    left_backends, _ = (
-        loaded_left._find_backends()
-    )  # xorq-style: disable=protected-access
-    right_backends, _ = (
-        loaded_right._find_backends()
-    )  # xorq-style: disable=protected-access
+    left_backends, _ = loaded_left._find_backends()
+    right_backends, _ = loaded_right._find_backends()
     assert left_backends[0] is not right_backends[0]
 
 


### PR DESCRIPTION
## What

Two changes, both only possible after #2274 landed.

- `.git-blame-ignore-revs`: skip the reformat @ray1097 did in #2274, so blame
  points at the authoring commit instead of the sweep.
- `python/xorq/ibis_yaml/tests/test_compiler.py`: drop four
  `# xorq-style: disable=protected-access` pragmas. `ProtectedAccessRule` skips
  test files, so they never suppressed anything.

Cherry-picked from @dlovell's unpublished `dan/chore/ruff-format-drift`,
authorship preserved. One correction, below.

## Why

`git blame` reports the last commit that changed each line, so a formatting
sweep hides the author of every line it touches. Line 227 of `combine.py`
blames to `e67f468a`, which only joined three lines into one.

Separate from #2274 because xorq squash-merges only. Its branch commits never
reached `main`; GitHub flattened them into a new SHA. dlovell's commit carried
`87bf1a1c`, his branch SHA, which does not exist on `main`. Retargeted to
`e67f468a`, which could not be known until after the merge.

An unresolvable entry is a silent no-op. `git blame` neither warns nor fails,
so the file looks correct and does nothing.

## Verification

| Check | Result |
|---|---|
| Both SHAs in the file are ancestors of `main` | OK |
| `ruff format --check` on the file | already formatted |
| `pytest python/xorq/ibis_yaml/tests/test_compiler.py` | 112 passed, 1 skipped |

## Not addressed

#2276 is still open. It reported 12 dead pragmas; the four removed here are the
only ones in test files, and #2278 (draft) handles the one genuinely dead pragma
in non-test code. The remaining 11 are live and stay.
