### PR TITLE
feat: add sidecar semantic metadata via Catalog.add(metadata)

### DIFF
--- a/docs/tutorials/core_tutorials/build_a_semantic_catalog.qmd
+++ b/docs/tutorials/core_tutorials/build_a_semantic_catalog.qmd
@@ -236,7 +236,16 @@ catalog_dir = Path("flights-catalog")
 catalog = Catalog.from_repo_path(catalog_dir, init=True)
 
 # <3>
-catalog.add(flights_model_expr, aliases=("flights-model",), sync=False)
+catalog.add(
+    flights_model_expr,
+    aliases=("flights-model",),
+    metadata={
+        "domain": "flights",
+        "owner": "analytics",
+        "tags": ["semantic-model", "tutorial"],
+    },
+    sync=False,
+)
 
 print("Catalog at:", catalog_dir.absolute())
 print("Aliases:   ", catalog.list_aliases())
@@ -244,11 +253,43 @@ print("Aliases:   ", catalog.list_aliases())
 1. `to_tagged(flights_model)` serializes the dimensions, measures, and underlying table into a Xorq expression with BSL metadata attached. Bind it to `flights_model_expr` to make the role explicit: it's the *expression form* of the model, ready for the catalog. You're cataloging the model itself, not the result of one of its queries.
 2. A stable path inside the project directory. Use anywhere you like—but a real folder (not a temp dir) is what lets the *next* script find the catalog by path. `Catalog.from_repo_path(..., init=True)` initializes a fresh git repo there.
 3. The alias `flights-model` is the human-readable handle. Internally each entry has a content-addressed hash; the alias just points at it.
+4. `metadata` stores optional catalog semantic metadata separately from the expression. Use JSON/YAML-compatible values with string mapping keys; it does not change the expression identity or the expression's existing builder metadata.
 
 ::: {.callout-note}
 ### Why go through the catalog?
 The catalog speaks the language of expressions: schemas, lineage, content hashes, deferred reads. By tagging the model and storing it as a catalog entry, the model travels through the same pipes as everything else—`xorq build`, `xorq run`, lineage tools—and `from_tagged` lets you get the rich Python object back when you need it.
 :::
+
+### Read catalog semantic metadata
+
+The metadata passed to `Catalog.add(...)` is available on the returned `CatalogEntry` through `semantic_metadata`. It is stored with the catalog entry and is separate from the expression's BSL metadata:
+
+```python
+entry = catalog.get_catalog_entry("flights-model", maybe_alias=True)
+print(entry.semantic_metadata)
+# {'domain': 'flights', 'owner': 'analytics',
+#  'tags': ['semantic-model', 'tutorial']}
+```
+
+The same sidecar data is included in structured CLI output. For example:
+
+```bash
+xorq catalog --path flights-catalog show flights-model --json
+```
+
+The JSON object includes a `semantic_metadata` field alongside the other entry metadata:
+
+```json
+{
+  "semantic_metadata": {
+    "domain": "flights",
+    "owner": "analytics",
+    "tags": ["semantic-model", "tutorial"]
+  }
+}
+```
+
+Entries created before semantic metadata support do not have this sidecar field; their `semantic_metadata` property is `None`. The `--raw` option continues to print the sidecar YAML as-is.
 
 ::: {.callout-tip}
 ### Pointing at a real catalog
@@ -368,7 +409,16 @@ flights_model_expr = to_tagged(flights_model)
 
 catalog_dir = Path("flights-catalog")
 catalog = Catalog.from_repo_path(catalog_dir, init=True)
