### PR TITLE
ci: gate formatting on the merge path

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Run Ruff
         run: uv run --no-sync ruff check --output-format=github python examples docs scripts
 
+      # A separate command, not a flag on the step above: `ruff check` is the
+      # linter and `ruff format` the formatter, and a file can be lint-clean and
+      # format-dirty at once. Same paths as the linter so the two stay in sync.
+      # No --output-format here; the formatter's is preview-gated.
+      - name: Run Ruff format check
+        run: uv run --no-sync ruff format --check python examples docs scripts
+
       - name: Verify no uncommitted changes
         run: |
           echo "Checking for uncommitted changes in the workspace..."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,3 @@
-ci:
-  autofix_commit_msg: "style: auto fixes from pre-commit.ci hooks"
-  autofix_prs: false
-  autoupdate_commit_msg: "chore(deps): pre-commit.ci autoupdate"
-  skip:
-    - ruff
 default_install_hook_types:
   - pre-commit
   - post-checkout


### PR DESCRIPTION
Closes #2263

## What

- `.github/workflows/ci-lint.yml`: add `ruff format --check` after the existing
  `ruff check` step, over the same paths.
- `.pre-commit-config.yaml`: delete the dead `ci:` block.

## Why

CI ran the linter but never the formatter, so unformatted code merged unnoticed.
#2274 had to clean up drift that got in through that gap. A file can pass
`ruff check` and fail `ruff format --check`; they are different commands.

`Verify no uncommitted changes` cannot backstop formatting. `ruff check` runs
without `--fix`, so it never touches a file and that `git diff` is always empty.

No pre-commit.ci check run appears on any pull request, so the app is not
installed and the `ci:` block does nothing. Its `skip: [ruff]` also named a hook
id that ruff-pre-commit has since renamed to `ruff-check`. #2263 asks for the
block to go in the same change, since installing the app and adding the step are
alternatives to each other.

I did not take #2263's other suggestion: `pre-commit run --all-files` in place
of a dedicated step. The `ruff-check` hook there runs with `--fix`, so it
rewrites files, and `Verify no uncommitted changes` exists to catch exactly
that.

## Verification

| Check | Result |
|---|---|
| Gate on a clean tree | exit 0, 697 files already formatted |
| Gate with one misformatted file | exit 1, `Would reformat:` |
| `actionlint` on the workflow | passed |
| `pre-commit` config still parses after the deletion | 5 hooks passed |
| ruff version, dev group vs pre-commit | both 0.15.12, no pin needed |

## Not addressed

The check runs but does not block. `lint (3.13)` is not a required status check
on `main`; the ruleset requires only `adr` and `adr-tests`. Making it one takes
an org owner and cannot be done from a pull request.

## Post-merge

#2278 conflicts with this. Both insert a step right after `Run Ruff`. Merging
this branch into `fix/style-gate-2276` fails with one conflict in `ci-lint.yml`.
Whichever lands second rebases.

I would revisit `pre-commit run --all-files` once `xorq-check-style` also runs
in pre-commit. That is what forces the consolidate-or-not decision, not #2278 on
its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