-catalog.add(flights_model_expr, aliases=("flights-model",), sync=False)
+catalog.add(
+    flights_model_expr,
+    aliases=("flights-model",),
+    metadata={
+        "domain": "flights",
+        "owner": "analytics",
+        "tags": ["semantic-model", "tutorial"],
+    },
+    sync=False,
+)
 ```
 
 `recover_flights.py`—reads the catalog from scratch, recovers the model, runs a new query:

--- a/examples/catalog_semantic_metadata_demo.py
+++ b/examples/catalog_semantic_metadata_demo.py
@@ -1,0 +1,48 @@
+"""Demo: catalog-level semantic metadata sidecar."""
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+import xorq.api as xo
+from xorq.catalog.catalog import Catalog
+
+catalog_dir = Path(tempfile.mkdtemp()) / "sales-catalog"
+
+con = xo.connect()
+orders = con.create_table(
+    "orders",
+    pd.DataFrame(
+        {
+            "region": ["west", "east", "west", "east", "north"],
+            "amount": [120.0, 85.0, 45.0, 200.0, 150.0],
+        }
+    ),
+)
+expr = orders.group_by("region").agg(total=orders.amount.sum())
+
+catalog = Catalog.from_repo_path(catalog_dir, init=True)
+entry = catalog.add(
+    expr,
+    aliases=("sales-by-region",),
+    metadata={
+        "domain": "sales",
+        "owner": "data-platform",
+        "tags": ["curated", "daily"],
+        "description": "Total order amount by region",
+    },
+    sync=False,
+)
+print("add ok:", entry.semantic_metadata)
+
+reloaded = Catalog.from_repo_path(catalog_dir, init=False).get_catalog_entry(
+    "sales-by-region", maybe_alias=True
+)
+print("reload ok:", reloaded.semantic_metadata)
+assert reloaded.semantic_metadata == entry.semantic_metadata
+
+untagged_expr = orders.filter(orders.amount > 100)
+untagged = catalog.add(untagged_expr, sync=False)
+print("untagged (no metadata):", untagged.semantic_metadata)
+assert untagged.semantic_metadata is None

--- a/examples/catalog_semantic_metadata_demo.py
+++ b/examples/catalog_semantic_metadata_demo.py
@@ -28,9 +28,12 @@ entry = catalog.add(
     aliases=("sales-by-region",),
     metadata={
         "domain": "sales",
-        "owner": "data-platform",
-        "tags": ["curated", "daily"],
         "description": "Total order amount by region",
+        "columns": {
+            "region": "Sales region code",
+            "amount": "Order total in USD",
+            "total": "Summed order amount by region",
+        },
     },
     sync=False,
 )

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -83,6 +83,21 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _normalize_semantic_metadata(value):
+    """Validate and normalize JSON/YAML-compatible catalog metadata."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise TypeError("semantic metadata mapping keys must be strings")
+        return {key: _normalize_semantic_metadata(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_semantic_metadata(item) for item in value]
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"unsupported semantic metadata value: {type(value).__name__}")
+
+
 def _check_backend_exclusive(
     content_store_config: ContentStoreConfig | None,
     annex: AnnexConfig | None | Literal[False],
@@ -356,21 +371,38 @@ class Catalog:
         embed_config = attr.evolve(readonly_config, embedcreds="yes")
         self.set_remote_config(embed_config)
 
-    def _add_zip(self, path, sync=True, aliases=(), exist_ok=False):
+    def _add_zip(
+        self, path, sync=True, aliases=(), exist_ok=False, semantic_metadata=None
+    ):
         # should we enable not syncing?
         with self.maybe_synchronizing(sync):
-            catalog_addition = CatalogAddition(BuildZip(path), self, aliases=aliases)
+            catalog_addition = CatalogAddition(
+                BuildZip(path),
+                self,
+                aliases=aliases,
+                semantic_metadata=_normalize_semantic_metadata(semantic_metadata),
+            )
             catalog_entry = catalog_addition.add(exist_ok=exist_ok)
             self.assert_consistency()
             return catalog_entry
 
     def _add_build_dir(
-        self, build_dir, sync=True, aliases=(), exist_ok=False, project_path=None
+        self,
+        build_dir,
+        sync=True,
+        aliases=(),
+        exist_ok=False,
+        project_path=None,
+        semantic_metadata=None,
     ):
         _ensure_wheel_artifacts(build_dir, project_path=project_path)
         with make_zip_context(build_dir) as zip_path:
             return self._add_zip(
-                zip_path, sync=sync, aliases=aliases, exist_ok=exist_ok
+                zip_path,
+                sync=sync,
+                aliases=aliases,
+                exist_ok=exist_ok,
+                semantic_metadata=semantic_metadata,
             )
 
     def _add_expr(
@@ -381,6 +413,7 @@ class Catalog:
         exist_ok: bool = False,
         project_path: Path | None = None,
         relocate_reads: bool = True,
+        semantic_metadata=None,
     ) -> CatalogEntry:
         with build_expr_context(expr, relocate_reads=relocate_reads) as path:
             return self._add_build_dir(
@@ -389,6 +422,7 @@ class Catalog:
                 aliases=aliases,
                 exist_ok=exist_ok,
                 project_path=project_path,
+                semantic_metadata=semantic_metadata,
             )
 
     def add(
@@ -399,6 +433,8 @@ class Catalog:
         exist_ok: bool = False,
         project_path: Path | None = None,
         relocate_reads: bool | None = None,
+        *,
+        metadata=None,
     ) -> CatalogEntry:
         """Add a build to the catalog.
 
@@ -431,14 +467,17 @@ class Catalog:
         shared = {"sync": sync, "aliases": aliases, "exist_ok": exist_ok}
         match obj:
             case Path() if obj.is_dir():
-                return self._add_build_dir(obj, project_path=project_path, **shared)
+                return self._add_build_dir(
+                    obj, project_path=project_path, semantic_metadata=metadata, **shared
+                )
             case Path() if obj.is_file():
-                return self._add_zip(obj, **shared)
+                return self._add_zip(obj, semantic_metadata=metadata, **shared)
             case Expr():
                 return self._add_expr(
                     obj,
                     project_path=project_path,
                     relocate_reads=True if relocate_reads is None else relocate_reads,
+                    semantic_metadata=metadata,
                     **shared,
                 )
             case _:
@@ -1328,6 +1367,7 @@ class CatalogAddition:
     build_zip = field(validator=instance_of(BuildZip))
     catalog = field(validator=instance_of(Catalog))
     aliases = field(validator=deep_iterable(instance_of(str)), default=())
+    semantic_metadata = field(default=None)
     _maybe_tmpfile = field(
         validator=optional(instance_of(tempfile._TemporaryFileWrapper)),
         default=None,
@@ -1355,6 +1395,7 @@ class CatalogAddition:
                 "md5sum": self.build_zip.md5sum,
                 "backends": backends,
                 "expr_metadata": expr_data,
+                "semantic_metadata": self.semantic_metadata,
             }.items()
             if v is not None
         }
@@ -1510,6 +1551,11 @@ class CatalogEntry:
     @cached_property
     def backends(self) -> tuple[str, ...]:
         return tuple(self.sidecar_metadata.get("backends", ()))
+
+    @property
+    def semantic_metadata(self):
+        """Optional catalog-level semantic metadata from the sidecar."""
+        return self.sidecar_metadata.get("semantic_metadata")
 
     @property
     def aliases(self):

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -84,15 +84,32 @@ logger = get_logger(__name__)
 
 
 def _normalize_semantic_metadata(value):
-    """Validate and normalize JSON/YAML-compatible catalog metadata."""
+    """Validate and normalize JSON/YAML-compatible catalog metadata.
+
+    Top-level value must be a dict (or None); nested values may be
+    dicts, lists/tuples, strings, numbers, booleans, or None.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise TypeError(
+            f"semantic metadata must be a dict, got {type(value).__name__}"
+        )
+    return _normalize_semantic_metadata_value(value)
+
+
+def _normalize_semantic_metadata_value(value):
     if value is None:
         return None
     if isinstance(value, dict):
         if not all(isinstance(key, str) for key in value):
             raise TypeError("semantic metadata mapping keys must be strings")
-        return {key: _normalize_semantic_metadata(item) for key, item in value.items()}
+        return {
+            key: _normalize_semantic_metadata_value(item)
+            for key, item in value.items()
+        }
     if isinstance(value, (list, tuple)):
-        return [_normalize_semantic_metadata(item) for item in value]
+        return [_normalize_semantic_metadata_value(item) for item in value]
     if isinstance(value, (str, int, float, bool)):
         return value
     raise TypeError(f"unsupported semantic metadata value: {type(value).__name__}")
@@ -455,6 +472,14 @@ class Catalog:
         is self-contained and resolves on both the load and fuse/bind paths
         (#2133) -- and is a no-op for a ``Path``. Passing ``relocate_reads=True``
         explicitly with a ``Path`` is a misuse and raises.
+
+        *metadata* is optional catalog-level semantic metadata stored in the
+        entry sidecar (separate from the expression's own metadata). It must
+        be a dict with string keys holding JSON/YAML-compatible values (or
+        ``None`` for no metadata). It is available as
+        ``CatalogEntry.semantic_metadata``. When the entry already exists and
+        *exist_ok* is true, a non-``None`` *metadata* that differs from the
+        stored value updates the sidecar; ``None`` leaves it untouched.
         """
         from xorq.api import Expr  # noqa: PLC0415
 
@@ -1422,6 +1447,17 @@ class CatalogAddition:
         if self.catalog.contains(self.name):
             if not exist_ok:
                 raise ValueError(f"Entry '{self.name}' already exists in catalog")
+            if self.semantic_metadata is not None:
+                existing = CatalogEntry(
+                    self.name, self.catalog, require_exists=True
+                )
+                if existing.semantic_metadata != self.semantic_metadata:
+                    sidecar = dict(existing.sidecar_metadata)
+                    sidecar["semantic_metadata"] = self.semantic_metadata
+                    existing.metadata_path.write_text(
+                        yaml12.format_yaml(sidecar)
+                    )
+                    self.catalog.backend.stage(existing.metadata_path)
             for catalog_alias in self.catalog_aliases:
                 catalog_alias._add()
             return CatalogEntry(self.name, self.catalog, require_exists=True)

--- a/python/xorq/catalog/catalog.py
+++ b/python/xorq/catalog/catalog.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import shutil
 import subprocess
 import tempfile
@@ -110,6 +111,10 @@ def _normalize_semantic_metadata_value(value):
         }
     if isinstance(value, (list, tuple)):
         return [_normalize_semantic_metadata_value(item) for item in value]
+    if isinstance(value, float) and not math.isfinite(value):
+        raise TypeError(
+            f"unsupported semantic metadata value: non-finite float {value!r}"
+        )
     if isinstance(value, (str, int, float, bool)):
         return value
     raise TypeError(f"unsupported semantic metadata value: {type(value).__name__}")
@@ -391,13 +396,15 @@ class Catalog:
     def _add_zip(
         self, path, sync=True, aliases=(), exist_ok=False, semantic_metadata=None
     ):
+        # Normalize before any I/O so invalid metadata fails fast (no pull/push).
+        semantic_metadata = _normalize_semantic_metadata(semantic_metadata)
         # should we enable not syncing?
         with self.maybe_synchronizing(sync):
             catalog_addition = CatalogAddition(
                 BuildZip(path),
                 self,
                 aliases=aliases,
-                semantic_metadata=_normalize_semantic_metadata(semantic_metadata),
+                semantic_metadata=semantic_metadata,
             )
             catalog_entry = catalog_addition.add(exist_ok=exist_ok)
             self.assert_consistency()
@@ -482,6 +489,9 @@ class Catalog:
         stored value updates the sidecar; ``None`` leaves it untouched.
         """
         from xorq.api import Expr  # noqa: PLC0415
+
+        # Fail fast on invalid metadata before any build work or sync I/O.
+        metadata = _normalize_semantic_metadata(metadata)
 
         if relocate_reads and not isinstance(obj, Expr):
             raise ValueError(
@@ -1392,7 +1402,7 @@ class CatalogAddition:
     build_zip = field(validator=instance_of(BuildZip))
     catalog = field(validator=instance_of(Catalog))
     aliases = field(validator=deep_iterable(instance_of(str)), default=())
-    semantic_metadata = field(default=None)
+    semantic_metadata = field(default=None, converter=_normalize_semantic_metadata)
     _maybe_tmpfile = field(
         validator=optional(instance_of(tempfile._TemporaryFileWrapper)),
         default=None,

--- a/python/xorq/catalog/cli.py
+++ b/python/xorq/catalog/cli.py
@@ -1289,6 +1289,8 @@ def show(ctx: click.Context, name: str, as_json: bool, as_raw: bool) -> None:
                 # normalize through the parser so legacy sidecars present the
                 # same sql_queries shape as `schema --json`; --raw stays verbatim
                 data["expr_metadata"] = entry.metadata.to_dict()
+            # always present (null when unset) so consumers can rely on the key
+            data.setdefault("semantic_metadata", None)
             click.echo(json.dumps(data, indent=2, default=str))
             return
 
@@ -1310,6 +1312,8 @@ def show(ctx: click.Context, name: str, as_json: bool, as_raw: bool) -> None:
         backends = entry.backends
         if backends:
             click.echo(f"{'Backends:':<15} {', '.join(backends)}")
+        if entry.semantic_metadata is not None:
+            click.echo(f"{'Semantic:':<15} {entry.semantic_metadata}")
         click.echo(
             f"{'Content local:':<15} {'yes' if entry.is_content_local else 'no'}"
         )

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -149,13 +149,17 @@ def test_catalog_add_exist_ok_updates_semantic_metadata(catalog, data_dict):
     path = next(iter(data_dict.values()))
     entry = catalog.add(path, metadata={"v": 1})
     assert entry.semantic_metadata == {"v": 1}
+    expr_before = entry.sidecar_metadata["expr_metadata"]
 
     updated = catalog.add(path, metadata={"v": 2}, exist_ok=True)
     assert updated.semantic_metadata == {"v": 2}
+    # rewriting the sidecar for one key must leave the rest untouched
+    assert updated.sidecar_metadata["expr_metadata"] == expr_before
     reloaded = Catalog.from_repo_path(
         catalog.repo_path, init=False
     ).get_catalog_entry(entry.name)
     assert reloaded.semantic_metadata == {"v": 2}
+    assert reloaded.sidecar_metadata["expr_metadata"] == expr_before
 
     # None leaves stored metadata untouched; same value is idempotent.
     untouched = catalog.add(path, exist_ok=True)

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -76,6 +76,56 @@ from xorq.common.utils.caching_utils import CacheKey
 from xorq.ibis_yaml.enums import REQUIRED_ARCHIVE_NAMES, ExprKind
 
 
+def test_catalog_add_semantic_metadata_roundtrip(catalog, data_dict):
+    path = next(iter(data_dict.values()))
+    metadata = {
+        "domain": "analytics",
+        "tags": ["daily", "trusted"],
+        "options": {"enabled": True, "threshold": 0.5},
+    }
+
+    entry = catalog.add(path, metadata=metadata)
+    reloaded = Catalog.from_repo_path(catalog.repo_path, init=False).get_catalog_entry(
+        entry.name
+    )
+
+    assert entry.semantic_metadata == metadata
+    assert reloaded.semantic_metadata == metadata
+    assert "semantic_metadata" in reloaded.sidecar_metadata
+    assert reloaded.sidecar_metadata["expr_metadata"] == entry.sidecar_metadata[
+        "expr_metadata"
+    ]
+
+
+def test_catalog_add_legacy_sidecar_has_no_semantic_metadata(catalog, data_dict):
+    path = next(iter(data_dict.values()))
+    entry = catalog.add(path)
+    assert entry.semantic_metadata is None
+
+    # A sidecar without the optional key is the legacy on-disk format.
+    sidecar = catalog_mod.yaml12.parse_yaml(entry.metadata_path.read_text())
+    sidecar.pop("semantic_metadata", None)
+    entry.metadata_path.write_text(catalog_mod.yaml12.format_yaml(sidecar))
+    reloaded = Catalog.from_repo_path(catalog.repo_path, init=False).get_catalog_entry(
+        entry.name
+    )
+    assert reloaded.semantic_metadata is None
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        object(),
+        {1: "non-string key"},
+        {"nested": {"bad": object()}},
+    ],
+)
+def test_catalog_add_rejects_invalid_semantic_metadata(catalog, data_dict, metadata):
+    path = next(iter(data_dict.values()))
+    with pytest.raises(TypeError, match="semantic metadata|unsupported"):
+        catalog.add(path, metadata=metadata)
+
+
 def test_catalog_add(catalog, data_dict):
     catalog_entries = tuple(catalog.add(path) for path in data_dict.values())
     assert all(catalog_entry.exists() for catalog_entry in catalog_entries)

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -120,12 +120,29 @@ def test_catalog_add_legacy_sidecar_has_no_semantic_metadata(catalog, data_dict)
         "top-level-string",
         {1: "non-string key"},
         {"nested": {"bad": object()}},
+        {"threshold": float("nan")},
+        {"threshold": float("inf")},
     ],
 )
 def test_catalog_add_rejects_invalid_semantic_metadata(catalog, data_dict, metadata):
     path = next(iter(data_dict.values()))
     with pytest.raises(TypeError, match="semantic metadata|unsupported"):
         catalog.add(path, metadata=metadata)
+
+
+def test_catalog_add_semantic_metadata_preserves_identity(catalog, tmp_path):
+    # Same expression content with absent/different metadata must resolve
+    # to the same content-derived entry name.
+    expr = xo.memtable({"a": [1, 2, 3]})
+    untagged = catalog.add(expr)
+    tagged = catalog.add(expr, metadata={"v": 1}, exist_ok=True)
+    assert tagged.name == untagged.name
+    assert tagged.semantic_metadata == {"v": 1}
+
+    other = Catalog.from_repo_path(tmp_path / "other-catalog", init=True)
+    retagged = other.add(expr, metadata={"v": 2})
+    assert retagged.name == untagged.name
+    assert retagged.semantic_metadata == {"v": 2}
 
 
 def test_catalog_add_exist_ok_updates_semantic_metadata(catalog, data_dict):

--- a/python/xorq/catalog/tests/test_catalog.py
+++ b/python/xorq/catalog/tests/test_catalog.py
@@ -116,6 +116,8 @@ def test_catalog_add_legacy_sidecar_has_no_semantic_metadata(catalog, data_dict)
     "metadata",
     [
         object(),
+        ["top-level", "list"],
+        "top-level-string",
         {1: "non-string key"},
         {"nested": {"bad": object()}},
     ],
@@ -124,6 +126,25 @@ def test_catalog_add_rejects_invalid_semantic_metadata(catalog, data_dict, metad
     path = next(iter(data_dict.values()))
     with pytest.raises(TypeError, match="semantic metadata|unsupported"):
         catalog.add(path, metadata=metadata)
+
+
+def test_catalog_add_exist_ok_updates_semantic_metadata(catalog, data_dict):
+    path = next(iter(data_dict.values()))
+    entry = catalog.add(path, metadata={"v": 1})
+    assert entry.semantic_metadata == {"v": 1}
+
+    updated = catalog.add(path, metadata={"v": 2}, exist_ok=True)
+    assert updated.semantic_metadata == {"v": 2}
+    reloaded = Catalog.from_repo_path(
+        catalog.repo_path, init=False
+    ).get_catalog_entry(entry.name)
+    assert reloaded.semantic_metadata == {"v": 2}
+
+    # None leaves stored metadata untouched; same value is idempotent.
+    untouched = catalog.add(path, exist_ok=True)
+    assert untouched.semantic_metadata == {"v": 2}
+    same = catalog.add(path, metadata={"v": 2}, exist_ok=True)
+    assert same.semantic_metadata == {"v": 2}
 
 
 def test_catalog_add(catalog, data_dict):

--- a/python/xorq/catalog/tests/test_cli_init_crud.py
+++ b/python/xorq/catalog/tests/test_cli_init_crud.py
@@ -40,6 +40,35 @@ def test_show_json_includes_semantic_metadata(runner, catalog, catalog_path, dat
     }
 
 
+def test_show_json_semantic_metadata_null_when_unset(
+    runner, catalog, catalog_path, data_dict
+):
+    source = next(iter(data_dict.values()))
+    entry = catalog.add(source)
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "show", entry.name, "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "semantic_metadata" in data
+    assert data["semantic_metadata"] is None
+
+
+def test_show_human_includes_semantic_metadata(
+    runner, catalog, catalog_path, data_dict
+):
+    source = next(iter(data_dict.values()))
+    entry = catalog.add(source, metadata={"owner": "analytics"})
+
+    result = runner.invoke(cli, ["--path", catalog_path, "show", entry.name])
+
+    assert result.exit_code == 0, result.output
+    assert "Semantic:" in result.output
+    assert "analytics" in result.output
+
+
 # --- init command ---
 
 

--- a/python/xorq/catalog/tests/test_cli_init_crud.py
+++ b/python/xorq/catalog/tests/test_cli_init_crud.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -19,6 +20,24 @@ from xorq.catalog.tests.conftest import (
     make_build_zip,
 )
 from xorq.catalog.zip_utils import extract_build_zip_context
+
+
+# --- show command ---
+
+
+def test_show_json_includes_semantic_metadata(runner, catalog, catalog_path, data_dict):
+    source = next(iter(data_dict.values()))
+    entry = catalog.add(source, metadata={"owner": "analytics", "labels": ["daily"]})
+
+    result = runner.invoke(
+        cli, ["--path", catalog_path, "show", entry.name, "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["semantic_metadata"] == {
+        "owner": "analytics",
+        "labels": ["daily"],
+    }
 
 
 # --- init command ---


### PR DESCRIPTION
`Catalog.add(..., metadata={...})` stores catalog-level metadata in the entry sidecar, exposed as `entry.semantic_metadata` and `show --json`.

Sidecar metadata (domain/owner/tags) shouldn't change the content hash like BSL/expr metadata does. Sidecar keeps it queryable + git-tracked.

 Verify:

 ```
   uv run examples/catalog_semantic_metadata_demo.py
   uv run xorq catalog --path /tmp/sales-catalog show sales-by-region --json
   uv run --with pytest pytest python/xorq/catalog/tests/test_catalog.py -k semantic_metadata -q
 ```